### PR TITLE
Fix(strider): Ignore descending into empty dir

### DIFF
--- a/default-tiles/strider/src/main.rs
+++ b/default-tiles/strider/src/main.rs
@@ -23,7 +23,7 @@ impl ZellijTile for State {
                     let next = self.selected().saturating_add(1);
                     *self.selected_mut() = min(self.files.len() - 1, next);
                 }
-                Key::Right | Key::Char('\n') | Key::Char('l') => {
+                Key::Right | Key::Char('\n') | Key::Char('l') if !self.files.is_empty() => {
                     match self.files[self.selected()].clone() {
                         FsEntry::Dir(p, _) => {
                             self.path = p;


### PR DESCRIPTION
Adds a guard to check if the directory is empty before
trying to descend into it.

Eg:
Doesn't error anymore, if inside ./git/branches directory
and pressing `l`.