### PR TITLE
fix(terminal): do not hang app if terminal refuses to quit

### DIFF
--- a/src/common/command_is_executing.rs
+++ b/src/common/command_is_executing.rs
@@ -23,7 +23,7 @@ impl CommandIsExecuting {
         let (lock, cvar) = &*self.closing_pane;
         let mut closing_pane = lock.lock().unwrap();
         *closing_pane = false;
-        cvar.notify_one();
+        cvar.notify_all();
     }
     pub fn opening_new_pane(&mut self) {
         let (lock, _cvar) = &*self.opening_new_pane;
@@ -34,7 +34,7 @@ impl CommandIsExecuting {
         let (lock, cvar) = &*self.opening_new_pane;
         let mut opening_new_pane = lock.lock().unwrap();
         *opening_new_pane = false;
-        cvar.notify_one();
+        cvar.notify_all();
     }
     pub fn wait_until_pane_is_closed(&self) {
         let (lock, cvar) = &*self.closing_pane;

--- a/src/common/os_input_output.rs
+++ b/src/common/os_input_output.rs
@@ -242,7 +242,13 @@ impl OsApi for OsInputOutput {
         Box::new(stdout)
     }
     fn kill(&mut self, pid: RawFd) -> Result<(), nix::Error> {
-        kill(Pid::from_raw(pid), Some(Signal::SIGINT)).unwrap();
+        // TODO:
+        // Ideally, we should be using SIGINT rather than SIGKILL here, but there are cases in which
+        // the terminal we're trying to kill hangs on SIGINT and so all the app gets stuck
+        // that's why we're sending SIGKILL here
+        // A better solution would be to send SIGINT here and not wait for it, and then have
+        // a background thread do the waitpid stuff and send SIGKILL if the process is stuck
+        kill(Pid::from_raw(pid), Some(Signal::SIGKILL)).unwrap();
         waitpid(Pid::from_raw(pid), None).unwrap();
         Ok(())
     }


### PR DESCRIPTION
This bug happened when we opened lots of new panes very quickly and there was no room for the last new pane. The app would try to kill the new pty that was opened, but would hang waiting for it - thus causing the whole app to be stuck.

I fixed this by sending a `SIGKILL` instead of  `SIGINT` to the pty (essentially the equivalent of doing `kill -9` instead of just `kill`). This is not an ideal solution (as mentioned in the comment I left) but solves the problem for now. A better and more involved solution is suggested in the comment for a future iteration.