### PR TITLE
CI workflow for automatic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,99 +1,80 @@
-name: Packaging
+# The way this works is the following:
+#
+# Reference:
+# - https://eugene-babichenko.github.io/blog/2020/05/09/github-actions-cross-platform-auto-releases/
 
+name: release
 on:
   push:
     tags:
       - 'v*.*.*'
-
 jobs:
-  publish:
-    name: Publish on ${{ matrix.os }} for ${{ matrix.target }}
+  build-release:
+    name: build-release
     runs-on: ${{ matrix.os }}
+    env:
+      RUST_BACKTRACE: 1
     strategy:
       matrix:
-        target:
-            - x86_64-unknown-linux-gnu
-            - x86_64-unknown-linux-musl
-            - x86_64-apple-darwin
-
+        build:
+          - linux musl x64
+          - macos x64
         include:
-          - os: ubuntu-18.04
-            target: x86_64-unknown-linux-gnu
-            client_artifact_name: target/x86_64-unknown-linux-gnu/release/mosaic
-            client_release_name: mosaic-x86_64-unknown-linux-gnu
-            strip: true
-
-          - os: ubuntu-18.04
+          - build: linux musl x64
+            os: ubuntu-latest
+            rust: stable
             target: x86_64-unknown-linux-musl
-            client_artifact_name: target/x86_64-unknown-linux-musl/release/mosaic
-            client_release_name: mosaic-x86_64-unknown-linux-musl
-            strip: true
-
-          - os: macos-latest
+          - build: macos x64
+            os: macos-latest
+            rust: stable
             target: x86_64-apple-darwin
-            client_artifact_name: target/x86_64-apple-darwin/release/mosaic
-            client_release_name: mosaic-x86_64-macos-darwin
-            strip: true
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-    - name: Setup Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        target: ${{ matrix.target }}
-        override: true
-
-    - name: Install musl
-      if: matrix.target == 'x86_64-unknown-linux-musl'
-      run: |
-        sudo apt update
-        sudo apt install musl-tools -y
-
-    - name: cargo build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --release --locked --target=${{ matrix.target }}
-
-
-    - name: Compress client
-      uses: svenstaro/upx-action@v2
-      with:
-        file: ${{ matrix.client_artifact_name }}
-        args: --lzma
-        strip: ${{ matrix.strip }}
-
-
-    # TODO?
-    # - name: Get CHANGELOG.md entry
-    #   id: changelog_reader
-    #   uses: mindsers/changelog-reader-action@v1.2.0
-    #   with:
-    #     path: ./CHANGELOG.md
-
-    - name: Upload client binaries to release
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ${{ matrix.client_artifact_name }}
-        asset_name: ${{ matrix.client_release_name }}
-        tag: ${{ github.ref }}
-
-  deb-build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - name: Deb Build
-        uses: ebbflow-io/cargo-deb-amd64-ubuntu@1.0
-
-      - name: Upload deb to release
-        uses: svenstaro/upload-release-action@v2
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: target/x86_64-unknown-linux-musl/debian/mosaic*
-          asset_name: mosaic-amd64.deb
-          tag: ${{ github.ref }}
-          file_glob: true
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+          override: true
+          target: ${{ matrix.target }}
+
+      - name: Add WASM target
+        run: rustup target add wasm32-wasi
+
+      - name: Install cargo-make
+        run: cargo install --debug cargo-make
+
+      - name: Install musl-tools
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get install -y --no-install-recommends musl-tools
+
+      - name: Install wasm-opt
+        run: brew install binaryen
+
+      - name: Build release binary
+        run: cargo make ci-build-release ${{ matrix.target }}
+
+      - name: Strip release binary
+        run: strip "target/${{ matrix.target }}/release/zellij"
+        
+      - name: Tar release
+        working-directory: ./target/${{ matrix.target }}/release
+        run: tar cvfz zellij-v${{ github.event.release.tag_name }}-${{matrix.target}}.tar.gz "zellij"
+  upload:
+    name: upload files
+    runs-on: ubuntu-latest
+    needs: build-release
+    steps:   
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: | 
+            target/${{ matrix.target }}/release/zellij
+            zellij-v${{ github.event.release.tag_name }}-${{matrix.target}}.tar.gz
+


### PR DESCRIPTION
This isn't ready but some work went to it, based heavily on stuff from  Bandwhich and online. 
In order to continue this work, we should cache builds and control output file names 