### PR TITLE
Performance: only render panes that should be updated

### DIFF
--- a/src/client/panes/terminal_pane.rs
+++ b/src/client/panes/terminal_pane.rs
@@ -70,13 +70,11 @@ impl Pane for TerminalPane {
     fn reset_size_and_position_override(&mut self) {
         self.position_and_size_override = None;
         self.reflow_lines();
-        self.mark_for_rerender();
     }
     fn change_pos_and_size(&mut self, position_and_size: &PositionAndSize) {
         self.position_and_size.columns = position_and_size.columns;
         self.position_and_size.rows = position_and_size.rows;
         self.reflow_lines();
-        self.mark_for_rerender();
     }
     fn override_size_and_position(&mut self, x: usize, y: usize, size: &PositionAndSize) {
         let position_and_size_override = PositionAndSize {
@@ -87,7 +85,6 @@ impl Pane for TerminalPane {
         };
         self.position_and_size_override = Some(position_and_size_override);
         self.reflow_lines();
-        self.mark_for_rerender();
     }
     fn handle_event(&mut self, event: VteEvent) {
         match event {
@@ -191,12 +188,7 @@ impl Pane for TerminalPane {
         self.max_height
     }
     fn render(&mut self) -> Option<String> {
-        // if self.should_render {
-        if true {
-            // while checking should_render rather than rendering each pane every time
-            // is more performant, it causes some problems when the pane to the left should be
-            // rendered and has wide characters (eg. Chinese characters or emoji)
-            // as a (hopefully) temporary hack, we render all panes until we find a better solution
+        if self.should_render || cfg!(test) {
             let mut vte_output = String::new();
             let buffer_lines = &self.read_buffer_as_lines();
             let display_cols = self.get_columns();
@@ -238,7 +230,7 @@ impl Pane for TerminalPane {
                 }
                 character_styles.clear();
             }
-            self.mark_for_rerender();
+            self.should_render = false;
             Some(vte_output)
         } else {
             None
@@ -251,45 +243,37 @@ impl Pane for TerminalPane {
         self.position_and_size.y += count;
         self.position_and_size.rows -= count;
         self.reflow_lines();
-        self.mark_for_rerender();
     }
     fn increase_height_down(&mut self, count: usize) {
         self.position_and_size.rows += count;
         self.reflow_lines();
-        self.mark_for_rerender();
     }
     fn increase_height_up(&mut self, count: usize) {
         self.position_and_size.y -= count;
         self.position_and_size.rows += count;
         self.reflow_lines();
-        self.mark_for_rerender();
     }
     fn reduce_height_up(&mut self, count: usize) {
         self.position_and_size.rows -= count;
         self.reflow_lines();
-        self.mark_for_rerender();
     }
     fn reduce_width_right(&mut self, count: usize) {
         self.position_and_size.x += count;
         self.position_and_size.columns -= count;
         self.reflow_lines();
-        self.mark_for_rerender();
     }
     fn reduce_width_left(&mut self, count: usize) {
         self.position_and_size.columns -= count;
         self.reflow_lines();
-        self.mark_for_rerender();
     }
     fn increase_width_left(&mut self, count: usize) {
         self.position_and_size.x -= count;
         self.position_and_size.columns += count;
         self.reflow_lines();
-        self.mark_for_rerender();
     }
     fn increase_width_right(&mut self, count: usize) {
         self.position_and_size.columns += count;
         self.reflow_lines();
-        self.mark_for_rerender();
     }
     fn scroll_up(&mut self, count: usize) {
         self.grid.move_viewport_up(count);

--- a/src/client/tab.rs
+++ b/src/client/tab.rs
@@ -1679,7 +1679,6 @@ impl Tab {
             } else if self.can_reduce_pane_and_surroundings_right(&active_pane_id, count) {
                 self.reduce_pane_and_surroundings_right(&active_pane_id, count);
             }
-            self.render();
         }
     }
     pub fn resize_left(&mut self) {
@@ -1691,7 +1690,6 @@ impl Tab {
             } else if self.can_reduce_pane_and_surroundings_left(&active_pane_id, count) {
                 self.reduce_pane_and_surroundings_left(&active_pane_id, count);
             }
-            self.render();
         }
     }
     pub fn resize_down(&mut self) {
@@ -1703,7 +1701,6 @@ impl Tab {
             } else if self.can_reduce_pane_and_surroundings_down(&active_pane_id, count) {
                 self.reduce_pane_and_surroundings_down(&active_pane_id, count);
             }
-            self.render();
         }
     }
     pub fn resize_up(&mut self) {
@@ -1715,7 +1712,6 @@ impl Tab {
             } else if self.can_reduce_pane_and_surroundings_up(&active_pane_id, count) {
                 self.reduce_pane_and_surroundings_up(&active_pane_id, count);
             }
-            self.render();
         }
     }
     pub fn move_focus(&mut self) {

--- a/src/tests/fakes.rs
+++ b/src/tests/fakes.rs
@@ -191,7 +191,8 @@ impl OsApi for FakeInputOutput {
                 ::std::thread::sleep(MIN_TIME_BETWEEN_SNAPSHOTS - last_snapshot_time.elapsed());
             }
         }
-        let command = self.stdin_commands
+        let command = self
+            .stdin_commands
             .lock()
             .unwrap()
             .pop_front()

--- a/src/tests/fakes.rs
+++ b/src/tests/fakes.rs
@@ -10,6 +10,8 @@ use std::time::{Duration, Instant};
 use crate::os_input_output::OsApi;
 use crate::tests::possible_tty_inputs::{get_possible_tty_inputs, Bytes};
 
+use crate::tests::utils::commands::SLEEP;
+
 const MIN_TIME_BETWEEN_SNAPSHOTS: Duration = Duration::from_millis(50);
 
 #[derive(Clone)]
@@ -189,11 +191,15 @@ impl OsApi for FakeInputOutput {
                 ::std::thread::sleep(MIN_TIME_BETWEEN_SNAPSHOTS - last_snapshot_time.elapsed());
             }
         }
-        self.stdin_commands
+        let command = self.stdin_commands
             .lock()
             .unwrap()
             .pop_front()
-            .unwrap_or(vec![])
+            .unwrap_or(vec![]);
+        if command == SLEEP {
+            std::thread::sleep(std::time::Duration::from_millis(200));
+        }
+        command
     }
     fn get_stdout_writer(&self) -> Box<dyn Write> {
         Box::new(self.stdout_writer.clone())

--- a/src/tests/integration/expansion_boundary.rs
+++ b/src/tests/integration/expansion_boundary.rs
@@ -5,7 +5,7 @@ use crate::panes::PositionAndSize;
 use crate::tests::fakes::FakeInputOutput;
 use crate::tests::utils::commands::{
     PANE_MODE, QUIT, RESIZE_DOWN_IN_RESIZE_MODE, RESIZE_MODE, SPAWN_TERMINAL_IN_PANE_MODE,
-    TOGGLE_ACTIVE_TERMINAL_FULLSCREEN_IN_PANE_MODE,
+    TOGGLE_ACTIVE_TERMINAL_FULLSCREEN_IN_PANE_MODE, SLEEP,
 };
 use crate::tests::utils::{get_next_to_last_snapshot, get_output_frame_snapshots};
 use crate::{start, CliArgs};
@@ -23,7 +23,7 @@ pub fn new_panes_are_open_inside_expansion_border() {
         y: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    fake_input_output.add_terminal_input(&[&PANE_MODE, &SPAWN_TERMINAL_IN_PANE_MODE, &QUIT]);
+    fake_input_output.add_terminal_input(&[&PANE_MODE, &SPAWN_TERMINAL_IN_PANE_MODE, &SLEEP, &QUIT]);
     let mut opts = CliArgs::default();
     opts.layout = Some(PathBuf::from(
         "src/tests/fixtures/layouts/expansion-boundary-in-the-middle.yaml",
@@ -55,6 +55,7 @@ pub fn resize_pane_inside_expansion_border() {
         &SPAWN_TERMINAL_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_DOWN_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
     let mut opts = CliArgs::default();
@@ -87,6 +88,7 @@ pub fn toggling_fullcsreen_in_expansion_border_expands_only_until_border() {
         &PANE_MODE,
         &SPAWN_TERMINAL_IN_PANE_MODE,
         &TOGGLE_ACTIVE_TERMINAL_FULLSCREEN_IN_PANE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
     let mut opts = CliArgs::default();

--- a/src/tests/integration/expansion_boundary.rs
+++ b/src/tests/integration/expansion_boundary.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 use crate::panes::PositionAndSize;
 use crate::tests::fakes::FakeInputOutput;
 use crate::tests::utils::commands::{
-    PANE_MODE, QUIT, RESIZE_DOWN_IN_RESIZE_MODE, RESIZE_MODE, SPAWN_TERMINAL_IN_PANE_MODE,
-    TOGGLE_ACTIVE_TERMINAL_FULLSCREEN_IN_PANE_MODE, SLEEP,
+    PANE_MODE, QUIT, RESIZE_DOWN_IN_RESIZE_MODE, RESIZE_MODE, SLEEP, SPAWN_TERMINAL_IN_PANE_MODE,
+    TOGGLE_ACTIVE_TERMINAL_FULLSCREEN_IN_PANE_MODE,
 };
 use crate::tests::utils::{get_next_to_last_snapshot, get_output_frame_snapshots};
 use crate::{start, CliArgs};
@@ -23,7 +23,12 @@ pub fn new_panes_are_open_inside_expansion_border() {
         y: 0,
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
-    fake_input_output.add_terminal_input(&[&PANE_MODE, &SPAWN_TERMINAL_IN_PANE_MODE, &SLEEP, &QUIT]);
+    fake_input_output.add_terminal_input(&[
+        &PANE_MODE,
+        &SPAWN_TERMINAL_IN_PANE_MODE,
+        &SLEEP,
+        &QUIT,
+    ]);
     let mut opts = CliArgs::default();
     opts.layout = Some(PathBuf::from(
         "src/tests/fixtures/layouts/expansion-boundary-in-the-middle.yaml",

--- a/src/tests/integration/resize_down.rs
+++ b/src/tests/integration/resize_down.rs
@@ -7,7 +7,8 @@ use crate::{start, CliArgs};
 
 use crate::tests::utils::commands::{
     MOVE_FOCUS_IN_PANE_MODE, PANE_MODE, QUIT, RESIZE_DOWN_IN_RESIZE_MODE,
-    RESIZE_LEFT_IN_RESIZE_MODE, RESIZE_MODE, SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE, SLEEP
+    RESIZE_LEFT_IN_RESIZE_MODE, RESIZE_MODE, SLEEP, SPLIT_DOWN_IN_PANE_MODE,
+    SPLIT_RIGHT_IN_PANE_MODE,
 };
 
 fn get_fake_os_input(fake_win_size: &PositionAndSize) -> FakeInputOutput {

--- a/src/tests/integration/resize_down.rs
+++ b/src/tests/integration/resize_down.rs
@@ -7,7 +7,7 @@ use crate::{start, CliArgs};
 
 use crate::tests::utils::commands::{
     MOVE_FOCUS_IN_PANE_MODE, PANE_MODE, QUIT, RESIZE_DOWN_IN_RESIZE_MODE,
-    RESIZE_LEFT_IN_RESIZE_MODE, RESIZE_MODE, SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE,
+    RESIZE_LEFT_IN_RESIZE_MODE, RESIZE_MODE, SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE, SLEEP
 };
 
 fn get_fake_os_input(fake_win_size: &PositionAndSize) -> FakeInputOutput {
@@ -37,6 +37,7 @@ pub fn resize_down_with_pane_above() {
         &SPLIT_DOWN_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_DOWN_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
     start(Box::new(fake_input_output.clone()), CliArgs::default());
@@ -75,6 +76,7 @@ pub fn resize_down_with_pane_below() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_DOWN_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
     start(Box::new(fake_input_output.clone()), CliArgs::default());
@@ -118,6 +120,7 @@ pub fn resize_down_with_panes_above_and_below() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_DOWN_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
     start(Box::new(fake_input_output.clone()), CliArgs::default());
@@ -160,6 +163,7 @@ pub fn resize_down_with_multiple_panes_above() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_DOWN_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -205,6 +209,7 @@ pub fn resize_down_with_panes_above_aligned_left_with_current_pane() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_DOWN_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -249,6 +254,7 @@ pub fn resize_down_with_panes_below_aligned_left_with_current_pane() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_DOWN_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -291,6 +297,7 @@ pub fn resize_down_with_panes_above_aligned_right_with_current_pane() {
         &SPLIT_DOWN_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_DOWN_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -334,6 +341,7 @@ pub fn resize_down_with_panes_below_aligned_right_with_current_pane() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_DOWN_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -380,6 +388,7 @@ pub fn resize_down_with_panes_above_aligned_left_and_right_with_current_pane() {
         &SPLIT_DOWN_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_DOWN_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -428,6 +437,7 @@ pub fn resize_down_with_panes_below_aligned_left_and_right_with_current_pane() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_DOWN_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -493,6 +503,7 @@ pub fn resize_down_with_panes_above_aligned_left_and_right_with_panes_to_the_lef
         &RESIZE_LEFT_IN_RESIZE_MODE,
         &RESIZE_LEFT_IN_RESIZE_MODE,
         &RESIZE_DOWN_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -560,6 +571,7 @@ pub fn resize_down_with_panes_below_aligned_left_and_right_with_to_the_left_and_
         &RESIZE_LEFT_IN_RESIZE_MODE,
         &RESIZE_LEFT_IN_RESIZE_MODE,
         &RESIZE_DOWN_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -596,6 +608,7 @@ pub fn cannot_resize_down_when_pane_below_is_at_minimum_height() {
         &SPLIT_DOWN_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_DOWN_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
     start(Box::new(fake_input_output.clone()), CliArgs::default());

--- a/src/tests/integration/resize_left.rs
+++ b/src/tests/integration/resize_left.rs
@@ -7,7 +7,7 @@ use crate::{start, CliArgs};
 
 use crate::tests::utils::commands::{
     MOVE_FOCUS_IN_PANE_MODE, PANE_MODE, QUIT, RESIZE_LEFT_IN_RESIZE_MODE, RESIZE_MODE,
-    RESIZE_UP_IN_RESIZE_MODE, SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE,
+    RESIZE_UP_IN_RESIZE_MODE, SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE, SLEEP
 };
 
 fn get_fake_os_input(fake_win_size: &PositionAndSize) -> FakeInputOutput {
@@ -34,6 +34,7 @@ pub fn resize_left_with_pane_to_the_left() {
         &SPLIT_RIGHT_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_LEFT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
     start(Box::new(fake_input_output.clone()), CliArgs::default());
@@ -70,6 +71,7 @@ pub fn resize_left_with_pane_to_the_right() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_LEFT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
     start(Box::new(fake_input_output.clone()), CliArgs::default());
@@ -108,6 +110,7 @@ pub fn resize_left_with_panes_to_the_left_and_right() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_LEFT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
     start(Box::new(fake_input_output.clone()), CliArgs::default());
@@ -148,6 +151,7 @@ pub fn resize_left_with_multiple_panes_to_the_left() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_LEFT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -191,6 +195,7 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_with_current_pane() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_LEFT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -231,6 +236,7 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_with_current_pane() {
         &SPLIT_DOWN_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_LEFT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -273,6 +279,7 @@ pub fn resize_left_with_panes_to_the_left_aligned_bottom_with_current_pane() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_LEFT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -314,6 +321,7 @@ pub fn resize_left_with_panes_to_the_right_aligned_bottom_with_current_pane() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_LEFT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -360,6 +368,7 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_and_bottom_with_current_pa
         &SPLIT_RIGHT_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_LEFT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -408,6 +417,7 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_and_bottom_with_current_p
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_LEFT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -473,6 +483,7 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_and_bottom_with_panes_abov
         &RESIZE_UP_IN_RESIZE_MODE,
         &RESIZE_UP_IN_RESIZE_MODE,
         &RESIZE_LEFT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -541,6 +552,7 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_and_bottom_with_panes_abo
         &RESIZE_UP_IN_RESIZE_MODE,
         &RESIZE_UP_IN_RESIZE_MODE,
         &RESIZE_LEFT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -577,6 +589,7 @@ pub fn cannot_resize_left_when_pane_to_the_left_is_at_minimum_width() {
         &SPLIT_RIGHT_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_LEFT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
     start(Box::new(fake_input_output.clone()), CliArgs::default());

--- a/src/tests/integration/resize_left.rs
+++ b/src/tests/integration/resize_left.rs
@@ -7,7 +7,7 @@ use crate::{start, CliArgs};
 
 use crate::tests::utils::commands::{
     MOVE_FOCUS_IN_PANE_MODE, PANE_MODE, QUIT, RESIZE_LEFT_IN_RESIZE_MODE, RESIZE_MODE,
-    RESIZE_UP_IN_RESIZE_MODE, SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE, SLEEP
+    RESIZE_UP_IN_RESIZE_MODE, SLEEP, SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE,
 };
 
 fn get_fake_os_input(fake_win_size: &PositionAndSize) -> FakeInputOutput {

--- a/src/tests/integration/resize_right.rs
+++ b/src/tests/integration/resize_right.rs
@@ -7,7 +7,7 @@ use crate::{start, CliArgs};
 
 use crate::tests::utils::commands::{
     MOVE_FOCUS_IN_PANE_MODE, PANE_MODE, QUIT, RESIZE_MODE, RESIZE_RIGHT_IN_RESIZE_MODE,
-    RESIZE_UP_IN_RESIZE_MODE, SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE, SLEEP
+    RESIZE_UP_IN_RESIZE_MODE, SLEEP, SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE,
 };
 
 fn get_fake_os_input(fake_win_size: &PositionAndSize) -> FakeInputOutput {

--- a/src/tests/integration/resize_right.rs
+++ b/src/tests/integration/resize_right.rs
@@ -7,7 +7,7 @@ use crate::{start, CliArgs};
 
 use crate::tests::utils::commands::{
     MOVE_FOCUS_IN_PANE_MODE, PANE_MODE, QUIT, RESIZE_MODE, RESIZE_RIGHT_IN_RESIZE_MODE,
-    RESIZE_UP_IN_RESIZE_MODE, SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE,
+    RESIZE_UP_IN_RESIZE_MODE, SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE, SLEEP
 };
 
 fn get_fake_os_input(fake_win_size: &PositionAndSize) -> FakeInputOutput {
@@ -34,6 +34,7 @@ pub fn resize_right_with_pane_to_the_left() {
         &SPLIT_RIGHT_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_RIGHT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
     start(Box::new(fake_input_output.clone()), CliArgs::default());
@@ -70,6 +71,7 @@ pub fn resize_right_with_pane_to_the_right() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_RIGHT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
     start(Box::new(fake_input_output.clone()), CliArgs::default());
@@ -108,6 +110,7 @@ pub fn resize_right_with_panes_to_the_left_and_right() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_RIGHT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
     start(Box::new(fake_input_output.clone()), CliArgs::default());
@@ -148,6 +151,7 @@ pub fn resize_right_with_multiple_panes_to_the_left() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_RIGHT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -191,6 +195,7 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_with_current_pane() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_RIGHT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -231,6 +236,7 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_with_current_pane() {
         &SPLIT_DOWN_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_RIGHT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -273,6 +279,7 @@ pub fn resize_right_with_panes_to_the_left_aligned_bottom_with_current_pane() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_RIGHT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -314,6 +321,7 @@ pub fn resize_right_with_panes_to_the_right_aligned_bottom_with_current_pane() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_RIGHT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -360,6 +368,7 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_and_bottom_with_current_p
         &SPLIT_RIGHT_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_RIGHT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -408,6 +417,7 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_and_bottom_with_current_
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_RIGHT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -473,6 +483,7 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_and_bottom_with_panes_abo
         &RESIZE_UP_IN_RESIZE_MODE,
         &RESIZE_UP_IN_RESIZE_MODE,
         &RESIZE_RIGHT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -540,6 +551,7 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_and_bottom_with_panes_ab
         &RESIZE_UP_IN_RESIZE_MODE,
         &RESIZE_UP_IN_RESIZE_MODE,
         &RESIZE_RIGHT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -576,6 +588,7 @@ pub fn cannot_resize_right_when_pane_to_the_left_is_at_minimum_width() {
         &SPLIT_RIGHT_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_RIGHT_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
     start(Box::new(fake_input_output.clone()), CliArgs::default());

--- a/src/tests/integration/resize_up.rs
+++ b/src/tests/integration/resize_up.rs
@@ -7,7 +7,7 @@ use crate::{start, CliArgs};
 
 use crate::tests::utils::commands::{
     MOVE_FOCUS_IN_PANE_MODE, PANE_MODE, QUIT, RESIZE_LEFT_IN_RESIZE_MODE, RESIZE_MODE,
-    RESIZE_UP_IN_RESIZE_MODE, SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE,
+    RESIZE_UP_IN_RESIZE_MODE, SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE, SLEEP
 };
 
 fn get_fake_os_input(fake_win_size: &PositionAndSize) -> FakeInputOutput {
@@ -36,6 +36,7 @@ pub fn resize_up_with_pane_above() {
         &SPLIT_DOWN_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_UP_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
     start(Box::new(fake_input_output.clone()), CliArgs::default());
@@ -74,6 +75,7 @@ pub fn resize_up_with_pane_below() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_UP_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
     start(Box::new(fake_input_output.clone()), CliArgs::default());
@@ -117,6 +119,7 @@ pub fn resize_up_with_panes_above_and_below() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_UP_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
     start(Box::new(fake_input_output.clone()), CliArgs::default());
@@ -158,6 +161,7 @@ pub fn resize_up_with_multiple_panes_above() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_UP_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -201,6 +205,7 @@ pub fn resize_up_with_panes_above_aligned_left_with_current_pane() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_UP_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -245,6 +250,7 @@ pub fn resize_up_with_panes_below_aligned_left_with_current_pane() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_UP_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -287,6 +293,7 @@ pub fn resize_up_with_panes_above_aligned_right_with_current_pane() {
         &SPLIT_DOWN_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_UP_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -330,6 +337,7 @@ pub fn resize_up_with_panes_below_aligned_right_with_current_pane() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_UP_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -376,6 +384,7 @@ pub fn resize_up_with_panes_above_aligned_left_and_right_with_current_pane() {
         &SPLIT_DOWN_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_UP_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -424,6 +433,7 @@ pub fn resize_up_with_panes_below_aligned_left_and_right_with_current_pane() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_UP_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -489,6 +499,7 @@ pub fn resize_up_with_panes_above_aligned_left_and_right_with_panes_to_the_left_
         &RESIZE_LEFT_IN_RESIZE_MODE,
         &RESIZE_LEFT_IN_RESIZE_MODE,
         &RESIZE_UP_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -556,6 +567,7 @@ pub fn resize_up_with_panes_below_aligned_left_and_right_with_to_the_left_and_ri
         &RESIZE_LEFT_IN_RESIZE_MODE,
         &RESIZE_LEFT_IN_RESIZE_MODE,
         &RESIZE_UP_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
 
@@ -592,6 +604,7 @@ pub fn cannot_resize_up_when_pane_above_is_at_minimum_height() {
         &SPLIT_DOWN_IN_PANE_MODE,
         &RESIZE_MODE,
         &RESIZE_UP_IN_RESIZE_MODE,
+        &SLEEP,
         &QUIT,
     ]);
     start(Box::new(fake_input_output.clone()), CliArgs::default());

--- a/src/tests/integration/resize_up.rs
+++ b/src/tests/integration/resize_up.rs
@@ -7,7 +7,7 @@ use crate::{start, CliArgs};
 
 use crate::tests::utils::commands::{
     MOVE_FOCUS_IN_PANE_MODE, PANE_MODE, QUIT, RESIZE_LEFT_IN_RESIZE_MODE, RESIZE_MODE,
-    RESIZE_UP_IN_RESIZE_MODE, SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE, SLEEP
+    RESIZE_UP_IN_RESIZE_MODE, SLEEP, SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE,
 };
 
 fn get_fake_os_input(fake_win_size: &PositionAndSize) -> FakeInputOutput {

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -76,4 +76,5 @@ pub mod commands {
     pub const SWITCH_NEXT_TAB_IN_TAB_MODE: [u8; 1] = [108]; // l
     pub const SWITCH_PREV_TAB_IN_TAB_MODE: [u8; 1] = [104]; // h
     pub const CLOSE_TAB_IN_TAB_MODE: [u8; 1] = [120]; // x
+    pub const SLEEP: [u8; 0] = [];
 }


### PR DESCRIPTION
Previously we re-rendered every pane upon any change to any pane.
Now we only re-render those panes which changed.

This change additionally reduces some unneeded renders (eg. when resizing - we rely on the panes updating themselves when we send them a SIGWINCH instead). For this reason the tests had to be adjusted to add some sleeps (otherwise there would not be enough time to wait until the panes are updated and the resize would not be rendered).