### PR TITLE
feature(strider): Show current parent folder

### DIFF
--- a/default-tiles/strider/src/main.rs
+++ b/default-tiles/strider/src/main.rs
@@ -13,6 +13,7 @@ impl ZellijTile for State {
     }
 
     fn draw(&mut self, rows: usize, cols: usize) {
+
         for i in 0..rows {
             if self.selected() < self.scroll() {
                 *self.scroll_mut() = self.selected();
@@ -23,6 +24,10 @@ impl ZellijTile for State {
             let i = self.scroll() + i;
             if let Some(entry) = self.files.get(i) {
                 let mut path = entry.as_line(cols).normal();
+
+                if !self.path.clone().into_os_string().is_empty() && i==0 {
+                println!("{}", FsEntry::from(self.path.clone()).as_line(cols).bold());
+                };
 
                 if let FsEntry::Dir(..) = entry {
                     path = path.dimmed().bold();

--- a/default-tiles/strider/src/main.rs
+++ b/default-tiles/strider/src/main.rs
@@ -13,7 +13,6 @@ impl ZellijTile for State {
     }
 
     fn draw(&mut self, rows: usize, cols: usize) {
-
         for i in 0..rows {
             if self.selected() < self.scroll() {
                 *self.scroll_mut() = self.selected();
@@ -25,8 +24,8 @@ impl ZellijTile for State {
             if let Some(entry) = self.files.get(i) {
                 let mut path = entry.as_line(cols).normal();
 
-                if !self.path.clone().into_os_string().is_empty() && i==0 {
-                println!("{}", FsEntry::from(self.path.clone()).as_line(cols).bold());
+                if !self.path.clone().into_os_string().is_empty() && i == 0 {
+                    println!("{}", FsEntry::from(self.path.clone()).as_line(cols).bold());
                 };
 
                 if let FsEntry::Dir(..) = entry {

--- a/default-tiles/strider/src/main.rs
+++ b/default-tiles/strider/src/main.rs
@@ -25,7 +25,7 @@ impl ZellijTile for State {
                 let mut path = entry.as_line(cols).normal();
 
                 if !self.path.clone().into_os_string().is_empty() && i == 0 {
-                    println!("{}", FsEntry::from(self.path.clone()).as_line(cols).bold());
+                    println!("{}", FsEntry::Header(self.path.clone(), 0).as_line(cols).bold());
                 };
 
                 if let FsEntry::Dir(..) = entry {
@@ -59,6 +59,7 @@ impl ZellijTile for State {
                         refresh_directory(self);
                     }
                     FsEntry::File(p, _) => open_file(&p),
+                    FsEntry::Header(_, _) => { },
                 }
             }
             Key::Left | Key::Char('h') => {

--- a/default-tiles/strider/src/main.rs
+++ b/default-tiles/strider/src/main.rs
@@ -25,7 +25,10 @@ impl ZellijTile for State {
                 let mut path = entry.as_line(cols).normal();
 
                 if !self.path.clone().into_os_string().is_empty() && i == 0 {
-                    println!("{}", FsEntry::Header(self.path.clone(), 0).as_line(cols).bold());
+                    println!(
+                        "{}",
+                        FsEntry::Header(self.path.clone()).as_line(cols).underline()
+                    );
                 };
 
                 if let FsEntry::Dir(..) = entry {
@@ -59,7 +62,7 @@ impl ZellijTile for State {
                         refresh_directory(self);
                     }
                     FsEntry::File(p, _) => open_file(&p),
-                    FsEntry::Header(_, _) => { },
+                    FsEntry::Header(_) => {}
                 }
             }
             Key::Left | Key::Char('h') => {

--- a/default-tiles/strider/src/state.rs
+++ b/default-tiles/strider/src/state.rs
@@ -32,7 +32,7 @@ impl State {
 pub enum FsEntry {
     Dir(PathBuf, usize),
     File(PathBuf, u64),
-    Header(PathBuf, usize),
+    Header(PathBuf),
 }
 
 impl FsEntry {
@@ -40,7 +40,7 @@ impl FsEntry {
         let path = match self {
             FsEntry::Dir(p, _) => p,
             FsEntry::File(p, _) => p,
-            FsEntry::Header(p, _) => p,
+            FsEntry::Header(p) => p,
         };
         path.file_name().unwrap().to_string_lossy().into_owned()
     }
@@ -49,7 +49,7 @@ impl FsEntry {
         let info = match self {
             FsEntry::Dir(_, s) => s.to_string(),
             FsEntry::File(_, s) => pb::convert(*s as f64),
-            FsEntry::Header(_, _) => "./".to_string(),
+            FsEntry::Header(_) => ".".to_string(),
         };
         let space = width - info.len();
         let name = self.name();

--- a/default-tiles/strider/src/state.rs
+++ b/default-tiles/strider/src/state.rs
@@ -1,6 +1,6 @@
 use pretty_bytes::converter as pb;
-use std::{collections::HashMap, path::PathBuf};
 use std::convert::From;
+use std::{collections::HashMap, path::PathBuf};
 
 #[derive(Default)]
 pub struct State {
@@ -45,7 +45,7 @@ impl FsEntry {
 
     pub fn as_line(&self, width: usize) -> String {
         let info = match self {
-            FsEntry::Dir(_, s) if s==&(0 as usize) => ".".to_string(),
+            FsEntry::Dir(_, s) if s == &(0 as usize) => ".".to_string(),
             FsEntry::Dir(_, s) => s.to_string(),
             FsEntry::File(_, s) => pb::convert(*s as f64),
         };
@@ -66,10 +66,10 @@ impl FsEntry {
 
 impl From<PathBuf> for FsEntry {
     fn from(path: PathBuf) -> Self {
-        if path.is_dir(){
-            FsEntry::Dir(path,0)
+        if path.is_dir() {
+            FsEntry::Dir(path, 0)
         } else {
-            FsEntry::File(path,0)
+            FsEntry::File(path, 0)
         }
     }
 }

--- a/default-tiles/strider/src/state.rs
+++ b/default-tiles/strider/src/state.rs
@@ -32,6 +32,7 @@ impl State {
 pub enum FsEntry {
     Dir(PathBuf, usize),
     File(PathBuf, u64),
+    Header(PathBuf, usize),
 }
 
 impl FsEntry {
@@ -39,15 +40,16 @@ impl FsEntry {
         let path = match self {
             FsEntry::Dir(p, _) => p,
             FsEntry::File(p, _) => p,
+            FsEntry::Header(p, _) => p,
         };
         path.file_name().unwrap().to_string_lossy().into_owned()
     }
 
     pub fn as_line(&self, width: usize) -> String {
         let info = match self {
-            FsEntry::Dir(_, s) if s == &(0 as usize) => ".".to_string(),
             FsEntry::Dir(_, s) => s.to_string(),
             FsEntry::File(_, s) => pb::convert(*s as f64),
+            FsEntry::Header(_, _) => "./".to_string(),
         };
         let space = width - info.len();
         let name = self.name();

--- a/default-tiles/strider/src/state.rs
+++ b/default-tiles/strider/src/state.rs
@@ -1,5 +1,6 @@
 use pretty_bytes::converter as pb;
 use std::{collections::HashMap, path::PathBuf};
+use std::convert::From;
 
 #[derive(Default)]
 pub struct State {
@@ -44,6 +45,7 @@ impl FsEntry {
 
     pub fn as_line(&self, width: usize) -> String {
         let info = match self {
+            FsEntry::Dir(_, s) if s==&(0 as usize) => ".".to_string(),
             FsEntry::Dir(_, s) => s.to_string(),
             FsEntry::File(_, s) => pb::convert(*s as f64),
         };
@@ -59,5 +61,15 @@ impl FsEntry {
 
     pub fn is_hidden_file(&self) -> bool {
         self.name().chars().nth(0).unwrap() == '.'.into()
+    }
+}
+
+impl From<PathBuf> for FsEntry {
+    fn from(path: PathBuf) -> Self {
+        if path.is_dir(){
+            FsEntry::Dir(path,0)
+        } else {
+            FsEntry::File(path,0)
+        }
     }
 }


### PR DESCRIPTION
#195

Shows the current parent folder, if opened inside
of strider eg:

It doesn't display the current folder on the root
pane of strider, but if opened a sub folder it displays
the parent folder.

![image](https://user-images.githubusercontent.com/65275785/111032694-c5a07280-840d-11eb-83d8-1cdfaed5c903.png)
![image](https://user-images.githubusercontent.com/65275785/111032702-d224cb00-840d-11eb-8ac7-2287b764d12c.png)

