### PR TITLE
feat(ci): build release binary for `aarch64-apple-darwin` (#279)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         build:
           - linux musl x64
           - macos x64
+          - macos aarch64
         include:
           - build: linux musl x64
             os: ubuntu-latest
@@ -28,6 +29,10 @@ jobs:
             os: macos-latest
             rust: stable
             target: x86_64-apple-darwin
+          - build: macos aarch64
+            os: macos-latest
+            rust: stable
+            target: aarch64-apple-darwin
 
     steps:
       - name: Checkout repository
@@ -53,6 +58,14 @@ jobs:
 
       - name: Install wasm-opt
         run: brew install binaryen
+
+      # Workaround for <https://github.com/actions/virtual-environments/issues/2557>
+      - name: Switch Xcode SDK
+        if: runner.os == 'macos'
+        run: |
+          cat <<EOF >> "$GITHUB_ENV"
+          SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+          EOF
 
       - name: Build release binary
         run: cargo make ci-build-release ${{ matrix.target }}


### PR DESCRIPTION
This adds `aarch64-apple-darwin` (Apple Silicon macOS) target support to #279.

I don't have an Apple Silicon Mac and didn't verify that the binary actually works, but it at least compiles fine.

Cc @qballer.