### PR TITLE
Qballer/workaround formac

### DIFF
--- a/src/terminal_pane.rs
+++ b/src/terminal_pane.rs
@@ -1604,7 +1604,7 @@ impl vte::Perform for TerminalOutput {
                 self.newline_indices = newline_indices;
                 self.reflow_lines();
             }
-        } else if c == 'q' {
+        } else if c == 'q' || c == 'd' || c == 'X' || c == 'G' {
             // ignore for now to run on mac
         } else {
             println!("unhandled csi: {:?}->{:?}", c, params);


### PR DESCRIPTION
In this tiny PR I'm ignoring CSI's which happen in mac. This makes mosaic runnable and not address them properly as we should.  