### PR TITLE
Fix Startup with Default in Same Folder

### DIFF
--- a/src/client/layout.rs
+++ b/src/client/layout.rs
@@ -205,6 +205,18 @@ impl Layout {
         layout
     }
 
+    // It wants to use Path here, but that doesn't compile.
+    #[warn(clippy::ptr_arg)]
+    pub fn from_defaults(layout_path: &PathBuf, data_dir: &Path) -> Self {
+        Self::new(
+            &data_dir
+                .join("layouts/")
+                .join(layout_path)
+                .with_extension("yaml"),
+            &data_dir,
+        )
+    }
+
     pub fn total_terminal_panes(&self) -> usize {
         let mut total_panes = 0;
         total_panes += self.parts.len();

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -186,8 +186,8 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: CliArgs) {
     let default_layout = None;
     let maybe_layout = opts
         .layout
-        .or(default_layout)
-        .map(|p| Layout::new(&p, &data_dir));
+        .map(|p| Layout::new(&p, &data_dir))
+        .or_else(|| default_layout.map(|p| Layout::from_defaults(&p, &data_dir)));
 
     #[cfg(not(test))]
     std::panic::set_hook({


### PR DESCRIPTION
Doesn't try loading `default` files, other than
the plugin directory by default anymore.

I think we need to separate the `layout` flag
into `layout` and `layout-path` in the future.
Where `layout` looks at all known plugin directories,
and `layout-path` looks at the specific path.

Adresses  #322.

