### PR TITLE
delete characters when renaming tab

### DIFF
--- a/default-tiles/tab-bar/src/main.rs
+++ b/default-tiles/tab-bar/src/main.rs
@@ -100,6 +100,9 @@ impl ZellijTile for State {
                 self.new_name.clear();
             }
             Key::Char(c) => self.new_name = format!("{}{}", self.new_name, c),
+            Key::Backspace | Key::Delete => {
+                self.new_name.pop();
+            }
             _ => {}
         }
     }

--- a/src/common/screen.rs
+++ b/src/common/screen.rs
@@ -294,6 +294,10 @@ impl Screen {
                 self.update_tabs();
                 self.render();
             }
+            "\u{007F}" | "\u{0008}" => {
+                //delete and backspace keys
+                self.tabname_buf.pop();
+            }
             c => {
                 self.tabname_buf.push_str(c);
             }


### PR DESCRIPTION
handle delete and backspace keys when renaming tab.

closes #221 