### PR TITLE
fix(ui): draw ui properly on terminal start

### DIFF
--- a/src/client/layout.rs
+++ b/src/client/layout.rs
@@ -20,7 +20,7 @@ fn split_space_to_parts_vertically(
         let (columns, max_columns) = match size {
             Some(SplitSize::Percent(percent)) => {
                 ((max_width as f32 * (percent as f32 / 100.0)) as usize, None)
-            }, // TODO: round properly
+            } // TODO: round properly
             Some(SplitSize::Fixed(size)) => (size as usize, Some(size as usize)),
             None => {
                 parts_to_grow.push(current_x_position);
@@ -86,9 +86,10 @@ fn split_space_to_parts_horizontally(
 
     for size in sizes {
         let (rows, max_rows) = match size {
-            Some(SplitSize::Percent(percent)) => {
-                ((max_height as f32 * (percent as f32 / 100.0)) as usize, None)
-            }, // TODO: round properly
+            Some(SplitSize::Percent(percent)) => (
+                (max_height as f32 * (percent as f32 / 100.0)) as usize,
+                None,
+            ), // TODO: round properly
             Some(SplitSize::Fixed(size)) => (size as usize, Some(size as usize)),
             None => {
                 parts_to_grow.push(current_y_position);

--- a/src/client/layout.rs
+++ b/src/client/layout.rs
@@ -17,14 +17,17 @@ fn split_space_to_parts_vertically(
 
     // First fit in the parameterized sizes
     for size in sizes {
-        let columns = match size {
+        let (columns, max_columns) = match size {
             Some(SplitSize::Percent(percent)) => {
-                (max_width as f32 * (percent as f32 / 100.0)) as usize
-            } // TODO: round properly
-            Some(SplitSize::Fixed(size)) => size as usize,
+                ((max_width as f32 * (percent as f32 / 100.0)) as usize, None)
+            }, // TODO: round properly
+            Some(SplitSize::Fixed(size)) => (size as usize, Some(size as usize)),
             None => {
                 parts_to_grow.push(current_x_position);
-                1 // This is grown later on
+                (
+                    1, // This is grown later on
+                    None,
+                )
             }
         };
         split_parts.push(PositionAndSize {
@@ -32,6 +35,8 @@ fn split_space_to_parts_vertically(
             y: space_to_split.y,
             columns,
             rows: space_to_split.rows,
+            max_columns,
+            ..Default::default()
         });
         current_width += columns;
         current_x_position += columns + 1; // 1 for gap
@@ -80,14 +85,17 @@ fn split_space_to_parts_horizontally(
     let mut parts_to_grow = Vec::new();
 
     for size in sizes {
-        let rows = match size {
+        let (rows, max_rows) = match size {
             Some(SplitSize::Percent(percent)) => {
-                (max_height as f32 * (percent as f32 / 100.0)) as usize
-            } // TODO: round properly
-            Some(SplitSize::Fixed(size)) => size as usize,
+                ((max_height as f32 * (percent as f32 / 100.0)) as usize, None)
+            }, // TODO: round properly
+            Some(SplitSize::Fixed(size)) => (size as usize, Some(size as usize)),
             None => {
                 parts_to_grow.push(current_y_position);
-                1 // This is grown later on
+                (
+                    1, // This is grown later on
+                    None,
+                )
             }
         };
         split_parts.push(PositionAndSize {
@@ -95,6 +103,8 @@ fn split_space_to_parts_horizontally(
             y: current_y_position,
             columns: space_to_split.columns,
             rows,
+            max_rows,
+            ..Default::default()
         });
         current_height += rows;
         current_y_position += rows + 1; // 1 for gap

--- a/src/client/panes/plugin_pane.rs
+++ b/src/client/panes/plugin_pane.rs
@@ -13,6 +13,7 @@ pub struct PluginPane {
     pub position_and_size_override: Option<PositionAndSize>,
     pub send_plugin_instructions: SenderWithContext<PluginInstruction>,
     pub max_height: Option<usize>,
+    pub max_width: Option<usize>,
 }
 
 impl PluginPane {
@@ -30,6 +31,7 @@ impl PluginPane {
             position_and_size_override: None,
             send_plugin_instructions,
             max_height: None,
+            max_width: None,
         }
     }
 }
@@ -73,6 +75,7 @@ impl Pane for PluginPane {
             y,
             rows: size.rows,
             columns: size.columns,
+            ..Default::default()
         };
         self.position_and_size_override = Some(position_and_size_override);
         self.should_render = true;
@@ -107,6 +110,9 @@ impl Pane for PluginPane {
     }
     fn set_max_height(&mut self, max_height: usize) {
         self.max_height = Some(max_height);
+    }
+    fn set_max_width(&mut self, max_width: usize) {
+        self.max_width = Some(max_width);
     }
     fn render(&mut self) -> Option<String> {
         // if self.should_render {
@@ -194,6 +200,9 @@ impl Pane for PluginPane {
     }
     fn max_height(&self) -> Option<usize> {
         self.max_height
+    }
+    fn max_width(&self) -> Option<usize> {
+        self.max_width
     }
     fn invisible_borders(&self) -> bool {
         self.invisible_borders

--- a/src/client/panes/terminal_pane.rs
+++ b/src/client/panes/terminal_pane.rs
@@ -23,6 +23,8 @@ pub struct PositionAndSize {
     pub y: usize,
     pub rows: usize,
     pub columns: usize,
+    pub max_rows: Option<usize>,
+    pub max_columns: Option<usize>,
 }
 
 impl From<Winsize> for PositionAndSize {
@@ -42,6 +44,7 @@ pub struct TerminalPane {
     pub position_and_size: PositionAndSize,
     pub position_and_size_override: Option<PositionAndSize>,
     pub max_height: Option<usize>,
+    pub max_width: Option<usize>,
     vte_parser: vte::Parser,
 }
 
@@ -73,6 +76,7 @@ impl Pane for TerminalPane {
             y,
             rows: size.rows,
             columns: size.columns,
+            ..Default::default()
         };
         self.position_and_size_override = Some(position_and_size_override);
         self.reflow_lines();
@@ -147,11 +151,17 @@ impl Pane for TerminalPane {
     fn set_max_height(&mut self, max_height: usize) {
         self.max_height = Some(max_height);
     }
+    fn set_max_width(&mut self, max_width: usize) {
+        self.max_width = Some(max_width);
+    }
     fn set_invisible_borders(&mut self, _invisible_borders: bool) {
         unimplemented!();
     }
     fn max_height(&self) -> Option<usize> {
         self.max_height
+    }
+    fn max_width(&self) -> Option<usize> {
+        self.max_width
     }
     fn render(&mut self) -> Option<String> {
         // FIXME:
@@ -284,6 +294,7 @@ impl TerminalPane {
             position_and_size,
             position_and_size_override: None,
             max_height: None,
+            max_width: None,
             vte_parser: vte::Parser::new(),
         }
     }

--- a/src/tests/integration/basic.rs
+++ b/src/tests/integration/basic.rs
@@ -22,6 +22,7 @@ pub fn starts_with_one_terminal() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[&QUIT]);
@@ -44,6 +45,7 @@ pub fn split_terminals_vertically() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[&PANE_MODE, &SPLIT_RIGHT_IN_PANE_MODE, &QUIT]);
@@ -66,6 +68,7 @@ pub fn split_terminals_horizontally() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[&PANE_MODE, &SPLIT_DOWN_IN_PANE_MODE, &QUIT]);
@@ -89,6 +92,7 @@ pub fn split_largest_terminal() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -117,6 +121,7 @@ pub fn cannot_split_terminals_vertically_when_active_terminal_is_too_small() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[&PANE_MODE, &SPLIT_RIGHT_IN_PANE_MODE, &QUIT]);
@@ -139,6 +144,7 @@ pub fn cannot_split_terminals_horizontally_when_active_terminal_is_too_small() {
         rows: 4,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[&PANE_MODE, &SPLIT_DOWN_IN_PANE_MODE, &QUIT]);
@@ -161,6 +167,7 @@ pub fn cannot_split_largest_terminal_when_there_is_no_room() {
         rows: 4,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[&PANE_MODE, &SPAWN_TERMINAL_IN_PANE_MODE, &QUIT]);
@@ -183,6 +190,7 @@ pub fn scrolling_up_inside_a_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -213,6 +221,7 @@ pub fn scrolling_down_inside_a_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -245,6 +254,7 @@ pub fn scrolling_page_up_inside_a_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -274,6 +284,7 @@ pub fn scrolling_page_down_inside_a_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -308,6 +319,7 @@ pub fn max_panes() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -339,6 +351,7 @@ pub fn toggle_focused_pane_fullscreen() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[

--- a/src/tests/integration/close_pane.rs
+++ b/src/tests/integration/close_pane.rs
@@ -30,6 +30,7 @@ pub fn close_pane_with_another_pane_above_it() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -66,6 +67,7 @@ pub fn close_pane_with_another_pane_below_it() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -101,6 +103,7 @@ pub fn close_pane_with_another_pane_to_the_left() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -135,6 +138,7 @@ pub fn close_pane_with_another_pane_to_the_right() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -172,6 +176,7 @@ pub fn close_pane_with_multiple_panes_above_it() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -212,6 +217,7 @@ pub fn close_pane_with_multiple_panes_below_it() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -250,6 +256,7 @@ pub fn close_pane_with_multiple_panes_to_the_left() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -290,6 +297,7 @@ pub fn close_pane_with_multiple_panes_to_the_right() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -328,6 +336,7 @@ pub fn close_pane_with_multiple_panes_above_it_away_from_screen_edges() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -388,6 +397,7 @@ pub fn close_pane_with_multiple_panes_below_it_away_from_screen_edges() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -446,6 +456,7 @@ pub fn close_pane_with_multiple_panes_to_the_left_away_from_screen_edges() {
         rows: 30,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -504,6 +515,7 @@ pub fn close_pane_with_multiple_panes_to_the_right_away_from_screen_edges() {
         rows: 30,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -552,6 +564,7 @@ pub fn closing_last_pane_exits_app() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[

--- a/src/tests/integration/compatibility.rs
+++ b/src/tests/integration/compatibility.rs
@@ -36,6 +36,7 @@ pub fn run_bandwhich_from_fish_shell() {
         rows: 28,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let fixture_name = "fish_and_bandwhich";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
@@ -59,6 +60,7 @@ pub fn fish_tab_completion_options() {
         rows: 28,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let fixture_name = "fish_tab_completion_options";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
@@ -87,6 +89,7 @@ pub fn fish_select_tab_completion_options() {
         rows: 28,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let fixture_name = "fish_select_tab_completion_options";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
@@ -119,6 +122,7 @@ pub fn vim_scroll_region_down() {
         rows: 28,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let fixture_name = "vim_scroll_region_down";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
@@ -148,6 +152,7 @@ pub fn vim_ctrl_d() {
         rows: 28,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let fixture_name = "vim_ctrl_d";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
@@ -176,6 +181,7 @@ pub fn vim_ctrl_u() {
         rows: 28,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let fixture_name = "vim_ctrl_u";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
@@ -199,6 +205,7 @@ pub fn htop() {
         rows: 28,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let fixture_name = "htop";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
@@ -222,6 +229,7 @@ pub fn htop_scrolling() {
         rows: 28,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let fixture_name = "htop_scrolling";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
@@ -245,6 +253,7 @@ pub fn htop_right_scrolling() {
         rows: 28,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let fixture_name = "htop_right_scrolling";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
@@ -276,6 +285,7 @@ pub fn vim_overwrite() {
         rows: 28,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let fixture_name = "vim_overwrite";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
@@ -302,6 +312,7 @@ pub fn clear_scroll_region() {
         rows: 28,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let fixture_name = "clear_scroll_region";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
@@ -325,6 +336,7 @@ pub fn display_tab_characters_properly() {
         rows: 28,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let fixture_name = "tab_characters";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
@@ -348,6 +360,7 @@ pub fn neovim_insert_mode() {
         rows: 28,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let fixture_name = "nvim_insert";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
@@ -373,6 +386,7 @@ pub fn bash_cursor_linewrap() {
         rows: 28,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let fixture_name = "bash_cursor_linewrap";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
@@ -398,6 +412,7 @@ pub fn fish_paste_multiline() {
         rows: 28,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let fixture_name = "fish_paste_multiline";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
@@ -421,6 +436,7 @@ pub fn git_log() {
         rows: 28,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let fixture_name = "git_log";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
@@ -446,6 +462,7 @@ pub fn git_diff_scrollup() {
         rows: 28,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let fixture_name = "git_diff_scrollup";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
@@ -469,6 +486,7 @@ pub fn emacs_longbuf() {
         rows: 60,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let fixture_name = "emacs_longbuf_tutorial";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
@@ -492,6 +510,7 @@ pub fn top_and_quit() {
         rows: 56,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let fixture_name = "top_and_quit";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
@@ -521,6 +540,7 @@ pub fn exa_plus_omf_theme() {
         rows: 56,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let fixture_name = "exa_plus_omf_theme";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);

--- a/src/tests/integration/layouts.rs
+++ b/src/tests/integration/layouts.rs
@@ -18,6 +18,7 @@ pub fn accepts_basic_layout() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[&QUIT]);

--- a/src/tests/integration/move_focus_down.rs
+++ b/src/tests/integration/move_focus_down.rs
@@ -21,6 +21,7 @@ pub fn move_focus_down() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -50,6 +51,7 @@ pub fn move_focus_down_to_the_largest_overlap() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[

--- a/src/tests/integration/move_focus_left.rs
+++ b/src/tests/integration/move_focus_left.rs
@@ -21,6 +21,7 @@ pub fn move_focus_left() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -49,6 +50,7 @@ pub fn move_focus_left_to_the_largest_overlap() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[

--- a/src/tests/integration/move_focus_right.rs
+++ b/src/tests/integration/move_focus_right.rs
@@ -21,6 +21,7 @@ pub fn move_focus_right() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -50,6 +51,7 @@ pub fn move_focus_right_to_the_largest_overlap() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[

--- a/src/tests/integration/move_focus_up.rs
+++ b/src/tests/integration/move_focus_up.rs
@@ -21,6 +21,7 @@ pub fn move_focus_up() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -49,6 +50,7 @@ pub fn move_focus_up_to_the_largest_overlap() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[

--- a/src/tests/integration/resize_down.rs
+++ b/src/tests/integration/resize_down.rs
@@ -31,6 +31,7 @@ pub fn resize_down_with_pane_above() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -69,6 +70,7 @@ pub fn resize_down_with_pane_below() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -112,6 +114,7 @@ pub fn resize_down_with_panes_above_and_below() {
         rows: 25,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -153,6 +156,7 @@ pub fn resize_down_with_multiple_panes_above() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -197,6 +201,7 @@ pub fn resize_down_with_panes_above_aligned_left_with_current_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -243,6 +248,7 @@ pub fn resize_down_with_panes_below_aligned_left_with_current_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -288,6 +294,7 @@ pub fn resize_down_with_panes_above_aligned_right_with_current_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -331,6 +338,7 @@ pub fn resize_down_with_panes_below_aligned_right_with_current_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -375,6 +383,7 @@ pub fn resize_down_with_panes_above_aligned_left_and_right_with_current_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -422,6 +431,7 @@ pub fn resize_down_with_panes_below_aligned_left_and_right_with_current_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -471,6 +481,7 @@ pub fn resize_down_with_panes_above_aligned_left_and_right_with_panes_to_the_lef
         rows: 40,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -537,6 +548,7 @@ pub fn resize_down_with_panes_below_aligned_left_and_right_with_to_the_left_and_
         rows: 40,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -603,6 +615,7 @@ pub fn cannot_resize_down_when_pane_below_is_at_minimum_height() {
         rows: 7,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[

--- a/src/tests/integration/resize_left.rs
+++ b/src/tests/integration/resize_left.rs
@@ -27,6 +27,7 @@ pub fn resize_left_with_pane_to_the_left() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -63,6 +64,7 @@ pub fn resize_left_with_pane_to_the_right() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -100,6 +102,7 @@ pub fn resize_left_with_panes_to_the_left_and_right() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -139,6 +142,7 @@ pub fn resize_left_with_multiple_panes_to_the_left() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -181,6 +185,7 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_with_current_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -225,6 +230,7 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_with_current_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -266,6 +272,7 @@ pub fn resize_left_with_panes_to_the_left_aligned_bottom_with_current_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -309,6 +316,7 @@ pub fn resize_left_with_panes_to_the_right_aligned_bottom_with_current_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -353,6 +361,7 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_and_bottom_with_current_pa
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -400,6 +409,7 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_and_bottom_with_current_p
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -449,6 +459,7 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_and_bottom_with_panes_abov
         rows: 40,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -516,6 +527,7 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_and_bottom_with_panes_abo
         rows: 40,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -582,6 +594,7 @@ pub fn cannot_resize_left_when_pane_to_the_left_is_at_minimum_width() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[

--- a/src/tests/integration/resize_right.rs
+++ b/src/tests/integration/resize_right.rs
@@ -27,6 +27,7 @@ pub fn resize_right_with_pane_to_the_left() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -63,6 +64,7 @@ pub fn resize_right_with_pane_to_the_right() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -100,6 +102,7 @@ pub fn resize_right_with_panes_to_the_left_and_right() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -139,6 +142,7 @@ pub fn resize_right_with_multiple_panes_to_the_left() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -181,6 +185,7 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_with_current_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -225,6 +230,7 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_with_current_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -266,6 +272,7 @@ pub fn resize_right_with_panes_to_the_left_aligned_bottom_with_current_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -309,6 +316,7 @@ pub fn resize_right_with_panes_to_the_right_aligned_bottom_with_current_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -353,6 +361,7 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_and_bottom_with_current_p
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -400,6 +409,7 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_and_bottom_with_current_
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -449,6 +459,7 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_and_bottom_with_panes_abo
         rows: 40,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -515,6 +526,7 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_and_bottom_with_panes_ab
         rows: 40,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -581,6 +593,7 @@ pub fn cannot_resize_right_when_pane_to_the_left_is_at_minimum_width() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[

--- a/src/tests/integration/resize_up.rs
+++ b/src/tests/integration/resize_up.rs
@@ -29,6 +29,7 @@ pub fn resize_up_with_pane_above() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -67,6 +68,7 @@ pub fn resize_up_with_pane_below() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -109,6 +111,7 @@ pub fn resize_up_with_panes_above_and_below() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -149,6 +152,7 @@ pub fn resize_up_with_multiple_panes_above() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -191,6 +195,7 @@ pub fn resize_up_with_panes_above_aligned_left_with_current_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -237,6 +242,7 @@ pub fn resize_up_with_panes_below_aligned_left_with_current_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -282,6 +288,7 @@ pub fn resize_up_with_panes_above_aligned_right_with_current_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -325,6 +332,7 @@ pub fn resize_up_with_panes_below_aligned_right_with_current_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -369,6 +377,7 @@ pub fn resize_up_with_panes_above_aligned_left_and_right_with_current_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -416,6 +425,7 @@ pub fn resize_up_with_panes_below_aligned_left_and_right_with_current_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -465,6 +475,7 @@ pub fn resize_up_with_panes_above_aligned_left_and_right_with_panes_to_the_left_
         rows: 40,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -531,6 +542,7 @@ pub fn resize_up_with_panes_below_aligned_left_and_right_with_to_the_left_and_ri
         rows: 40,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
 
@@ -597,6 +609,7 @@ pub fn cannot_resize_up_when_pane_above_is_at_minimum_height() {
         rows: 7,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[

--- a/src/tests/integration/tabs.rs
+++ b/src/tests/integration/tabs.rs
@@ -22,6 +22,7 @@ pub fn open_new_tab() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -51,6 +52,7 @@ pub fn switch_to_prev_tab() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -81,6 +83,7 @@ pub fn switch_to_next_tab() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -111,6 +114,7 @@ pub fn close_tab() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -141,6 +145,7 @@ pub fn close_last_pane_in_a_tab() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -172,6 +177,7 @@ pub fn close_the_middle_tab() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -205,6 +211,7 @@ pub fn close_the_tab_that_has_a_pane_in_fullscreen() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -243,6 +250,7 @@ pub fn closing_last_tab_exits_the_app() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[

--- a/src/tests/integration/terminal_window_resize.rs
+++ b/src/tests/integration/terminal_window_resize.rs
@@ -17,6 +17,7 @@ pub fn window_width_decrease_with_one_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[&QUIT]);
@@ -25,6 +26,7 @@ pub fn window_width_decrease_with_one_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     });
     let opts = CliArgs::default();
     start(Box::new(fake_input_output.clone()), opts);
@@ -46,6 +48,7 @@ pub fn window_width_increase_with_one_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[&QUIT]);
@@ -54,6 +57,7 @@ pub fn window_width_increase_with_one_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     });
     let opts = CliArgs::default();
     start(Box::new(fake_input_output.clone()), opts);
@@ -75,6 +79,7 @@ pub fn window_height_increase_with_one_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[&QUIT]);
@@ -83,6 +88,7 @@ pub fn window_height_increase_with_one_pane() {
         rows: 30,
         x: 0,
         y: 0,
+        ..Default::default()
     });
     let opts = CliArgs::default();
     start(Box::new(fake_input_output.clone()), opts);
@@ -104,6 +110,7 @@ pub fn window_width_and_height_decrease_with_one_pane() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[&QUIT]);
@@ -112,6 +119,7 @@ pub fn window_width_and_height_decrease_with_one_pane() {
         rows: 10,
         x: 0,
         y: 0,
+        ..Default::default()
     });
     let opts = CliArgs::default();
     start(Box::new(fake_input_output.clone()), opts);

--- a/src/tests/integration/toggle_fullscreen.rs
+++ b/src/tests/integration/toggle_fullscreen.rs
@@ -21,6 +21,7 @@ pub fn adding_new_terminal_in_fullscreen() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[
@@ -50,6 +51,7 @@ pub fn move_focus_is_disabled_in_fullscreen() {
         rows: 20,
         x: 0,
         y: 0,
+        ..Default::default()
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[


### PR DESCRIPTION
This is a fix for https://github.com/zellij-org/zellij/issues/301 and https://github.com/zellij-org/zellij/issues/303

The problem was:
For some reason, if invoked as the default command in a terminal, when Zellij requests the terminal size from the OS it gets a wrong window size. Very shortly afterwards, the OS sends a SIGWINCH and then Zellij gets the correct window size.

In this scenario, we had a bug where plugins (in this case, the tab bar) would only set their "max_height" limitation (which is supposed to prevent this issue from happening) *after* the layout has already been arranged (and in most cases, the initial correct SIGWINCH received).

This fixes the issue by having the `Fixed` attribute in the layout do the same as `set_max_height`/`set_max_width` in the plugin API. This is probably the correct behaviour, even though it creates somewhat of a duplication. I left `set_max_height` and `set_max_width` because they happen at runtime, and I can imagine situations where plugins might want to change these values as a reaction to certain things that happen.