### PR TITLE
First documentation step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 *.new
 .vscode
+.vim

--- a/src/client/panes/terminal_pane.rs
+++ b/src/client/panes/terminal_pane.rs
@@ -18,6 +18,9 @@ pub enum PaneId {
     Terminal(RawFd),
     Plugin(u32), // FIXME: Drop the trait object, make this a wrapper for the struct?
 }
+
+/// Contains the position and size of a [`Pane`], or more generally of any terminal, measured
+/// in character rows and columns.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct PositionAndSize {
     pub x: usize,

--- a/src/client/tab.rs
+++ b/src/client/tab.rs
@@ -1,4 +1,4 @@
-//! `Tab`s holds multiple panes (currently terminal panes). It tracks their coordinates (x/y) and size, as well as how they should be resized
+//! `Tab`s holds multiple panes. It tracks their coordinates (x/y) and size, as well as how they should be resized
 
 use crate::common::{AppInstruction, SenderWithContext};
 use crate::panes::{PaneId, PositionAndSize, TerminalPane};

--- a/src/client/tab.rs
+++ b/src/client/tab.rs
@@ -1,3 +1,5 @@
+//! `Tab`s holds multiple panes (currently terminal panes). It tracks their coordinates (x/y) and size, as well as how they should be resized
+
 use crate::common::{AppInstruction, SenderWithContext};
 use crate::panes::{PaneId, PositionAndSize, TerminalPane};
 use crate::pty_bus::{PtyInstruction, VteEvent};
