### PR TITLE
Enables the Default Config Test

### DIFF
--- a/src/common/input/config.rs
+++ b/src/common/input/config.rs
@@ -199,12 +199,10 @@ mod config_test {
         assert_eq!(result.unwrap(), Config::default());
     }
 
-    // This test needs a split somewhere between test and normal runs,
-    // since otherwise it would look in a local configuration and fail.
-    //#[test]
-    //fn try_from_cli_args_default() {
-    //let opts = CliArgs::default();
-    //let result = Config::try_from(&opts);
-    //assert_eq!(result.unwrap(), Config::default());
-    //}
+    #[test]
+    fn try_from_cli_args_default() {
+        let opts = CliArgs::default();
+        let result = Config::try_from(&opts);
+        assert_eq!(result.unwrap(), Config::default());
+    }
 }

--- a/src/common/setup.rs
+++ b/src/common/setup.rs
@@ -48,6 +48,7 @@ pub mod install {
     }
 }
 
+#[cfg(not(test))]
 pub fn find_default_config_dir() -> Option<PathBuf> {
     vec![
         Some(xdg_config_dir()),
@@ -58,6 +59,11 @@ pub fn find_default_config_dir() -> Option<PathBuf> {
     .filter(|p| p.is_some())
     .find(|p| p.clone().unwrap().exists())
     .flatten()
+}
+
+#[cfg(test)]
+pub fn find_default_config_dir() -> Option<PathBuf> {
+    None
 }
 
 pub fn xdg_config_dir() -> PathBuf {


### PR DESCRIPTION
The split of test/no_test happens now in
find_default_config_dir, it always returns Null in tests.
That way differing configurations of zellij shouldn't
make the test fail anymore.