### PR TITLE
Add ability to set tab name

### DIFF
--- a/assets/layouts/default.yaml
+++ b/assets/layouts/default.yaml
@@ -5,6 +5,8 @@ parts:
     split_size:
       Fixed: 1
     plugin: tab-bar
+    events:
+      - Tab
   - direction: Vertical
     expansion_boundary: true
   - direction: Vertical

--- a/default-tiles/status-bar/src/main.rs
+++ b/default-tiles/status-bar/src/main.rs
@@ -104,7 +104,7 @@ fn key_path(help: &Help) -> LinePart {
                 len,
             )
         }
-        InputMode::Tab => {
+        InputMode::Tab | InputMode::RenameTab => {
             let mode_shortcut_text = "t ";
             let superkey = superkey_text.bold().on_magenta();
             let first_superkey_separator = ARROW_SEPARATOR.magenta().on_black();

--- a/default-tiles/tab-bar/src/line.rs
+++ b/default-tiles/tab-bar/src/line.rs
@@ -115,8 +115,7 @@ fn add_next_tabs_msg(
     title_bar: &mut Vec<LinePart>,
     cols: usize,
 ) {
-    while get_current_title_len(&title_bar) +
-        right_more_message(tabs_after_active.len()).len
+    while get_current_title_len(&title_bar) + right_more_message(tabs_after_active.len()).len
         >= cols
     {
         tabs_after_active.insert(0, title_bar.pop().unwrap());

--- a/default-tiles/tab-bar/src/line.rs
+++ b/default-tiles/tab-bar/src/line.rs
@@ -116,7 +116,6 @@ fn add_next_tabs_msg(
     cols: usize,
 ) {
     while get_current_title_len(&title_bar) +
-        // get_tabs_after_len(tabs_after_active.len()) >= cols {
         right_more_message(tabs_after_active.len()).len
         >= cols
     {

--- a/default-tiles/tab-bar/src/main.rs
+++ b/default-tiles/tab-bar/src/main.rs
@@ -63,6 +63,8 @@ impl ZellijTile for State {
                     tabname = self.new_name.clone();
                 }
                 active_tab_index = t.position;
+            } else if t.active {
+                active_tab_index = t.position;
             }
             let tab = tab_style(tabname, t.active, t.position);
             all_tabs.push(tab);

--- a/default-tiles/tab-bar/src/main.rs
+++ b/default-tiles/tab-bar/src/main.rs
@@ -57,7 +57,11 @@ impl ZellijTile for State {
         for t in self.tabs.iter_mut() {
             let mut tabname = t.name.clone();
             if t.active && self.mode == BarMode::Rename {
-                tabname = self.new_name.clone();
+                if self.new_name.is_empty() {
+                    tabname = String::from("Enter name...");
+                } else {
+                    tabname = self.new_name.clone();
+                }
                 active_tab_index = t.position;
             }
             let tab = tab_style(tabname, t.active, t.position);

--- a/default-tiles/tab-bar/src/main.rs
+++ b/default-tiles/tab-bar/src/main.rs
@@ -12,11 +12,24 @@ pub struct LinePart {
     len: usize,
 }
 
+enum Mode {
+    Normal,
+    Rename,
+}
+
+impl Default for Mode {
+    fn default() -> Self {
+        Mode::Normal
+    }
+}
+
 #[derive(Default)]
 struct State {
     active_tab_index: usize,
     num_tabs: usize,
     tabs: Vec<TabData>,
+    mode: Mode,
+    new_name: String,
 }
 
 static ARROW_SEPARATOR: &str = "";
@@ -30,29 +43,48 @@ impl ZellijTile for State {
         set_max_height(1);
         self.active_tab_index = 0;
         self.num_tabs = 0;
+        self.mode = Mode::Normal;
+        self.new_name = String::new();
     }
 
     fn draw(&mut self, _rows: usize, cols: usize) {
-        let mut all_tabs: Vec<LinePart> = vec![];
-        let mut active_tab_index = 0;
-        for t in &self.tabs {
-            let tab = tab_style(t.name.clone(), t.active, t.position);
-            all_tabs.push(tab);
-            if t.active {
-                active_tab_index = t.position;
+        match self.mode {
+            Mode::Normal => {
+                if self.tabs.is_empty() {
+                    return;
+                }
+                let mut all_tabs: Vec<LinePart> = vec![];
+                let mut active_tab_index = 0;
+                for t in &self.tabs {
+                    let tab = tab_style(t.name.clone(), t.active, t.position);
+                    all_tabs.push(tab);
+                    if t.active {
+                        active_tab_index = t.position;
+                    }
+                }
+                let tab_line = tab_line(all_tabs, active_tab_index, cols);
+                let mut s = String::new();
+                for bar_part in tab_line {
+                    s = format!("{}{}", s, bar_part.part);
+                }
+                println!("{}\u{1b}[40m\u{1b}[0K", s);
+            }
+            Mode::Rename => {
+                println!("Enter name: {}\u{1b}[40m\u{1b}[0K", self.new_name);
             }
         }
-
-        let tab_line = tab_line(all_tabs, active_tab_index, cols);
-
-        let mut s = String::new();
-        for bar_part in tab_line {
-            s = format!("{}{}", s, bar_part.part);
-        }
-        println!("{}\u{1b}[40m\u{1b}[0K", s);
     }
 
     fn update_tabs(&mut self) {
         self.tabs = get_tabs();
+    }
+
+    fn handle_key(&mut self, key: Key) {
+        self.mode = Mode::Rename;
+        match key {
+            Key::Char('\n') => self.mode = Mode::Normal,
+            Key::Char(c) => self.new_name = format!("{}{}", self.new_name, c),
+            _ => {}
+        }
     }
 }

--- a/default-tiles/tab-bar/src/main.rs
+++ b/default-tiles/tab-bar/src/main.rs
@@ -75,7 +75,7 @@ impl ZellijTile for State {
         self.tabs = get_tabs();
     }
 
-    fn handle_tab_event(&mut self, key: Key) {
+    fn handle_tab_rename_keypress(&mut self, key: Key) {
         self.mode = BarMode::Rename;
         match key {
             Key::Char('\n') | Key::Esc => {

--- a/default-tiles/tab-bar/src/main.rs
+++ b/default-tiles/tab-bar/src/main.rs
@@ -12,14 +12,15 @@ pub struct LinePart {
     len: usize,
 }
 
-enum Mode {
+#[derive(PartialEq)]
+enum BarMode {
     Normal,
     Rename,
 }
 
-impl Default for Mode {
+impl Default for BarMode {
     fn default() -> Self {
-        Mode::Normal
+        BarMode::Normal
     }
 }
 
@@ -28,7 +29,7 @@ struct State {
     active_tab_index: usize,
     num_tabs: usize,
     tabs: Vec<TabData>,
-    mode: Mode,
+    mode: BarMode,
     new_name: String,
 }
 
@@ -43,36 +44,31 @@ impl ZellijTile for State {
         set_max_height(1);
         self.active_tab_index = 0;
         self.num_tabs = 0;
-        self.mode = Mode::Normal;
+        self.mode = BarMode::Normal;
         self.new_name = String::new();
     }
 
     fn draw(&mut self, _rows: usize, cols: usize) {
-        match self.mode {
-            Mode::Normal => {
-                if self.tabs.is_empty() {
-                    return;
-                }
-                let mut all_tabs: Vec<LinePart> = vec![];
-                let mut active_tab_index = 0;
-                for t in &self.tabs {
-                    let tab = tab_style(t.name.clone(), t.active, t.position);
-                    all_tabs.push(tab);
-                    if t.active {
-                        active_tab_index = t.position;
-                    }
-                }
-                let tab_line = tab_line(all_tabs, active_tab_index, cols);
-                let mut s = String::new();
-                for bar_part in tab_line {
-                    s = format!("{}{}", s, bar_part.part);
-                }
-                println!("{}\u{1b}[40m\u{1b}[0K", s);
-            }
-            Mode::Rename => {
-                println!("Enter name: {}\u{1b}[40m\u{1b}[0K", self.new_name);
-            }
+        if self.tabs.is_empty() {
+            return;
         }
+        let mut all_tabs: Vec<LinePart> = vec![];
+        let mut active_tab_index = 0;
+        for t in self.tabs.iter_mut() {
+            let mut tabname = t.name.clone();
+            if t.active && self.mode == BarMode::Rename {
+                tabname = self.new_name.clone();
+                active_tab_index = t.position;
+            }
+            let tab = tab_style(tabname, t.active, t.position);
+            all_tabs.push(tab);
+        }
+        let tab_line = tab_line(all_tabs, active_tab_index, cols);
+        let mut s = String::new();
+        for bar_part in tab_line {
+            s = format!("{}{}", s, bar_part.part);
+        }
+        println!("{}\u{1b}[40m\u{1b}[0K", s);
     }
 
     fn update_tabs(&mut self) {
@@ -80,9 +76,12 @@ impl ZellijTile for State {
     }
 
     fn handle_tab_event(&mut self, key: Key) {
-        self.mode = Mode::Rename;
+        self.mode = BarMode::Rename;
         match key {
-            Key::Char('\n') => self.mode = Mode::Normal,
+            Key::Char('\n') | Key::Esc => {
+                self.mode = BarMode::Normal;
+                self.new_name.clear();
+            }
             Key::Char(c) => self.new_name = format!("{}{}", self.new_name, c),
             _ => {}
         }

--- a/default-tiles/tab-bar/src/main.rs
+++ b/default-tiles/tab-bar/src/main.rs
@@ -4,7 +4,7 @@ mod tab;
 use zellij_tile::*;
 
 use crate::line::tab_line;
-use crate::tab::nameless_tab;
+use crate::tab::tab_style;
 
 #[derive(Debug)]
 pub struct LinePart {
@@ -16,6 +16,7 @@ pub struct LinePart {
 struct State {
     active_tab_index: usize,
     num_tabs: usize,
+    tabs: Vec<TabData>,
 }
 
 static ARROW_SEPARATOR: &str = "";
@@ -32,16 +33,17 @@ impl ZellijTile for State {
     }
 
     fn draw(&mut self, _rows: usize, cols: usize) {
-        if self.num_tabs == 0 {
-            return;
-        }
         let mut all_tabs: Vec<LinePart> = vec![];
-        for i in 0..self.num_tabs {
-            let tab = nameless_tab(i, i == self.active_tab_index);
+        let mut active_tab_index = 0;
+        for t in &self.tabs {
+            let tab = tab_style(t.name.clone(), t.active, t.position);
             all_tabs.push(tab);
+            if t.active {
+                active_tab_index = t.position;
+            }
         }
 
-        let tab_line = tab_line(all_tabs, self.active_tab_index, cols);
+        let tab_line = tab_line(all_tabs, active_tab_index, cols);
 
         let mut s = String::new();
         for bar_part in tab_line {
@@ -50,8 +52,7 @@ impl ZellijTile for State {
         println!("{}\u{1b}[40m\u{1b}[0K", s);
     }
 
-    fn update_tabs(&mut self, active_tab_index: usize, num_tabs: usize) {
-        self.active_tab_index = active_tab_index;
-        self.num_tabs = num_tabs;
+    fn update_tabs(&mut self) {
+        self.tabs = get_tabs();
     }
 }

--- a/default-tiles/tab-bar/src/main.rs
+++ b/default-tiles/tab-bar/src/main.rs
@@ -79,7 +79,7 @@ impl ZellijTile for State {
         self.tabs = get_tabs();
     }
 
-    fn handle_key(&mut self, key: Key) {
+    fn handle_tab_event(&mut self, key: Key) {
         self.mode = Mode::Rename;
         match key {
             Key::Char('\n') => self.mode = Mode::Normal,

--- a/default-tiles/tab-bar/src/tab.rs
+++ b/default-tiles/tab-bar/src/tab.rs
@@ -38,15 +38,16 @@ pub fn non_active_tab(text: String, is_furthest_to_the_left: bool) -> LinePart {
     }
 }
 
-pub fn tab(text: String, is_active_tab: bool, is_furthest_to_the_left: bool) -> LinePart {
-    if is_active_tab {
-        active_tab(text, is_furthest_to_the_left)
+pub fn tab_style(text: String, is_active_tab: bool, position: usize) -> LinePart {
+    let tab_text;
+    if text.is_empty() {
+        tab_text = format!(" Tab #{} ", position + 1);
     } else {
-        non_active_tab(text, is_furthest_to_the_left)
+        tab_text = text;
     }
-}
-
-pub fn nameless_tab(index: usize, is_active_tab: bool) -> LinePart {
-    let tab_text = format!(" Tab #{} ", index + 1);
-    tab(tab_text, is_active_tab, index == 0)
+    if is_active_tab {
+        active_tab(tab_text, position == 0)
+    } else {
+        non_active_tab(tab_text, position == 0)
+    }
 }

--- a/default-tiles/tab-bar/src/tab.rs
+++ b/default-tiles/tab-bar/src/tab.rs
@@ -9,11 +9,11 @@ pub fn active_tab(text: String, is_furthest_to_the_left: bool) -> LinePart {
         ARROW_SEPARATOR.black().on_magenta()
     };
     let right_separator = ARROW_SEPARATOR.magenta().on_black();
-    let tab_styled_text = format!("{}{}{}", left_separator, text, right_separator)
+    let tab_styled_text = format!("{} {} {}", left_separator, text, right_separator)
         .black()
         .bold()
         .on_magenta();
-    let tab_text_len = text.chars().count() + 2; // 2 for left and right separators
+    let tab_text_len = text.chars().count() + 4; // 2 for left and right separators, 2 for the text padding
     LinePart {
         part: format!("{}", tab_styled_text),
         len: tab_text_len,
@@ -31,7 +31,7 @@ pub fn non_active_tab(text: String, is_furthest_to_the_left: bool) -> LinePart {
         .black()
         .bold()
         .on_green();
-    let tab_text_len = text.chars().count() + 2; // 2 for the left and right separators
+    let tab_text_len = text.chars().count() + 4; // 2 for the left and right separators, 2 for the text padding
     LinePart {
         part: format!("{}", tab_styled_text),
         len: tab_text_len,
@@ -41,7 +41,7 @@ pub fn non_active_tab(text: String, is_furthest_to_the_left: bool) -> LinePart {
 pub fn tab_style(text: String, is_active_tab: bool, position: usize) -> LinePart {
     let tab_text;
     if text.is_empty() {
-        tab_text = format!(" Tab #{} ", position + 1);
+        tab_text = format!("Tab #{}", position + 1);
     } else {
         tab_text = text;
     }

--- a/default-tiles/tab-bar/src/tab.rs
+++ b/default-tiles/tab-bar/src/tab.rs
@@ -27,7 +27,7 @@ pub fn non_active_tab(text: String, is_furthest_to_the_left: bool) -> LinePart {
         ARROW_SEPARATOR.black().on_green()
     };
     let right_separator = ARROW_SEPARATOR.green().on_black();
-    let tab_styled_text = format!("{}{}{}", left_separator, text, right_separator)
+    let tab_styled_text = format!("{} {} {}", left_separator, text, right_separator)
         .black()
         .bold()
         .on_green();

--- a/src/client/layout.rs
+++ b/src/client/layout.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::{fs::File, io::prelude::*};
 
+use crate::common::wasm_vm::EventType;
 use crate::panes::PositionAndSize;
 
 fn split_space_to_parts_vertically(
@@ -180,6 +181,8 @@ pub struct Layout {
     pub plugin: Option<PathBuf>,
     #[serde(default)]
     pub expansion_boundary: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub events: Vec<EventType>,
 }
 
 impl Layout {

--- a/src/common/errors.rs
+++ b/src/common/errors.rs
@@ -198,6 +198,7 @@ pub enum ScreenContext {
     SwitchTabPrev,
     CloseTab,
     GoToTab,
+    UpdateTabName,
 }
 
 impl From<&ScreenInstruction> for ScreenContext {
@@ -236,6 +237,7 @@ impl From<&ScreenInstruction> for ScreenContext {
             ScreenInstruction::SwitchTabPrev => ScreenContext::SwitchTabPrev,
             ScreenInstruction::CloseTab => ScreenContext::CloseTab,
             ScreenInstruction::GoToTab(_) => ScreenContext::GoToTab,
+            ScreenInstruction::UpdateTabName(_) => ScreenContext::UpdateTabName,
         }
     }
 }

--- a/src/common/input/actions.rs
+++ b/src/common/input/actions.rs
@@ -48,4 +48,6 @@ pub enum Action {
     /// Close the current tab.
     CloseTab,
     GoToTab(u32),
+    TabNameInput(Vec<u8>),
+    SaveTabName,
 }

--- a/src/common/input/handler.rs
+++ b/src/common/input/handler.rs
@@ -232,6 +232,22 @@ impl InputHandler {
                     .send(ScreenInstruction::GoToTab(i))
                     .unwrap();
             }
+            Action::TabNameInput(c) => {
+                self.send_plugin_instructions
+                    .send(PluginInstruction::Input(0, c.clone()))
+                    .unwrap();
+                self.send_screen_instructions
+                    .send(ScreenInstruction::UpdateTabName(c))
+                    .unwrap();
+            }
+            Action::SaveTabName => {
+                self.send_plugin_instructions
+                    .send(PluginInstruction::Input(0, vec![b'\n']))
+                    .unwrap();
+                self.send_screen_instructions
+                    .send(ScreenInstruction::UpdateTabName(vec![b'\n']))
+                    .unwrap();
+            }
             Action::NoOp => {}
         }
 
@@ -265,6 +281,7 @@ pub enum InputMode {
     Tab,
     /// `Scroll` mode allows scrolling up and down within a pane.
     Scroll,
+    RenameTab,
 }
 
 /// Represents the contents of the help message that is printed in the status bar,
@@ -310,9 +327,13 @@ pub fn get_help(mode: InputMode) -> Help {
             keybinds.push(("←↓↑→".to_string(), "Move focus".to_string()));
             keybinds.push(("n".to_string(), "New".to_string()));
             keybinds.push(("x".to_string(), "Close".to_string()));
+            keybinds.push(("r".to_string(), "Rename".to_string()));
         }
         InputMode::Scroll => {
             keybinds.push(("↓↑".to_string(), "Scroll".to_string()));
+        }
+        InputMode::RenameTab => {
+            keybinds.push(("Enter".to_string(), "when done".to_string()));
         }
     }
     keybinds.push(("ESC".to_string(), "BACK".to_string()));

--- a/src/common/input/handler.rs
+++ b/src/common/input/handler.rs
@@ -7,7 +7,7 @@ use crate::errors::ContextType;
 use crate::os_input_output::OsApi;
 use crate::pty_bus::PtyInstruction;
 use crate::screen::ScreenInstruction;
-use crate::wasm_vm::PluginInstruction;
+use crate::wasm_vm::{EventType, PluginInputType, PluginInstruction};
 use crate::CommandIsExecuting;
 
 use serde::{Deserialize, Serialize};
@@ -234,7 +234,10 @@ impl InputHandler {
             }
             Action::TabNameInput(c) => {
                 self.send_plugin_instructions
-                    .send(PluginInstruction::Input(0, c.clone()))
+                    .send(PluginInstruction::Input(
+                        PluginInputType::Event(EventType::Tab),
+                        c.clone(),
+                    ))
                     .unwrap();
                 self.send_screen_instructions
                     .send(ScreenInstruction::UpdateTabName(c))
@@ -242,7 +245,10 @@ impl InputHandler {
             }
             Action::SaveTabName => {
                 self.send_plugin_instructions
-                    .send(PluginInstruction::Input(0, vec![b'\n']))
+                    .send(PluginInstruction::Input(
+                        PluginInputType::Event(EventType::Tab),
+                        vec![b'\n'],
+                    ))
                     .unwrap();
                 self.send_screen_instructions
                     .send(ScreenInstruction::UpdateTabName(vec![b'\n']))

--- a/src/common/input/keybinds.rs
+++ b/src/common/input/keybinds.rs
@@ -171,7 +171,13 @@ fn get_defaults_for_mode(mode: &InputMode) -> Result<ModeKeybinds, String> {
                 Key::Ctrl('g'),
                 vec![Action::SwitchToMode(InputMode::Normal)],
             );
-            defaults.insert(Key::Esc, vec![Action::SwitchToMode(InputMode::Command)]);
+            defaults.insert(
+                Key::Esc,
+                vec![
+                    Action::TabNameInput(vec![0x1b]),
+                    Action::SwitchToMode(InputMode::Tab),
+                ],
+            );
         }
     }
 

--- a/src/common/input/keybinds.rs
+++ b/src/common/input/keybinds.rs
@@ -128,6 +128,13 @@ fn get_defaults_for_mode(mode: &InputMode) -> Result<ModeKeybinds, String> {
             defaults.insert(Key::Char('n'), vec![Action::NewTab]);
             defaults.insert(Key::Char('x'), vec![Action::CloseTab]);
 
+            defaults.insert(
+                Key::Char('r'),
+                vec![
+                    Action::SwitchToMode(InputMode::RenameTab),
+                    Action::TabNameInput(vec![0]),
+                ],
+            );
             defaults.insert(Key::Char('q'), vec![Action::Quit]);
             defaults.insert(
                 Key::Ctrl('g'),
@@ -149,6 +156,17 @@ fn get_defaults_for_mode(mode: &InputMode) -> Result<ModeKeybinds, String> {
             defaults.insert(Key::Ctrl('p'), vec![Action::ScrollUp]);
 
             defaults.insert(Key::Char('q'), vec![Action::Quit]);
+            defaults.insert(
+                Key::Ctrl('g'),
+                vec![Action::SwitchToMode(InputMode::Normal)],
+            );
+            defaults.insert(Key::Esc, vec![Action::SwitchToMode(InputMode::Command)]);
+        }
+        InputMode::RenameTab => {
+            defaults.insert(
+                Key::Char('\n'),
+                vec![Action::SaveTabName, Action::SwitchToMode(InputMode::Tab)],
+            );
             defaults.insert(
                 Key::Ctrl('g'),
                 vec![Action::SwitchToMode(InputMode::Normal)],
@@ -178,6 +196,7 @@ pub fn key_to_actions(
     };
     match *mode {
         InputMode::Normal => mode_keybind_or_action(Action::Write(input)),
+        InputMode::RenameTab => mode_keybind_or_action(Action::TabNameInput(input)),
         _ => mode_keybind_or_action(Action::NoOp),
     }
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -444,7 +444,7 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: CliArgs) {
             let mut plugin_id = 0;
             let mut plugin_map = HashMap::new();
             let handler_map: HashMap<EventType, String> =
-                [(EventType::Tab, "handle_tab_event".to_string())]
+                [(EventType::Tab, "handle_tab_rename_keypress".to_string())]
                     .iter()
                     .cloned()
                     .collect();

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -514,15 +514,15 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: CliArgs) {
 
                         buf_tx.send(wasi_stdout(&plugin_env.wasi_env)).unwrap();
                     }
-                    PluginInstruction::UpdateTabs(active_tab_index, num_tabs) => {
-                        for (instance, _) in plugin_map.values() {
+                    PluginInstruction::UpdateTabs(mut tabs) => {
+                        for (instance, plugin_env) in plugin_map.values() {
                             let handler = instance.exports.get_function("update_tabs").unwrap();
-                            handler
-                                .call(&[
-                                    Value::I32(active_tab_index as i32),
-                                    Value::I32(num_tabs as i32),
-                                ])
-                                .unwrap();
+                            tabs.sort_by(|a, b| a.position.cmp(&b.position));
+                            wasi_write_string(
+                                &plugin_env.wasi_env,
+                                &serde_json::to_string(&tabs).unwrap(),
+                            );
+                            handler.call(&[]).unwrap();
                         }
                     }
                     // FIXME: Deduplicate this with the callback below!

--- a/src/common/wasm_vm.rs
+++ b/src/common/wasm_vm.rs
@@ -12,7 +12,7 @@ use super::{
     PaneId, SenderWithContext,
 };
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Hash, Eq, Serialize, Deserialize)]
 pub enum EventType {
     Tab,
 }

--- a/src/common/wasm_vm.rs
+++ b/src/common/wasm_vm.rs
@@ -1,4 +1,5 @@
 use crate::tab::TabData;
+use serde::{Deserialize, Serialize};
 use std::{
     path::PathBuf,
     sync::mpsc::{channel, Sender},
@@ -11,11 +12,22 @@ use super::{
     PaneId, SenderWithContext,
 };
 
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum EventType {
+    Tab,
+}
+
+#[derive(Clone, Debug)]
+pub enum PluginInputType {
+    Normal(u32),
+    Event(EventType),
+}
+
 #[derive(Clone, Debug)]
 pub enum PluginInstruction {
-    Load(Sender<u32>, PathBuf),
+    Load(Sender<u32>, PathBuf, Vec<EventType>),
     Draw(Sender<String>, u32, usize, usize), // String buffer, plugin id, rows, cols
-    Input(u32, Vec<u8>),                     // plugin id, input bytes
+    Input(PluginInputType, Vec<u8>),         // plugin id, input bytes
     GlobalInput(Vec<u8>),                    // input bytes
     Unload(u32),
     UpdateTabs(Vec<TabData>), // num tabs, active tab
@@ -29,6 +41,7 @@ pub struct PluginEnv {
     pub send_app_instructions: SenderWithContext<AppInstruction>,
     pub send_pty_instructions: SenderWithContext<PtyInstruction>, // FIXME: This should be a big bundle of all of the channels
     pub wasi_env: WasiEnv,
+    pub events: Vec<EventType>,
 }
 
 // Plugin API ---------------------------------------------------------------------------------------------------------

--- a/src/common/wasm_vm.rs
+++ b/src/common/wasm_vm.rs
@@ -1,10 +1,10 @@
+use crate::tab::TabData;
 use std::{
     path::PathBuf,
     sync::mpsc::{channel, Sender},
 };
 use wasmer::{imports, Function, ImportObject, Store, WasmerEnv};
 use wasmer_wasi::WasiEnv;
-// use crate::utils::logging::debug_log_to_file;
 
 use super::{
     input::handler::get_help, pty_bus::PtyInstruction, screen::ScreenInstruction, AppInstruction,
@@ -18,7 +18,7 @@ pub enum PluginInstruction {
     Input(u32, Vec<u8>),                     // plugin id, input bytes
     GlobalInput(Vec<u8>),                    // input bytes
     Unload(u32),
-    UpdateTabs(usize, usize), // num tabs, active tab
+    UpdateTabs(Vec<TabData>), // num tabs, active tab
     Quit,
 }
 

--- a/zellij-tile/src/lib.rs
+++ b/zellij-tile/src/lib.rs
@@ -7,7 +7,9 @@ pub trait ZellijTile {
     fn draw(&mut self, rows: usize, cols: usize) {}
     fn handle_key(&mut self, key: Key) {}
     fn handle_global_key(&mut self, key: Key) {}
-    fn update_tabs(&mut self, active_tab_index: usize, num_active_tabs: usize) {}
+    fn update_tabs(&mut self) {
+        get_tabs();
+    }
 }
 
 #[macro_export]
@@ -45,11 +47,9 @@ macro_rules! register_tile {
         }
 
         #[no_mangle]
-        pub fn update_tabs(active_tab_index: i32, num_active_tabs: i32) {
+        pub fn update_tabs() {
             STATE.with(|state| {
-                state
-                    .borrow_mut()
-                    .update_tabs(active_tab_index as usize, num_active_tabs as usize);
+                state.borrow_mut().update_tabs();
             })
         }
     };

--- a/zellij-tile/src/lib.rs
+++ b/zellij-tile/src/lib.rs
@@ -7,9 +7,8 @@ pub trait ZellijTile {
     fn draw(&mut self, rows: usize, cols: usize) {}
     fn handle_key(&mut self, key: Key) {}
     fn handle_global_key(&mut self, key: Key) {}
-    fn update_tabs(&mut self) {
-        get_tabs();
-    }
+    fn update_tabs(&mut self) {}
+    fn handle_tab_event(&mut self, key: Key) {}
 }
 
 #[macro_export]
@@ -50,6 +49,13 @@ macro_rules! register_tile {
         pub fn update_tabs() {
             STATE.with(|state| {
                 state.borrow_mut().update_tabs();
+            })
+        }
+
+        #[no_mangle]
+        pub fn handle_tab_event() {
+            STATE.with(|state| {
+                state.borrow_mut().handle_tab_event($crate::get_key());
             })
         }
     };

--- a/zellij-tile/src/lib.rs
+++ b/zellij-tile/src/lib.rs
@@ -8,7 +8,7 @@ pub trait ZellijTile {
     fn handle_key(&mut self, key: Key) {}
     fn handle_global_key(&mut self, key: Key) {}
     fn update_tabs(&mut self) {}
-    fn handle_tab_event(&mut self, key: Key) {}
+    fn handle_tab_rename_keypress(&mut self, key: Key) {}
 }
 
 #[macro_export]
@@ -53,9 +53,11 @@ macro_rules! register_tile {
         }
 
         #[no_mangle]
-        pub fn handle_tab_event() {
+        pub fn handle_tab_rename_keypress() {
             STATE.with(|state| {
-                state.borrow_mut().handle_tab_event($crate::get_key());
+                state
+                    .borrow_mut()
+                    .handle_tab_rename_keypress($crate::get_key());
             })
         }
     };

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -38,6 +38,7 @@ pub enum InputMode {
     Resize,
     Pane,
     Tab,
+    RenameTab,
     Scroll,
     Exiting,
 }

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -42,6 +42,14 @@ pub enum InputMode {
     Exiting,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TabData {
+    /* subset of fields to publish to plugins */
+    pub position: usize,
+    pub name: String,
+    pub active: bool,
+}
+
 impl Default for InputMode {
     fn default() -> InputMode {
         InputMode::Normal
@@ -73,6 +81,10 @@ pub fn set_selectable(selectable: bool) {
 
 pub fn get_help() -> Help {
     unsafe { host_get_help() };
+    deserialize_from_stdin().unwrap_or_default()
+}
+
+pub fn get_tabs() -> Vec<TabData> {
     deserialize_from_stdin().unwrap_or_default()
 }
 


### PR DESCRIPTION
#166 
Ctrl-G/t/r to rename the active tab.


This is a fairly moderate change as I needed a way to selectively funnel input streams to a specific plugin. I got the idea that the  `PluginInstruction::Input` needs to be divided into two cases:

1. the input needs to be forwarded to the active pane, which happens to be a plugin, identified by pid (existing case)
2. the input needs to be forwarded to one or more plugins, based on whether or not they are interested in that information

I implemented this by adding  `events` to the layout. When an input comes in that is destined for a plugin (decided based on the InputMode) it is forwarded to the plugin:

In layout.yml:
```
parts:
  - direction: Vertical
    split_size:
      Fixed: 1
    plugin: tab-bar
    events:
      - Tab
```
When a tab loads a plugin it now sends the layout.events:
```
fn apply_layout{
                ...
                self.send_plugin_instructions
                    .send(PluginInstruction::Load(
                        pid_tx,
                        plugin.clone(),
                        layout.events.clone(),
                    ))
```

and then when sending the instruction to the wasm thread:
```
                self.send_plugin_instructions
                    .send(PluginInstruction::Input(
                        PluginInputType::Event(EventType::Tab),
                        c.clone(),
                    ))
```
In the wasm thread I initialize a hashmap that tells which handler is associated with this event type:
```
            let handler_map: HashMap<EventType, String> = [(EventType::Tab, "handle_tab_event".to_string())].iter().cloned().collect();
```

When handling this instruction there are two checks:
```
                               for (instance, plugin_env) in plugin_map.values() {
                                    if !plugin_env.events.contains(&event) {
                                        continue;
                                    }
                                    let handle_key = instance.exports.get_function(
                                        handler_map.get(&event).unwrap()
                                    ).unwrap();
```

First the `plugin_env` is extended to include the event types that the plugin wants to subscribe to (decided at load time), so we skip over plugins that don't care about this type of event. Then we get the handler associated with this event type, and forward it.

The same trick is used for `update_tabs` now. Before, the default handler consumed the stream to keep the plugins stdin clean, now the plugin can be specified as a subscriber for the event. 