### PR TITLE
Disable Default Config Test

### DIFF
--- a/src/common/input/config.rs
+++ b/src/common/input/config.rs
@@ -196,10 +196,12 @@ mod config_test {
         assert_eq!(result.unwrap(), Config::default());
     }
 
-    #[test]
-    fn try_from_cli_args_default() {
-        let opts = CliArgs::default();
-        let result = Config::try_from(&opts);
-        assert_eq!(result.unwrap(), Config::default());
-    }
+    // This test needs a split somewhere between test and normal runs,
+    // since otherwise it would look in a local configuration and fail.
+    //#[test]
+    //fn try_from_cli_args_default() {
+    //let opts = CliArgs::default();
+    //let result = Config::try_from(&opts);
+    //assert_eq!(result.unwrap(), Config::default());
+    //}
 }


### PR DESCRIPTION
For now, it fails if there is a local config, differing
from the default config.

There needs to be a split again, I think between normal runs and test runs.