### PR TITLE
Fix(Mouse): Remove unimplemented! Macro for Mouse

### DIFF
--- a/src/common/input/handler.rs
+++ b/src/common/input/handler.rs
@@ -81,7 +81,8 @@ impl InputHandler {
                             }
                             termion::event::Event::Mouse(_)
                             | termion::event::Event::Unsupported(_) => {
-                                unimplemented!("Mouse and unsupported events aren't supported!");
+                                // Mouse and unsupported events aren't implemented yet,
+                                // use a NoOp untill then.
                             }
                         },
                         Err(err) => panic!("Encountered read error: {:?}", err),


### PR DESCRIPTION
Remove `unimplemented!` macro for mouse and unsupported events,
essentialy mimicking the NoOp.

Should not crash anymore when handling mouse events.

Alternatives:
Keep the `unimplemented!` macro for `termion::event::Event::Unsupported` ?

closes #243