### PR TITLE
Input normal mode

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,4 +5,4 @@
 # version: "nightly-1.0.0"
 channel = "stable"
 components = [ "rustfmt", "rust-src", "clippy", "rust-analysis"]
-targets = [ "wasm32-wasi" ]
+# targets = [ ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,8 @@
+# https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
+[toolchain]
+# can be further pinned eg:
+# date: "stable-2020-07-10"
+# version: "nightly-1.0.0"
+channel = "stable"
+components = [ "rustfmt", "rust-src", "clippy", "rust-analysis"]
+targets = [ "wasm32-wasi" ]

--- a/src/client/tab.rs
+++ b/src/client/tab.rs
@@ -606,6 +606,10 @@ impl Tab {
             self.full_screen_ws.columns as u16,
             self.full_screen_ws.rows as u16,
         );
+        let hide_cursor = "\u{1b}[?25l";
+        stdout
+            .write_all(&hide_cursor.as_bytes())
+            .expect("cannot write to stdout");
         for (kind, terminal) in self.panes.iter_mut() {
             if !self.panes_to_hide.contains(&terminal.pid()) {
                 boundaries.add_rect(terminal.as_ref());

--- a/src/common/input/actions.rs
+++ b/src/common/input/actions.rs
@@ -39,6 +39,8 @@ pub enum Action {
     CloseFocus,
     /// Create a new tab.
     NewTab,
+    /// Do nothing.
+    NoOp,
     /// Go to the next tab.
     GoToNextTab,
     /// Go to the previous tab.

--- a/src/common/input/handler.rs
+++ b/src/common/input/handler.rs
@@ -227,6 +227,7 @@ impl InputHandler {
                     .unwrap();
                 self.command_is_executing.wait_until_pane_is_closed();
             }
+            Action::NoOp => {}
         }
 
         should_break

--- a/src/common/input/keybinds.rs
+++ b/src/common/input/keybinds.rs
@@ -165,15 +165,16 @@ pub fn key_to_actions(
     mode: &InputMode,
     keybinds: &Keybinds,
 ) -> Vec<Action> {
-    if let Some(mode_keybinds) = keybinds.get(mode) {
-        mode_keybinds
+    let mode_keybind_or_action = |action: Action| {
+        keybinds
+            .get(mode)
+            .unwrap_or_else(|| unreachable!("Unrecognized mode: {:?}", mode))
             .get(key)
             .cloned()
-            // FIXME in command mode, unbound keystrokes should probably do nothing instead of
-            // writing to the terminal. Will be easier to implement after a big refactor of the
-            // input system (@categorille)
-            .unwrap_or_else(|| vec![Action::Write(input)])
-    } else {
-        unreachable!("Unrecognized mode: {:?}", mode);
+            .unwrap_or_else(|| vec![action])
+    };
+    match *mode {
+        InputMode::Normal => mode_keybind_or_action(Action::Write(input)),
+        _ => mode_keybind_or_action(Action::NoOp),
     }
 }


### PR DESCRIPTION
closes #184

Added the NoOp from:
https://github.com/zellij-org/zellij/issues/184

Now text is only written in normal Mode.