### PR TITLE
feat(plugin): simple timers implemented via the `set_timeout()` call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Completions are not assets anymore, but commands `option --generate-completion [shell]` (https://github.com/zellij-org/zellij/pull/369)
 * Fixes in the default configuration `default.yaml` file. Adds initial tmux-compat keybindings `tmux.yaml` (https://github.com/zellij-org/zellij/pull/362)
 * Added the `get_plugin_ids()` query function to the plugin API (https://github.com/zellij-org/zellij/pull/392)
+* Implemented simple plugin timers via the `set_timeout()` call (https://github.com/zellij-org/zellij/pull/394)
 
 ## [0.5.1] - 2021-04-23
 * Change config to flag (https://github.com/zellij-org/zellij/pull/300)

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -462,6 +462,18 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: CliArgs) {
             let mut plugin_id = 0;
             let mut plugin_map = HashMap::new();
             move || loop {
+                // BLUEPRINT:
+                /* next = binheap.get_timer(); // peek
+                let event = if let Some(time) = next {
+                    // match for the right timeout error here...
+                    if let Some(event) = chan.recv_timeout(time) {
+                        event
+                    } else {
+                        continue
+                    }
+                } else {
+                    ch.recv().unwrap()
+                } */
                 let (event, mut err_ctx) = receive_plugin_instructions
                     .recv()
                     .expect("failed to receive event on channel");
@@ -510,7 +522,7 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: CliArgs) {
 
                         let start = instance.exports.get_function("_start").unwrap();
 
-                        // This eventually calls the `.init()` method
+                        // This eventually calls the `.load()` method
                         start.call(&[]).unwrap();
 
                         plugin_map.insert(plugin_id, (instance, plugin_env));

--- a/src/common/wasm_vm.rs
+++ b/src/common/wasm_vm.rs
@@ -1,5 +1,12 @@
-use serde::Serialize;
-use std::{collections::HashSet, path::PathBuf, process, sync::{mpsc::Sender, Arc, Mutex}, time::{Duration, Instant}};
+use serde::{de::DeserializeOwned, Serialize};
+use std::{
+    collections::HashSet,
+    path::PathBuf,
+    process,
+    sync::{mpsc::Sender, Arc, Mutex},
+    thread,
+    time::{Duration, Instant},
+};
 use wasmer::{imports, Function, ImportObject, Store, WasmerEnv};
 use wasmer_wasi::WasiEnv;
 use zellij_tile::data::{Event, EventType, PluginIds};
@@ -20,18 +27,13 @@ pub enum PluginInstruction {
 #[derive(WasmerEnv, Clone)]
 pub struct PluginEnv {
     pub plugin_id: u32,
+    // FIXME: This should be a big bundle of all of the channels
     pub send_screen_instructions: SenderWithContext<ScreenInstruction>,
     pub send_app_instructions: SenderWithContext<AppInstruction>,
-    pub send_pty_instructions: SenderWithContext<PtyInstruction>, // FIXME: This should be a big bundle of all of the channels
+    pub send_pty_instructions: SenderWithContext<PtyInstruction>,
+    pub send_plugin_instructions: SenderWithContext<PluginInstruction>,
     pub wasi_env: WasiEnv,
     pub subscriptions: Arc<Mutex<HashSet<EventType>>>,
-    // FIXME: Add timers struct here! BinaryHeap?
-}
-
-struct CallbackTimer {
-    wake_time: Instant,
-    plugin_id: u32,
-    recurring: bool,
 }
 
 // Plugin API ---------------------------------------------------------------------------------------------------------
@@ -56,18 +58,19 @@ pub fn zellij_exports(store: &Store, plugin_env: &PluginEnv) -> ImportObject {
         host_set_selectable,
         host_get_plugin_ids,
         host_open_file,
+        host_set_timeout,
     }
 }
 
 fn host_subscribe(plugin_env: &PluginEnv) {
     let mut subscriptions = plugin_env.subscriptions.lock().unwrap();
-    let new: HashSet<EventType> = serde_json::from_str(&wasi_stdout(&plugin_env.wasi_env)).unwrap();
+    let new: HashSet<EventType> = wasi_read_object(&plugin_env.wasi_env);
     subscriptions.extend(new);
 }
 
 fn host_unsubscribe(plugin_env: &PluginEnv) {
     let mut subscriptions = plugin_env.subscriptions.lock().unwrap();
-    let old: HashSet<EventType> = serde_json::from_str(&wasi_stdout(&plugin_env.wasi_env)).unwrap();
+    let old: HashSet<EventType> = wasi_read_object(&plugin_env.wasi_env);
     subscriptions.retain(|k| !old.contains(k));
 }
 
@@ -109,21 +112,49 @@ fn host_get_plugin_ids(plugin_env: &PluginEnv) {
         plugin_id: plugin_env.plugin_id,
         zellij_pid: process::id(),
     };
-    wasi_write_json(&plugin_env.wasi_env, &ids);
+    wasi_write_object(&plugin_env.wasi_env, &ids);
 }
 
 fn host_open_file(plugin_env: &PluginEnv) {
-    let path = PathBuf::from(wasi_stdout(&plugin_env.wasi_env).lines().next().unwrap());
+    let path: PathBuf = wasi_read_object(&plugin_env.wasi_env);
     plugin_env
         .send_pty_instructions
         .send(PtyInstruction::SpawnTerminal(Some(path)))
         .unwrap();
 }
 
+fn host_set_timeout(plugin_env: &PluginEnv, secs: f64) {
+    // There is a fancy, high-performance way to do this with zero additional threads:
+    // If the plugin thread keeps a BinaryHeap of timer structs, it can manage multiple and easily `.peek()` at the
+    // next time to trigger in O(1) time. Once the wake-up time is known, the `wasm` thread can use `recv_timeout()`
+    // to wait for an event with the timeout set to be the time of the next wake up. If events come in in the meantime,
+    // they are handled, but if the timeout triggers, we replace the event from `recv()` with an
+    // `Update(pid, TimerEvent)` and pop the timer from the Heap (or reschedule it). No additional threads for as many
+    // timers as we'd like.
+    //
+    // But that's a lot of code, and this is a few lines:
+    let send_plugin_instructions = plugin_env.send_plugin_instructions.clone();
+    let update_target = Some(plugin_env.plugin_id);
+    thread::spawn(move || {
+        let start_time = Instant::now();
+        thread::sleep(Duration::from_secs_f64(secs));
+        // FIXME: The way that elapsed time is being calculated here is not exact; it doesn't take into account the
+        // time it takes an event to actually reach the plugin after it's sent to the `wasm` thread.
+        let elapsed_time = Instant::now().duration_since(start_time).as_secs_f64();
+
+        send_plugin_instructions
+            .send(PluginInstruction::Update(
+                update_target,
+                Event::Timer(elapsed_time),
+            ))
+            .unwrap();
+    });
+}
+
 // Helper Functions ---------------------------------------------------------------------------------------------------
 
 // FIXME: Unwrap city
-pub fn wasi_stdout(wasi_env: &WasiEnv) -> String {
+pub fn wasi_read_string(wasi_env: &WasiEnv) -> String {
     let mut state = wasi_env.state();
     let wasi_file = state.fs.stdout_mut().unwrap().as_mut().unwrap();
     let mut buf = String::new();
@@ -137,6 +168,11 @@ pub fn wasi_write_string(wasi_env: &WasiEnv, buf: &str) {
     writeln!(wasi_file, "{}\r", buf).unwrap();
 }
 
-pub fn wasi_write_json(wasi_env: &WasiEnv, object: &impl Serialize) {
+pub fn wasi_write_object(wasi_env: &WasiEnv, object: &impl Serialize) {
     wasi_write_string(wasi_env, &serde_json::to_string(&object).unwrap());
+}
+
+pub fn wasi_read_object<T: DeserializeOwned>(wasi_env: &WasiEnv) -> T {
+    let json = wasi_read_string(wasi_env);
+    serde_json::from_str(&json).unwrap()
 }

--- a/src/common/wasm_vm.rs
+++ b/src/common/wasm_vm.rs
@@ -1,10 +1,5 @@
 use serde::Serialize;
-use std::{
-    collections::HashSet,
-    path::PathBuf,
-    process,
-    sync::{mpsc::Sender, Arc, Mutex},
-};
+use std::{collections::HashSet, path::PathBuf, process, sync::{mpsc::Sender, Arc, Mutex}, time::{Duration, Instant}};
 use wasmer::{imports, Function, ImportObject, Store, WasmerEnv};
 use wasmer_wasi::WasiEnv;
 use zellij_tile::data::{Event, EventType, PluginIds};
@@ -30,6 +25,13 @@ pub struct PluginEnv {
     pub send_pty_instructions: SenderWithContext<PtyInstruction>, // FIXME: This should be a big bundle of all of the channels
     pub wasi_env: WasiEnv,
     pub subscriptions: Arc<Mutex<HashSet<EventType>>>,
+    // FIXME: Add timers struct here! BinaryHeap?
+}
+
+struct CallbackTimer {
+    wake_time: Instant,
+    plugin_id: u32,
+    recurring: bool,
 }
 
 // Plugin API ---------------------------------------------------------------------------------------------------------

--- a/zellij-tile/src/data.rs
+++ b/zellij-tile/src/data.rs
@@ -23,9 +23,7 @@ pub enum Key {
     Esc,
 }
 
-#[derive(
-    Debug, Clone, PartialEq, Eq, Hash, EnumDiscriminants, ToString, Serialize, Deserialize,
-)]
+#[derive(Debug, Clone, PartialEq, EnumDiscriminants, ToString, Serialize, Deserialize)]
 #[strum_discriminants(derive(EnumString, Hash, Serialize, Deserialize))]
 #[strum_discriminants(name(EventType))]
 #[non_exhaustive]
@@ -33,6 +31,7 @@ pub enum Event {
     ModeUpdate(ModeInfo),
     TabUpdate(Vec<TabInfo>),
     KeyPress(Key),
+    Timer(f64),
 }
 
 /// Describes the different input modes, which change the way that keystrokes will be interpreted.

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -1,4 +1,4 @@
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Serialize};
 use std::{io, path::Path};
 
 use crate::data::*;
@@ -6,12 +6,12 @@ use crate::data::*;
 // Subscription Handling
 
 pub fn subscribe(event_types: &[EventType]) {
-    println!("{}", serde_json::to_string(event_types).unwrap());
+    object_to_stdout(&event_types);
     unsafe { host_subscribe() };
 }
 
 pub fn unsubscribe(event_types: &[EventType]) {
-    println!("{}", serde_json::to_string(event_types).unwrap());
+    object_to_stdout(&event_types);
     unsafe { host_unsubscribe() };
 }
 
@@ -38,8 +38,12 @@ pub fn get_plugin_ids() -> PluginIds {
 // Host Functions
 
 pub fn open_file(path: &Path) {
-    println!("{}", path.to_string_lossy());
+    object_to_stdout(&path);
     unsafe { host_open_file() };
+}
+
+pub fn set_timeout(secs: f64) {
+    unsafe { host_set_timeout(secs) };
 }
 
 // Internal Functions
@@ -51,6 +55,11 @@ pub fn object_from_stdin<T: DeserializeOwned>() -> T {
     serde_json::from_str(&json).unwrap()
 }
 
+#[doc(hidden)]
+pub fn object_to_stdout(object: &impl Serialize) {
+    println!("{}", serde_json::to_string(object).unwrap());
+}
+
 #[link(wasm_import_module = "zellij")]
 extern "C" {
     fn host_subscribe();
@@ -60,4 +69,5 @@ extern "C" {
     fn host_set_invisible_borders(invisible_borders: i32);
     fn host_get_plugin_ids();
     fn host_open_file();
+    fn host_set_timeout(secs: f64);
 }


### PR DESCRIPTION
This plugin:

```rust
impl ZellijPlugin for State {
    fn load(&mut self) {
        subscribe(&[EventType::Timer]);
        set_timeout(1.0);
    }

    fn update(&mut self, event: Event) {
        if let Event::Timer(secs) = event {
            dbg!(secs);
            set_timeout(secs * 2.0);
        }
    }
}
```

Outputs:
```
[default-plugins/strider/src/main.rs:18] secs = 1.000064727
[default-plugins/strider/src/main.rs:18] secs = 2.000187283
[default-plugins/strider/src/main.rs:18] secs = 4.000435719
[default-plugins/strider/src/main.rs:18] secs = 8.000938307
[default-plugins/strider/src/main.rs:18] secs = 16.001934982
```