### PR TITLE
Rename install -> setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Fix the tab '(Sync)' suffix in named tabs (https://github.com/zellij-org/zellij/pull/410)
 * Improve performance when multiple panes are open (https://github.com/zellij-org/zellij/pull/318)
 * Improve error reporting and tests of configuration (https://github.com/zellij-org/zellij/pull/423)
+* Refactor install module to setup module (https://github.com/zellij-org/zellij/pull/431)
 
 ## [0.6.0] - 2021-04-29
 * Doesn't quit anymore on single `q` press while in tab mode  (https://github.com/zellij-org/zellij/pull/342)

--- a/src/common/input/config.rs
+++ b/src/common/input/config.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 use super::keybinds::{Keybinds, KeybindsFromYaml};
 use crate::cli::{CliArgs, ConfigCli};
-use crate::common::install;
+use crate::common::setup;
 
 use serde::Deserialize;
 use std::convert::TryFrom;
@@ -61,7 +61,10 @@ impl TryFrom<&CliArgs> for Config {
             }
         }
 
-        let config_dir = opts.config_dir.clone().or_else(install::default_config_dir);
+        let config_dir = opts
+            .config_dir
+            .clone()
+            .or_else(setup::find_default_config_dir);
 
         if let Some(ref config) = config_dir {
             let path = config.join(DEFAULT_CONFIG_FILE_NAME);
@@ -101,7 +104,7 @@ impl Config {
     // TODO Deserialize the Configuration from bytes &[u8],
     // once serde-yaml supports zero-copy
     pub fn from_default_assets() -> ConfigResult {
-        Self::from_yaml(String::from_utf8(install::DEFAULT_CONFIG.to_vec())?.as_str())
+        Self::from_yaml(String::from_utf8(setup::DEFAULT_CONFIG.to_vec())?.as_str())
     }
 }
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,11 +1,11 @@
 pub mod command_is_executing;
 pub mod errors;
 pub mod input;
-pub mod install;
 pub mod ipc;
 pub mod os_input_output;
 pub mod pty_bus;
 pub mod screen;
+pub mod setup;
 pub mod utils;
 pub mod wasm_vm;
 
@@ -34,11 +34,11 @@ use errors::{
     ScreenContext,
 };
 use input::handler::input_loop;
-use install::populate_data_dir;
 use os_input_output::OsApi;
 use pty_bus::{PtyBus, PtyInstruction};
 use screen::{Screen, ScreenInstruction};
 use serde::{Deserialize, Serialize};
+use setup::install;
 use utils::consts::ZELLIJ_IPC_PIPE;
 use wasm_vm::{wasi_read_string, wasi_write_object, zellij_exports, PluginEnv, PluginInstruction};
 use wasmer::{ChainableNamedResolver, Instance, Module, Store, Value};
@@ -168,7 +168,7 @@ pub fn start(mut os_input: Box<dyn OsApi>, opts: CliArgs, config: Config) {
     let data_dir = opts
         .data_dir
         .unwrap_or_else(|| project_dirs.data_dir().to_path_buf());
-    populate_data_dir(&data_dir);
+    install::populate_data_dir(&data_dir);
 
     // Don't use default layouts in tests, but do everywhere else
     #[cfg(not(test))]

--- a/src/common/setup.rs
+++ b/src/common/setup.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 use std::{fs, path::Path, path::PathBuf};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
+const CONFIG_LOCATION: &str = "/.config/zellij";
 
 #[macro_export]
 macro_rules! asset_map {
@@ -18,32 +19,36 @@ macro_rules! asset_map {
     }
 }
 
-pub fn populate_data_dir(data_dir: &Path) {
-    // First run installation of default plugins & layouts
-    let mut assets = asset_map! {
-        "assets/layouts/default.yaml" => "layouts/default.yaml",
-        "assets/layouts/strider.yaml" => "layouts/strider.yaml",
-    };
-    assets.extend(asset_map! {
-        "assets/plugins/status-bar.wasm" => "plugins/status-bar.wasm",
-        "assets/plugins/tab-bar.wasm" => "plugins/tab-bar.wasm",
-        "assets/plugins/strider.wasm" => "plugins/strider.wasm",
-    });
-    assets.insert("VERSION", VERSION.as_bytes().to_vec());
+pub mod install {
+    use super::*;
 
-    let last_version = fs::read_to_string(data_dir.join("VERSION")).unwrap_or_default();
-    let out_of_date = VERSION != last_version;
+    pub fn populate_data_dir(data_dir: &Path) {
+        // First run installation of default plugins & layouts
+        let mut assets = asset_map! {
+            "assets/layouts/default.yaml" => "layouts/default.yaml",
+            "assets/layouts/strider.yaml" => "layouts/strider.yaml",
+        };
+        assets.extend(asset_map! {
+            "assets/plugins/status-bar.wasm" => "plugins/status-bar.wasm",
+            "assets/plugins/tab-bar.wasm" => "plugins/tab-bar.wasm",
+            "assets/plugins/strider.wasm" => "plugins/strider.wasm",
+        });
+        assets.insert("VERSION", VERSION.as_bytes().to_vec());
 
-    for (path, bytes) in assets {
-        let path = data_dir.join(path);
-        fs::create_dir_all(path.parent().unwrap()).unwrap();
-        if out_of_date || !path.exists() {
-            fs::write(path, bytes).expect("Failed to install default assets!");
+        let last_version = fs::read_to_string(data_dir.join("VERSION")).unwrap_or_default();
+        let out_of_date = VERSION != last_version;
+
+        for (path, bytes) in assets {
+            let path = data_dir.join(path);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            if out_of_date || !path.exists() {
+                fs::write(path, bytes).expect("Failed to install default assets!");
+            }
         }
     }
 }
 
-pub fn default_config_dir() -> Option<PathBuf> {
+pub fn find_default_config_dir() -> Option<PathBuf> {
     vec![
         Some(xdg_config_dir()),
         home_config_dir(),
@@ -62,7 +67,7 @@ pub fn xdg_config_dir() -> PathBuf {
 
 pub fn home_config_dir() -> Option<PathBuf> {
     if let Some(user_dirs) = BaseDirs::new() {
-        let config_dir = user_dirs.home_dir().join("/.config/zellij");
+        let config_dir = user_dirs.home_dir().join(CONFIG_LOCATION);
         Some(config_dir)
     } else {
         None

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use crate::utils::{
 };
 use client::{boundaries, layout, panes, tab};
 use common::{
-    command_is_executing, errors, install, os_input_output, pty_bus, screen, start, utils, wasm_vm,
+    command_is_executing, errors, os_input_output, pty_bus, screen, setup, start, utils, wasm_vm,
     ApiCommand,
 };
 use std::convert::TryFrom;
@@ -69,7 +69,7 @@ pub fn main() {
         let mut out = std::io::stdout();
         CliArgs::clap().gen_completions_to("zellij", shell, &mut out);
     } else if let Some(crate::cli::ConfigCli::Setup { .. }) = opts.option {
-        install::dump_default_config().expect("Failed to print to stdout");
+        setup::dump_default_config().expect("Failed to print to stdout");
         std::process::exit(1);
     } else {
         let os_input = get_os_input();


### PR DESCRIPTION
* Renaming of the install module to convey the intent more,
move functions that install to a sub module install of setup.

* Fix a clippy lint.