### PR TITLE
Load config before start()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2205,6 +2205,7 @@ dependencies = [
  "strip-ansi-escapes",
  "structopt",
  "strum",
+ "tempfile",
  "termion",
  "termios",
  "unicode-truncate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ features = ["unstable"]
 
 [dev-dependencies]
 insta = "1.6.0"
+tempfile = "3.2.0"
 
 [build-dependencies]
 structopt = "0.3"

--- a/src/common/input/config.rs
+++ b/src/common/input/config.rs
@@ -6,14 +6,17 @@ use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 
 use super::keybinds::{Keybinds, KeybindsFromYaml};
-use crate::cli::ConfigCli;
+use crate::cli::{CliArgs, ConfigCli};
 use crate::common::install;
 
 use serde::Deserialize;
+use std::convert::TryFrom;
+
+const DEFAULT_CONFIG_FILE_NAME: &str = "config.yaml";
 
 type ConfigResult = Result<Config, ConfigError>;
 
-/// Intermediate deserialisation config struct
+/// Intermediate deserialization config struct
 #[derive(Debug, Deserialize)]
 pub struct ConfigFromYaml {
     pub keybinds: Option<KeybindsFromYaml>,
@@ -27,13 +30,13 @@ pub struct Config {
 
 #[derive(Debug)]
 pub enum ConfigError {
-    // Deserialisation error
+    // Deserialization error
     Serde(serde_yaml::Error),
     // Io error
     Io(io::Error),
     // Io error with path context
     IoPath(io::Error, PathBuf),
-    // Internal Deserialisation Error
+    // Internal Deserialization Error
     FromUtf8(std::string::FromUtf8Error),
 }
 
@@ -41,6 +44,35 @@ impl Default for Config {
     fn default() -> Self {
         let keybinds = Keybinds::default();
         Config { keybinds }
+    }
+}
+
+impl TryFrom<&CliArgs> for Config {
+    type Error = ConfigError;
+
+    fn try_from(opts: &CliArgs) -> ConfigResult {
+        if let Some(ref path) = opts.config {
+            return Config::new(&path);
+        }
+
+        if let Some(ConfigCli::Config { clean, .. }) = opts.option {
+            if clean {
+                return Config::from_default_assets();
+            }
+        }
+
+        let config_dir = opts.config_dir.clone().or_else(install::default_config_dir);
+
+        if let Some(ref config) = config_dir {
+            let path = config.join(DEFAULT_CONFIG_FILE_NAME);
+            if path.exists() {
+                Config::new(&path)
+            } else {
+                Config::from_default_assets()
+            }
+        } else {
+            Config::from_default_assets()
+        }
     }
 }
 
@@ -71,45 +103,6 @@ impl Config {
     pub fn from_default_assets() -> ConfigResult {
         Self::from_yaml(String::from_utf8(install::DEFAULT_CONFIG.to_vec())?.as_str())
     }
-
-    /// Entry point of the configuration
-    #[cfg(not(test))]
-    pub fn from_cli_config(
-        location: Option<PathBuf>,
-        cli_config: Option<ConfigCli>,
-        config_dir: Option<PathBuf>,
-    ) -> ConfigResult {
-        if let Some(path) = location {
-            return Config::new(&path);
-        }
-
-        if let Some(ConfigCli::Config { clean, .. }) = cli_config {
-            if clean {
-                return Config::from_default_assets();
-            }
-        }
-
-        if let Some(config) = config_dir {
-            let path = config.join("config.yaml");
-            if path.exists() {
-                Config::new(&path)
-            } else {
-                Config::from_default_assets()
-            }
-        } else {
-            Config::from_default_assets()
-        }
-    }
-
-    /// In order not to mess up tests from changing configurations
-    #[cfg(test)]
-    pub fn from_cli_config(
-        _: Option<PathBuf>,
-        _: Option<ConfigCli>,
-        _: Option<PathBuf>,
-    ) -> ConfigResult {
-        Ok(Config::default())
-    }
 }
 
 impl Display for ConfigError {
@@ -119,7 +112,7 @@ impl Display for ConfigError {
             ConfigError::IoPath(ref err, ref path) => {
                 write!(formatter, "IoError: {}, File: {}", err, path.display(),)
             }
-            ConfigError::Serde(ref err) => write!(formatter, "Deserialisation error: {}", err),
+            ConfigError::Serde(ref err) => write!(formatter, "Deserialization error: {}", err),
             ConfigError::FromUtf8(ref err) => write!(formatter, "FromUtf8Error: {}", err),
         }
     }
@@ -157,20 +150,56 @@ impl From<std::string::FromUtf8Error> for ConfigError {
 // The unit test location.
 #[cfg(test)]
 mod config_test {
+    use std::io::Write;
+
+    use tempfile::tempdir;
+
     use super::*;
 
     #[test]
-    fn clean_option_equals_default_config() {
-        let cli_config = ConfigCli::Config { clean: true };
-        let config = Config::from_cli_config(None, Some(cli_config), None).unwrap();
-        let default = Config::default();
-        assert_eq!(config, default);
+    fn try_from_cli_args_with_config() {
+        let arbitrary_config = PathBuf::from("nonexistent.yaml");
+        let mut opts = CliArgs::default();
+        opts.config = Some(arbitrary_config);
+        println!("OPTS= {:?}", opts);
+        let result = Config::try_from(&opts);
+        assert!(result.is_err());
     }
 
     #[test]
-    fn no_config_option_file_equals_default_config() {
-        let config = Config::from_cli_config(None, None, None).unwrap();
-        let default = Config::default();
-        assert_eq!(config, default);
+    fn try_from_cli_args_with_option_clean() {
+        let mut opts = CliArgs::default();
+        opts.option = Some(ConfigCli::Config { clean: true });
+        let result = Config::try_from(&opts);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn try_from_cli_args_with_config_dir() {
+        let mut opts = CliArgs::default();
+        let tmp = tempdir().unwrap();
+        File::create(tmp.path().join(DEFAULT_CONFIG_FILE_NAME))
+            .unwrap()
+            .write_all(b"keybinds: invalid\n")
+            .unwrap();
+        opts.config_dir = Some(tmp.path().to_path_buf());
+        let result = Config::try_from(&opts);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn try_from_cli_args_with_config_dir_without_config() {
+        let mut opts = CliArgs::default();
+        let tmp = tempdir().unwrap();
+        opts.config_dir = Some(tmp.path().to_path_buf());
+        let result = Config::try_from(&opts);
+        assert_eq!(result.unwrap(), Config::default());
+    }
+
+    #[test]
+    fn try_from_cli_args_default() {
+        let opts = CliArgs::default();
+        let result = Config::try_from(&opts);
+        assert_eq!(result.unwrap(), Config::default());
     }
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -120,7 +120,7 @@ pub enum AppInstruction {
 
 /// Start Zellij with the specified [`OsApi`] and command-line arguments.
 // FIXME this should definitely be modularized and split into different functions.
-pub fn start(mut os_input: Box<dyn OsApi>, opts: CliArgs) {
+pub fn start(mut os_input: Box<dyn OsApi>, opts: CliArgs, config: Config) {
     let take_snapshot = "\u{1b}[?1049h";
     os_input.unset_raw_mode(0);
     let _ = os_input
@@ -129,15 +129,6 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: CliArgs) {
         .unwrap();
 
     env::set_var(&"ZELLIJ", "0");
-
-    let config_dir = opts.config_dir.or_else(install::default_config_dir);
-
-    let config = Config::from_cli_config(opts.config, opts.option, config_dir)
-        .map_err(|e| {
-            eprintln!("There was an error in the config file:\n{}", e);
-            std::process::exit(1);
-        })
-        .unwrap();
 
     let command_is_executing = CommandIsExecuting::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod client;
 
 use crate::cli::CliArgs;
 use crate::command_is_executing::CommandIsExecuting;
+use crate::common::input::config::Config;
 use crate::os_input_output::get_os_input;
 use crate::utils::{
     consts::{ZELLIJ_IPC_PIPE, ZELLIJ_TMP_DIR, ZELLIJ_TMP_LOG_DIR},
@@ -17,12 +18,20 @@ use common::{
     command_is_executing, errors, install, os_input_output, pty_bus, screen, start, utils, wasm_vm,
     ApiCommand,
 };
+use std::convert::TryFrom;
 use std::io::Write;
 use std::os::unix::net::UnixStream;
 use structopt::StructOpt;
 
 pub fn main() {
     let opts = CliArgs::from_args();
+    let config = match Config::try_from(&opts) {
+        Ok(config) => config,
+        Err(e) => {
+            eprintln!("There was an error in the config file:\n{}", e);
+            std::process::exit(1);
+        }
+    };
     if let Some(split_dir) = opts.split {
         match split_dir {
             'h' => {
@@ -66,6 +75,6 @@ pub fn main() {
         let os_input = get_os_input();
         atomic_create_dir(ZELLIJ_TMP_DIR).unwrap();
         atomic_create_dir(ZELLIJ_TMP_LOG_DIR).unwrap();
-        start(Box::new(os_input), opts);
+        start(Box::new(os_input), opts, config);
     }
 }

--- a/src/tests/integration/basic.rs
+++ b/src/tests/integration/basic.rs
@@ -1,6 +1,7 @@
 use crate::panes::PositionAndSize;
 use ::insta::assert_snapshot;
 
+use crate::common::input::config::Config;
 use crate::tests::fakes::FakeInputOutput;
 use crate::tests::utils::commands::{
     PANE_MODE, QUIT, SCROLL_DOWN_IN_SCROLL_MODE, SCROLL_MODE, SCROLL_PAGE_DOWN_IN_SCROLL_MODE,
@@ -26,7 +27,11 @@ pub fn starts_with_one_terminal() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[&QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -49,7 +54,11 @@ pub fn split_terminals_vertically() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[&PANE_MODE, &SPLIT_RIGHT_IN_PANE_MODE, &QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -72,7 +81,11 @@ pub fn split_terminals_horizontally() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[&PANE_MODE, &SPLIT_DOWN_IN_PANE_MODE, &QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -102,7 +115,11 @@ pub fn split_largest_terminal() {
         &SPAWN_TERMINAL_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -125,7 +142,11 @@ pub fn cannot_split_terminals_vertically_when_active_terminal_is_too_small() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[&PANE_MODE, &SPLIT_RIGHT_IN_PANE_MODE, &QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -148,7 +169,11 @@ pub fn cannot_split_terminals_horizontally_when_active_terminal_is_too_small() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[&PANE_MODE, &SPLIT_DOWN_IN_PANE_MODE, &QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -171,7 +196,11 @@ pub fn cannot_split_largest_terminal_when_there_is_no_room() {
     };
     let mut fake_input_output = get_fake_os_input(&fake_win_size);
     fake_input_output.add_terminal_input(&[&PANE_MODE, &SPAWN_TERMINAL_IN_PANE_MODE, &QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -202,7 +231,11 @@ pub fn scrolling_up_inside_a_pane() {
         &SCROLL_UP_IN_SCROLL_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -235,7 +268,11 @@ pub fn scrolling_down_inside_a_pane() {
         &SCROLL_DOWN_IN_SCROLL_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -265,7 +302,11 @@ pub fn scrolling_page_up_inside_a_pane() {
         &SCROLL_PAGE_UP_IN_SCROLL_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -298,7 +339,11 @@ pub fn scrolling_page_down_inside_a_pane() {
         &SCROLL_PAGE_DOWN_IN_SCROLL_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -332,7 +377,7 @@ pub fn max_panes() {
     ]);
     let mut opts = CliArgs::default();
     opts.max_panes = Some(4);
-    start(Box::new(fake_input_output.clone()), opts);
+    start(Box::new(fake_input_output.clone()), opts, Config::default());
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -364,7 +409,7 @@ pub fn toggle_focused_pane_fullscreen() {
     ]);
     let mut opts = CliArgs::default();
     opts.max_panes = Some(4);
-    start(Box::new(fake_input_output.clone()), opts);
+    start(Box::new(fake_input_output.clone()), opts, Config::default());
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames

--- a/src/tests/integration/close_pane.rs
+++ b/src/tests/integration/close_pane.rs
@@ -5,6 +5,7 @@ use crate::tests::fakes::FakeInputOutput;
 use crate::tests::utils::{get_next_to_last_snapshot, get_output_frame_snapshots};
 use crate::{start, CliArgs};
 
+use crate::common::input::config::Config;
 use crate::tests::utils::commands::{
     CLOSE_PANE_IN_PANE_MODE, ESC, MOVE_FOCUS_IN_PANE_MODE, PANE_MODE, QUIT,
     RESIZE_DOWN_IN_RESIZE_MODE, RESIZE_LEFT_IN_RESIZE_MODE, RESIZE_MODE, RESIZE_UP_IN_RESIZE_MODE,
@@ -39,7 +40,11 @@ pub fn close_pane_with_another_pane_above_it() {
         &CLOSE_PANE_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -77,7 +82,11 @@ pub fn close_pane_with_another_pane_below_it() {
         &CLOSE_PANE_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -112,7 +121,11 @@ pub fn close_pane_with_another_pane_to_the_left() {
         &CLOSE_PANE_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -148,7 +161,11 @@ pub fn close_pane_with_another_pane_to_the_right() {
         &CLOSE_PANE_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -189,7 +206,11 @@ pub fn close_pane_with_multiple_panes_above_it() {
         &CLOSE_PANE_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -228,7 +249,11 @@ pub fn close_pane_with_multiple_panes_below_it() {
         &CLOSE_PANE_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -269,7 +294,11 @@ pub fn close_pane_with_multiple_panes_to_the_left() {
         &CLOSE_PANE_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -308,7 +337,11 @@ pub fn close_pane_with_multiple_panes_to_the_right() {
         &CLOSE_PANE_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -369,7 +402,11 @@ pub fn close_pane_with_multiple_panes_above_it_away_from_screen_edges() {
         &CLOSE_PANE_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -426,7 +463,11 @@ pub fn close_pane_with_multiple_panes_below_it_away_from_screen_edges() {
         &CLOSE_PANE_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -485,7 +526,11 @@ pub fn close_pane_with_multiple_panes_to_the_left_away_from_screen_edges() {
         &CLOSE_PANE_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -544,7 +589,11 @@ pub fn close_pane_with_multiple_panes_to_the_right_away_from_screen_edges() {
         &CLOSE_PANE_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -576,7 +625,11 @@ pub fn closing_last_pane_exits_app() {
         &CLOSE_PANE_IN_PANE_MODE,
         &CLOSE_PANE_IN_PANE_MODE,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer

--- a/src/tests/integration/compatibility.rs
+++ b/src/tests/integration/compatibility.rs
@@ -7,6 +7,7 @@ use crate::tests::possible_tty_inputs::Bytes;
 use crate::tests::utils::{get_next_to_last_snapshot, get_output_frame_snapshots};
 use crate::{start, CliArgs};
 
+use crate::common::input::config::Config;
 use crate::tests::utils::commands::QUIT;
 
 /*
@@ -41,7 +42,11 @@ pub fn run_bandwhich_from_fish_shell() {
     let fixture_name = "fish_and_bandwhich";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
     fake_input_output.add_terminal_input(&[&QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -65,7 +70,11 @@ pub fn fish_tab_completion_options() {
     let fixture_name = "fish_tab_completion_options";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
     fake_input_output.add_terminal_input(&[&QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -94,7 +103,11 @@ pub fn fish_select_tab_completion_options() {
     let fixture_name = "fish_select_tab_completion_options";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
     fake_input_output.add_terminal_input(&[&QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -127,7 +140,11 @@ pub fn vim_scroll_region_down() {
     let fixture_name = "vim_scroll_region_down";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
     fake_input_output.add_terminal_input(&[&QUIT]); // quit (ctrl-q)
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -157,7 +174,11 @@ pub fn vim_ctrl_d() {
     let fixture_name = "vim_ctrl_d";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
     fake_input_output.add_terminal_input(&[&QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -186,7 +207,11 @@ pub fn vim_ctrl_u() {
     let fixture_name = "vim_ctrl_u";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
     fake_input_output.add_terminal_input(&[&QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -210,7 +235,11 @@ pub fn htop() {
     let fixture_name = "htop";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
     fake_input_output.add_terminal_input(&[&QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -234,7 +263,11 @@ pub fn htop_scrolling() {
     let fixture_name = "htop_scrolling";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
     fake_input_output.add_terminal_input(&[&QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -258,7 +291,11 @@ pub fn htop_right_scrolling() {
     let fixture_name = "htop_right_scrolling";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
     fake_input_output.add_terminal_input(&[&QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -290,7 +327,11 @@ pub fn vim_overwrite() {
     let fixture_name = "vim_overwrite";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
     fake_input_output.add_terminal_input(&[&QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -317,7 +358,11 @@ pub fn clear_scroll_region() {
     let fixture_name = "clear_scroll_region";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
     fake_input_output.add_terminal_input(&[&QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -341,7 +386,11 @@ pub fn display_tab_characters_properly() {
     let fixture_name = "tab_characters";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
     fake_input_output.add_terminal_input(&[&QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -365,7 +414,11 @@ pub fn neovim_insert_mode() {
     let fixture_name = "nvim_insert";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
     fake_input_output.add_terminal_input(&[&QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -391,7 +444,11 @@ pub fn bash_cursor_linewrap() {
     let fixture_name = "bash_cursor_linewrap";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
     fake_input_output.add_terminal_input(&[&QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -417,7 +474,11 @@ pub fn fish_paste_multiline() {
     let fixture_name = "fish_paste_multiline";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
     fake_input_output.add_terminal_input(&[&QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -441,7 +502,11 @@ pub fn git_log() {
     let fixture_name = "git_log";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
     fake_input_output.add_terminal_input(&[&QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -467,7 +532,11 @@ pub fn git_diff_scrollup() {
     let fixture_name = "git_diff_scrollup";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
     fake_input_output.add_terminal_input(&[&QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -491,7 +560,11 @@ pub fn emacs_longbuf() {
     let fixture_name = "emacs_longbuf_tutorial";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
     fake_input_output.add_terminal_input(&[&QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -515,7 +588,11 @@ pub fn top_and_quit() {
     let fixture_name = "top_and_quit";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
     fake_input_output.add_terminal_input(&[&QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -545,7 +622,11 @@ pub fn exa_plus_omf_theme() {
     let fixture_name = "exa_plus_omf_theme";
     let mut fake_input_output = get_fake_os_input(&fake_win_size, fixture_name);
     fake_input_output.add_terminal_input(&[&QUIT]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames

--- a/src/tests/integration/layouts.rs
+++ b/src/tests/integration/layouts.rs
@@ -1,6 +1,7 @@
 use insta::assert_snapshot;
 use std::path::PathBuf;
 
+use crate::common::input::config::Config;
 use crate::panes::PositionAndSize;
 use crate::tests::fakes::FakeInputOutput;
 use crate::tests::utils::commands::QUIT;
@@ -27,7 +28,7 @@ pub fn accepts_basic_layout() {
         "src/tests/fixtures/layouts/three-panes-with-nesting.yaml",
     ));
 
-    start(Box::new(fake_input_output.clone()), opts);
+    start(Box::new(fake_input_output.clone()), opts, Config::default());
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames

--- a/src/tests/integration/move_focus_down.rs
+++ b/src/tests/integration/move_focus_down.rs
@@ -5,6 +5,7 @@ use crate::tests::fakes::FakeInputOutput;
 use crate::tests::utils::{get_next_to_last_snapshot, get_output_frame_snapshots};
 use crate::{start, CliArgs};
 
+use crate::common::input::config::Config;
 use crate::tests::utils::commands::{
     MOVE_FOCUS_DOWN_IN_PANE_MODE, MOVE_FOCUS_UP_IN_PANE_MODE, PANE_MODE, QUIT,
     SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE,
@@ -31,7 +32,11 @@ pub fn move_focus_down() {
         &MOVE_FOCUS_DOWN_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -63,7 +68,11 @@ pub fn move_focus_down_to_the_most_recently_used_pane() {
         &MOVE_FOCUS_DOWN_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer

--- a/src/tests/integration/move_focus_left.rs
+++ b/src/tests/integration/move_focus_left.rs
@@ -5,6 +5,7 @@ use crate::tests::fakes::FakeInputOutput;
 use crate::tests::utils::{get_next_to_last_snapshot, get_output_frame_snapshots};
 use crate::{start, CliArgs};
 
+use crate::common::input::config::Config;
 use crate::tests::utils::commands::{
     MOVE_FOCUS_LEFT_IN_PANE_MODE, MOVE_FOCUS_RIGHT_IN_PANE_MODE, PANE_MODE, QUIT,
     SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE,
@@ -30,7 +31,11 @@ pub fn move_focus_left() {
         &MOVE_FOCUS_LEFT_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -63,7 +68,11 @@ pub fn move_focus_left_to_the_most_recently_used_pane() {
         &MOVE_FOCUS_LEFT_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer

--- a/src/tests/integration/move_focus_right.rs
+++ b/src/tests/integration/move_focus_right.rs
@@ -5,6 +5,7 @@ use crate::tests::fakes::FakeInputOutput;
 use crate::tests::utils::{get_next_to_last_snapshot, get_output_frame_snapshots};
 use crate::{start, CliArgs};
 
+use crate::common::input::config::Config;
 use crate::tests::utils::commands::{
     MOVE_FOCUS_LEFT_IN_PANE_MODE, MOVE_FOCUS_RIGHT_IN_PANE_MODE, PANE_MODE, QUIT,
     SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE,
@@ -31,7 +32,11 @@ pub fn move_focus_right() {
         &MOVE_FOCUS_RIGHT_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -63,7 +68,11 @@ pub fn move_focus_right_to_the_most_recently_used_pane() {
         &MOVE_FOCUS_RIGHT_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer

--- a/src/tests/integration/move_focus_up.rs
+++ b/src/tests/integration/move_focus_up.rs
@@ -5,6 +5,7 @@ use crate::tests::fakes::FakeInputOutput;
 use crate::tests::utils::{get_next_to_last_snapshot, get_output_frame_snapshots};
 use crate::{start, CliArgs};
 
+use crate::common::input::config::Config;
 use crate::tests::utils::commands::{
     MOVE_FOCUS_DOWN_IN_PANE_MODE, MOVE_FOCUS_UP_IN_PANE_MODE, PANE_MODE, QUIT,
     SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE,
@@ -30,7 +31,11 @@ pub fn move_focus_up() {
         &MOVE_FOCUS_UP_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -63,7 +68,11 @@ pub fn move_focus_up_to_the_most_recently_used_pane() {
         &MOVE_FOCUS_UP_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer

--- a/src/tests/integration/resize_down.rs
+++ b/src/tests/integration/resize_down.rs
@@ -5,6 +5,7 @@ use crate::tests::fakes::FakeInputOutput;
 use crate::tests::utils::{get_next_to_last_snapshot, get_output_frame_snapshots};
 use crate::{start, CliArgs};
 
+use crate::common::input::config::Config;
 use crate::tests::utils::commands::{
     MOVE_FOCUS_IN_PANE_MODE, PANE_MODE, QUIT, RESIZE_DOWN_IN_RESIZE_MODE,
     RESIZE_LEFT_IN_RESIZE_MODE, RESIZE_MODE, SLEEP, SPLIT_DOWN_IN_PANE_MODE,
@@ -42,7 +43,11 @@ pub fn resize_down_with_pane_above() {
         &SLEEP,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -82,7 +87,11 @@ pub fn resize_down_with_pane_below() {
         &SLEEP,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -128,7 +137,11 @@ pub fn resize_down_with_panes_above_and_below() {
         &SLEEP,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -173,7 +186,11 @@ pub fn resize_down_with_multiple_panes_above() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -220,7 +237,11 @@ pub fn resize_down_with_panes_above_aligned_left_with_current_pane() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -266,7 +287,11 @@ pub fn resize_down_with_panes_below_aligned_left_with_current_pane() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -310,7 +335,11 @@ pub fn resize_down_with_panes_above_aligned_right_with_current_pane() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -355,7 +384,11 @@ pub fn resize_down_with_panes_below_aligned_right_with_current_pane() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -403,7 +436,11 @@ pub fn resize_down_with_panes_above_aligned_left_and_right_with_current_pane() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -453,7 +490,11 @@ pub fn resize_down_with_panes_below_aligned_left_and_right_with_current_pane() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -520,7 +561,11 @@ pub fn resize_down_with_panes_above_aligned_left_and_right_with_panes_to_the_lef
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -589,7 +634,11 @@ pub fn resize_down_with_panes_below_aligned_left_and_right_with_to_the_left_and_
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -626,7 +675,11 @@ pub fn cannot_resize_down_when_pane_below_is_at_minimum_height() {
         &SLEEP,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer

--- a/src/tests/integration/resize_left.rs
+++ b/src/tests/integration/resize_left.rs
@@ -5,6 +5,7 @@ use crate::tests::fakes::FakeInputOutput;
 use crate::tests::utils::{get_next_to_last_snapshot, get_output_frame_snapshots};
 use crate::{start, CliArgs};
 
+use crate::common::input::config::Config;
 use crate::tests::utils::commands::{
     MOVE_FOCUS_IN_PANE_MODE, PANE_MODE, QUIT, RESIZE_LEFT_IN_RESIZE_MODE, RESIZE_MODE,
     RESIZE_UP_IN_RESIZE_MODE, SLEEP, SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE,
@@ -38,7 +39,11 @@ pub fn resize_left_with_pane_to_the_left() {
         &SLEEP,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -76,7 +81,11 @@ pub fn resize_left_with_pane_to_the_right() {
         &SLEEP,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -116,7 +125,11 @@ pub fn resize_left_with_panes_to_the_left_and_right() {
         &SLEEP,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -159,7 +172,11 @@ pub fn resize_left_with_multiple_panes_to_the_left() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -204,7 +221,11 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_with_current_pane() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -246,7 +267,11 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_with_current_pane() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -290,7 +315,11 @@ pub fn resize_left_with_panes_to_the_left_aligned_bottom_with_current_pane() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -333,7 +362,11 @@ pub fn resize_left_with_panes_to_the_right_aligned_bottom_with_current_pane() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -381,7 +414,11 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_and_bottom_with_current_pa
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -431,7 +468,11 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_and_bottom_with_current_p
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -498,7 +539,11 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_and_bottom_with_panes_abov
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -568,7 +613,11 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_and_bottom_with_panes_abo
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -605,7 +654,11 @@ pub fn cannot_resize_left_when_pane_to_the_left_is_at_minimum_width() {
         &SLEEP,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer

--- a/src/tests/integration/resize_right.rs
+++ b/src/tests/integration/resize_right.rs
@@ -5,6 +5,7 @@ use crate::tests::fakes::FakeInputOutput;
 use crate::tests::utils::{get_next_to_last_snapshot, get_output_frame_snapshots};
 use crate::{start, CliArgs};
 
+use crate::common::input::config::Config;
 use crate::tests::utils::commands::{
     MOVE_FOCUS_IN_PANE_MODE, PANE_MODE, QUIT, RESIZE_MODE, RESIZE_RIGHT_IN_RESIZE_MODE,
     RESIZE_UP_IN_RESIZE_MODE, SLEEP, SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE,
@@ -38,7 +39,11 @@ pub fn resize_right_with_pane_to_the_left() {
         &SLEEP,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -76,7 +81,11 @@ pub fn resize_right_with_pane_to_the_right() {
         &SLEEP,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -116,7 +125,11 @@ pub fn resize_right_with_panes_to_the_left_and_right() {
         &SLEEP,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -159,7 +172,11 @@ pub fn resize_right_with_multiple_panes_to_the_left() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -204,7 +221,11 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_with_current_pane() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -246,7 +267,11 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_with_current_pane() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -290,7 +315,11 @@ pub fn resize_right_with_panes_to_the_left_aligned_bottom_with_current_pane() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -333,7 +362,11 @@ pub fn resize_right_with_panes_to_the_right_aligned_bottom_with_current_pane() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -381,7 +414,11 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_and_bottom_with_current_p
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -431,7 +468,11 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_and_bottom_with_current_
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -498,7 +539,11 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_and_bottom_with_panes_abo
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -567,7 +612,11 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_and_bottom_with_panes_ab
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -604,7 +653,11 @@ pub fn cannot_resize_right_when_pane_to_the_left_is_at_minimum_width() {
         &SLEEP,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer

--- a/src/tests/integration/resize_up.rs
+++ b/src/tests/integration/resize_up.rs
@@ -5,6 +5,7 @@ use crate::tests::fakes::FakeInputOutput;
 use crate::tests::utils::{get_next_to_last_snapshot, get_output_frame_snapshots};
 use crate::{start, CliArgs};
 
+use crate::common::input::config::Config;
 use crate::tests::utils::commands::{
     MOVE_FOCUS_IN_PANE_MODE, PANE_MODE, QUIT, RESIZE_LEFT_IN_RESIZE_MODE, RESIZE_MODE,
     RESIZE_UP_IN_RESIZE_MODE, SLEEP, SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE,
@@ -40,7 +41,11 @@ pub fn resize_up_with_pane_above() {
         &SLEEP,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -80,7 +85,11 @@ pub fn resize_up_with_pane_below() {
         &SLEEP,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -125,7 +134,11 @@ pub fn resize_up_with_panes_above_and_below() {
         &SLEEP,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -169,7 +182,11 @@ pub fn resize_up_with_multiple_panes_above() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -214,7 +231,11 @@ pub fn resize_up_with_panes_above_aligned_left_with_current_pane() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -260,7 +281,11 @@ pub fn resize_up_with_panes_below_aligned_left_with_current_pane() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -304,7 +329,11 @@ pub fn resize_up_with_panes_above_aligned_right_with_current_pane() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -349,7 +378,11 @@ pub fn resize_up_with_panes_below_aligned_right_with_current_pane() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -397,7 +430,11 @@ pub fn resize_up_with_panes_above_aligned_left_and_right_with_current_pane() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -447,7 +484,11 @@ pub fn resize_up_with_panes_below_aligned_left_and_right_with_current_pane() {
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -514,7 +555,11 @@ pub fn resize_up_with_panes_above_aligned_left_and_right_with_panes_to_the_left_
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -583,7 +628,11 @@ pub fn resize_up_with_panes_below_aligned_left_and_right_with_to_the_left_and_ri
         &QUIT,
     ]);
 
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -620,7 +669,11 @@ pub fn cannot_resize_up_when_pane_above_is_at_minimum_height() {
         &SLEEP,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer

--- a/src/tests/integration/tabs.rs
+++ b/src/tests/integration/tabs.rs
@@ -5,6 +5,7 @@ use crate::tests::utils::{get_next_to_last_snapshot, get_output_frame_snapshots}
 use crate::{panes::PositionAndSize, tests::utils::commands::CLOSE_PANE_IN_PANE_MODE};
 use crate::{start, CliArgs};
 
+use crate::common::input::config::Config;
 use crate::tests::utils::commands::{
     CLOSE_TAB_IN_TAB_MODE, NEW_TAB_IN_TAB_MODE, PANE_MODE, QUIT, SPLIT_DOWN_IN_PANE_MODE,
     SWITCH_NEXT_TAB_IN_TAB_MODE, SWITCH_PREV_TAB_IN_TAB_MODE, TAB_MODE,
@@ -32,7 +33,11 @@ pub fn open_new_tab() {
         &NEW_TAB_IN_TAB_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -63,7 +68,11 @@ pub fn switch_to_prev_tab() {
         &SWITCH_PREV_TAB_IN_TAB_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -94,7 +103,11 @@ pub fn switch_to_next_tab() {
         &SWITCH_NEXT_TAB_IN_TAB_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -125,7 +138,11 @@ pub fn close_tab() {
         &CLOSE_TAB_IN_TAB_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -157,7 +174,11 @@ pub fn close_last_pane_in_a_tab() {
         &CLOSE_PANE_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -191,7 +212,11 @@ pub fn close_the_middle_tab() {
         &CLOSE_TAB_IN_TAB_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -230,7 +255,11 @@ pub fn close_the_tab_that_has_a_pane_in_fullscreen() {
         &CLOSE_TAB_IN_TAB_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -261,7 +290,11 @@ pub fn closing_last_tab_exits_the_app() {
         &CLOSE_TAB_IN_TAB_MODE,
         &CLOSE_TAB_IN_TAB_MODE,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer

--- a/src/tests/integration/terminal_window_resize.rs
+++ b/src/tests/integration/terminal_window_resize.rs
@@ -1,6 +1,7 @@
 use crate::panes::PositionAndSize;
 use ::insta::assert_snapshot;
 
+use crate::common::input::config::Config;
 use crate::tests::fakes::FakeInputOutput;
 use crate::tests::utils::commands::QUIT;
 use crate::tests::utils::{get_next_to_last_snapshot, get_output_frame_snapshots};
@@ -29,7 +30,7 @@ pub fn window_width_decrease_with_one_pane() {
         ..Default::default()
     });
     let opts = CliArgs::default();
-    start(Box::new(fake_input_output.clone()), opts);
+    start(Box::new(fake_input_output.clone()), opts, Config::default());
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -60,7 +61,7 @@ pub fn window_width_increase_with_one_pane() {
         ..Default::default()
     });
     let opts = CliArgs::default();
-    start(Box::new(fake_input_output.clone()), opts);
+    start(Box::new(fake_input_output.clone()), opts, Config::default());
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -91,7 +92,7 @@ pub fn window_height_increase_with_one_pane() {
         ..Default::default()
     });
     let opts = CliArgs::default();
-    start(Box::new(fake_input_output.clone()), opts);
+    start(Box::new(fake_input_output.clone()), opts, Config::default());
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames
@@ -122,7 +123,7 @@ pub fn window_width_and_height_decrease_with_one_pane() {
         ..Default::default()
     });
     let opts = CliArgs::default();
-    start(Box::new(fake_input_output.clone()), opts);
+    start(Box::new(fake_input_output.clone()), opts, Config::default());
     let output_frames = fake_input_output
         .stdout_writer
         .output_frames

--- a/src/tests/integration/toggle_fullscreen.rs
+++ b/src/tests/integration/toggle_fullscreen.rs
@@ -5,6 +5,7 @@ use crate::tests::fakes::FakeInputOutput;
 use crate::tests::utils::{get_next_to_last_snapshot, get_output_frame_snapshots};
 use crate::{start, CliArgs};
 
+use crate::common::input::config::Config;
 use crate::tests::utils::commands::{
     MOVE_FOCUS_IN_PANE_MODE, PANE_MODE, QUIT, SPLIT_DOWN_IN_PANE_MODE, SPLIT_RIGHT_IN_PANE_MODE,
     TOGGLE_ACTIVE_TERMINAL_FULLSCREEN_IN_PANE_MODE,
@@ -31,7 +32,11 @@ pub fn adding_new_terminal_in_fullscreen() {
         &SPLIT_DOWN_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer
@@ -61,7 +66,11 @@ pub fn move_focus_is_disabled_in_fullscreen() {
         &MOVE_FOCUS_IN_PANE_MODE,
         &QUIT,
     ]);
-    start(Box::new(fake_input_output.clone()), CliArgs::default());
+    start(
+        Box::new(fake_input_output.clone()),
+        CliArgs::default(),
+        Config::default(),
+    );
 
     let output_frames = fake_input_output
         .stdout_writer


### PR DESCRIPTION
Close #414

Previously, a config file was loaded within `start()`, and if the config file is invalid, Zellij was supposed to show a user what's wrong with it. However, since `start()` starts setting up its terminal with an alternative screen buffer, neither standard output nor standard error could display such an error.

This change intends to address this issue by making Zellij load a config file before `start()`.

In addition, the patch also includes some refactorings:

* Redefine `from_cli_config` with `TryFrom`, which was introduced in Rust 1.34
* Remove conditional declaration `cfg(not(test))` because `start()` now receive a `Config` as the third argument
* Introduce [`tempfile`](https://crates.io/crates/tempfile) in order to run tests with actual files
* Typo?: "Deserialisation" -> "Deserialization"