### PR TITLE
fix(ci): use `actions/upload-artifact` action (#279)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,20 +61,29 @@ jobs:
         run: strip "target/${{ matrix.target }}/release/zellij"
         
       - name: Tar release
+        id: make-artifact
         working-directory: ./target/${{ matrix.target }}/release
-        run: tar cvfz zellij-v${{ github.event.release.tag_name }}-${{matrix.target}}.tar.gz "zellij"
+        run: |
+          name="zellij-${GITHUB_REF#refs/tags/}-${{ matrix.target }}.tar.gz"
+          tar cvfz "${name}" "zellij"
+          echo "::set-output name=name::${name}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: target/${{ matrix.target }}/release/${{ steps.make-artifact.outputs.name }}
   upload:
     name: upload files
     runs-on: ubuntu-latest
     needs: build-release
     steps:   
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: | 
-            target/${{ matrix.target }}/release/zellij
-            zellij-v${{ github.event.release.tag_name }}-${{matrix.target}}.tar.gz
+          files: artifact/*
 


### PR DESCRIPTION
This fixes the GitHub Actions workflow of #279.

Each job in a GitHub Actions workflow runs in a fresh instance of the virtual environment and does not share artifacts with previous jobs by default. You need to use [`actions/upload-artifact`] to share artifacts between jobs.

[`actions/upload-artifact`]: <https://github.com/actions/upload-artifact>