### PR TITLE
Pin to nightly 2021-04-23

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2021-04-23"
 components = ["rustfmt", "clippy", "rust-analysis"]
 targets = ["wasm32-wasi"]


### PR DESCRIPTION
Rustfmt doesn't build on current nightly.

Please check out the toolchain before merge! `rustup update`, should do it I think.
I consume this file a little differently. 

Also if it takes a while to merge, check if the pin is still necessary. It shouldn't be a big fix for rustfmt.