### PR TITLE
Add rust-toolchain.toml file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,4 +5,4 @@
 # version: "nightly-1.0.0"
 channel = "stable"
 components = [ "rustfmt", "rust-src", "clippy", "rust-analysis"]
-targets = [ "wasm32-wasi" ]
+# targets = [ ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,8 @@
+# https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
+[toolchain]
+# can be further pinned eg:
+# date: "stable-2020-07-10"
+# version: "nightly-1.0.0"
+channel = "stable"
+components = [ "rustfmt", "rust-src", "clippy", "rust-analysis"]
+targets = [ "wasm32-wasi" ]


### PR DESCRIPTION
https://github.com/zellij-org/zellij/issues/187

I added a simple rust-toolchain file for now. 
Please suggest appropriate targets and or 
components for it.

The rust-toolchain file makes
it possible to share a basic
rustup configuration across the
project.

https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file

Important to note, this is the
current rustup hierarchy:

1. An explicit toolchain, e.g. cargo +beta,
2. The RUSTUP_TOOLCHAIN environment variable,
3. A directory override, ala rustup override set beta,
4. The rust-toolchain file,
5. The default toolchain,

source:
https://github.com/ebroto/rustup/blob/c2db7dac6b38c99538eec472db9d23d18f918409/README.md#toolchain-override-shorthand

This can especially be helpful if in the future we depend on certain rust versions.