### PR TITLE
fix(grid): do not crash when reflowing lines with an empty top buffer

### DIFF
--- a/src/client/panes/grid.rs
+++ b/src/client/panes/grid.rs
@@ -70,6 +70,10 @@ fn transfer_rows_down(
                         }
                         None => vec![Row::from_rows(next_lines)],
                     };
+                    if next_lines.is_empty() {
+                        // no more lines at source, the line we popped was probably empty
+                        break;
+                    }
                 }
                 None => break, // no more rows
             }


### PR DESCRIPTION
This happened in certain edge cases where we would reflow lines in a pane and try to pull more lines from the top buffer than it had.