### PR TITLE
additional performance improvements

### DIFF
--- a/src/common/os_input_output.rs
+++ b/src/common/os_input_output.rs
@@ -1,5 +1,4 @@
 use crate::panes::PositionAndSize;
-use nix::fcntl::{fcntl, FcntlArg, OFlag};
 use nix::pty::{forkpty, Winsize};
 use nix::sys::signal::{kill, Signal};
 use nix::sys::termios;
@@ -116,12 +115,7 @@ fn spawn_terminal(file_to_open: Option<PathBuf>, orig_termios: termios::Termios)
             Ok(fork_pty_res) => {
                 let pid_primary = fork_pty_res.master;
                 let pid_secondary = match fork_pty_res.fork_result {
-                    ForkResult::Parent { child } => {
-                        // fcntl(pid_primary, FcntlArg::F_SETFL(OFlag::empty())).expect("could not fcntl");
-                        fcntl(pid_primary, FcntlArg::F_SETFL(OFlag::O_NONBLOCK))
-                            .expect("could not fcntl");
-                        child
-                    }
+                    ForkResult::Parent { child } => child,
                     ForkResult::Child => match file_to_open {
                         Some(file_to_open) => {
                             if env::var("EDITOR").is_err() && env::var("VISUAL").is_err() {

--- a/src/common/os_input_output.rs
+++ b/src/common/os_input_output.rs
@@ -1,4 +1,5 @@
 use crate::panes::PositionAndSize;
+use nix::fcntl::{fcntl, FcntlArg, OFlag};
 use nix::pty::{forkpty, Winsize};
 use nix::sys::signal::{kill, Signal};
 use nix::sys::termios;
@@ -115,7 +116,13 @@ fn spawn_terminal(file_to_open: Option<PathBuf>, orig_termios: termios::Termios)
             Ok(fork_pty_res) => {
                 let pid_primary = fork_pty_res.master;
                 let pid_secondary = match fork_pty_res.fork_result {
-                    ForkResult::Parent { child } => child,
+                    ForkResult::Parent { child } => {
+                        // fcntl(pid_primary, FcntlArg::F_SETFL(OFlag::empty())).expect("could not fcntl");
+                        #[cfg(test)]
+                        fcntl(pid_primary, FcntlArg::F_SETFL(OFlag::O_NONBLOCK))
+                            .expect("could not fcntl");
+                        child
+                    }
                     ForkResult::Child => match file_to_open {
                         Some(file_to_open) => {
                             if env::var("EDITOR").is_err() && env::var("VISUAL").is_err() {

--- a/src/common/pty_bus.rs
+++ b/src/common/pty_bus.rs
@@ -42,13 +42,10 @@ impl ReadFromPid {
         }
     }
 
+    #[cfg(not(test))]
     async fn next(&mut self) -> Option<Vec<u8>> {
         let mut buf = [0; 65535];
-        #[cfg(not(test))]
-        let data = self.file.as_ref().unwrap().read(&mut buf).await;
-        #[cfg(test)]
-        let data = self.os_input.read_from_tty_stdout(self.pid, &mut buf);
-        match data {
+        match self.file.as_ref().unwrap().read(&mut buf).await {
             Ok(bytes) => {
                 if bytes == 0 {
                     Some(vec![])
@@ -57,6 +54,39 @@ impl ReadFromPid {
                 }
             }
             _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+impl Stream for ReadFromPid {
+    type Item = Vec<u8>;
+    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut read_buffer = [0; 65535];
+        let pid = self.pid;
+        let read_result = &self.os_input.read_from_tty_stdout(pid, &mut read_buffer);
+        match read_result {
+            Ok(res) => {
+                if *res == 0 {
+                    // indicates end of file
+                    Poll::Ready(None)
+                } else {
+                    let res = Some(read_buffer[..=*res].to_vec());
+                    Poll::Ready(res)
+                }
+            }
+            Err(e) => {
+                match e {
+                    nix::Error::Sys(errno) => {
+                        if *errno == nix::errno::Errno::EAGAIN {
+                            Poll::Ready(Some(vec![])) // TODO: better with timeout waker somehow
+                        } else {
+                            Poll::Ready(None)
+                        }
+                    }
+                    _ => Poll::Ready(None),
+                }
+            }
         }
     }
 }

--- a/src/common/pty_bus.rs
+++ b/src/common/pty_bus.rs
@@ -151,6 +151,10 @@ fn stream_terminal_bytes(
                 }
                 buf = vec![0; 1024];
             }
+            #[cfg(not(test))]
+            // this is a little hacky, and is because the tests end the file as soon as
+            // we read everything, rather than hanging until there is new data
+            // a better solution would be to fix the test fakes, but this will do for now
             send_screen_instructions
                 .send(ScreenInstruction::ClosePane(PaneId::Terminal(pid)))
                 .unwrap();


### PR DESCRIPTION
polling all pty fds was causing idle cpu utilization and also increasing the load when stuff was happening.

Instead use `async_std::fs::File`, which handles polling the fd.

the savings are easiest to see when idle. here is zellij release build with one pane displaying htop showing it's own usage:

release build off main:
![image](https://user-images.githubusercontent.com/10764469/111056610-5dbe4c00-844e-11eb-82b6-b216a84163d1.png)

release build from this PR:
![image](https://user-images.githubusercontent.com/10764469/111056626-79c1ed80-844e-11eb-86c7-b269d201c6b0.png)