@@ -12,15 +14,6 @@ use std::{
 use std::{io::Write, sync::mpsc::channel};
 
 use crate::utils::logging::debug_log_to_file;
-
-/*
- * Tab
- *
- * this holds multiple panes (currently terminal panes) which are currently displayed
- * when this tab is active.
- * it tracks their coordinates (x/y) and size, as well as how they should be resized
- *
- */
 
 const CURSOR_HEIGHT_WIDTH_RATIO: usize = 4; // this is not accurate and kind of a magic number, TODO: look into this
 const MIN_TERMINAL_HEIGHT: usize = 2;

--- a/src/common/errors.rs
+++ b/src/common/errors.rs
@@ -1,4 +1,5 @@
-//! All things related to errors and error contexts.
+//! Error context system based on a thread-local representation of the call stack, itself based on
+//! the instructions that are sent between threads.
 
 use super::{AppInstruction, OPENCALLS};
 use crate::pty_bus::PtyInstruction;
@@ -6,12 +7,15 @@ use crate::screen::ScreenInstruction;
 
 use std::fmt::{Display, Error, Formatter};
 
+/// The maximum amount of calls an [`ErrorContext`] will keep track
+/// of in its stack representation. This is a per-thread maximum.
 const MAX_THREAD_CALL_STACK: usize = 6;
 
 #[cfg(not(test))]
 use super::SenderWithContext;
 #[cfg(not(test))]
 use std::panic::PanicInfo;
+/// Custom panic handler/hook. Prints the [`ErrorContext`].
 #[cfg(not(test))]
 pub fn handle_panic(
     info: &PanicInfo<'_>,
@@ -68,19 +72,22 @@ pub fn handle_panic(
     }
 }
 
-/// An [`ErrorContext`] struct contains a representation of the call stack
+/// A representation of the call stack.
 #[derive(Clone, Copy)]
 pub struct ErrorContext {
     calls: [ContextType; MAX_THREAD_CALL_STACK],
 }
 
 impl ErrorContext {
+    /// Returns a new, blank [`ErrorContext`] containing only [`Empty`](ContextType::Empty)
+    /// calls.
     pub fn new() -> Self {
         Self {
             calls: [ContextType::Empty; MAX_THREAD_CALL_STACK],
         }
     }
 
+    /// Adds a call to this [`ErrorContext`]'s call stack representation.
     pub fn add_call(&mut self, call: ContextType) {
         for ctx in self.calls.iter_mut() {
             if *ctx == ContextType::Empty {
@@ -111,20 +118,26 @@ impl Display for ErrorContext {
     }
 }
 
-/// Different types of contexts that form an [`ErrorContext`] call stack.
+/// Different types of calls that form an [`ErrorContext`] call stack.
 ///
 /// Complex variants store a variant of a related enum, whose variants can be built from
-/// the related custom Zellij MSPC instruction enum variants ([`ScreenInstruction`],
-/// [`PtyInstruction`], [`AppInstruction`], etc.
+/// the corresponding Zellij MSPC instruction enum variants ([`ScreenInstruction`],
+/// [`PtyInstruction`], [`AppInstruction`], etc).
 #[derive(Copy, Clone, PartialEq)]
 pub enum ContextType {
+    /// A screen-related call.
     Screen(ScreenContext),
+    /// A PTY-related call.
     Pty(PtyContext),
+    /// A plugin-related call.
     Plugin(PluginContext),
+    /// An app-related call.
     App(AppContext),
     IPCServer,
     StdinHandler,
     AsyncTask,
+    /// An empty, placeholder call. This should be thought of as representing no call at all.
+    /// A call stack representation filled with these is the representation of an empty call stack.
     Empty,
 }
 
@@ -151,7 +164,7 @@ impl Display for ContextType {
     }
 }
 
-/// An element of the error context related to [`ScreenInstruction`]s.
+/// Stack call representations corresponding to the different types of [`ScreenInstruction`]s.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ScreenContext {
     HandlePtyEvent,
@@ -225,7 +238,7 @@ impl From<&ScreenInstruction> for ScreenContext {
     }
 }
 
-/// An element of the error context related to [`PtyInstruction`]s.
+/// Stack call representations corresponding to the different types of [`PtyInstruction`]s.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PtyContext {
     SpawnTerminal,
@@ -255,7 +268,7 @@ impl From<&PtyInstruction> for PtyContext {
 
 use crate::wasm_vm::PluginInstruction;
 
-/// An element of the error context related to [`PluginInstruction`]s.
+/// Stack call representations corresponding to the different types of [`PluginInstruction`]s.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PluginContext {
     Load,
@@ -279,7 +292,7 @@ impl From<&PluginInstruction> for PluginContext {
     }
 }
 
-/// An element of the error context related to [`AppInstruction`]s.
+/// Stack call representations corresponding to the different types of [`AppInstruction`]s.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum AppContext {
     GetState,

--- a/src/common/errors.rs
+++ b/src/common/errors.rs
@@ -1,3 +1,5 @@
+//! All things related to errors and error contexts.
+
 use super::{AppInstruction, OPENCALLS};
 use crate::pty_bus::PtyInstruction;
 use crate::screen::ScreenInstruction;
@@ -66,6 +68,7 @@ pub fn handle_panic(
     }
 }
 
+/// An [`ErrorContext`] struct contains a representation of the call stack
 #[derive(Clone, Copy)]
 pub struct ErrorContext {
     calls: [ContextType; MAX_THREAD_CALL_STACK],
@@ -108,11 +111,15 @@ impl Display for ErrorContext {
     }
 }
 
+/// Different types of contexts that form an [`ErrorContext`] call stack.
+///
+/// Complex variants store a variant of a related enum, whose variants can be built from
+/// the related custom Zellij MSPC instruction enum variants ([`ScreenInstruction`],
+/// [`PtyInstruction`], [`AppInstruction`], etc.
 #[derive(Copy, Clone, PartialEq)]
 pub enum ContextType {
     Screen(ScreenContext),
     Pty(PtyContext),
-
     Plugin(PluginContext),
     App(AppContext),
     IPCServer,
@@ -121,6 +128,7 @@ pub enum ContextType {
     Empty,
 }
 
+// TODO use the `colored` crate for color formatting
 impl Display for ContextType {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         let purple = "\u{1b}[1;35m";
@@ -143,6 +151,7 @@ impl Display for ContextType {
     }
 }
 
+/// An element of the error context related to [`ScreenInstruction`]s.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ScreenContext {
     HandlePtyEvent,
@@ -216,6 +225,7 @@ impl From<&ScreenInstruction> for ScreenContext {
     }
 }
 
+/// An element of the error context related to [`PtyInstruction`]s.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PtyContext {
     SpawnTerminal,
@@ -245,6 +255,7 @@ impl From<&PtyInstruction> for PtyContext {
 
 use crate::wasm_vm::PluginInstruction;
 
+/// An element of the error context related to [`PluginInstruction`]s.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PluginContext {
     Load,
@@ -268,6 +279,7 @@ impl From<&PluginInstruction> for PluginContext {
     }
 }
 
+/// An element of the error context related to [`AppInstruction`]s.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum AppContext {
     GetState,

--- a/src/common/input/actions.rs
+++ b/src/common/input/actions.rs
@@ -1,8 +1,8 @@
-/// This module is for defining the set of actions that can be taken in
-/// response to a keybind and also passing actions back to the handler
-/// for dispatch.
+//! Definition of the actions that can be bound to keys.
+
 use super::handler;
 
+/// The four directions (left, right, up, down).
 #[derive(Clone)]
 pub enum Direction {
     Left,
@@ -11,6 +11,7 @@ pub enum Direction {
     Down,
 }
 
+/// Actions that can be bound to keys.
 #[derive(Clone)]
 pub enum Action {
     /// Quit Zellij.

--- a/src/common/input/handler.rs
+++ b/src/common/input/handler.rs
@@ -19,6 +19,7 @@ use super::keybinds::key_to_actions;
 /// Handles the dispatching of [`Action`]s according to the current
 /// [`InputMode`], and keep tracks of the current [`InputMode`].
 struct InputHandler {
+    /// The current input mode
     mode: InputMode,
     os_input: Box<dyn OsApi>,
     command_is_executing: CommandIsExecuting,

--- a/src/common/input/keybinds.rs
+++ b/src/common/input/keybinds.rs
@@ -1,4 +1,4 @@
-//! Mapping of inputs to sequences of actions
+//! Mapping of inputs to sequences of actions.
 
 use super::actions::{Action, Direction};
 use super::handler::InputMode;
@@ -152,7 +152,6 @@ fn get_defaults_for_mode(mode: &InputMode) -> Result<ModeKeybinds, String> {
             );
             defaults.insert(Key::Esc, vec![Action::SwitchToMode(InputMode::Command)]);
         }
-        InputMode::Exiting => {}
     }
 
     Ok(defaults)

--- a/src/common/input/mod.rs
+++ b/src/common/input/mod.rs
@@ -1,3 +1,5 @@
+//! The way terminal iput is handled.
+
 pub mod actions;
 pub mod handler;
 pub mod keybinds;

--- a/src/common/ipc.rs
+++ b/src/common/ipc.rs
@@ -1,4 +1,5 @@
-// IPC stuff for starting to split things into a client and server model
+//! IPC stuff for starting to split things into a client and server model.
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -63,9 +63,15 @@ pub fn update_state(
 }
 
 /// An [MPSC](mpsc) asynchronous channel with added context.
-pub type ChannelWithContext<T> = (mpsc::Sender<(T, ErrorContext)>, mpsc::Receiver<(T, ErrorContext)>);
+pub type ChannelWithContext<T> = (
+    mpsc::Sender<(T, ErrorContext)>,
+    mpsc::Receiver<(T, ErrorContext)>,
+);
 /// An [MPSC](mpsc) synchronous channel with added context.
-pub type SyncChannelWithContext<T> = (mpsc::SyncSender<(T, ErrorContext)>, mpsc::Receiver<(T, ErrorContext)>);
+pub type SyncChannelWithContext<T> = (
+    mpsc::SyncSender<(T, ErrorContext)>,
+    mpsc::Receiver<(T, ErrorContext)>,
+);
 
 /// Wrappers around the two standard [MPSC](mpsc) sender types, [`mpsc::Sender`] and [`mpsc::SyncSender`], with an additional [`ErrorContext`].
 #[derive(Clone)]

--- a/src/common/os_input_output.rs
+++ b/src/common/os_input_output.rs
@@ -6,8 +6,8 @@ use nix::sys::termios;
 use nix::sys::wait::waitpid;
 use nix::unistd;
 use nix::unistd::{ForkResult, Pid};
-use std::io::prelude::*;
 use std::io;
+use std::io::prelude::*;
 use std::os::unix::io::RawFd;
 use std::path::PathBuf;
 use std::process::{Child, Command};
@@ -175,11 +175,11 @@ pub trait OsApi: Send + Sync {
     fn write_to_tty_stdin(&mut self, fd: RawFd, buf: &mut [u8]) -> Result<usize, nix::Error>;
     /// Wait until all output written to the object referred to by `fd` has been transmitted.
     fn tcdrain(&mut self, fd: RawFd) -> Result<(), nix::Error>;
-    /// Terminate the 
+    /// Terminate the
     // FIXME `RawFd` is semantically the wrong type here. It should either be a raw libc::pid_t,
     // or a nix::unistd::Pid.
     fn kill(&mut self, fd: RawFd) -> Result<(), nix::Error>;
-    /// 
+    ///
     fn read_from_stdin(&self) -> Vec<u8>;
     fn get_stdout_writer(&self) -> Box<dyn io::Write>;
     fn box_clone(&self) -> Box<dyn OsApi>;

--- a/src/common/pty_bus.rs
+++ b/src/common/pty_bus.rs
@@ -145,6 +145,7 @@ impl vte::Perform for VteEventSender {
     }
 }
 
+/// Instructions related to PTYs (pseudoterminals).
 #[derive(Clone, Debug)]
 pub enum PtyInstruction {
     SpawnTerminal(Option<PathBuf>),

--- a/src/common/utils/consts.rs
+++ b/src/common/utils/consts.rs
@@ -1,3 +1,5 @@
+//! Zellij program-wide constants.
+
 pub const ZELLIJ_TMP_DIR: &str = "/tmp/zellij";
 pub const ZELLIJ_TMP_LOG_DIR: &str = "/tmp/zellij/zellij-log";
 pub const ZELLIJ_TMP_LOG_FILE: &str = "/tmp/zellij/zellij-log/log.txt";

--- a/src/common/utils/logging.rs
+++ b/src/common/utils/logging.rs
@@ -1,3 +1,5 @@
+//! Zellij logging utility functions.
+
 use std::{
     fs,
     io::{self, prelude::*},

--- a/src/common/utils/mod.rs
+++ b/src/common/utils/mod.rs
@@ -1,3 +1,5 @@
+//! Zellij utilities.
+
 pub mod consts;
 pub mod logging;
 pub mod shared;

--- a/src/common/utils/shared.rs
+++ b/src/common/utils/shared.rs
@@ -1,8 +1,10 @@
+//! Some general utility functions.
+
 use std::{iter, str::from_utf8};
 
 use strip_ansi_escapes::strip;
 
-pub fn ansi_len(s: &str) -> usize {
+fn ansi_len(s: &str) -> usize {
     from_utf8(&strip(s.as_bytes()).unwrap())
         .unwrap()
         .chars()


### PR DESCRIPTION
### Goal(s) of this PR

Adding some documentation wherever I felt confident enough to do so in a clear and concise manner.

### What changed

Mostly just added documentation (`///`) comments throughout the project. These comments aren't limited to public items, as the documentation is meant for developers. `cargo doc` should therefore be passed the `--document-private-items` flag.

I have also reworked some (not many) of the `use` directives, as I think we should try to not `use` functions from external crates directly, but rather `use` the module they live in, as to not confuse them with locally-defined functions (true of `struct`s to a certain extent as well, see the official Rust book's [comment on idiomatic `use` paths](https://doc.rust-lang.org/stable/book/ch07-04-bringing-paths-into-scope-with-the-use-keyword.html#creating-idiomatic-use-paths).

### Future perspectives

I plan to suggest changes to `CONTRIBUTING.md` regarding documentation and `use` directive requirements. The rest of the existing codebase still needs to be documented.

### Other comments

The individual commits are big because I didn't go through the codebase linearly, and didn't know what lines to split my commits along.