### PR TITLE
Reduce crate size by 4.8MB using `cargo diet`, to 77kB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "A terminal workspace with batteries included"
 license = "MIT"
 repository = "https://github.com/zellij-org/zellij"
 homepage = "https://zellij.dev"
-include = ["src/**/*", "assets/plugins/*", "assets/layouts/*", "assets/completions/*", "LICENSE.md", "README.md", "build.rs", "!**/*_test.*", "!**/tests/**/*"]
+include = ["src/**/*", "assets/plugins/*", "assets/layouts/*", "LICENSE.md", "README.md", "!**/*_test.*", "!**/tests/**/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "A terminal workspace with batteries included"
 license = "MIT"
 repository = "https://github.com/zellij-org/zellij"
 homepage = "https://zellij.dev"
+include = ["src/**/*", "assets/plugins/*", "assets/layouts/*", "assets/completions/*", "LICENSE.md", "README.md", "build.rs", "!**/*_test.*", "!**/tests/**/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Here is my call to action :D: 
<img width="275" alt="Screenshot 2021-04-21 at 09 25 07" src="https://user-images.githubusercontent.com/63622/115483489-79a1e280-a283-11eb-8af4-f27840c1ef2c.png">


On top of that I verified that `cargo package` is still able to build,
adjusting the includes in the process to assure required assets are
packaged, too.

I am happy to adjust the includes to your liking so we find a way to reduce the overall crate size.