### PR TITLE
Rewriting the plugin API to be more general

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,9 +11,9 @@ dependencies = [
 
 [[package]]
 name = "adler"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bedc89c5c7b5550ffb9372eb5c5ffc7f9f705cc3f4a128bd4669b9745f555093"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ansi_term"
@@ -214,9 +214,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitvec"
-version = "0.19.4"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ba35e9565969edb811639dbebfe34edc0368e472c5018474c8eb2543397f81"
+checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
 dependencies = [
  "funty",
  "radium",
@@ -527,9 +527,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "enumset"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70e3089d60da62772627697a83dd166615072eebe1a52ac05f16bdbd0165dc3"
+checksum = "fbd795df6708a599abf1ee10eacc72efd052b7a5f70fdf0715e4d5151a6db9c3"
 dependencies = [
  "enumset_derive",
 ]
@@ -798,9 +798,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -809,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.6.3"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd354a2c8c8083d58414597a4ecada1984f9b82ea7e87eeabddc869eaf120992"
+checksum = "e1b6cf41e31a7e7b78055b548826da45c7dc74e6a13a3fa6b897a17a01322f26"
 dependencies = [
  "console",
  "lazy_static",
@@ -833,16 +833,16 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98969eda6bf33b8532e8a7b8f157afc43556188741fa0df8c92b8780f8654e52"
+checksum = "1c58ec7fbda1df9a93f587b780659db3c99f61f4be27f9c82c9b37684ffd0366"
 dependencies = [
  "blocking",
  "cfg-if 1.0.0",
  "futures",
  "intmap",
- "lazy_static",
  "libc",
+ "once_cell",
  "spinning",
  "thiserror",
  "winapi",
@@ -884,9 +884,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.47"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
+checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -927,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
 
 [[package]]
 name = "libloading"
@@ -1084,9 +1084,9 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "once_cell"
-version = "1.7.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10acf907b94fc1b1a152d08ef97e7759650268cf986bf127f387e602b02c7e5a"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "parking"
@@ -1096,9 +1096,9 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "pin-utils"
@@ -1361,9 +1361,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
 dependencies = [
  "serde_derive",
 ]
@@ -1379,9 +1379,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1390,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43535db9747a4ba938c0ce0a98cc631a46ebf943c9e1d604e091df6007620bf6"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
@@ -1572,9 +1572,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "123a78a3596b24fee53a6464ce52d8ecbf62241e6294c7e7fe12086cd161f512"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1879,9 +1879,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
+checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -1889,9 +1889,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
+checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1904,9 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de431a2910c86679c34283a33f66f4e4abd7e0aec27b6669060148872aadf94"
+checksum = "8e67a5806118af01f0d9045915676b22aaebecf4178ae7021bc171dab0b897ab"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -1916,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
+checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1926,9 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
+checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1939,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
+checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
 
 [[package]]
 name = "wasmer"
@@ -2145,27 +2145,27 @@ checksum = "87cc2fe6350834b4e528ba0901e7aa405d78b89dc1fa3145359eb4de0e323fcf"
 
 [[package]]
 name = "wast"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de71ea922e46a60d0bde4b27ebf24ab7c4991006fd5de23ce9c58e129b3ab3c"
+checksum = "db5ae96da18bb5926341516fd409b5a8ce4e4714da7f0a1063d3b20ac9f9a1e1"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474403335b9a90b21120ab8131dd888f0a8d041c2d365ab960feddfe5a73c4b6"
+checksum = "0b0fa059022c5dabe129f02b429d67086400deb8277f89c975555dacc1dadbcc"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.47"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
+checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2258,7 +2258,6 @@ dependencies = [
  "strip-ansi-escapes",
  "structopt",
  "strum",
- "strum_macros",
  "termion_temporary_zellij_fork",
  "termios",
  "toml",
@@ -2268,6 +2267,7 @@ dependencies = [
  "walkdir",
  "wasmer",
  "wasmer-wasi",
+ "zellij-tile",
 ]
 
 [[package]]
@@ -2276,4 +2276,6 @@ version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,12 +1271,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
@@ -1290,7 +1284,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
 dependencies = [
- "redox_syscall 0.2.5",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -1300,7 +1294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom",
- "redox_syscall 0.2.5",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -1621,7 +1615,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand",
- "redox_syscall 0.2.5",
+ "redox_syscall",
  "remove_dir_all",
  "winapi",
 ]
@@ -1637,16 +1631,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "termion_temporary_zellij_fork"
-version = "1.6.0"
+name = "termion"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65175afb01727f72d690bc8b2a2ac411c0243ec43988b7bd96d428301197bed0"
+checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
 dependencies = [
  "libc",
  "numtoa",
- "redox_syscall 0.1.57",
+ "redox_syscall",
  "redox_termios",
- "serde",
 ]
 
 [[package]]
@@ -2269,7 +2262,7 @@ dependencies = [
  "strip-ansi-escapes",
  "structopt",
  "strum",
- "termion_temporary_zellij_fork",
+ "termion",
  "termios",
  "toml",
  "unicode-truncate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ signal-hook = "0.1.10"
 strip-ansi-escapes = "0.1.0"
 structopt = "0.3"
 # termion = { git = "https://gitlab.com/TheLostLambda/termion.git", version = "1.6.0", features = ["serde"] }
-termion = { package = "termion_temporary_zellij_fork", version = "1.6.0", features = ["serde"]}
+termion = "1.5.0"
 termios = "0.3"
 unicode-truncate = "0.2.0"
 unicode-width = "0.1.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ serde_yaml = "0.8"
 signal-hook = "0.1.10"
 strip-ansi-escapes = "0.1.0"
 structopt = "0.3"
-# termion = { git = "https://gitlab.com/TheLostLambda/termion.git", version = "1.6.0", features = ["serde"] }
 termion = "1.5.0"
 termios = "0.3"
 unicode-truncate = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,17 +27,17 @@ signal-hook = "0.1.10"
 strip-ansi-escapes = "0.1.0"
 structopt = "0.3"
 # termion = { git = "https://gitlab.com/TheLostLambda/termion.git", version = "1.6.0", features = ["serde"] }
-termion = { package = "termion_temporary_zellij_fork" , version = "1.6.0", features = ["serde"]}
+termion = { package = "termion_temporary_zellij_fork", version = "1.6.0", features = ["serde"]}
 termios = "0.3"
 unicode-truncate = "0.2.0"
 unicode-width = "0.1.8"
 vte = "0.8.0"
 strum = "0.20.0"
-strum_macros = "0.20.0"
 lazy_static = "1.4.0"
 wasmer = "1.0.0"
 wasmer-wasi = "1.0.0"
 interprocess = "1.0.1"
+zellij-tile = { path = "zellij-tile/", version = "0.5.0" }
 
 [dependencies.async-std]
 version = "1.3.0"

--- a/assets/layouts/default.yaml
+++ b/assets/layouts/default.yaml
@@ -5,8 +5,6 @@ parts:
     split_size:
       Fixed: 1
     plugin: tab-bar
-    events:
-      - Tab
   - direction: Vertical
     expansion_boundary: true
   - direction: Vertical

--- a/assets/layouts/strider.yaml
+++ b/assets/layouts/strider.yaml
@@ -5,8 +5,6 @@ parts:
     split_size:
       Fixed: 1
     plugin: tab-bar
-    events:
-      - Tab
   - direction: Vertical
     parts:
       - direction: Horizontal

--- a/build-all.sh
+++ b/build-all.sh
@@ -1,29 +1,25 @@
 #!/bin/sh
 
-total=6
+total=5
 
 # This is temporary while https://github.com/rust-lang/cargo/issues/7004 is open
 
-echo "Building zellij-tile (1/$total)..."
-cd zellij-tile
+echo "Building status-bar (1/$total)..."
+cd default-tiles/status-bar
 cargo build --release --target-dir ../../target
 
-echo "Building status-bar (2/$total)..."
-cd ../default-tiles/status-bar
-cargo build --release --target-dir ../../target
-
-echo "Building strider (3/$total)..."
+echo "Building strider (2/$total)..."
 cd ../strider
 cargo build --release --target-dir ../../target
 
-echo "Building tab-bar (4/$total)..."
+echo "Building tab-bar (3/$total)..."
 cd ../tab-bar
 cargo build --release --target-dir ../../target
 
-echo "Optimising WASM executables (5/$total)..."
+echo "Optimising WASM executables (4/$total)..."
 cd ../..
 wasm-opt -O target/wasm32-wasi/release/status-bar.wasm -o target/status-bar.wasm || cp target/wasm32-wasi/release/status-bar.wasm target/status-bar.wasm
 wasm-opt -O target/wasm32-wasi/release/strider.wasm -o target/strider.wasm || cp target/wasm32-wasi/release/strider.wasm target/strider.wasm
 wasm-opt -O target/wasm32-wasi/release/tab-bar.wasm -o target/tab-bar.wasm || cp target/wasm32-wasi/release/tab-bar.wasm target/tab-bar.wasm
-echo "Building zellij (6/$total)..."
+echo "Building zellij (5/$total)..."
 cargo build --target-dir target $@

--- a/default-tiles/status-bar/src/first_line.rs
+++ b/default-tiles/status-bar/src/first_line.rs
@@ -83,7 +83,11 @@ fn unselected_mode_shortcut(letter: char, text: &str) -> LinePart {
         .on(BRIGHT_GRAY)
         .bold()
         .paint(">");
-    let styled_text = Style::new().fg(BLACK).on(BRIGHT_GRAY).bold().paint(text);
+    let styled_text = Style::new()
+        .fg(BLACK)
+        .on(BRIGHT_GRAY)
+        .bold()
+        .paint(format!("{} ", text));
     let suffix_separator = Style::new().fg(BRIGHT_GRAY).on(GRAY).paint(ARROW_SEPARATOR);
     LinePart {
         part: ANSIStrings(&[
@@ -109,7 +113,11 @@ fn selected_mode_shortcut(letter: char, text: &str) -> LinePart {
         .bold()
         .paint(letter.to_string());
     let char_right_separator = Style::new().bold().fg(BLACK).on(GREEN).bold().paint(">");
-    let styled_text = Style::new().fg(BLACK).on(GREEN).bold().paint(text);
+    let styled_text = Style::new()
+        .fg(BLACK)
+        .on(GREEN)
+        .bold()
+        .paint(format!("{} ", text));
     let suffix_separator = Style::new().fg(GREEN).on(GRAY).paint(ARROW_SEPARATOR);
     LinePart {
         part: ANSIStrings(&[
@@ -127,7 +135,11 @@ fn selected_mode_shortcut(letter: char, text: &str) -> LinePart {
 
 fn disabled_mode_shortcut(text: &str) -> LinePart {
     let prefix_separator = Style::new().fg(GRAY).on(BRIGHT_GRAY).paint(ARROW_SEPARATOR);
-    let styled_text = Style::new().fg(GRAY).on(BRIGHT_GRAY).dimmed().paint(text);
+    let styled_text = Style::new()
+        .fg(GRAY)
+        .on(BRIGHT_GRAY)
+        .dimmed()
+        .paint(format!("{} ", text));
     let suffix_separator = Style::new().fg(BRIGHT_GRAY).on(GRAY).paint(ARROW_SEPARATOR);
     LinePart {
         part: format!("{}{}{}", prefix_separator, styled_text, suffix_separator),
@@ -136,7 +148,7 @@ fn disabled_mode_shortcut(text: &str) -> LinePart {
 }
 
 fn selected_mode_shortcut_single_letter(letter: char) -> LinePart {
-    let char_shortcut_text = letter.to_string();
+    let char_shortcut_text = format!(" {} ", letter);
     let len = char_shortcut_text.chars().count() + 4; // 2 for the arrows, 2 for the padding
     let prefix_separator = Style::new().fg(GRAY).on(GREEN).paint(ARROW_SEPARATOR);
     let char_shortcut = Style::new()
@@ -153,7 +165,7 @@ fn selected_mode_shortcut_single_letter(letter: char) -> LinePart {
 }
 
 fn unselected_mode_shortcut_single_letter(letter: char) -> LinePart {
-    let char_shortcut_text = letter.to_string();
+    let char_shortcut_text = format!(" {} ", letter);
     let len = char_shortcut_text.chars().count() + 4; // 2 for the arrows, 2 for the padding
     let prefix_separator = Style::new().fg(GRAY).on(BRIGHT_GRAY).paint(ARROW_SEPARATOR);
     let char_shortcut = Style::new()

--- a/default-tiles/status-bar/src/first_line.rs
+++ b/default-tiles/status-bar/src/first_line.rs
@@ -70,90 +70,64 @@ fn unselected_mode_shortcut(letter: char, text: &str) -> LinePart {
         .fg(BLACK)
         .on(BRIGHT_GRAY)
         .bold()
-        .paint(format!(" <"));
+        .paint(" <");
     let char_shortcut = Style::new()
         .bold()
         .fg(RED)
         .on(BRIGHT_GRAY)
         .bold()
-        .paint(format!("{}", letter));
+        .paint(letter.to_string());
     let char_right_separator = Style::new()
         .bold()
         .fg(BLACK)
         .on(BRIGHT_GRAY)
         .bold()
-        .paint(format!(">"));
-    let styled_text = Style::new()
-        .fg(BLACK)
-        .on(BRIGHT_GRAY)
-        .bold()
-        .paint(format!("{} ", text));
+        .paint(">");
+    let styled_text = Style::new().fg(BLACK).on(BRIGHT_GRAY).bold().paint(text);
     let suffix_separator = Style::new().fg(BRIGHT_GRAY).on(GRAY).paint(ARROW_SEPARATOR);
     LinePart {
-        part: format!(
-            "{}",
-            ANSIStrings(&[
-                prefix_separator,
-                char_left_separator,
-                char_shortcut,
-                char_right_separator,
-                styled_text,
-                suffix_separator
-            ])
-        ),
+        part: ANSIStrings(&[
+            prefix_separator,
+            char_left_separator,
+            char_shortcut,
+            char_right_separator,
+            styled_text,
+            suffix_separator,
+        ])
+        .to_string(),
         len: text.chars().count() + 6, // 2 for the arrows, 3 for the char separators, 1 for the character
     }
 }
 
 fn selected_mode_shortcut(letter: char, text: &str) -> LinePart {
     let prefix_separator = Style::new().fg(GRAY).on(GREEN).paint(ARROW_SEPARATOR);
-    let char_left_separator = Style::new()
-        .bold()
-        .fg(BLACK)
-        .on(GREEN)
-        .bold()
-        .paint(format!(" <"));
+    let char_left_separator = Style::new().bold().fg(BLACK).on(GREEN).bold().paint(" <");
     let char_shortcut = Style::new()
         .bold()
         .fg(RED)
         .on(GREEN)
         .bold()
-        .paint(format!("{}", letter));
-    let char_right_separator = Style::new()
-        .bold()
-        .fg(BLACK)
-        .on(GREEN)
-        .bold()
-        .paint(format!(">"));
-    let styled_text = Style::new()
-        .fg(BLACK)
-        .on(GREEN)
-        .bold()
-        .paint(format!("{} ", text));
+        .paint(letter.to_string());
+    let char_right_separator = Style::new().bold().fg(BLACK).on(GREEN).bold().paint(">");
+    let styled_text = Style::new().fg(BLACK).on(GREEN).bold().paint(text);
     let suffix_separator = Style::new().fg(GREEN).on(GRAY).paint(ARROW_SEPARATOR);
     LinePart {
-        part: format!(
-            "{}",
-            ANSIStrings(&[
-                prefix_separator,
-                char_left_separator,
-                char_shortcut,
-                char_right_separator,
-                styled_text,
-                suffix_separator
-            ])
-        ),
+        part: ANSIStrings(&[
+            prefix_separator,
+            char_left_separator,
+            char_shortcut,
+            char_right_separator,
+            styled_text,
+            suffix_separator,
+        ])
+        .to_string(),
         len: text.chars().count() + 6, // 2 for the arrows, 3 for the char separators, 1 for the character
     }
 }
 
 fn disabled_mode_shortcut(text: &str) -> LinePart {
     let prefix_separator = Style::new().fg(GRAY).on(BRIGHT_GRAY).paint(ARROW_SEPARATOR);
-    let styled_text = Style::new()
-        .fg(GRAY)
-        .on(BRIGHT_GRAY)
-        .dimmed()
-        .paint(format!("{} ", text));
+    let styled_text = Style::new().fg(GRAY).on(BRIGHT_GRAY).dimmed().paint(text);
     let suffix_separator = Style::new().fg(BRIGHT_GRAY).on(GRAY).paint(ARROW_SEPARATOR);
     LinePart {
         part: format!("{}{}{}", prefix_separator, styled_text, suffix_separator),
@@ -162,7 +136,7 @@ fn disabled_mode_shortcut(text: &str) -> LinePart {
 }
 
 fn selected_mode_shortcut_single_letter(letter: char) -> LinePart {
-    let char_shortcut_text = format!(" {} ", letter);
+    let char_shortcut_text = letter.to_string();
     let len = char_shortcut_text.chars().count() + 4; // 2 for the arrows, 2 for the padding
     let prefix_separator = Style::new().fg(GRAY).on(GREEN).paint(ARROW_SEPARATOR);
     let char_shortcut = Style::new()
@@ -173,16 +147,13 @@ fn selected_mode_shortcut_single_letter(letter: char) -> LinePart {
         .paint(char_shortcut_text);
     let suffix_separator = Style::new().fg(GREEN).on(GRAY).paint(ARROW_SEPARATOR);
     LinePart {
-        part: format!(
-            "{}",
-            ANSIStrings(&[prefix_separator, char_shortcut, suffix_separator])
-        ),
+        part: ANSIStrings(&[prefix_separator, char_shortcut, suffix_separator]).to_string(),
         len,
     }
 }
 
 fn unselected_mode_shortcut_single_letter(letter: char) -> LinePart {
-    let char_shortcut_text = format!(" {} ", letter);
+    let char_shortcut_text = letter.to_string();
     let len = char_shortcut_text.chars().count() + 4; // 2 for the arrows, 2 for the padding
     let prefix_separator = Style::new().fg(GRAY).on(BRIGHT_GRAY).paint(ARROW_SEPARATOR);
     let char_shortcut = Style::new()
@@ -193,10 +164,7 @@ fn unselected_mode_shortcut_single_letter(letter: char) -> LinePart {
         .paint(char_shortcut_text);
     let suffix_separator = Style::new().fg(BRIGHT_GRAY).on(GRAY).paint(ARROW_SEPARATOR);
     LinePart {
-        part: format!(
-            "{}",
-            ANSIStrings(&[prefix_separator, char_shortcut, suffix_separator])
-        ),
+        part: ANSIStrings(&[prefix_separator, char_shortcut, suffix_separator]).to_string(),
         len,
     }
 }
@@ -225,12 +193,8 @@ fn shortened_ctrl_key(key: &CtrlKeyShortcut) -> LinePart {
         _ => shortened_text,
     };
     match key.mode {
-        CtrlKeyMode::Unselected => {
-            unselected_mode_shortcut(letter_shortcut, &format!("{}", shortened_text))
-        }
-        CtrlKeyMode::Selected => {
-            selected_mode_shortcut(letter_shortcut, &format!("{}", shortened_text))
-        }
+        CtrlKeyMode::Unselected => unselected_mode_shortcut(letter_shortcut, &shortened_text),
+        CtrlKeyMode::Selected => selected_mode_shortcut(letter_shortcut, &shortened_text),
         CtrlKeyMode::Disabled => {
             disabled_mode_shortcut(&format!(" <{}>{}", letter_shortcut, shortened_text))
         }
@@ -282,7 +246,7 @@ pub fn superkey() -> LinePart {
     let prefix_text = " Ctrl + ";
     let prefix = Style::new().fg(WHITE).on(GRAY).bold().paint(prefix_text);
     LinePart {
-        part: format!("{}", prefix),
+        part: prefix.to_string(),
         len: prefix_text.chars().count(),
     }
 }
@@ -291,7 +255,7 @@ pub fn ctrl_keys(help: &ModeInfo, max_len: usize) -> LinePart {
     match &help.mode {
         InputMode::Locked => key_indicators(
             max_len,
-            &vec![
+            &[
                 CtrlKeyShortcut::new(CtrlKeyMode::Selected, CtrlKeyAction::Lock),
                 CtrlKeyShortcut::new(CtrlKeyMode::Disabled, CtrlKeyAction::Pane),
                 CtrlKeyShortcut::new(CtrlKeyMode::Disabled, CtrlKeyAction::Tab),
@@ -302,7 +266,7 @@ pub fn ctrl_keys(help: &ModeInfo, max_len: usize) -> LinePart {
         ),
         InputMode::Resize => key_indicators(
             max_len,
-            &vec![
+            &[
                 CtrlKeyShortcut::new(CtrlKeyMode::Unselected, CtrlKeyAction::Lock),
                 CtrlKeyShortcut::new(CtrlKeyMode::Unselected, CtrlKeyAction::Pane),
                 CtrlKeyShortcut::new(CtrlKeyMode::Unselected, CtrlKeyAction::Tab),
@@ -313,7 +277,7 @@ pub fn ctrl_keys(help: &ModeInfo, max_len: usize) -> LinePart {
         ),
         InputMode::Pane => key_indicators(
             max_len,
-            &vec![
+            &[
                 CtrlKeyShortcut::new(CtrlKeyMode::Unselected, CtrlKeyAction::Lock),
                 CtrlKeyShortcut::new(CtrlKeyMode::Selected, CtrlKeyAction::Pane),
                 CtrlKeyShortcut::new(CtrlKeyMode::Unselected, CtrlKeyAction::Tab),
@@ -324,7 +288,7 @@ pub fn ctrl_keys(help: &ModeInfo, max_len: usize) -> LinePart {
         ),
         InputMode::Tab | InputMode::RenameTab => key_indicators(
             max_len,
-            &vec![
+            &[
                 CtrlKeyShortcut::new(CtrlKeyMode::Unselected, CtrlKeyAction::Lock),
                 CtrlKeyShortcut::new(CtrlKeyMode::Unselected, CtrlKeyAction::Pane),
                 CtrlKeyShortcut::new(CtrlKeyMode::Selected, CtrlKeyAction::Tab),
@@ -335,7 +299,7 @@ pub fn ctrl_keys(help: &ModeInfo, max_len: usize) -> LinePart {
         ),
         InputMode::Scroll => key_indicators(
             max_len,
-            &vec![
+            &[
                 CtrlKeyShortcut::new(CtrlKeyMode::Unselected, CtrlKeyAction::Lock),
                 CtrlKeyShortcut::new(CtrlKeyMode::Unselected, CtrlKeyAction::Pane),
                 CtrlKeyShortcut::new(CtrlKeyMode::Unselected, CtrlKeyAction::Tab),
@@ -346,7 +310,7 @@ pub fn ctrl_keys(help: &ModeInfo, max_len: usize) -> LinePart {
         ),
         InputMode::Normal => key_indicators(
             max_len,
-            &vec![
+            &[
                 CtrlKeyShortcut::new(CtrlKeyMode::Unselected, CtrlKeyAction::Lock),
                 CtrlKeyShortcut::new(CtrlKeyMode::Unselected, CtrlKeyAction::Pane),
                 CtrlKeyShortcut::new(CtrlKeyMode::Unselected, CtrlKeyAction::Tab),

--- a/default-tiles/status-bar/src/first_line.rs
+++ b/default-tiles/status-bar/src/first_line.rs
@@ -287,7 +287,7 @@ pub fn superkey() -> LinePart {
     }
 }
 
-pub fn ctrl_keys(help: &Help, max_len: usize) -> LinePart {
+pub fn ctrl_keys(help: &ModeInfo, max_len: usize) -> LinePart {
     match &help.mode {
         InputMode::Locked => key_indicators(
             max_len,

--- a/default-tiles/status-bar/src/main.rs
+++ b/default-tiles/status-bar/src/main.rs
@@ -1,6 +1,6 @@
 use colored::*;
 use std::fmt::{Display, Error, Formatter};
-use zellij_tile::*;
+use zellij_tile::prelude::*;
 
 // for more of these, copy paste from: https://en.wikipedia.org/wiki/Box-drawing_character
 static ARROW_SEPARATOR: &str = " ";
@@ -152,7 +152,7 @@ fn key_path(help: &Help) -> LinePart {
                 len,
             )
         }
-        InputMode::Normal | _ => {
+        InputMode::Normal => {
             let key_path = superkey_text.on_green();
             let separator = ARROW_SEPARATOR.green().on_black();
             (

--- a/default-tiles/status-bar/src/main.rs
+++ b/default-tiles/status-bar/src/main.rs
@@ -236,7 +236,7 @@ impl ZellijTile for State {
         set_max_height(1);
     }
 
-    fn draw(&mut self, _rows: usize, cols: usize) {
+    fn render(&mut self, _rows: usize, cols: usize) {
         let help = get_help();
         let line_prefix = prefix(&help);
         let key_path = key_path(&help);

--- a/default-tiles/status-bar/src/main.rs
+++ b/default-tiles/status-bar/src/main.rs
@@ -230,7 +230,7 @@ fn keybinds(help: &Help, max_width: usize) -> LinePart {
 }
 
 impl ZellijTile for State {
-    fn init(&mut self) {
+    fn load(&mut self) {
         set_selectable(false);
         set_invisible_borders(true);
         set_max_height(1);

--- a/default-tiles/status-bar/src/main.rs
+++ b/default-tiles/status-bar/src/main.rs
@@ -23,7 +23,9 @@ static ARROW_SEPARATOR: &str = "";
 static MORE_MSG: &str = " ... ";
 
 #[derive(Default)]
-struct State {}
+struct State {
+    mode_info: ModeInfo,
+}
 
 register_tile!(State);
 
@@ -44,15 +46,21 @@ impl ZellijTile for State {
         set_selectable(false);
         set_invisible_borders(true);
         set_max_height(2);
+        subscribe(&[EventType::ModeUpdate]);
+    }
+
+    fn update(&mut self, event: Event) {
+        if let Event::ModeUpdate(mode_info) = event {
+            self.mode_info = mode_info;
+        }
     }
 
     fn render(&mut self, _rows: usize, cols: usize) {
-        let help = get_help();
         let superkey = superkey();
-        let ctrl_keys = ctrl_keys(&help, cols - superkey.len);
+        let ctrl_keys = ctrl_keys(&self.mode_info, cols - superkey.len);
 
         let first_line = format!("{}{}", superkey, ctrl_keys);
-        let second_line = keybinds(&help, cols);
+        let second_line = keybinds(&self.mode_info, cols);
 
         // [48;5;238m is gray background, [0K is so that it fills the rest of the line
         // [48;5;16m is black background, [0K is so that it fills the rest of the line

--- a/default-tiles/status-bar/src/second_line.rs
+++ b/default-tiles/status-bar/src/second_line.rs
@@ -97,7 +97,7 @@ fn select_pane_shortcut(is_first_shortcut: bool) -> LinePart {
     }
 }
 
-fn full_shortcut_list(help: &Help) -> LinePart {
+fn full_shortcut_list(help: &ModeInfo) -> LinePart {
     match help.mode {
         InputMode::Normal => LinePart::default(),
         InputMode::Locked => locked_interface_indication(),
@@ -116,7 +116,7 @@ fn full_shortcut_list(help: &Help) -> LinePart {
     }
 }
 
-fn shortened_shortcut_list(help: &Help) -> LinePart {
+fn shortened_shortcut_list(help: &ModeInfo) -> LinePart {
     match help.mode {
         InputMode::Normal => LinePart::default(),
         InputMode::Locked => locked_interface_indication(),
@@ -135,7 +135,7 @@ fn shortened_shortcut_list(help: &Help) -> LinePart {
     }
 }
 
-fn best_effort_shortcut_list(help: &Help, max_len: usize) -> LinePart {
+fn best_effort_shortcut_list(help: &ModeInfo, max_len: usize) -> LinePart {
     match help.mode {
         InputMode::Normal => LinePart::default(),
         InputMode::Locked => {
@@ -169,7 +169,7 @@ fn best_effort_shortcut_list(help: &Help, max_len: usize) -> LinePart {
     }
 }
 
-pub fn keybinds(help: &Help, max_width: usize) -> LinePart {
+pub fn keybinds(help: &ModeInfo, max_width: usize) -> LinePart {
     let full_shortcut_list = full_shortcut_list(help);
     if full_shortcut_list.len <= max_width {
         return full_shortcut_list;

--- a/default-tiles/status-bar/src/second_line.rs
+++ b/default-tiles/status-bar/src/second_line.rs
@@ -108,7 +108,7 @@ fn full_shortcut_list(help: &ModeInfo) -> LinePart {
                 line_part.len += shortcut.len;
                 line_part.part = format!("{}{}", line_part.part, shortcut,);
             }
-            let select_pane_shortcut = select_pane_shortcut(help.keybinds.len() == 0);
+            let select_pane_shortcut = select_pane_shortcut(help.keybinds.is_empty());
             line_part.len += select_pane_shortcut.len;
             line_part.part = format!("{}{}", line_part.part, select_pane_shortcut,);
             line_part
@@ -127,7 +127,7 @@ fn shortened_shortcut_list(help: &ModeInfo) -> LinePart {
                 line_part.len += shortcut.len;
                 line_part.part = format!("{}{}", line_part.part, shortcut,);
             }
-            let select_pane_shortcut = select_pane_shortcut(help.keybinds.len() == 0);
+            let select_pane_shortcut = select_pane_shortcut(help.keybinds.is_empty());
             line_part.len += select_pane_shortcut.len;
             line_part.part = format!("{}{}", line_part.part, select_pane_shortcut,);
             line_part
@@ -159,7 +159,7 @@ fn best_effort_shortcut_list(help: &ModeInfo, max_len: usize) -> LinePart {
                 line_part.len += shortcut.len;
                 line_part.part = format!("{}{}", line_part.part, shortcut,);
             }
-            let select_pane_shortcut = select_pane_shortcut(help.keybinds.len() == 0);
+            let select_pane_shortcut = select_pane_shortcut(help.keybinds.is_empty());
             if line_part.len + select_pane_shortcut.len <= max_len {
                 line_part.len += select_pane_shortcut.len;
                 line_part.part = format!("{}{}", line_part.part, select_pane_shortcut,);
@@ -178,5 +178,5 @@ pub fn keybinds(help: &ModeInfo, max_width: usize) -> LinePart {
     if shortened_shortcut_list.len <= max_width {
         return shortened_shortcut_list;
     }
-    return best_effort_shortcut_list(help, max_width);
+    best_effort_shortcut_list(help, max_width)
 }

--- a/default-tiles/strider/src/main.rs
+++ b/default-tiles/strider/src/main.rs
@@ -12,7 +12,7 @@ impl ZellijTile for State {
         refresh_directory(self);
     }
 
-    fn draw(&mut self, rows: usize, cols: usize) {
+    fn render(&mut self, rows: usize, cols: usize) {
         for i in 0..rows {
             if self.selected() < self.scroll() {
                 *self.scroll_mut() = self.selected();

--- a/default-tiles/strider/src/main.rs
+++ b/default-tiles/strider/src/main.rs
@@ -3,7 +3,7 @@ mod state;
 use colored::*;
 use state::{FsEntry, State};
 use std::{cmp::min, fs::read_dir};
-use zellij_tile::*;
+use zellij_tile::prelude::*;
 
 register_tile!(State);
 

--- a/default-tiles/strider/src/main.rs
+++ b/default-tiles/strider/src/main.rs
@@ -8,7 +8,7 @@ use zellij_tile::*;
 register_tile!(State);
 
 impl ZellijTile for State {
-    fn init(&mut self) {
+    fn load(&mut self) {
         refresh_directory(self);
     }
 

--- a/default-tiles/strider/src/state.rs
+++ b/default-tiles/strider/src/state.rs
@@ -58,6 +58,6 @@ impl FsEntry {
     }
 
     pub fn is_hidden_file(&self) -> bool {
-        self.name().chars().nth(0).unwrap() == '.'.into()
+        self.name().starts_with('.')
     }
 }

--- a/default-tiles/tab-bar/src/line.rs
+++ b/default-tiles/tab-bar/src/line.rs
@@ -56,7 +56,7 @@ fn left_more_message(tab_count_to_the_left: usize) -> LinePart {
     let more_text = if tab_count_to_the_left < 10000 {
         format!(" ← +{} ", tab_count_to_the_left)
     } else {
-        format!(" ← +many ")
+        " ← +many ".to_string()
     };
     let more_styled_text = format!(
         "{}{}",
@@ -79,7 +79,7 @@ fn right_more_message(tab_count_to_the_right: usize) -> LinePart {
     let more_text = if tab_count_to_the_right < 10000 {
         format!(" +{} → ", tab_count_to_the_right)
     } else {
-        format!(" +many → ")
+        " +many → ".to_string()
     };
     let more_styled_text = format!(
         "{}{}{}",

--- a/default-tiles/tab-bar/src/line.rs
+++ b/default-tiles/tab-bar/src/line.rs
@@ -130,7 +130,7 @@ fn add_next_tabs_msg(
 }
 
 fn tab_line_prefix() -> LinePart {
-    let prefix_text = format!(" Zellij ");
+    let prefix_text = " Zellij ".to_string();
     let prefix_text_len = prefix_text.chars().count();
     let prefix_styled_text = Style::new().fg(WHITE).on(GRAY).bold().paint(prefix_text);
     LinePart {

--- a/default-tiles/tab-bar/src/main.rs
+++ b/default-tiles/tab-bar/src/main.rs
@@ -44,7 +44,7 @@ impl ZellijTile for State {
         self.new_name = String::new();
     }
 
-    fn draw(&mut self, _rows: usize, cols: usize) {
+    fn render(&mut self, _rows: usize, cols: usize) {
         if self.tabs.is_empty() {
             return;
         }

--- a/default-tiles/tab-bar/src/main.rs
+++ b/default-tiles/tab-bar/src/main.rs
@@ -38,7 +38,7 @@ static ARROW_SEPARATOR: &str = "";
 register_tile!(State);
 
 impl ZellijTile for State {
-    fn init(&mut self) {
+    fn load(&mut self) {
         set_selectable(false);
         set_invisible_borders(true);
         set_max_height(1);

--- a/default-tiles/tab-bar/src/main.rs
+++ b/default-tiles/tab-bar/src/main.rs
@@ -51,8 +51,13 @@ impl ZellijTile for State {
         set_selectable(false);
         set_invisible_borders(true);
         set_max_height(1);
-        self.mode = BarMode::Normal;
-        self.new_name = String::new();
+        subscribe(&[EventType::TabUpdate]);
+    }
+
+    fn update(&mut self, event: Event) {
+        if let Event::TabUpdate(tabs) = event {
+            self.tabs = tabs;
+        }
     }
 
     fn render(&mut self, _rows: usize, cols: usize) {
@@ -82,10 +87,6 @@ impl ZellijTile for State {
             s = format!("{}{}", s, bar_part.part);
         }
         println!("{}\u{1b}[48;5;238m\u{1b}[0K", s);
-    }
-
-    fn update_tabs(&mut self) {
-        self.tabs = get_tabs();
     }
 
     fn handle_tab_rename_keypress(&mut self, key: Key) {

--- a/default-tiles/tab-bar/src/main.rs
+++ b/default-tiles/tab-bar/src/main.rs
@@ -26,8 +26,6 @@ impl Default for BarMode {
 
 #[derive(Default)]
 struct State {
-    active_tab_index: usize,
-    num_tabs: usize,
     tabs: Vec<TabInfo>,
     mode: BarMode,
     new_name: String,
@@ -42,8 +40,6 @@ impl ZellijTile for State {
         set_selectable(false);
         set_invisible_borders(true);
         set_max_height(1);
-        self.active_tab_index = 0;
-        self.num_tabs = 0;
         self.mode = BarMode::Normal;
         self.new_name = String::new();
     }

--- a/default-tiles/tab-bar/src/main.rs
+++ b/default-tiles/tab-bar/src/main.rs
@@ -28,7 +28,7 @@ impl Default for BarMode {
 struct State {
     active_tab_index: usize,
     num_tabs: usize,
-    tabs: Vec<TabData>,
+    tabs: Vec<TabInfo>,
     mode: BarMode,
     new_name: String,
 }

--- a/default-tiles/tab-bar/src/main.rs
+++ b/default-tiles/tab-bar/src/main.rs
@@ -1,7 +1,7 @@
 mod line;
 mod tab;
 
-use zellij_tile::*;
+use zellij_tile::prelude::*;
 
 use crate::line::tab_line;
 use crate::tab::tab_style;

--- a/src/client/layout.rs
+++ b/src/client/layout.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::{fs::File, io::prelude::*};
 
-use crate::common::wasm_vm::EventType;
+use crate::common::wasm_vm::NaughtyEventType;
 use crate::panes::PositionAndSize;
 
 fn split_space_to_parts_vertically(
@@ -182,7 +182,7 @@ pub struct Layout {
     #[serde(default)]
     pub expansion_boundary: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub events: Vec<EventType>,
+    pub events: Vec<NaughtyEventType>,
 }
 
 impl Layout {

--- a/src/client/layout.rs
+++ b/src/client/layout.rs
@@ -1,10 +1,8 @@
-use crate::utils::consts::ZELLIJ_ROOT_LAYOUT_DIR;
 use directories_next::ProjectDirs;
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::{fs::File, io::prelude::*};
 
-use crate::common::wasm_vm::NaughtyEventType;
 use crate::panes::PositionAndSize;
 
 fn split_space_to_parts_vertically(
@@ -181,19 +179,15 @@ pub struct Layout {
     pub plugin: Option<PathBuf>,
     #[serde(default)]
     pub expansion_boundary: bool,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub events: Vec<NaughtyEventType>,
 }
 
 impl Layout {
     pub fn new(layout_path: PathBuf) -> Self {
         let project_dirs = ProjectDirs::from("org", "Zellij Contributors", "Zellij").unwrap();
         let layout_dir = project_dirs.data_dir().join("layouts/");
-        let root_layout_dir = Path::new(ZELLIJ_ROOT_LAYOUT_DIR);
         let mut layout_file = File::open(&layout_path)
             .or_else(|_| File::open(&layout_path.with_extension("yaml")))
             .or_else(|_| File::open(&layout_dir.join(&layout_path).with_extension("yaml")))
-            .or_else(|_| File::open(root_layout_dir.join(&layout_path).with_extension("yaml")))
             .unwrap_or_else(|_| panic!("cannot find layout {}", &layout_path.display()));
 
         let mut layout = String::new();

--- a/src/client/panes/plugin_pane.rs
+++ b/src/client/panes/plugin_pane.rs
@@ -120,7 +120,7 @@ impl Pane for PluginPane {
             let (buf_tx, buf_rx) = channel();
 
             self.send_plugin_instructions
-                .send(PluginInstruction::Draw(
+                .send(PluginInstruction::Render(
                     buf_tx,
                     self.pid,
                     self.rows(),

--- a/src/client/panes/terminal_character.rs
+++ b/src/client/panes/terminal_character.rs
@@ -23,7 +23,7 @@ pub enum AnsiCode {
     On,
     Reset,
     NamedColor(NamedColor),
-    RGBCode((u8, u8, u8)),
+    RgbCode((u8, u8, u8)),
     ColorIndex(u8),
 }
 
@@ -336,7 +336,7 @@ impl CharacterStyles {
             [36, ..] => *self = self.foreground(Some(AnsiCode::NamedColor(NamedColor::Cyan))),
             [37, ..] => *self = self.foreground(Some(AnsiCode::NamedColor(NamedColor::White))),
             [38, 2, ..] => {
-                let ansi_code = AnsiCode::RGBCode((
+                let ansi_code = AnsiCode::RgbCode((
                     *ansi_params.get(2).unwrap() as u8,
                     *ansi_params.get(3).unwrap() as u8,
                     *ansi_params.get(4).unwrap() as u8,
@@ -364,7 +364,7 @@ impl CharacterStyles {
             [46, ..] => *self = self.background(Some(AnsiCode::NamedColor(NamedColor::Cyan))),
             [47, ..] => *self = self.background(Some(AnsiCode::NamedColor(NamedColor::White))),
             [48, 2, ..] => {
-                let ansi_code = AnsiCode::RGBCode((
+                let ansi_code = AnsiCode::RgbCode((
                     *ansi_params.get(2).unwrap() as u8,
                     *ansi_params.get(3).unwrap() as u8,
                     *ansi_params.get(4).unwrap() as u8,
@@ -416,7 +416,7 @@ impl Display for CharacterStyles {
         }
         if let Some(ansi_code) = self.foreground {
             match ansi_code {
-                AnsiCode::RGBCode((r, g, b)) => {
+                AnsiCode::RgbCode((r, g, b)) => {
                     write!(f, "\u{1b}[38;2;{};{};{}m", r, g, b)?;
                 }
                 AnsiCode::ColorIndex(color_index) => {
@@ -433,7 +433,7 @@ impl Display for CharacterStyles {
         };
         if let Some(ansi_code) = self.background {
             match ansi_code {
-                AnsiCode::RGBCode((r, g, b)) => {
+                AnsiCode::RgbCode((r, g, b)) => {
                     write!(f, "\u{1b}[48;2;{};{};{}m", r, g, b)?;
                 }
                 AnsiCode::ColorIndex(color_index) => {

--- a/src/client/tab.rs
+++ b/src/client/tab.rs
@@ -8,7 +8,6 @@ use crate::pty_bus::{PtyInstruction, VteEvent};
 use crate::wasm_vm::{PluginInputType, PluginInstruction};
 use crate::{boundaries::Boundaries, panes::PluginPane};
 use crate::{os_input_output::OsApi, utils::shared::pad_to_size};
-use serde::{Deserialize, Serialize};
 use std::os::unix::io::RawFd;
 use std::{
     cmp::Reverse,
@@ -65,14 +64,6 @@ pub struct Tab {
     pub send_plugin_instructions: SenderWithContext<PluginInstruction>,
     pub send_app_instructions: SenderWithContext<AppInstruction>,
     expansion_boundary: Option<PositionAndSize>,
-}
-
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct TabData {
-    /* subset of fields to publish to plugins */
-    pub position: usize,
-    pub name: String,
-    pub active: bool,
 }
 
 // FIXME: Use a struct that has a pane_type enum, to reduce all of the duplication

--- a/src/common/errors.rs
+++ b/src/common/errors.rs
@@ -305,8 +305,6 @@ impl From<&PluginInstruction> for PluginContext {
 /// Stack call representations corresponding to the different types of [`AppInstruction`]s.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum AppContext {
-    GetState,
-    SetState,
     Exit,
     Error,
 }
@@ -314,8 +312,6 @@ pub enum AppContext {
 impl From<&AppInstruction> for AppContext {
     fn from(app_instruction: &AppInstruction) -> Self {
         match *app_instruction {
-            AppInstruction::GetState(_) => AppContext::GetState,
-            AppInstruction::SetState(_) => AppContext::SetState,
             AppInstruction::Exit => AppContext::Exit,
             AppInstruction::Error(_) => AppContext::Error,
         }

--- a/src/common/errors.rs
+++ b/src/common/errors.rs
@@ -281,7 +281,6 @@ pub enum PluginContext {
     Update,
     Render,
     Input,
-    GlobalInput,
     Unload,
     Quit,
     Tabs,
@@ -291,10 +290,9 @@ impl From<&PluginInstruction> for PluginContext {
     fn from(plugin_instruction: &PluginInstruction) -> Self {
         match *plugin_instruction {
             PluginInstruction::Load(..) => PluginContext::Load,
-            PluginInstruction::Update(_) => PluginContext::Update,
+            PluginInstruction::Update(..) => PluginContext::Update,
             PluginInstruction::Render(..) => PluginContext::Render,
             PluginInstruction::Input(..) => PluginContext::Input,
-            PluginInstruction::GlobalInput(_) => PluginContext::GlobalInput,
             PluginInstruction::Unload(_) => PluginContext::Unload,
             PluginInstruction::Quit => PluginContext::Quit,
             PluginInstruction::UpdateTabs(..) => PluginContext::Tabs,

--- a/src/common/errors.rs
+++ b/src/common/errors.rs
@@ -285,7 +285,6 @@ pub enum PluginContext {
     Input,
     Unload,
     Quit,
-    Tabs,
 }
 
 impl From<&PluginInstruction> for PluginContext {
@@ -297,7 +296,6 @@ impl From<&PluginInstruction> for PluginContext {
             PluginInstruction::Input(..) => PluginContext::Input,
             PluginInstruction::Unload(_) => PluginContext::Unload,
             PluginInstruction::Quit => PluginContext::Quit,
-            PluginInstruction::UpdateTabs(..) => PluginContext::Tabs,
         }
     }
 }

--- a/src/common/errors.rs
+++ b/src/common/errors.rs
@@ -164,6 +164,7 @@ impl Display for ContextType {
     }
 }
 
+// FIXME: Just deriving EnumDiscriminants from strum will remove the need for any of this!!!
 /// Stack call representations corresponding to the different types of [`ScreenInstruction`]s.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ScreenContext {
@@ -201,6 +202,7 @@ pub enum ScreenContext {
     UpdateTabName,
 }
 
+// FIXME: Just deriving EnumDiscriminants from strum will remove the need for any of this!!!
 impl From<&ScreenInstruction> for ScreenContext {
     fn from(screen_instruction: &ScreenInstruction) -> Self {
         match *screen_instruction {

--- a/src/common/errors.rs
+++ b/src/common/errors.rs
@@ -133,7 +133,7 @@ pub enum ContextType {
     Plugin(PluginContext),
     /// An app-related call.
     App(AppContext),
-    IPCServer,
+    IpcServer,
     StdinHandler,
     AsyncTask,
     /// An empty, placeholder call. This should be thought of as representing no call at all.
@@ -152,7 +152,7 @@ impl Display for ContextType {
 
             ContextType::Plugin(c) => write!(f, "{}plugin_thread: {}{:?}", purple, green, c),
             ContextType::App(c) => write!(f, "{}main_thread: {}{:?}", purple, green, c),
-            ContextType::IPCServer => write!(f, "{}ipc_server: {}AcceptInput", purple, green),
+            ContextType::IpcServer => write!(f, "{}ipc_server: {}AcceptInput", purple, green),
             ContextType::StdinHandler => {
                 write!(f, "{}stdin_handler_thread: {}AcceptInput", purple, green)
             }

--- a/src/common/errors.rs
+++ b/src/common/errors.rs
@@ -282,7 +282,6 @@ pub enum PluginContext {
     Load,
     Update,
     Render,
-    Input,
     Unload,
     Quit,
 }
@@ -293,7 +292,6 @@ impl From<&PluginInstruction> for PluginContext {
             PluginInstruction::Load(..) => PluginContext::Load,
             PluginInstruction::Update(..) => PluginContext::Update,
             PluginInstruction::Render(..) => PluginContext::Render,
-            PluginInstruction::Input(..) => PluginContext::Input,
             PluginInstruction::Unload(_) => PluginContext::Unload,
             PluginInstruction::Quit => PluginContext::Quit,
         }

--- a/src/common/errors.rs
+++ b/src/common/errors.rs
@@ -278,7 +278,7 @@ use crate::wasm_vm::PluginInstruction;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PluginContext {
     Load,
-    Draw,
+    Render,
     Input,
     GlobalInput,
     Unload,
@@ -290,7 +290,7 @@ impl From<&PluginInstruction> for PluginContext {
     fn from(plugin_instruction: &PluginInstruction) -> Self {
         match *plugin_instruction {
             PluginInstruction::Load(..) => PluginContext::Load,
-            PluginInstruction::Draw(..) => PluginContext::Draw,
+            PluginInstruction::Render(..) => PluginContext::Render,
             PluginInstruction::Input(..) => PluginContext::Input,
             PluginInstruction::GlobalInput(_) => PluginContext::GlobalInput,
             PluginInstruction::Unload(_) => PluginContext::Unload,

--- a/src/common/errors.rs
+++ b/src/common/errors.rs
@@ -278,6 +278,7 @@ use crate::wasm_vm::PluginInstruction;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PluginContext {
     Load,
+    Update,
     Render,
     Input,
     GlobalInput,
@@ -290,6 +291,7 @@ impl From<&PluginInstruction> for PluginContext {
     fn from(plugin_instruction: &PluginInstruction) -> Self {
         match *plugin_instruction {
             PluginInstruction::Load(..) => PluginContext::Load,
+            PluginInstruction::Update(_) => PluginContext::Update,
             PluginInstruction::Render(..) => PluginContext::Render,
             PluginInstruction::Input(..) => PluginContext::Input,
             PluginInstruction::GlobalInput(_) => PluginContext::GlobalInput,

--- a/src/common/input/actions.rs
+++ b/src/common/input/actions.rs
@@ -49,5 +49,4 @@ pub enum Action {
     CloseTab,
     GoToTab(u32),
     TabNameInput(Vec<u8>),
-    SaveTabName,
 }

--- a/src/common/input/actions.rs
+++ b/src/common/input/actions.rs
@@ -1,6 +1,6 @@
 //! Definition of the actions that can be bound to keys.
 
-use super::handler;
+use zellij_tile::data::InputMode;
 
 /// The four directions (left, right, up, down).
 #[derive(Clone, Debug)]
@@ -19,7 +19,7 @@ pub enum Action {
     /// Write to the terminal.
     Write(Vec<u8>),
     /// Switch to the specified input mode.
-    SwitchToMode(handler::InputMode),
+    SwitchToMode(InputMode),
     /// Resize focus pane in specified direction.
     Resize(Direction),
     /// Switch focus to next pane in specified direction.

--- a/src/common/input/handler.rs
+++ b/src/common/input/handler.rs
@@ -11,7 +11,7 @@ use crate::wasm_vm::{NaughtyEventType, PluginInputType, PluginInstruction};
 use crate::CommandIsExecuting;
 
 use termion::input::{TermRead, TermReadEventsAndRaw};
-use zellij_tile::data::{Help, InputMode, Key};
+use zellij_tile::data::{InputMode, Key, ModeInfo};
 
 use super::keybinds::key_to_actions;
 
@@ -273,7 +273,7 @@ impl InputHandler {
 /// Creates a [`Help`] struct indicating the current [`InputMode`] and its keybinds
 /// (as pairs of [`String`]s).
 // TODO this should probably be automatically generated in some way
-pub fn get_help(mode: InputMode) -> Help {
+pub fn get_help(mode: InputMode) -> ModeInfo {
     let mut keybinds: Vec<(String, String)> = vec![];
     match mode {
         InputMode::Normal | InputMode::Locked => {}
@@ -302,7 +302,7 @@ pub fn get_help(mode: InputMode) -> Help {
             keybinds.push(("Enter".to_string(), "when done".to_string()));
         }
     }
-    Help { mode, keybinds }
+    ModeInfo { mode, keybinds }
 }
 
 /// Entry point to the module. Instantiates an [`InputHandler`] and starts

--- a/src/common/input/handler.rs
+++ b/src/common/input/handler.rs
@@ -7,7 +7,7 @@ use crate::errors::ContextType;
 use crate::os_input_output::OsApi;
 use crate::pty_bus::PtyInstruction;
 use crate::screen::ScreenInstruction;
-use crate::wasm_vm::{EventType, PluginInputType, PluginInstruction};
+use crate::wasm_vm::{NaughtyEventType, PluginInputType, PluginInstruction};
 use crate::CommandIsExecuting;
 
 use termion::input::TermReadEventsAndRaw;
@@ -234,7 +234,7 @@ impl InputHandler {
             Action::TabNameInput(c) => {
                 self.send_plugin_instructions
                     .send(PluginInstruction::Input(
-                        PluginInputType::Event(EventType::Tab),
+                        PluginInputType::Event(NaughtyEventType::Tab),
                         c.clone(),
                     ))
                     .unwrap();
@@ -245,7 +245,7 @@ impl InputHandler {
             Action::SaveTabName => {
                 self.send_plugin_instructions
                     .send(PluginInstruction::Input(
-                        PluginInputType::Event(EventType::Tab),
+                        PluginInputType::Event(NaughtyEventType::Tab),
                         vec![b'\n'],
                     ))
                     .unwrap();

--- a/src/common/input/handler.rs
+++ b/src/common/input/handler.rs
@@ -73,15 +73,12 @@ impl InputHandler {
                                 // framework relies on it to not create dead threads that loop
                                 // and eat up CPUs. Do not remove until the test framework has
                                 // been revised. Sorry about this (@categorille)
-                                if {
-                                    let mut should_break = false;
-                                    for action in
-                                        key_to_actions(&key, raw_bytes, &self.mode, &keybinds)
-                                    {
-                                        should_break |= self.dispatch_action(action);
-                                    }
-                                    should_break
-                                } {
+                                let mut should_break = false;
+                                for action in key_to_actions(&key, raw_bytes, &self.mode, &keybinds)
+                                {
+                                    should_break |= self.dispatch_action(action);
+                                }
+                                if should_break {
                                     break 'input_loop;
                                 }
                             }

--- a/src/common/input/handler.rs
+++ b/src/common/input/handler.rs
@@ -10,9 +10,8 @@ use crate::screen::ScreenInstruction;
 use crate::wasm_vm::{EventType, PluginInputType, PluginInstruction};
 use crate::CommandIsExecuting;
 
-use serde::{Deserialize, Serialize};
-use strum_macros::EnumIter;
 use termion::input::TermReadEventsAndRaw;
+use zellij_tile::data::{Help, InputMode};
 
 use super::keybinds::key_to_actions;
 
@@ -266,42 +265,6 @@ impl InputHandler {
         self.send_app_instructions
             .send(AppInstruction::Exit)
             .unwrap();
-    }
-}
-
-/// Describes the different input modes, which change the way that keystrokes will be interpreted.
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, EnumIter, Serialize, Deserialize)]
-pub enum InputMode {
-    /// In `Normal` mode, input is always written to the terminal, except for one special input that
-    /// triggers the switch to [`InputMode::Command`] mode.
-    Normal,
-    /// In `Command` mode, input is bound to actions (more precisely, sequences of actions).
-    /// `Command` mode gives access to the other modes non-`InputMode::Normal` modes.
-    /// etc.
-    Command,
-    /// `Resize` mode allows resizing the different existing panes.
-    Resize,
-    /// `Pane` mode allows creating and closing panes, as well as moving between them.
-    Pane,
-    /// `Tab` mode allows creating and closing tabs, as well as moving between them.
-    Tab,
-    /// `Scroll` mode allows scrolling up and down within a pane.
-    Scroll,
-    RenameTab,
-}
-
-/// Represents the contents of the help message that is printed in the status bar,
-/// which indicates the current [`InputMode`] and what the keybinds for that mode
-/// are. Related to the default `status-bar` plugin.
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
-pub struct Help {
-    pub mode: InputMode,
-    pub keybinds: Vec<(String, String)>, // <shortcut> => <shortcut description>
-}
-
-impl Default for InputMode {
-    fn default() -> InputMode {
-        InputMode::Normal
     }
 }
 

--- a/src/common/input/keybinds.rs
+++ b/src/common/input/keybinds.rs
@@ -5,7 +5,6 @@ use super::actions::{Action, Direction};
 use std::collections::HashMap;
 
 use strum::IntoEnumIterator;
-use termion::event::Key;
 use zellij_tile::data::*;
 
 type Keybinds = HashMap<InputMode, ModeKeybinds>;

--- a/src/common/input/keybinds.rs
+++ b/src/common/input/keybinds.rs
@@ -226,10 +226,7 @@ fn get_defaults_for_mode(mode: &InputMode) -> ModeKeybinds {
             defaults.insert(Key::Up, vec![Action::ScrollUp]);
         }
         InputMode::RenameTab => {
-            defaults.insert(
-                Key::Char('\n'),
-                vec![Action::SaveTabName, Action::SwitchToMode(InputMode::Tab)],
-            );
+            defaults.insert(Key::Char('\n'), vec![Action::SwitchToMode(InputMode::Tab)]);
             defaults.insert(
                 Key::Ctrl('g'),
                 vec![Action::SwitchToMode(InputMode::Normal)],

--- a/src/common/input/keybinds.rs
+++ b/src/common/input/keybinds.rs
@@ -1,12 +1,12 @@
 //! Mapping of inputs to sequences of actions.
 
 use super::actions::{Action, Direction};
-use super::handler::InputMode;
 
 use std::collections::HashMap;
 
 use strum::IntoEnumIterator;
 use termion::event::Key;
+use zellij_tile::data::*;
 
 type Keybinds = HashMap<InputMode, ModeKeybinds>;
 type ModeKeybinds = HashMap<Key, Vec<Action>>;

--- a/src/common/input/keybinds.rs
+++ b/src/common/input/keybinds.rs
@@ -17,14 +17,14 @@ pub fn get_default_keybinds() -> Result<Keybinds, String> {
     let mut defaults = Keybinds::new();
 
     for mode in InputMode::iter() {
-        defaults.insert(mode, get_defaults_for_mode(&mode)?);
+        defaults.insert(mode, get_defaults_for_mode(&mode));
     }
 
     Ok(defaults)
 }
 
 /// Returns the default keybinds for a givent [`InputMode`].
-fn get_defaults_for_mode(mode: &InputMode) -> Result<ModeKeybinds, String> {
+fn get_defaults_for_mode(mode: &InputMode) -> ModeKeybinds {
     let mut defaults = ModeKeybinds::new();
 
     match *mode {
@@ -181,7 +181,7 @@ fn get_defaults_for_mode(mode: &InputMode) -> Result<ModeKeybinds, String> {
         }
     }
 
-    Ok(defaults)
+    defaults
 }
 
 /// Converts a [`Key`] terminal event to a sequence of [`Action`]s according to the current

--- a/src/common/ipc.rs
+++ b/src/common/ipc.rs
@@ -3,12 +3,12 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
-type SessionID = u64;
+type SessionId = u64;
 
 #[derive(PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct Session {
     // Unique ID for this session
-    id: SessionID,
+    id: SessionId,
     // Identifier for the underlying IPC primitive (socket, pipe)
     conn_name: String,
     // User configured alias for the session
@@ -30,9 +30,9 @@ pub enum ClientToServerMsg {
     // Create a new session
     CreateSession,
     // Attach to a running session
-    AttachToSession(SessionID, ClientType),
+    AttachToSession(SessionId, ClientType),
     // Force detach
-    DetachSession(SessionID),
+    DetachSession(SessionId),
     // Disconnect from the session we're connected to
     DisconnectFromSession,
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -553,14 +553,12 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: CliArgs) {
                                 let (instance, plugin_env) = plugin_map.get(&pid).unwrap();
                                 let handle_key =
                                     instance.exports.get_function("handle_key").unwrap();
-                                for key in input_bytes.keys() {
-                                    if let Ok(key) = key {
-                                        wasi_write_string(
-                                            &plugin_env.wasi_env,
-                                            &serde_json::to_string(&key).unwrap(),
-                                        );
-                                        handle_key.call(&[]).unwrap();
-                                    }
+                                for key in input_bytes.keys().flatten() {
+                                    wasi_write_string(
+                                        &plugin_env.wasi_env,
+                                        &serde_json::to_string(&key).unwrap(),
+                                    );
+                                    handle_key.call(&[]).unwrap();
                                 }
                             }
                             PluginInputType::Event(event) => {
@@ -572,14 +570,12 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: CliArgs) {
                                         .exports
                                         .get_function(handler_map.get(&event).unwrap())
                                         .unwrap();
-                                    for key in input_bytes.keys() {
-                                        if let Ok(key) = key {
-                                            wasi_write_string(
-                                                &plugin_env.wasi_env,
-                                                &serde_json::to_string(&key).unwrap(),
-                                            );
-                                            handle_key.call(&[]).unwrap();
-                                        }
+                                    for key in input_bytes.keys().flatten() {
+                                        wasi_write_string(
+                                            &plugin_env.wasi_env,
+                                            &serde_json::to_string(&key).unwrap(),
+                                        );
+                                        handle_key.call(&[]).unwrap();
                                     }
                                 }
                             }
@@ -591,14 +587,12 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: CliArgs) {
                         for (instance, plugin_env) in plugin_map.values() {
                             let handler =
                                 instance.exports.get_function("handle_global_key").unwrap();
-                            for key in input_bytes.keys() {
-                                if let Ok(key) = key {
-                                    wasi_write_string(
-                                        &plugin_env.wasi_env,
-                                        &serde_json::to_string(&key).unwrap(),
-                                    );
-                                    handler.call(&[]).unwrap();
-                                }
+                            for key in input_bytes.keys().flatten() {
+                                wasi_write_string(
+                                    &plugin_env.wasi_env,
+                                    &serde_json::to_string(&key).unwrap(),
+                                );
+                                handler.call(&[]).unwrap();
                             }
                         }
 
@@ -626,7 +620,7 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: CliArgs) {
                 let listener = std::os::unix::net::UnixListener::bind(ZELLIJ_IPC_PIPE)
                     .expect("could not listen on ipc socket");
                 let mut err_ctx = OPENCALLS.with(|ctx| *ctx.borrow());
-                err_ctx.add_call(ContextType::IPCServer);
+                err_ctx.add_call(ContextType::IpcServer);
                 send_pty_instructions.update(err_ctx);
                 send_screen_instructions.update(err_ctx);
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -593,25 +593,25 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: CliArgs) {
                     }
                     // FIXME: Deduplicate this with the callback below!
                     PluginInstruction::Input(input_type, input_bytes) => {
-                        if let PluginInputType::Event(event) = input_type {
-                            for (instance, plugin_env) in plugin_map.values() {
-                                if !plugin_env.events.contains(&event) {
-                                    continue;
-                                }
-                                let handle_key = instance
-                                    .exports
-                                    .get_function(handler_map.get(&event).unwrap())
-                                    .unwrap();
-                                for key in input_bytes.keys().flatten() {
-                                    let key = cast_termion_key(key);
-                                    wasi_write_string(
-                                        &plugin_env.wasi_env,
-                                        &serde_json::to_string(&key).unwrap(),
-                                    );
-                                    handle_key.call(&[]).unwrap();
-                                }
+                        let PluginInputType::Event(event) = input_type;
+                        for (instance, plugin_env) in plugin_map.values() {
+                            if !plugin_env.events.contains(&event) {
+                                continue;
+                            }
+                            let handle_key = instance
+                                .exports
+                                .get_function(handler_map.get(&event).unwrap())
+                                .unwrap();
+                            for key in input_bytes.keys().flatten() {
+                                let key = cast_termion_key(key);
+                                wasi_write_string(
+                                    &plugin_env.wasi_env,
+                                    &serde_json::to_string(&key).unwrap(),
+                                );
+                                handle_key.call(&[]).unwrap();
                             }
                         }
+
                         drop(send_screen_instructions.send(ScreenInstruction::Render));
                     }
                     PluginInstruction::Unload(pid) => drop(plugin_map.remove(&pid)),

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -16,27 +16,26 @@ use std::thread;
 use std::{cell::RefCell, sync::mpsc::TrySendError};
 use std::{collections::HashMap, fs};
 
-use crate::panes::PaneId;
-use directories_next::ProjectDirs;
-use input::handler::InputMode;
-use serde::{Deserialize, Serialize};
-use termion::input::TermRead;
-use wasm_vm::PluginEnv;
-use wasmer::{ChainableNamedResolver, Instance, Module, Store, Value};
-use wasmer_wasi::{Pipe, WasiState};
-
 use crate::cli::CliArgs;
 use crate::layout::Layout;
+use crate::panes::PaneId;
 use command_is_executing::CommandIsExecuting;
+use directories_next::ProjectDirs;
 use errors::{AppContext, ContextType, ErrorContext, PluginContext, PtyContext, ScreenContext};
 use input::handler::input_loop;
 use os_input_output::OsApi;
 use pty_bus::{PtyBus, PtyInstruction};
 use screen::{Screen, ScreenInstruction};
+use serde::{Deserialize, Serialize};
+use termion::input::TermRead;
 use utils::consts::{ZELLIJ_IPC_PIPE, ZELLIJ_ROOT_PLUGIN_DIR};
+use wasm_vm::PluginEnv;
 use wasm_vm::{
     wasi_stdout, wasi_write_string, zellij_imports, EventType, PluginInputType, PluginInstruction,
 };
+use wasmer::{ChainableNamedResolver, Instance, Module, Store, Value};
+use wasmer_wasi::{Pipe, WasiState};
+use zellij_tile::data::InputMode;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum ApiCommand {

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -524,7 +524,7 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: CliArgs) {
                             let subs = plugin_env.subscriptions.lock().unwrap();
                             // FIXME: This is very janky... Maybe I should write my own macro for Event -> EventType?
                             let event_type = EventType::from_str(&event.to_string()).unwrap();
-                            if pid.is_none() || pid == Some(i) && subs.contains(&event_type) {
+                            if (pid.is_none() || pid == Some(i)) && subs.contains(&event_type) {
                                 let update = instance.exports.get_function("update").unwrap();
                                 wasi_write_string(
                                     &plugin_env.wasi_env,
@@ -545,20 +545,6 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: CliArgs) {
                             .unwrap();
 
                         buf_tx.send(wasi_stdout(&plugin_env.wasi_env)).unwrap();
-                    }
-                    PluginInstruction::UpdateTabs(mut tabs) => {
-                        for (instance, plugin_env) in plugin_map.values() {
-                            if !plugin_env.events.contains(&NaughtyEventType::Tab) {
-                                continue;
-                            }
-                            let handler = instance.exports.get_function("update_tabs").unwrap();
-                            tabs.sort_by(|a, b| a.position.cmp(&b.position));
-                            wasi_write_string(
-                                &plugin_env.wasi_env,
-                                &serde_json::to_string(&tabs).unwrap(),
-                            );
-                            handler.call(&[]).unwrap();
-                        }
                     }
                     // FIXME: Deduplicate this with the callback below!
                     PluginInstruction::Input(input_type, input_bytes) => {

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -522,12 +522,13 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: CliArgs) {
                         pid_tx.send(plugin_id).unwrap();
                         plugin_id += 1;
                     }
-                    PluginInstruction::Draw(buf_tx, pid, rows, cols) => {
+                    PluginInstruction::Render(buf_tx, pid, rows, cols) => {
                         let (instance, plugin_env) = plugin_map.get(&pid).unwrap();
 
-                        let draw = instance.exports.get_function("draw").unwrap();
+                        let render = instance.exports.get_function("render").unwrap();
 
-                        draw.call(&[Value::I32(rows as i32), Value::I32(cols as i32)])
+                        render
+                            .call(&[Value::I32(rows as i32), Value::I32(cols as i32)])
                             .unwrap();
 
                         buf_tx.send(wasi_stdout(&plugin_env.wasi_env)).unwrap();

--- a/src/common/os_input_output.rs
+++ b/src/common/os_input_output.rs
@@ -82,15 +82,10 @@ fn handle_command_exit(mut child: Child) {
         }
 
         for signal in signals.pending() {
-            // FIXME: We need to handle more signals here!
-            #[allow(clippy::single_match)]
-            match signal {
-                signal_hook::SIGINT => {
-                    child.kill().unwrap();
-                    child.wait().unwrap();
-                    break 'handle_exit;
-                }
-                _ => {}
+            if signal == signal_hook::SIGINT {
+                child.kill().unwrap();
+                child.wait().unwrap();
+                break 'handle_exit;
             }
         }
     }

--- a/src/common/screen.rs
+++ b/src/common/screen.rs
@@ -171,15 +171,12 @@ impl Screen {
     pub fn go_to_tab(&mut self, mut tab_index: usize) {
         tab_index -= 1;
         let active_tab = self.get_active_tab().unwrap();
-        match self.tabs.values().find(|t| t.position == tab_index) {
-            Some(t) => {
-                if t.index != active_tab.index {
-                    self.active_tab_index = Some(t.index);
-                    self.update_tabs();
-                    self.render();
-                }
+        if let Some(t) = self.tabs.values().find(|t| t.position == tab_index) {
+            if t.index != active_tab.index {
+                self.active_tab_index = Some(t.index);
+                self.update_tabs();
+                self.render();
             }
-            None => {}
         }
     }
 

--- a/src/common/screen.rs
+++ b/src/common/screen.rs
@@ -13,7 +13,7 @@ use crate::tab::Tab;
 use crate::{errors::ErrorContext, wasm_vm::PluginInstruction};
 use crate::{layout::Layout, panes::PaneId};
 
-use zellij_tile::data::TabData;
+use zellij_tile::data::TabInfo;
 
 /// Instructions that can be sent to the [`Screen`].
 #[derive(Debug, Clone)]
@@ -272,7 +272,7 @@ impl Screen {
         let mut tab_data = vec![];
         let active_tab_index = self.active_tab_index.unwrap();
         for tab in self.tabs.values() {
-            tab_data.push(TabData {
+            tab_data.push(TabInfo {
                 position: tab.position,
                 name: tab.name.clone(),
                 active: active_tab_index == tab.index,

--- a/src/common/screen.rs
+++ b/src/common/screen.rs
@@ -74,7 +74,6 @@ pub struct Screen {
     active_tab_index: Option<usize>,
     /// The [`OsApi`] this [`Screen`] uses.
     os_api: Box<dyn OsApi>,
-    tabname_buf: String,
     input_mode: InputMode,
 }
 
@@ -100,7 +99,6 @@ impl Screen {
             active_tab_index: None,
             tabs: BTreeMap::new(),
             os_api,
-            tabname_buf: String::new(),
             input_mode,
         }
     }
@@ -288,25 +286,20 @@ impl Screen {
 
     pub fn update_active_tab_name(&mut self, buf: Vec<u8>) {
         let s = str::from_utf8(&buf).unwrap();
+        let active_tab = self.get_active_tab_mut().unwrap();
         match s {
             "\0" => {
-                self.tabname_buf = String::new();
-            }
-            "\n" => {
-                let new_name = self.tabname_buf.clone();
-                let active_tab = self.get_active_tab_mut().unwrap();
-                active_tab.name = new_name;
-                self.update_tabs();
-                self.render();
+                active_tab.name = String::new();
             }
             "\u{007F}" | "\u{0008}" => {
                 //delete and backspace keys
-                self.tabname_buf.pop();
+                active_tab.name.pop();
             }
             c => {
-                self.tabname_buf.push_str(c);
+                active_tab.name.push_str(c);
             }
         }
+        self.update_tabs();
     }
     pub fn change_input_mode(&mut self, input_mode: InputMode) {
         self.input_mode = input_mode;

--- a/src/common/screen.rs
+++ b/src/common/screen.rs
@@ -13,7 +13,7 @@ use crate::tab::Tab;
 use crate::{errors::ErrorContext, wasm_vm::PluginInstruction};
 use crate::{layout::Layout, panes::PaneId};
 
-use zellij_tile::data::{InputMode, TabInfo};
+use zellij_tile::data::{Event, InputMode, TabInfo};
 
 /// Instructions that can be sent to the [`Screen`].
 #[derive(Debug, Clone)]
@@ -282,7 +282,7 @@ impl Screen {
             });
         }
         self.send_plugin_instructions
-            .send(PluginInstruction::UpdateTabs(tab_data))
+            .send(PluginInstruction::Update(None, Event::TabUpdate(tab_data)))
             .unwrap();
     }
 

--- a/src/common/screen.rs
+++ b/src/common/screen.rs
@@ -9,9 +9,11 @@ use super::{AppInstruction, SenderWithContext};
 use crate::os_input_output::OsApi;
 use crate::panes::PositionAndSize;
 use crate::pty_bus::{PtyInstruction, VteEvent};
-use crate::tab::{Tab, TabData};
+use crate::tab::Tab;
 use crate::{errors::ErrorContext, wasm_vm::PluginInstruction};
 use crate::{layout::Layout, panes::PaneId};
+
+use zellij_tile::data::TabData;
 
 /// Instructions that can be sent to the [`Screen`].
 #[derive(Debug, Clone)]

--- a/src/common/utils/consts.rs
+++ b/src/common/utils/consts.rs
@@ -4,5 +4,3 @@ pub const ZELLIJ_TMP_DIR: &str = "/tmp/zellij";
 pub const ZELLIJ_TMP_LOG_DIR: &str = "/tmp/zellij/zellij-log";
 pub const ZELLIJ_TMP_LOG_FILE: &str = "/tmp/zellij/zellij-log/log.txt";
 pub const ZELLIJ_IPC_PIPE: &str = "/tmp/zellij/ipc";
-pub const ZELLIJ_ROOT_PLUGIN_DIR: &str = "/usr/share/zellij/plugins";
-pub const ZELLIJ_ROOT_LAYOUT_DIR: &str = "/usr/share/zellij/layouts";

--- a/src/common/wasm_vm.rs
+++ b/src/common/wasm_vm.rs
@@ -6,7 +6,7 @@ use std::{
 };
 use wasmer::{imports, Function, ImportObject, Store, WasmerEnv};
 use wasmer_wasi::WasiEnv;
-use zellij_tile::data::{Event, EventType, TabInfo};
+use zellij_tile::data::{Event, EventType};
 
 use super::{
     pty_bus::PtyInstruction, screen::ScreenInstruction, AppInstruction, PaneId, SenderWithContext,
@@ -29,7 +29,6 @@ pub enum PluginInstruction {
     Render(Sender<String>, u32, usize, usize), // String buffer, plugin id, rows, cols
     Input(PluginInputType, Vec<u8>), // plugin id, input bytes
     Unload(u32),
-    UpdateTabs(Vec<TabInfo>), // num tabs, active tab
     Quit,
 }
 

--- a/src/common/wasm_vm.rs
+++ b/src/common/wasm_vm.rs
@@ -30,10 +30,9 @@ pub enum PluginInputType {
 #[derive(Clone, Debug)]
 pub enum PluginInstruction {
     Load(Sender<u32>, PathBuf, Vec<NaughtyEventType>),
-    Update(Event),
+    Update(Option<u32>, Event), // Focused plugin / broadcast, event data
     Render(Sender<String>, u32, usize, usize), // String buffer, plugin id, rows, cols
-    Input(PluginInputType, Vec<u8>),           // plugin id, input bytes
-    GlobalInput(Vec<u8>),                      // input bytes
+    Input(PluginInputType, Vec<u8>), // plugin id, input bytes
     Unload(u32),
     UpdateTabs(Vec<TabInfo>), // num tabs, active tab
     Quit,

--- a/src/common/wasm_vm.rs
+++ b/src/common/wasm_vm.rs
@@ -23,7 +23,6 @@ pub enum NaughtyEventType {
 
 #[derive(Clone, Debug)]
 pub enum PluginInputType {
-    Normal(u32),
     Event(NaughtyEventType),
 }
 

--- a/src/common/wasm_vm.rs
+++ b/src/common/wasm_vm.rs
@@ -9,7 +9,7 @@ use std::{
 };
 use wasmer::{imports, Function, ImportObject, Store, WasmerEnv};
 use wasmer_wasi::WasiEnv;
-use zellij_tile::data::{EventType, TabInfo};
+use zellij_tile::data::{Event, EventType, TabInfo};
 
 use super::{
     input::handler::get_help, pty_bus::PtyInstruction, screen::ScreenInstruction, AppInstruction,
@@ -30,6 +30,7 @@ pub enum PluginInputType {
 #[derive(Clone, Debug)]
 pub enum PluginInstruction {
     Load(Sender<u32>, PathBuf, Vec<NaughtyEventType>),
+    Update(Event),
     Render(Sender<String>, u32, usize, usize), // String buffer, plugin id, rows, cols
     Input(PluginInputType, Vec<u8>),           // plugin id, input bytes
     GlobalInput(Vec<u8>),                      // input bytes

--- a/src/common/wasm_vm.rs
+++ b/src/common/wasm_vm.rs
@@ -1,4 +1,3 @@
-use serde::{Deserialize, Serialize};
 use std::{
     collections::HashSet,
     path::PathBuf,
@@ -12,22 +11,11 @@ use super::{
     pty_bus::PtyInstruction, screen::ScreenInstruction, AppInstruction, PaneId, SenderWithContext,
 };
 
-#[derive(Clone, Debug, PartialEq, Hash, Eq, Serialize, Deserialize)]
-pub enum NaughtyEventType {
-    Tab,
-}
-
-#[derive(Clone, Debug)]
-pub enum PluginInputType {
-    Event(NaughtyEventType),
-}
-
 #[derive(Clone, Debug)]
 pub enum PluginInstruction {
-    Load(Sender<u32>, PathBuf, Vec<NaughtyEventType>),
+    Load(Sender<u32>, PathBuf),
     Update(Option<u32>, Event), // Focused plugin / broadcast, event data
     Render(Sender<String>, u32, usize, usize), // String buffer, plugin id, rows, cols
-    Input(PluginInputType, Vec<u8>), // plugin id, input bytes
     Unload(u32),
     Quit,
 }
@@ -40,7 +28,6 @@ pub struct PluginEnv {
     pub send_pty_instructions: SenderWithContext<PtyInstruction>, // FIXME: This should be a big bundle of all of the channels
     pub wasi_env: WasiEnv,
     pub subscriptions: Arc<Mutex<HashSet<EventType>>>,
-    pub events: Vec<NaughtyEventType>, // FIXME: Murder this very soon (should not survive into main)
 }
 
 // Plugin API ---------------------------------------------------------------------------------------------------------

--- a/src/common/wasm_vm.rs
+++ b/src/common/wasm_vm.rs
@@ -30,9 +30,9 @@ pub enum PluginInputType {
 #[derive(Clone, Debug)]
 pub enum PluginInstruction {
     Load(Sender<u32>, PathBuf, Vec<NaughtyEventType>),
-    Draw(Sender<String>, u32, usize, usize), // String buffer, plugin id, rows, cols
-    Input(PluginInputType, Vec<u8>),         // plugin id, input bytes
-    GlobalInput(Vec<u8>),                    // input bytes
+    Render(Sender<String>, u32, usize, usize), // String buffer, plugin id, rows, cols
+    Input(PluginInputType, Vec<u8>),           // plugin id, input bytes
+    GlobalInput(Vec<u8>),                      // input bytes
     Unload(u32),
     UpdateTabs(Vec<TabInfo>), // num tabs, active tab
     Quit,

--- a/src/common/wasm_vm.rs
+++ b/src/common/wasm_vm.rs
@@ -1,4 +1,3 @@
-use crate::tab::TabData;
 use serde::{Deserialize, Serialize};
 use std::{
     path::PathBuf,
@@ -6,6 +5,7 @@ use std::{
 };
 use wasmer::{imports, Function, ImportObject, Store, WasmerEnv};
 use wasmer_wasi::WasiEnv;
+use zellij_tile::data::TabData;
 
 use super::{
     input::handler::get_help, pty_bus::PtyInstruction, screen::ScreenInstruction, AppInstruction,

--- a/zellij-tile/Cargo.toml
+++ b/zellij-tile/Cargo.toml
@@ -9,3 +9,5 @@ license = "MIT"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+strum = "0.20.0"
+strum_macros = "0.20.0"

--- a/zellij-tile/src/data.rs
+++ b/zellij-tile/src/data.rs
@@ -1,0 +1,68 @@
+use serde::{Deserialize, Serialize};
+use strum_macros::EnumIter;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Key {
+    Backspace,
+    Left,
+    Right,
+    Up,
+    Down,
+    Home,
+    End,
+    PageUp,
+    PageDown,
+    BackTab,
+    Delete,
+    Insert,
+    F(u8),
+    Char(char),
+    Alt(char),
+    Ctrl(char),
+    Null,
+    Esc,
+}
+
+/// Describes the different input modes, which change the way that keystrokes will be interpreted.
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, EnumIter, Serialize, Deserialize)]
+pub enum InputMode {
+    /// In `Normal` mode, input is always written to the terminal, except for one special input that
+    /// triggers the switch to [`InputMode::Command`] mode.
+    Normal,
+    /// In `Command` mode, input is bound to actions (more precisely, sequences of actions).
+    /// `Command` mode gives access to the other modes non-`InputMode::Normal` modes.
+    /// etc.
+    Command,
+    /// `Resize` mode allows resizing the different existing panes.
+    Resize,
+    /// `Pane` mode allows creating and closing panes, as well as moving between them.
+    Pane,
+    /// `Tab` mode allows creating and closing tabs, as well as moving between them.
+    Tab,
+    /// `Scroll` mode allows scrolling up and down within a pane.
+    Scroll,
+    RenameTab,
+}
+
+impl Default for InputMode {
+    fn default() -> InputMode {
+        InputMode::Normal
+    }
+}
+
+/// Represents the contents of the help message that is printed in the status bar,
+/// which indicates the current [`InputMode`] and what the keybinds for that mode
+/// are. Related to the default `status-bar` plugin.
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct Help {
+    pub mode: InputMode,
+    pub keybinds: Vec<(String, String)>, // <shortcut> => <shortcut description>
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TabData {
+    /* subset of fields to publish to plugins */
+    pub position: usize,
+    pub name: String,
+    pub active: bool,
+}

--- a/zellij-tile/src/data.rs
+++ b/zellij-tile/src/data.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use strum_macros::{EnumDiscriminants, EnumIter, ToString};
+use strum_macros::{EnumDiscriminants, EnumIter, EnumString, ToString};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Key {
@@ -24,7 +24,7 @@ pub enum Key {
 }
 
 #[derive(Debug, Clone, EnumDiscriminants, ToString, Serialize, Deserialize)]
-#[strum_discriminants(derive(Hash, Serialize, Deserialize))]
+#[strum_discriminants(derive(EnumString, Hash, Serialize, Deserialize))]
 #[strum_discriminants(name(EventType))]
 pub enum Event {
     ModeUpdate(Help), // FIXME: Rename the `Help` struct

--- a/zellij-tile/src/data.rs
+++ b/zellij-tile/src/data.rs
@@ -27,7 +27,7 @@ pub enum Key {
 #[strum_discriminants(derive(EnumString, Hash, Serialize, Deserialize))]
 #[strum_discriminants(name(EventType))]
 pub enum Event {
-    ModeUpdate(Help), // FIXME: Rename the `Help` struct
+    ModeUpdate(ModeInfo),
     TabUpdate(TabInfo),
     KeyPress(Key),
 }
@@ -62,7 +62,7 @@ impl Default for InputMode {
 /// which indicates the current [`InputMode`] and what the keybinds for that mode
 /// are. Related to the default `status-bar` plugin.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
-pub struct Help {
+pub struct ModeInfo {
     pub mode: InputMode,
     // FIXME: This should probably return Keys and Actions, then sort out strings plugin-side
     pub keybinds: Vec<(String, String)>, // <shortcut> => <shortcut description>

--- a/zellij-tile/src/data.rs
+++ b/zellij-tile/src/data.rs
@@ -28,7 +28,7 @@ pub enum Key {
 #[strum_discriminants(name(EventType))]
 pub enum Event {
     ModeUpdate(ModeInfo),
-    TabUpdate(TabInfo),
+    TabUpdate(Vec<TabInfo>),
     KeyPress(Key),
 }
 

--- a/zellij-tile/src/data.rs
+++ b/zellij-tile/src/data.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use strum_macros::EnumIter;
+use strum_macros::{EnumDiscriminants, EnumIter, ToString};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Key {
@@ -21,6 +21,15 @@ pub enum Key {
     Ctrl(char),
     Null,
     Esc,
+}
+
+#[derive(Debug, EnumDiscriminants, ToString, Serialize, Deserialize)]
+#[strum_discriminants(derive(Hash, Serialize, Deserialize))]
+#[strum_discriminants(name(EventType))]
+pub enum Event {
+    ModeUpdate(Help), // FIXME: Rename the `Help` struct
+    TabUpdate(TabInfo),
+    KeyPress(Key),
 }
 
 /// Describes the different input modes, which change the way that keystrokes will be interpreted.
@@ -56,11 +65,12 @@ impl Default for InputMode {
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct Help {
     pub mode: InputMode,
+    // FIXME: This should probably return Keys and Actions, then sort out strings plugin-side
     pub keybinds: Vec<(String, String)>, // <shortcut> => <shortcut description>
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct TabData {
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+pub struct TabInfo {
     /* subset of fields to publish to plugins */
     pub position: usize,
     pub name: String,

--- a/zellij-tile/src/data.rs
+++ b/zellij-tile/src/data.rs
@@ -23,7 +23,7 @@ pub enum Key {
     Esc,
 }
 
-#[derive(Debug, EnumDiscriminants, ToString, Serialize, Deserialize)]
+#[derive(Debug, Clone, EnumDiscriminants, ToString, Serialize, Deserialize)]
 #[strum_discriminants(derive(Hash, Serialize, Deserialize))]
 #[strum_discriminants(name(EventType))]
 pub enum Event {

--- a/zellij-tile/src/lib.rs
+++ b/zellij-tile/src/lib.rs
@@ -10,8 +10,6 @@ pub trait ZellijTile {
     fn update(&mut self, event: Event) {}
     fn render(&mut self, rows: usize, cols: usize) {}
     // FIXME: Everything below this line should be purged
-    fn handle_key(&mut self, key: Key) {}
-    fn handle_global_key(&mut self, key: Key) {}
     fn update_tabs(&mut self) {}
     fn handle_tab_rename_keypress(&mut self, key: Key) {}
 }
@@ -42,22 +40,6 @@ macro_rules! register_tile {
         pub fn render(rows: i32, cols: i32) {
             STATE.with(|state| {
                 state.borrow_mut().render(rows as usize, cols as usize);
-            });
-        }
-
-        #[no_mangle]
-        pub fn handle_key() {
-            STATE.with(|state| {
-                state.borrow_mut().handle_key($crate::shim::get_key());
-            });
-        }
-
-        #[no_mangle]
-        pub fn handle_global_key() {
-            STATE.with(|state| {
-                state
-                    .borrow_mut()
-                    .handle_global_key($crate::shim::get_key());
             });
         }
 

--- a/zellij-tile/src/lib.rs
+++ b/zellij-tile/src/lib.rs
@@ -7,6 +7,7 @@ use data::*;
 #[allow(unused_variables)]
 pub trait ZellijTile {
     fn load(&mut self) {}
+    fn update(&mut self, event: Event) {}
     fn render(&mut self, rows: usize, cols: usize) {}
     // FIXME: Everything below this line should be purged
     fn handle_key(&mut self, key: Key) {}
@@ -25,6 +26,15 @@ macro_rules! register_tile {
         fn main() {
             STATE.with(|state| {
                 state.borrow_mut().load();
+            });
+        }
+
+        #[no_mangle]
+        pub fn update() {
+            STATE.with(|state| {
+                state
+                    .borrow_mut()
+                    .update($crate::shim::deserialize_from_stdin().unwrap());
             });
         }
 

--- a/zellij-tile/src/lib.rs
+++ b/zellij-tile/src/lib.rs
@@ -9,8 +9,6 @@ pub trait ZellijTile {
     fn load(&mut self) {}
     fn update(&mut self, event: Event) {}
     fn render(&mut self, rows: usize, cols: usize) {}
-    // FIXME: Everything below this line should be purged
-    fn handle_tab_rename_keypress(&mut self, key: Key) {}
 }
 
 #[macro_export]
@@ -29,9 +27,7 @@ macro_rules! register_tile {
         #[no_mangle]
         pub fn update() {
             STATE.with(|state| {
-                state
-                    .borrow_mut()
-                    .update($crate::shim::deserialize_from_stdin().unwrap());
+                state.borrow_mut().update($crate::shim::object_from_stdin());
             });
         }
 
@@ -40,15 +36,6 @@ macro_rules! register_tile {
             STATE.with(|state| {
                 state.borrow_mut().render(rows as usize, cols as usize);
             });
-        }
-
-        #[no_mangle]
-        pub fn handle_tab_rename_keypress() {
-            STATE.with(|state| {
-                state
-                    .borrow_mut()
-                    .handle_tab_rename_keypress($crate::shim::get_key());
-            })
         }
     };
 }

--- a/zellij-tile/src/lib.rs
+++ b/zellij-tile/src/lib.rs
@@ -7,7 +7,8 @@ use data::*;
 #[allow(unused_variables)]
 pub trait ZellijTile {
     fn load(&mut self) {}
-    fn draw(&mut self, rows: usize, cols: usize) {}
+    fn render(&mut self, rows: usize, cols: usize) {}
+    // FIXME: Everything below this line should be purged
     fn handle_key(&mut self, key: Key) {}
     fn handle_global_key(&mut self, key: Key) {}
     fn update_tabs(&mut self) {}
@@ -28,9 +29,9 @@ macro_rules! register_tile {
         }
 
         #[no_mangle]
-        pub fn draw(rows: i32, cols: i32) {
+        pub fn render(rows: i32, cols: i32) {
             STATE.with(|state| {
-                state.borrow_mut().draw(rows as usize, cols as usize);
+                state.borrow_mut().render(rows as usize, cols as usize);
             });
         }
 

--- a/zellij-tile/src/lib.rs
+++ b/zellij-tile/src/lib.rs
@@ -1,6 +1,9 @@
-mod shim;
+pub mod data;
+pub mod prelude;
+pub mod shim;
 
-pub use shim::*;
+use data::*;
+
 #[allow(unused_variables)]
 pub trait ZellijTile {
     fn load(&mut self) {}
@@ -34,14 +37,16 @@ macro_rules! register_tile {
         #[no_mangle]
         pub fn handle_key() {
             STATE.with(|state| {
-                state.borrow_mut().handle_key($crate::get_key());
+                state.borrow_mut().handle_key($crate::shim::get_key());
             });
         }
 
         #[no_mangle]
         pub fn handle_global_key() {
             STATE.with(|state| {
-                state.borrow_mut().handle_global_key($crate::get_key());
+                state
+                    .borrow_mut()
+                    .handle_global_key($crate::shim::get_key());
             });
         }
 
@@ -57,7 +62,7 @@ macro_rules! register_tile {
             STATE.with(|state| {
                 state
                     .borrow_mut()
-                    .handle_tab_rename_keypress($crate::get_key());
+                    .handle_tab_rename_keypress($crate::shim::get_key());
             })
         }
     };

--- a/zellij-tile/src/lib.rs
+++ b/zellij-tile/src/lib.rs
@@ -10,7 +10,6 @@ pub trait ZellijTile {
     fn update(&mut self, event: Event) {}
     fn render(&mut self, rows: usize, cols: usize) {}
     // FIXME: Everything below this line should be purged
-    fn update_tabs(&mut self) {}
     fn handle_tab_rename_keypress(&mut self, key: Key) {}
 }
 
@@ -41,13 +40,6 @@ macro_rules! register_tile {
             STATE.with(|state| {
                 state.borrow_mut().render(rows as usize, cols as usize);
             });
-        }
-
-        #[no_mangle]
-        pub fn update_tabs() {
-            STATE.with(|state| {
-                state.borrow_mut().update_tabs();
-            })
         }
 
         #[no_mangle]

--- a/zellij-tile/src/lib.rs
+++ b/zellij-tile/src/lib.rs
@@ -3,7 +3,7 @@ mod shim;
 pub use shim::*;
 #[allow(unused_variables)]
 pub trait ZellijTile {
-    fn init(&mut self) {}
+    fn load(&mut self) {}
     fn draw(&mut self, rows: usize, cols: usize) {}
     fn handle_key(&mut self, key: Key) {}
     fn handle_global_key(&mut self, key: Key) {}
@@ -20,7 +20,7 @@ macro_rules! register_tile {
 
         fn main() {
             STATE.with(|state| {
-                state.borrow_mut().init();
+                state.borrow_mut().load();
             });
         }
 

--- a/zellij-tile/src/prelude.rs
+++ b/zellij-tile/src/prelude.rs
@@ -1,0 +1,3 @@
+pub use crate::data::*;
+pub use crate::shim::*;
+pub use crate::*;

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -36,11 +36,6 @@ pub fn set_selectable(selectable: bool) {
     unsafe { host_set_selectable(selectable) };
 }
 
-pub fn get_help() -> ModeInfo {
-    unsafe { host_get_help() };
-    deserialize_from_stdin().unwrap_or_default()
-}
-
 pub fn get_tabs() -> Vec<TabInfo> {
     deserialize_from_stdin().unwrap_or_default()
 }
@@ -61,5 +56,4 @@ extern "C" {
     fn host_set_max_height(max_height: i32);
     fn host_set_selectable(selectable: i32);
     fn host_set_invisible_borders(invisible_borders: i32);
-    fn host_get_help();
 }

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -1,61 +1,7 @@
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::de::DeserializeOwned;
 use std::{io, path::Path};
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum Key {
-    Backspace,
-    Left,
-    Right,
-    Up,
-    Down,
-    Home,
-    End,
-    PageUp,
-    PageDown,
-    BackTab,
-    Delete,
-    Insert,
-    F(u8),
-    Char(char),
-    Alt(char),
-    Ctrl(char),
-    Null,
-    Esc,
-}
-
-// TODO: use same struct from main crate?
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
-pub struct Help {
-    pub mode: InputMode,
-    pub keybinds: Vec<(String, String)>,
-}
-
-// TODO: use same struct from main crate?
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub enum InputMode {
-    Normal,
-    Command,
-    Resize,
-    Pane,
-    Tab,
-    RenameTab,
-    Scroll,
-    Exiting,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct TabData {
-    /* subset of fields to publish to plugins */
-    pub position: usize,
-    pub name: String,
-    pub active: bool,
-}
-
-impl Default for InputMode {
-    fn default() -> InputMode {
-        InputMode::Normal
-    }
-}
+use crate::data::*;
 
 pub fn get_key() -> Key {
     deserialize_from_stdin().unwrap()

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -36,7 +36,7 @@ pub fn set_selectable(selectable: bool) {
     unsafe { host_set_selectable(selectable) };
 }
 
-pub fn get_help() -> Help {
+pub fn get_help() -> ModeInfo {
     unsafe { host_get_help() };
     deserialize_from_stdin().unwrap_or_default()
 }

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -45,7 +45,9 @@ pub fn get_tabs() -> Vec<TabInfo> {
     deserialize_from_stdin().unwrap_or_default()
 }
 
-fn deserialize_from_stdin<T: DeserializeOwned>() -> Option<T> {
+#[doc(hidden)]
+// FIXME: Make this just return T and do a .unwrap() at the end; also naming?
+pub fn deserialize_from_stdin<T: DeserializeOwned>() -> Option<T> {
     let mut json = String::new();
     io::stdin().read_line(&mut json).unwrap();
     serde_json::from_str(&json).ok()

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -3,9 +3,7 @@ use std::{io, path::Path};
 
 use crate::data::*;
 
-pub fn get_key() -> Key {
-    deserialize_from_stdin().unwrap()
-}
+// Subscription Handling
 
 pub fn subscribe(event_types: &[EventType]) {
     println!("{}", serde_json::to_string(event_types).unwrap());
@@ -17,31 +15,34 @@ pub fn unsubscribe(event_types: &[EventType]) {
     unsafe { host_unsubscribe() };
 }
 
-pub fn open_file(path: &Path) {
-    println!("{}", path.to_string_lossy());
-    unsafe { host_open_file() };
-}
+// Plugin Settings
 
 pub fn set_max_height(max_height: i32) {
     unsafe { host_set_max_height(max_height) };
 }
 
 pub fn set_invisible_borders(invisible_borders: bool) {
-    let invisible_borders = if invisible_borders { 1 } else { 0 };
-    unsafe { host_set_invisible_borders(invisible_borders) };
+    unsafe { host_set_invisible_borders(if invisible_borders { 1 } else { 0 }) };
 }
 
 pub fn set_selectable(selectable: bool) {
-    let selectable = if selectable { 1 } else { 0 };
-    unsafe { host_set_selectable(selectable) };
+    unsafe { host_set_selectable(if selectable { 1 } else { 0 }) };
 }
 
+// Host Functions
+
+pub fn open_file(path: &Path) {
+    println!("{}", path.to_string_lossy());
+    unsafe { host_open_file() };
+}
+
+// Internal Functions
+
 #[doc(hidden)]
-// FIXME: Make this just return T and do a .unwrap() at the end; also naming?
-pub fn deserialize_from_stdin<T: DeserializeOwned>() -> Option<T> {
+pub fn object_from_stdin<T: DeserializeOwned>() -> T {
     let mut json = String::new();
     io::stdin().read_line(&mut json).unwrap();
-    serde_json::from_str(&json).ok()
+    serde_json::from_str(&json).unwrap()
 }
 
 #[link(wasm_import_module = "zellij")]

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -36,10 +36,6 @@ pub fn set_selectable(selectable: bool) {
     unsafe { host_set_selectable(selectable) };
 }
 
-pub fn get_tabs() -> Vec<TabInfo> {
-    deserialize_from_stdin().unwrap_or_default()
-}
-
 #[doc(hidden)]
 // FIXME: Make this just return T and do a .unwrap() at the end; also naming?
 pub fn deserialize_from_stdin<T: DeserializeOwned>() -> Option<T> {

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -7,6 +7,16 @@ pub fn get_key() -> Key {
     deserialize_from_stdin().unwrap()
 }
 
+pub fn subscribe(event_types: &[EventType]) {
+    println!("{}", serde_json::to_string(event_types).unwrap());
+    unsafe { host_subscribe() };
+}
+
+pub fn unsubscribe(event_types: &[EventType]) {
+    println!("{}", serde_json::to_string(event_types).unwrap());
+    unsafe { host_unsubscribe() };
+}
+
 pub fn open_file(path: &Path) {
     println!("{}", path.to_string_lossy());
     unsafe { host_open_file() };
@@ -31,7 +41,7 @@ pub fn get_help() -> Help {
     deserialize_from_stdin().unwrap_or_default()
 }
 
-pub fn get_tabs() -> Vec<TabData> {
+pub fn get_tabs() -> Vec<TabInfo> {
     deserialize_from_stdin().unwrap_or_default()
 }
 
@@ -43,6 +53,8 @@ fn deserialize_from_stdin<T: DeserializeOwned>() -> Option<T> {
 
 #[link(wasm_import_module = "zellij")]
 extern "C" {
+    fn host_subscribe();
+    fn host_unsubscribe();
     fn host_open_file();
     fn host_set_max_height(max_height: i32);
     fn host_set_selectable(selectable: i32);


### PR DESCRIPTION
This will take a little while to finish, but we can keep track of things here:

- [x] Change `init()` to `load()`
- [x] Deduplicate structs that are in both `zellij` and `zellij-tile`
- [x] WASM thread keeps a mapping of plugins and event subscriptions
- [x] Add host-functions for subscribing and unsubscribing from events
- [x] Introduce the `update(event)` callback into the API (which is called to handle plugin events)
- [x] Make mode changes send an event to the WASM thread
- [x] Murder the `AppInstruction::Get/SetState` calls (and any global state)
- [x] Murder the `get_help()` host function
- [x] Add an event system for key-presses
- [x] Add an event for updating tabs
- [x] Add support for renaming tabs
- [x] Murder every callback other than `load()`, `update(event)`, and `draw(rows, cols)`
- [x] Murder every WASM thread event other than Load, Draw, and Update
- [x] Call render after a plugin is updated
- [x] Switch back to upstream `termion`
- [x] Probably more... (loads of lint fixing)
- [x] Don't break everything?