### PR TITLE
fix(colors): stabilize colors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,12 +1113,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
-
-[[package]]
 name = "polling"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,27 +2182,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
-name = "x11"
-version = "2.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ecd092546cb16f25783a5451538e73afc8d32e242648d54f4ae5459ba1e773"
-dependencies = [
- "libc",
- "pkg-config",
-]
-
-[[package]]
-name = "xrdb"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2dd91a21c92e87678e22f95956a03bfd314ce3232f39dbedd49dddb50f0c6d"
-dependencies = [
- "libc",
- "scopeguard",
- "x11",
-]
-
-[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2249,7 +2222,6 @@ dependencies = [
  "vte 0.8.0",
  "wasmer",
  "wasmer-wasi",
- "xrdb",
  "zellij-tile",
  "zellij-tile-extra",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ lazy_static = "1.4.0"
 wasmer = "1.0.0"
 wasmer-wasi = "1.0.0"
 interprocess = "1.0.1"
-xrdb = "0.1.1"
 colors-transform = "0.2.5"
 zellij-tile = { path = "zellij-tile/", version = "1.1.0" }
 zellij-tile-extra = { path = "zellij-tile-extra/", version="1.0.0" }

--- a/default-plugins/status-bar/src/first_line.rs
+++ b/default-plugins/status-bar/src/first_line.rs
@@ -232,7 +232,7 @@ fn key_indicators(max_len: usize, keys: &[CtrlKeyShortcut], palette: ColoredElem
 }
 
 pub fn superkey(palette: ColoredElements) -> LinePart {
-    let prefix_text = " Ctrl + ";
+    let prefix_text = " Ctrl +";
     let prefix = palette.superkey_prefix.paint(prefix_text);
     let suffix_separator = palette.superkey_suffix_separator.paint(ARROW_SEPARATOR);
     LinePart {

--- a/default-plugins/status-bar/src/main.rs
+++ b/default-plugins/status-bar/src/main.rs
@@ -150,21 +150,11 @@ impl ZellijPlugin for State {
         // [48;5;238m is gray background, [0K is so that it fills the rest of the line
         // [m is background reset, [0K is so that it clears the rest of the line
         match self.mode_info.palette.bg {
-            PaletteColor::RGB((r, g, b)) => {
-                println!(
-                    "{}\u{1b}[48;2;{};{};{}m\u{1b}[0K",
-                    first_line,
-                    r,
-                    g,
-                    b
-                );
-            },
+            PaletteColor::Rgb((r, g, b)) => {
+                println!("{}\u{1b}[48;2;{};{};{}m\u{1b}[0K", first_line, r, g, b);
+            }
             PaletteColor::EightBit(color) => {
-                println!(
-                    "{}\u{1b}[48;5;{}m\u{1b}[0K",
-                    first_line,
-                    color
-                );
+                println!("{}\u{1b}[48;5;{}m\u{1b}[0K", first_line, color);
             }
         }
         println!("\u{1b}[m{}\u{1b}[0K", second_line);

--- a/default-plugins/status-bar/src/main.rs
+++ b/default-plugins/status-bar/src/main.rs
@@ -80,18 +80,18 @@ fn color_elements(palette: Palette) -> ColoredElements {
             selected_styled_text: style!(palette.black, palette.green).bold(),
             selected_suffix_separator: style!(palette.green, palette.bg).bold(),
             unselected_prefix_separator: style!(palette.bg, palette.fg),
-            unselected_char_left_separator: style!(palette.bg, palette.fg).bold(),
+            unselected_char_left_separator: style!(palette.black, palette.fg).bold(),
             unselected_char_shortcut: style!(palette.red, palette.fg).bold(),
-            unselected_char_right_separator: style!(palette.bg, palette.fg).bold(),
+            unselected_char_right_separator: style!(palette.black, palette.fg).bold(),
             unselected_styled_text: style!(palette.black, palette.fg).bold(),
             unselected_suffix_separator: style!(palette.fg, palette.bg),
             disabled_prefix_separator: style!(palette.bg, palette.fg),
             disabled_styled_text: style!(palette.bg, palette.fg).dimmed(),
             disabled_suffix_separator: style!(palette.fg, palette.bg),
-            selected_single_letter_prefix_separator: style!(palette.fg, palette.green),
+            selected_single_letter_prefix_separator: style!(palette.bg, palette.green),
             selected_single_letter_char_shortcut: style!(palette.red, palette.green).bold(),
-            selected_single_letter_suffix_separator: style!(palette.green, palette.fg),
-            unselected_single_letter_prefix_separator: style!(palette.fg, palette.bg),
+            selected_single_letter_suffix_separator: style!(palette.green, palette.bg),
+            unselected_single_letter_prefix_separator: style!(palette.bg, palette.fg),
             unselected_single_letter_char_shortcut: style!(palette.red, palette.fg).bold(),
             unselected_single_letter_suffix_separator: style!(palette.fg, palette.bg),
             superkey_prefix: style!(palette.white, palette.bg).bold(),
@@ -149,13 +149,24 @@ impl ZellijPlugin for State {
 
         // [48;5;238m is gray background, [0K is so that it fills the rest of the line
         // [m is background reset, [0K is so that it clears the rest of the line
-        println!(
-            "{}\u{1b}[48;2;{};{};{}m\u{1b}[0K",
-            first_line,
-            self.mode_info.palette.bg.0,
-            self.mode_info.palette.bg.1,
-            self.mode_info.palette.bg.2
-        );
+        match self.mode_info.palette.bg {
+            PaletteColor::RGB((r, g, b)) => {
+                println!(
+                    "{}\u{1b}[48;2;{};{};{}m\u{1b}[0K",
+                    first_line,
+                    r,
+                    g,
+                    b
+                );
+            },
+            PaletteColor::EightBit(color) => {
+                println!(
+                    "{}\u{1b}[48;5;{}m\u{1b}[0K",
+                    first_line,
+                    color
+                );
+            }
+        }
         println!("\u{1b}[m{}\u{1b}[0K", second_line);
     }
 }

--- a/default-plugins/status-bar/src/second_line.rs
+++ b/default-plugins/status-bar/src/second_line.rs
@@ -1,4 +1,8 @@
-use ansi_term::{ANSIStrings, Color::{RGB, Fixed}, Style};
+use ansi_term::{
+    ANSIStrings,
+    Color::{Fixed, RGB},
+    Style,
+};
 use zellij_tile::prelude::*;
 
 use crate::{LinePart, MORE_MSG};
@@ -10,41 +14,21 @@ fn full_length_shortcut(
     palette: Palette,
 ) -> LinePart {
     let white_color = match palette.white {
-        PaletteColor::RGB((r, g, b)) => {
-            RGB(r, g, b)
-        }
-        PaletteColor::EightBit(color) => {
-            Fixed(color)
-        }
+        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
+        PaletteColor::EightBit(color) => Fixed(color),
     };
     let green_color = match palette.green {
-        PaletteColor::RGB((r, g, b)) => {
-            RGB(r, g, b)
-        }
-        PaletteColor::EightBit(color) => {
-            Fixed(color)
-        }
+        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
+        PaletteColor::EightBit(color) => Fixed(color),
     };
     let separator = if is_first_shortcut { " " } else { " / " };
-    let separator = Style::new()
-        .fg(white_color)
-        .paint(separator);
+    let separator = Style::new().fg(white_color).paint(separator);
     let shortcut_len = letter.chars().count() + 3; // 2 for <>'s around shortcut, 1 for the space
-    let shortcut_left_separator = Style::new()
-        .fg(white_color)
-        .paint("<");
-    let shortcut = Style::new()
-        .fg(green_color)
-        .bold()
-        .paint(letter);
-    let shortcut_right_separator = Style::new()
-        .fg(white_color)
-        .paint("> ");
+    let shortcut_left_separator = Style::new().fg(white_color).paint("<");
+    let shortcut = Style::new().fg(green_color).bold().paint(letter);
+    let shortcut_right_separator = Style::new().fg(white_color).paint("> ");
     let description_len = description.chars().count();
-    let description = Style::new()
-        .fg(white_color)
-        .bold()
-        .paint(description);
+    let description = Style::new().fg(white_color).bold().paint(description);
     let len = shortcut_len + description_len + separator.chars().count();
     LinePart {
         part: format!(
@@ -68,36 +52,19 @@ fn first_word_shortcut(
     palette: Palette,
 ) -> LinePart {
     let white_color = match palette.white {
-        PaletteColor::RGB((r, g, b)) => {
-            RGB(r, g, b)
-        }
-        PaletteColor::EightBit(color) => {
-            Fixed(color)
-        }
+        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
+        PaletteColor::EightBit(color) => Fixed(color),
     };
     let green_color = match palette.green {
-        PaletteColor::RGB((r, g, b)) => {
-            RGB(r, g, b)
-        }
-        PaletteColor::EightBit(color) => {
-            Fixed(color)
-        }
+        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
+        PaletteColor::EightBit(color) => Fixed(color),
     };
     let separator = if is_first_shortcut { " " } else { " / " };
-    let separator = Style::new()
-        .fg(white_color)
-        .paint(separator);
+    let separator = Style::new().fg(white_color).paint(separator);
     let shortcut_len = letter.chars().count() + 3; // 2 for <>'s around shortcut, 1 for the space
-    let shortcut_left_separator = Style::new()
-        .fg(white_color)
-        .paint("<");
-    let shortcut = Style::new()
-        .fg(green_color)
-        .bold()
-        .paint(letter);
-    let shortcut_right_separator = Style::new()
-        .fg(white_color)
-        .paint("> ");
+    let shortcut_left_separator = Style::new().fg(white_color).paint("<");
+    let shortcut = Style::new().fg(green_color).bold().paint(letter);
+    let shortcut_right_separator = Style::new().fg(white_color).paint("> ");
     let description_first_word = description.split(' ').next().unwrap_or("");
     let description_first_word_length = description_first_word.chars().count();
     let description_first_word = Style::new()
@@ -143,49 +110,29 @@ fn quicknav_full(palette: Palette) -> LinePart {
         + hjkl_navigation.chars().count()
         + text_sixths_part.chars().count();
     let green_color = match palette.green {
-        PaletteColor::RGB((r, g, b)) => {
-            RGB(r, g, b)
-        }
-        PaletteColor::EightBit(color) => {
-            Fixed(color)
-        }
+        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
+        PaletteColor::EightBit(color) => Fixed(color),
     };
     let orange_color = match palette.orange {
-        PaletteColor::RGB((r, g, b)) => {
-            RGB(r, g, b)
-        }
-        PaletteColor::EightBit(color) => {
-            Fixed(color)
-        }
+        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
+        PaletteColor::EightBit(color) => Fixed(color),
     };
     LinePart {
         part: format!(
             "{}{}{}{}{}{}{}{}{}{}{}",
             text_first_part,
-            Style::new()
-                .fg(orange_color)
-                .bold()
-                .paint(alt),
+            Style::new().fg(orange_color).bold().paint(alt),
             text_second_part,
-            Style::new()
-                .fg(green_color)
-                .bold()
-                .paint(new_pane_shortcut),
+            Style::new().fg(green_color).bold().paint(new_pane_shortcut),
             text_third_part,
-            Style::new()
-                .fg(orange_color)
-                .bold()
-                .paint(second_alt),
+            Style::new().fg(orange_color).bold().paint(second_alt),
             text_fourth_part,
             Style::new()
                 .fg(green_color)
                 .bold()
                 .paint(brackets_navigation),
             text_fifth_part,
-            Style::new()
-                .fg(green_color)
-                .bold()
-                .paint(hjkl_navigation),
+            Style::new().fg(green_color).bold().paint(hjkl_navigation),
             text_sixths_part,
         ),
         len,
@@ -216,49 +163,29 @@ fn quicknav_medium(palette: Palette) -> LinePart {
         + hjkl_navigation.chars().count()
         + text_sixths_part.chars().count();
     let green_color = match palette.green {
-        PaletteColor::RGB((r, g, b)) => {
-            RGB(r, g, b)
-        }
-        PaletteColor::EightBit(color) => {
-            Fixed(color)
-        }
+        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
+        PaletteColor::EightBit(color) => Fixed(color),
     };
     let orange_color = match palette.orange {
-        PaletteColor::RGB((r, g, b)) => {
-            RGB(r, g, b)
-        }
-        PaletteColor::EightBit(color) => {
-            Fixed(color)
-        }
+        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
+        PaletteColor::EightBit(color) => Fixed(color),
     };
     LinePart {
         part: format!(
             "{}{}{}{}{}{}{}{}{}{}{}",
             text_first_part,
-            Style::new()
-                .fg(orange_color)
-                .bold()
-                .paint(alt),
+            Style::new().fg(orange_color).bold().paint(alt),
             text_second_part,
-            Style::new()
-                .fg(green_color)
-                .bold()
-                .paint(new_pane_shortcut),
+            Style::new().fg(green_color).bold().paint(new_pane_shortcut),
             text_third_part,
-            Style::new()
-                .fg(orange_color)
-                .bold()
-                .paint(second_alt),
+            Style::new().fg(orange_color).bold().paint(second_alt),
             text_fourth_part,
             Style::new()
                 .fg(green_color)
                 .bold()
                 .paint(brackets_navigation),
             text_fifth_part,
-            Style::new()
-                .fg(green_color)
-                .bold()
-                .paint(hjkl_navigation),
+            Style::new().fg(green_color).bold().paint(hjkl_navigation),
             text_sixths_part,
         ),
         len,
@@ -283,44 +210,27 @@ fn quicknav_short(palette: Palette) -> LinePart {
         + text_fifth_part.chars().count()
         + hjkl_navigation.chars().count();
     let green_color = match palette.green {
-        PaletteColor::RGB((r, g, b)) => {
-            RGB(r, g, b)
-        }
-        PaletteColor::EightBit(color) => {
-            Fixed(color)
-        }
+        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
+        PaletteColor::EightBit(color) => Fixed(color),
     };
     let orange_color = match palette.orange {
-        PaletteColor::RGB((r, g, b)) => {
-            RGB(r, g, b)
-        }
-        PaletteColor::EightBit(color) => {
-            Fixed(color)
-        }
+        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
+        PaletteColor::EightBit(color) => Fixed(color),
     };
     LinePart {
         part: format!(
             "{}{}{}{}{}{}{}{}",
             text_first_part,
-            Style::new()
-                .fg(orange_color)
-                .bold()
-                .paint(alt),
+            Style::new().fg(orange_color).bold().paint(alt),
             text_second_part,
-            Style::new()
-                .fg(green_color)
-                .bold()
-                .paint(new_pane_shortcut),
+            Style::new().fg(green_color).bold().paint(new_pane_shortcut),
             text_third_part,
             Style::new()
                 .fg(green_color)
                 .bold()
                 .paint(brackets_navigation),
             text_fifth_part,
-            Style::new()
-                .fg(green_color)
-                .bold()
-                .paint(hjkl_navigation),
+            Style::new().fg(green_color).bold().paint(hjkl_navigation),
         ),
         len,
     }
@@ -330,17 +240,10 @@ fn locked_interface_indication(palette: Palette) -> LinePart {
     let locked_text = " -- INTERFACE LOCKED -- ";
     let locked_text_len = locked_text.chars().count();
     let white_color = match palette.white {
-        PaletteColor::RGB((r, g, b)) => {
-            RGB(r, g, b)
-        }
-        PaletteColor::EightBit(color) => {
-            Fixed(color)
-        }
+        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
+        PaletteColor::EightBit(color) => Fixed(color),
     };
-    let locked_styled_text = Style::new()
-        .fg(white_color)
-        .bold()
-        .paint(locked_text);
+    let locked_styled_text = Style::new().fg(white_color).bold().paint(locked_text);
     LinePart {
         part: format!("{}", locked_styled_text),
         len: locked_text_len,
@@ -352,40 +255,20 @@ fn select_pane_shortcut(is_first_shortcut: bool, palette: Palette) -> LinePart {
     let description = "Select pane";
     let separator = if is_first_shortcut { " " } else { " / " };
     let white_color = match palette.white {
-        PaletteColor::RGB((r, g, b)) => {
-            RGB(r, g, b)
-        }
-        PaletteColor::EightBit(color) => {
-            Fixed(color)
-        }
+        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
+        PaletteColor::EightBit(color) => Fixed(color),
     };
     let orange_color = match palette.orange {
-        PaletteColor::RGB((r, g, b)) => {
-            RGB(r, g, b)
-        }
-        PaletteColor::EightBit(color) => {
-            Fixed(color)
-        }
+        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
+        PaletteColor::EightBit(color) => Fixed(color),
     };
-    let separator = Style::new()
-        .fg(white_color)
-        .paint(separator);
+    let separator = Style::new().fg(white_color).paint(separator);
     let shortcut_len = shortcut.chars().count() + 3; // 2 for <>'s around shortcut, 1 for the space
-    let shortcut_left_separator = Style::new()
-        .fg(white_color)
-        .paint("<");
-    let shortcut = Style::new()
-        .fg(orange_color)
-        .bold()
-        .paint(shortcut);
-    let shortcut_right_separator = Style::new()
-        .fg(white_color)
-        .paint("> ");
+    let shortcut_left_separator = Style::new().fg(white_color).paint("<");
+    let shortcut = Style::new().fg(orange_color).bold().paint(shortcut);
+    let shortcut_right_separator = Style::new().fg(white_color).paint("> ");
     let description_len = description.chars().count();
-    let description = Style::new()
-        .fg(white_color)
-        .bold()
-        .paint(description);
+    let description = Style::new().fg(white_color).bold().paint(description);
     let len = shortcut_len + description_len + separator.chars().count();
     LinePart {
         part: format!(

--- a/default-plugins/status-bar/src/second_line.rs
+++ b/default-plugins/status-bar/src/second_line.rs
@@ -1,5 +1,4 @@
-// use colored::*;
-use ansi_term::{ANSIStrings, Color::RGB, Style};
+use ansi_term::{ANSIStrings, Color::{RGB, Fixed}, Style};
 use zellij_tile::prelude::*;
 
 use crate::{LinePart, MORE_MSG};
@@ -10,24 +9,40 @@ fn full_length_shortcut(
     description: &str,
     palette: Palette,
 ) -> LinePart {
+    let white_color = match palette.white {
+        PaletteColor::RGB((r, g, b)) => {
+            RGB(r, g, b)
+        }
+        PaletteColor::EightBit(color) => {
+            Fixed(color)
+        }
+    };
+    let green_color = match palette.green {
+        PaletteColor::RGB((r, g, b)) => {
+            RGB(r, g, b)
+        }
+        PaletteColor::EightBit(color) => {
+            Fixed(color)
+        }
+    };
     let separator = if is_first_shortcut { " " } else { " / " };
     let separator = Style::new()
-        .fg(RGB(palette.fg.0, palette.fg.1, palette.fg.2))
+        .fg(white_color)
         .paint(separator);
     let shortcut_len = letter.chars().count() + 3; // 2 for <>'s around shortcut, 1 for the space
     let shortcut_left_separator = Style::new()
-        .fg(RGB(palette.fg.0, palette.fg.1, palette.fg.2))
+        .fg(white_color)
         .paint("<");
     let shortcut = Style::new()
-        .fg(RGB(palette.green.0, palette.green.1, palette.green.2))
+        .fg(green_color)
         .bold()
         .paint(letter);
     let shortcut_right_separator = Style::new()
-        .fg(RGB(palette.fg.0, palette.fg.1, palette.fg.2))
+        .fg(white_color)
         .paint("> ");
     let description_len = description.chars().count();
     let description = Style::new()
-        .fg(RGB(palette.fg.0, palette.fg.1, palette.fg.2))
+        .fg(white_color)
         .bold()
         .paint(description);
     let len = shortcut_len + description_len + separator.chars().count();
@@ -52,25 +67,41 @@ fn first_word_shortcut(
     description: &str,
     palette: Palette,
 ) -> LinePart {
+    let white_color = match palette.white {
+        PaletteColor::RGB((r, g, b)) => {
+            RGB(r, g, b)
+        }
+        PaletteColor::EightBit(color) => {
+            Fixed(color)
+        }
+    };
+    let green_color = match palette.green {
+        PaletteColor::RGB((r, g, b)) => {
+            RGB(r, g, b)
+        }
+        PaletteColor::EightBit(color) => {
+            Fixed(color)
+        }
+    };
     let separator = if is_first_shortcut { " " } else { " / " };
     let separator = Style::new()
-        .fg(RGB(palette.fg.0, palette.fg.1, palette.fg.2))
+        .fg(white_color)
         .paint(separator);
     let shortcut_len = letter.chars().count() + 3; // 2 for <>'s around shortcut, 1 for the space
     let shortcut_left_separator = Style::new()
-        .fg(RGB(palette.fg.0, palette.fg.1, palette.fg.2))
+        .fg(white_color)
         .paint("<");
     let shortcut = Style::new()
-        .fg(RGB(palette.green.0, palette.green.1, palette.green.2))
+        .fg(green_color)
         .bold()
         .paint(letter);
     let shortcut_right_separator = Style::new()
-        .fg(RGB(palette.fg.0, palette.fg.1, palette.fg.2))
+        .fg(white_color)
         .paint("> ");
     let description_first_word = description.split(' ').next().unwrap_or("");
     let description_first_word_length = description_first_word.chars().count();
     let description_first_word = Style::new()
-        .fg(RGB(palette.fg.0, palette.fg.1, palette.fg.2))
+        .fg(white_color)
         .bold()
         .paint(description_first_word);
     let len = shortcut_len + description_first_word_length + separator.chars().count();
@@ -111,32 +142,48 @@ fn quicknav_full(palette: Palette) -> LinePart {
         + text_fifth_part.chars().count()
         + hjkl_navigation.chars().count()
         + text_sixths_part.chars().count();
+    let green_color = match palette.green {
+        PaletteColor::RGB((r, g, b)) => {
+            RGB(r, g, b)
+        }
+        PaletteColor::EightBit(color) => {
+            Fixed(color)
+        }
+    };
+    let orange_color = match palette.orange {
+        PaletteColor::RGB((r, g, b)) => {
+            RGB(r, g, b)
+        }
+        PaletteColor::EightBit(color) => {
+            Fixed(color)
+        }
+    };
     LinePart {
         part: format!(
             "{}{}{}{}{}{}{}{}{}{}{}",
             text_first_part,
             Style::new()
-                .fg(RGB(palette.orange.0, palette.orange.1, palette.orange.2))
+                .fg(orange_color)
                 .bold()
                 .paint(alt),
             text_second_part,
             Style::new()
-                .fg(RGB(palette.green.0, palette.green.1, palette.green.2))
+                .fg(green_color)
                 .bold()
                 .paint(new_pane_shortcut),
             text_third_part,
             Style::new()
-                .fg(RGB(palette.orange.0, palette.orange.1, palette.orange.2))
+                .fg(orange_color)
                 .bold()
                 .paint(second_alt),
             text_fourth_part,
             Style::new()
-                .fg(RGB(palette.green.0, palette.green.1, palette.green.2))
+                .fg(green_color)
                 .bold()
                 .paint(brackets_navigation),
             text_fifth_part,
             Style::new()
-                .fg(RGB(palette.green.0, palette.green.1, palette.green.2))
+                .fg(green_color)
                 .bold()
                 .paint(hjkl_navigation),
             text_sixths_part,
@@ -168,32 +215,48 @@ fn quicknav_medium(palette: Palette) -> LinePart {
         + text_fifth_part.chars().count()
         + hjkl_navigation.chars().count()
         + text_sixths_part.chars().count();
+    let green_color = match palette.green {
+        PaletteColor::RGB((r, g, b)) => {
+            RGB(r, g, b)
+        }
+        PaletteColor::EightBit(color) => {
+            Fixed(color)
+        }
+    };
+    let orange_color = match palette.orange {
+        PaletteColor::RGB((r, g, b)) => {
+            RGB(r, g, b)
+        }
+        PaletteColor::EightBit(color) => {
+            Fixed(color)
+        }
+    };
     LinePart {
         part: format!(
             "{}{}{}{}{}{}{}{}{}{}{}",
             text_first_part,
             Style::new()
-                .fg(RGB(palette.orange.0, palette.orange.1, palette.orange.2))
+                .fg(orange_color)
                 .bold()
                 .paint(alt),
             text_second_part,
             Style::new()
-                .fg(RGB(palette.green.0, palette.green.1, palette.green.2))
+                .fg(green_color)
                 .bold()
                 .paint(new_pane_shortcut),
             text_third_part,
             Style::new()
-                .fg(RGB(palette.orange.0, palette.orange.1, palette.orange.2))
+                .fg(orange_color)
                 .bold()
                 .paint(second_alt),
             text_fourth_part,
             Style::new()
-                .fg(RGB(palette.green.0, palette.green.1, palette.green.2))
+                .fg(green_color)
                 .bold()
                 .paint(brackets_navigation),
             text_fifth_part,
             Style::new()
-                .fg(RGB(palette.green.0, palette.green.1, palette.green.2))
+                .fg(green_color)
                 .bold()
                 .paint(hjkl_navigation),
             text_sixths_part,
@@ -219,27 +282,43 @@ fn quicknav_short(palette: Palette) -> LinePart {
         + brackets_navigation.chars().count()
         + text_fifth_part.chars().count()
         + hjkl_navigation.chars().count();
+    let green_color = match palette.green {
+        PaletteColor::RGB((r, g, b)) => {
+            RGB(r, g, b)
+        }
+        PaletteColor::EightBit(color) => {
+            Fixed(color)
+        }
+    };
+    let orange_color = match palette.orange {
+        PaletteColor::RGB((r, g, b)) => {
+            RGB(r, g, b)
+        }
+        PaletteColor::EightBit(color) => {
+            Fixed(color)
+        }
+    };
     LinePart {
         part: format!(
             "{}{}{}{}{}{}{}{}",
             text_first_part,
             Style::new()
-                .fg(RGB(palette.orange.0, palette.orange.1, palette.orange.2))
+                .fg(orange_color)
                 .bold()
                 .paint(alt),
             text_second_part,
             Style::new()
-                .fg(RGB(palette.green.0, palette.green.1, palette.green.2))
+                .fg(green_color)
                 .bold()
                 .paint(new_pane_shortcut),
             text_third_part,
             Style::new()
-                .fg(RGB(palette.green.0, palette.green.1, palette.green.2))
+                .fg(green_color)
                 .bold()
                 .paint(brackets_navigation),
             text_fifth_part,
             Style::new()
-                .fg(RGB(palette.green.0, palette.green.1, palette.green.2))
+                .fg(green_color)
                 .bold()
                 .paint(hjkl_navigation),
         ),
@@ -250,8 +329,16 @@ fn quicknav_short(palette: Palette) -> LinePart {
 fn locked_interface_indication(palette: Palette) -> LinePart {
     let locked_text = " -- INTERFACE LOCKED -- ";
     let locked_text_len = locked_text.chars().count();
+    let white_color = match palette.white {
+        PaletteColor::RGB((r, g, b)) => {
+            RGB(r, g, b)
+        }
+        PaletteColor::EightBit(color) => {
+            Fixed(color)
+        }
+    };
     let locked_styled_text = Style::new()
-        .fg(RGB(palette.fg.0, palette.fg.1, palette.fg.2))
+        .fg(white_color)
         .bold()
         .paint(locked_text);
     LinePart {
@@ -264,23 +351,39 @@ fn select_pane_shortcut(is_first_shortcut: bool, palette: Palette) -> LinePart {
     let shortcut = "ENTER";
     let description = "Select pane";
     let separator = if is_first_shortcut { " " } else { " / " };
+    let white_color = match palette.white {
+        PaletteColor::RGB((r, g, b)) => {
+            RGB(r, g, b)
+        }
+        PaletteColor::EightBit(color) => {
+            Fixed(color)
+        }
+    };
+    let orange_color = match palette.orange {
+        PaletteColor::RGB((r, g, b)) => {
+            RGB(r, g, b)
+        }
+        PaletteColor::EightBit(color) => {
+            Fixed(color)
+        }
+    };
     let separator = Style::new()
-        .fg(RGB(palette.fg.0, palette.fg.1, palette.fg.2))
+        .fg(white_color)
         .paint(separator);
     let shortcut_len = shortcut.chars().count() + 3; // 2 for <>'s around shortcut, 1 for the space
     let shortcut_left_separator = Style::new()
-        .fg(RGB(palette.fg.0, palette.fg.1, palette.fg.2))
+        .fg(white_color)
         .paint("<");
     let shortcut = Style::new()
-        .fg(RGB(palette.orange.0, palette.orange.1, palette.orange.2))
+        .fg(orange_color)
         .bold()
         .paint(shortcut);
     let shortcut_right_separator = Style::new()
-        .fg(RGB(palette.fg.0, palette.fg.1, palette.fg.2))
+        .fg(white_color)
         .paint("> ");
     let description_len = description.chars().count();
     let description = Style::new()
-        .fg(RGB(palette.fg.0, palette.fg.1, palette.fg.2))
+        .fg(white_color)
         .bold()
         .paint(description);
     let len = shortcut_len + description_len + separator.chars().count();

--- a/default-plugins/tab-bar/src/line.rs
+++ b/default-plugins/tab-bar/src/line.rs
@@ -63,7 +63,9 @@ fn left_more_message(tab_count_to_the_left: usize, palette: Palette) -> LinePart
     // 238
     let more_text_len = more_text.chars().count() + 2; // 2 for the arrows
     let left_separator = style!(palette.bg, palette.orange).paint(ARROW_SEPARATOR);
-    let more_styled_text = style!(palette.black, palette.orange).bold().paint(more_text);
+    let more_styled_text = style!(palette.black, palette.orange)
+        .bold()
+        .paint(more_text);
     let right_separator = style!(palette.orange, palette.bg).paint(ARROW_SEPARATOR);
     let more_styled_text = format!(
         "{}",
@@ -89,7 +91,9 @@ fn right_more_message(tab_count_to_the_right: usize, palette: Palette) -> LinePa
     };
     let more_text_len = more_text.chars().count() + 1; // 2 for the arrow
     let left_separator = style!(palette.bg, palette.orange).paint(ARROW_SEPARATOR);
-    let more_styled_text = style!(palette.black, palette.orange).bold().paint(more_text);
+    let more_styled_text = style!(palette.black, palette.orange)
+        .bold()
+        .paint(more_text);
     let right_separator = style!(palette.orange, palette.bg).paint(ARROW_SEPARATOR);
     let more_styled_text = format!(
         "{}",

--- a/default-plugins/tab-bar/src/line.rs
+++ b/default-plugins/tab-bar/src/line.rs
@@ -62,8 +62,8 @@ fn left_more_message(tab_count_to_the_left: usize, palette: Palette) -> LinePart
     };
     // 238
     let more_text_len = more_text.chars().count() + 2; // 2 for the arrows
-    let left_separator = style!(palette.fg, palette.orange).paint(ARROW_SEPARATOR);
-    let more_styled_text = style!(palette.fg, palette.orange).bold().paint(more_text);
+    let left_separator = style!(palette.bg, palette.orange).paint(ARROW_SEPARATOR);
+    let more_styled_text = style!(palette.black, palette.orange).bold().paint(more_text);
     let right_separator = style!(palette.orange, palette.bg).paint(ARROW_SEPARATOR);
     let more_styled_text = format!(
         "{}",
@@ -88,8 +88,8 @@ fn right_more_message(tab_count_to_the_right: usize, palette: Palette) -> LinePa
         " +many → ".to_string()
     };
     let more_text_len = more_text.chars().count() + 1; // 2 for the arrow
-    let left_separator = style!(palette.fg, palette.orange).paint(ARROW_SEPARATOR);
-    let more_styled_text = style!(palette.fg, palette.orange).bold().paint(more_text);
+    let left_separator = style!(palette.bg, palette.orange).paint(ARROW_SEPARATOR);
+    let more_styled_text = style!(palette.black, palette.orange).bold().paint(more_text);
     let right_separator = style!(palette.orange, palette.bg).paint(ARROW_SEPARATOR);
     let more_styled_text = format!(
         "{}",
@@ -137,7 +137,7 @@ fn add_next_tabs_msg(
 fn tab_line_prefix(palette: Palette) -> LinePart {
     let prefix_text = " Zellij ".to_string();
     let prefix_text_len = prefix_text.chars().count();
-    let prefix_styled_text = style!(palette.fg, palette.bg).bold().paint(prefix_text);
+    let prefix_styled_text = style!(palette.white, palette.bg).bold().paint(prefix_text);
     LinePart {
         part: format!("{}", prefix_styled_text),
         len: prefix_text_len,

--- a/default-plugins/tab-bar/src/main.rs
+++ b/default-plugins/tab-bar/src/main.rs
@@ -69,21 +69,11 @@ impl ZellijPlugin for State {
             s = format!("{}{}", s, bar_part.part);
         }
         match self.mode_info.palette.bg {
-            PaletteColor::RGB((r, g, b)) => {
-                println!(
-                    "{}\u{1b}[48;2;{};{};{}m\u{1b}[0K",
-                    s,
-                    r,
-                    g,
-                    b
-                );
-            },
+            PaletteColor::Rgb((r, g, b)) => {
+                println!("{}\u{1b}[48;2;{};{};{}m\u{1b}[0K", s, r, g, b);
+            }
             PaletteColor::EightBit(color) => {
-                println!(
-                    "{}\u{1b}[48;5;{}m\u{1b}[0K",
-                    s,
-                    color
-                );
+                println!("{}\u{1b}[48;5;{}m\u{1b}[0K", s, color);
             }
         }
     }

--- a/default-plugins/tab-bar/src/main.rs
+++ b/default-plugins/tab-bar/src/main.rs
@@ -68,12 +68,23 @@ impl ZellijPlugin for State {
         for bar_part in tab_line {
             s = format!("{}{}", s, bar_part.part);
         }
-        println!(
-            "{}\u{1b}[48;2;{};{};{}m\u{1b}[0K",
-            s,
-            self.mode_info.palette.bg.0,
-            self.mode_info.palette.bg.1,
-            self.mode_info.palette.bg.2
-        );
+        match self.mode_info.palette.bg {
+            PaletteColor::RGB((r, g, b)) => {
+                println!(
+                    "{}\u{1b}[48;2;{};{};{}m\u{1b}[0K",
+                    s,
+                    r,
+                    g,
+                    b
+                );
+            },
+            PaletteColor::EightBit(color) => {
+                println!(
+                    "{}\u{1b}[48;5;{}m\u{1b}[0K",
+                    s,
+                    color
+                );
+            }
+        }
     }
 }

--- a/default-plugins/tab-bar/src/tab.rs
+++ b/default-plugins/tab-bar/src/tab.rs
@@ -6,7 +6,7 @@ use zellij_tile_extra::*;
 pub fn active_tab(text: String, palette: Palette) -> LinePart {
     let left_separator = style!(palette.bg, palette.green).paint(ARROW_SEPARATOR);
     let tab_text_len = text.chars().count() + 4; // 2 for left and right separators, 2 for the text padding
-    let tab_styled_text = style!(palette.bg, palette.green)
+    let tab_styled_text = style!(palette.black, palette.green)
         .bold()
         .paint(format!(" {} ", text));
     let right_separator = style!(palette.green, palette.bg).paint(ARROW_SEPARATOR);
@@ -21,12 +21,12 @@ pub fn active_tab(text: String, palette: Palette) -> LinePart {
 }
 
 pub fn non_active_tab(text: String, palette: Palette) -> LinePart {
-    let left_separator = style!(palette.bg, palette.bg).paint(ARROW_SEPARATOR);
+    let left_separator = style!(palette.bg, palette.fg).paint(ARROW_SEPARATOR);
     let tab_text_len = text.chars().count() + 4; // 2 for left and right separators, 2 for the padding
-    let tab_styled_text = style!(palette.fg, palette.bg)
+    let tab_styled_text = style!(palette.black, palette.fg)
         .bold()
         .paint(format!(" {} ", text));
-    let right_separator = style!(palette.bg, palette.bg).paint(ARROW_SEPARATOR);
+    let right_separator = style!(palette.fg, palette.bg).paint(ARROW_SEPARATOR);
     let tab_styled_text = format!(
         "{}",
         ANSIStrings(&[left_separator, tab_styled_text, right_separator,])

--- a/src/client/boundaries.rs
+++ b/src/client/boundaries.rs
@@ -1,6 +1,6 @@
 use crate::tab::Pane;
 use crate::utils::shared::colors;
-use ansi_term::Colour::{RGB, Fixed};
+use ansi_term::Colour::{Fixed, RGB};
 use std::collections::HashMap;
 use zellij_tile::data::{InputMode, Palette, PaletteColor};
 
@@ -51,18 +51,12 @@ impl Display for BoundarySymbol {
         match self.invisible {
             true => write!(f, " "),
             false => match self.color {
-                Some(color) => {
-                    match color {
-                        PaletteColor::RGB((r, g, b)) => {
-                            write!(
-                                f,
-                                "{}",
-                                RGB(r, g, b).paint(self.boundary_type)
-                            )
-                        },
-                        PaletteColor::EightBit(color) => {
-                            write!(f, "{}", Fixed(color).paint(self.boundary_type))
-                        }
+                Some(color) => match color {
+                    PaletteColor::Rgb((r, g, b)) => {
+                        write!(f, "{}", RGB(r, g, b).paint(self.boundary_type))
+                    }
+                    PaletteColor::EightBit(color) => {
+                        write!(f, "{}", Fixed(color).paint(self.boundary_type))
                     }
                 },
                 None => write!(f, "{}", self.boundary_type),

--- a/src/client/boundaries.rs
+++ b/src/client/boundaries.rs
@@ -1,8 +1,8 @@
 use crate::tab::Pane;
 use crate::utils::shared::colors;
-use ansi_term::Colour::RGB;
+use ansi_term::Colour::{RGB, Fixed};
 use std::collections::HashMap;
-use zellij_tile::data::{InputMode, Palette};
+use zellij_tile::data::{InputMode, Palette, PaletteColor};
 
 use std::fmt::{Display, Error, Formatter};
 pub mod boundary_type {
@@ -19,20 +19,13 @@ pub mod boundary_type {
     pub const CROSS: &str = "┼";
 }
 
-// pub mod colors {
-//     use ansi_term::Colour::{self, Fixed};
-//     pub const GREEN: Colour = Fixed(154);
-//     pub const GRAY: Colour = Fixed(238);
-//     pub const ORANGE: Colour = Fixed(166);
-// }
-
 pub type BoundaryType = &'static str; // easy way to refer to boundary_type above
 
 #[derive(Clone, Copy, Debug)]
 pub struct BoundarySymbol {
     boundary_type: BoundaryType,
     invisible: bool,
-    color: Option<(u8, u8, u8)>,
+    color: Option<PaletteColor>,
 }
 
 impl BoundarySymbol {
@@ -40,14 +33,14 @@ impl BoundarySymbol {
         BoundarySymbol {
             boundary_type,
             invisible: false,
-            color: Some(colors::GRAY),
+            color: Some(PaletteColor::EightBit(colors::GRAY)),
         }
     }
     pub fn invisible(mut self) -> Self {
         self.invisible = true;
         self
     }
-    pub fn color(&mut self, color: Option<(u8, u8, u8)>) -> Self {
+    pub fn color(&mut self, color: Option<PaletteColor>) -> Self {
         self.color = color;
         *self
     }
@@ -58,11 +51,20 @@ impl Display for BoundarySymbol {
         match self.invisible {
             true => write!(f, " "),
             false => match self.color {
-                Some(color) => write!(
-                    f,
-                    "{}",
-                    RGB(color.0, color.1, color.2).paint(self.boundary_type)
-                ),
+                Some(color) => {
+                    match color {
+                        PaletteColor::RGB((r, g, b)) => {
+                            write!(
+                                f,
+                                "{}",
+                                RGB(r, g, b).paint(self.boundary_type)
+                            )
+                        },
+                        PaletteColor::EightBit(color) => {
+                            write!(f, "{}", Fixed(color).paint(self.boundary_type))
+                        }
+                    }
+                },
                 None => write!(f, "{}", self.boundary_type),
             },
         }

--- a/src/common/os_input_output.rs
+++ b/src/common/os_input_output.rs
@@ -1,5 +1,5 @@
 use crate::panes::PositionAndSize;
-use crate::utils::shared::{default_palette, detect_theme, hex_to_rgb};
+use crate::utils::shared::default_palette;
 use nix::fcntl::{fcntl, FcntlArg, OFlag};
 use nix::pty::{forkpty, Winsize};
 use nix::sys::signal::{kill, Signal};
@@ -13,8 +13,7 @@ use std::os::unix::io::RawFd;
 use std::path::PathBuf;
 use std::process::{Child, Command};
 use std::sync::{Arc, Mutex};
-use xrdb::Colors;
-use zellij_tile::data::{Palette, PaletteSource};
+use zellij_tile::data::Palette;
 
 use signal_hook::{consts::signal::*, iterator::Signals};
 
@@ -266,49 +265,7 @@ impl OsApi for OsInputOutput {
         }
     }
     fn load_palette(&self) -> Palette {
-        let palette = match Colors::new("xresources") {
-            Some(palette) => {
-                let fg = if let Some(foreground) = palette.fg.as_deref().map(hex_to_rgb) {
-                    foreground
-                } else {
-                    return default_palette();
-                };
-
-                let bg = if let Some(background) = palette.bg.as_deref().map(hex_to_rgb) {
-                    background
-                } else {
-                    return default_palette();
-                };
-
-                // NOTE: `16` is the same as the length of `palette.colors`.
-                let mut colors: [(u8, u8, u8); 16] = [(0, 0, 0); 16];
-                for (idx, color) in palette.colors.iter().enumerate() {
-                    if let Some(c) = color {
-                        colors[idx] = hex_to_rgb(c);
-                    } else {
-                        return default_palette();
-                    }
-                }
-                let theme = detect_theme(bg);
-                Palette {
-                    source: PaletteSource::Xresources,
-                    theme,
-                    fg,
-                    bg,
-                    black: colors[0],
-                    red: colors[1],
-                    green: colors[2],
-                    yellow: colors[3],
-                    blue: colors[4],
-                    magenta: colors[5],
-                    cyan: colors[6],
-                    white: colors[7],
-                    orange: colors[9],
-                }
-            }
-            None => default_palette(),
-        };
-        palette
+        default_palette()
     }
 }
 

--- a/src/common/utils/shared.rs
+++ b/src/common/utils/shared.rs
@@ -5,7 +5,7 @@ use std::{iter, str::from_utf8};
 use strip_ansi_escapes::strip;
 
 use colors_transform::{Color, Rgb};
-use zellij_tile::data::{Palette, PaletteSource, PaletteColor, Theme};
+use zellij_tile::data::{Palette, PaletteColor, PaletteSource, Theme};
 
 fn ansi_len(s: &str) -> usize {
     from_utf8(&strip(s.as_bytes()).unwrap())
@@ -71,7 +71,7 @@ pub fn default_palette() -> Palette {
 // Dark magic
 pub fn detect_theme(bg: PaletteColor) -> Theme {
     match bg {
-        PaletteColor::RGB((r, g, b)) => {
+        PaletteColor::Rgb((r, g, b)) => {
             // HSP, P stands for perceived brightness
             let hsp: f64 = (0.299 * (r as f64 * r as f64)
                 + 0.587 * (g as f64 * g as f64)

--- a/src/common/utils/shared.rs
+++ b/src/common/utils/shared.rs
@@ -5,7 +5,7 @@ use std::{iter, str::from_utf8};
 use strip_ansi_escapes::strip;
 
 use colors_transform::{Color, Rgb};
-use zellij_tile::data::{Palette, PaletteSource, Theme};
+use zellij_tile::data::{Palette, PaletteSource, PaletteColor, Theme};
 
 fn ansi_len(s: &str) -> usize {
     from_utf8(&strip(s.as_bytes()).unwrap())
@@ -34,13 +34,13 @@ pub fn adjust_to_size(s: &str, rows: usize, columns: usize) -> String {
 
 // Colors
 pub mod colors {
-    pub const WHITE: (u8, u8, u8) = (238, 238, 238);
-    pub const GREEN: (u8, u8, u8) = (175, 255, 0);
-    pub const GRAY: (u8, u8, u8) = (68, 68, 68);
-    pub const BRIGHT_GRAY: (u8, u8, u8) = (138, 138, 138);
-    pub const RED: (u8, u8, u8) = (135, 0, 0);
-    pub const ORANGE: (u8, u8, u8) = (215, 95, 0);
-    pub const BLACK: (u8, u8, u8) = (0, 0, 0);
+    pub const WHITE: u8 = 255;
+    pub const GREEN: u8 = 154;
+    pub const GRAY: u8 = 238;
+    pub const BRIGHT_GRAY: u8 = 245;
+    pub const RED: u8 = 88;
+    pub const ORANGE: u8 = 166;
+    pub const BLACK: u8 = 16;
 }
 
 pub fn hex_to_rgb(hex: &str) -> (u8, u8, u8) {
@@ -54,30 +54,34 @@ pub fn default_palette() -> Palette {
     Palette {
         source: PaletteSource::Default,
         theme: Theme::Dark,
-        fg: colors::BRIGHT_GRAY,
-        bg: colors::GRAY,
-        black: colors::BLACK,
-        red: colors::RED,
-        green: colors::GREEN,
-        yellow: colors::GRAY,
-        blue: colors::GRAY,
-        magenta: colors::GRAY,
-        cyan: colors::GRAY,
-        white: colors::WHITE,
-        orange: colors::ORANGE,
+        fg: PaletteColor::EightBit(colors::BRIGHT_GRAY),
+        bg: PaletteColor::EightBit(colors::GRAY),
+        black: PaletteColor::EightBit(colors::BLACK),
+        red: PaletteColor::EightBit(colors::RED),
+        green: PaletteColor::EightBit(colors::GREEN),
+        yellow: PaletteColor::EightBit(colors::GRAY),
+        blue: PaletteColor::EightBit(colors::GRAY),
+        magenta: PaletteColor::EightBit(colors::GRAY),
+        cyan: PaletteColor::EightBit(colors::GRAY),
+        white: PaletteColor::EightBit(colors::WHITE),
+        orange: PaletteColor::EightBit(colors::ORANGE),
     }
 }
 
 // Dark magic
-pub fn detect_theme(bg: (u8, u8, u8)) -> Theme {
-    let (r, g, b) = bg;
-    // HSP, P stands for perceived brightness
-    let hsp: f64 = (0.299 * (r as f64 * r as f64)
-        + 0.587 * (g as f64 * g as f64)
-        + 0.114 * (b as f64 * b as f64))
-        .sqrt();
-    match hsp > 127.5 {
-        true => Theme::Light,
-        false => Theme::Dark,
+pub fn detect_theme(bg: PaletteColor) -> Theme {
+    match bg {
+        PaletteColor::RGB((r, g, b)) => {
+            // HSP, P stands for perceived brightness
+            let hsp: f64 = (0.299 * (r as f64 * r as f64)
+                + 0.587 * (g as f64 * g as f64)
+                + 0.114 * (b as f64 * b as f64))
+                .sqrt();
+            match hsp > 127.5 {
+                true => Theme::Light,
+                false => Theme::Dark,
+            }
+        }
+        _ => Theme::Dark,
     }
 }

--- a/src/tests/fakes.rs
+++ b/src/tests/fakes.rs
@@ -8,8 +8,8 @@ use std::time::{Duration, Instant};
 
 use crate::os_input_output::OsApi;
 use crate::tests::possible_tty_inputs::{get_possible_tty_inputs, Bytes};
-use crate::utils::shared::colors;
-use zellij_tile::data::{Palette, PaletteSource, Theme};
+use crate::utils::shared::default_palette;
+use zellij_tile::data::Palette;
 
 use crate::tests::utils::commands::{QUIT, SLEEP};
 
@@ -75,7 +75,6 @@ pub struct FakeInputOutput {
     last_snapshot_time: Arc<Mutex<Instant>>,
     should_trigger_sigwinch: Arc<(Mutex<bool>, Condvar)>,
     sigwinch_event: Option<PositionAndSize>,
-    palette: Arc<Mutex<Palette>>,
 }
 
 impl FakeInputOutput {
@@ -84,21 +83,6 @@ impl FakeInputOutput {
         let last_snapshot_time = Arc::new(Mutex::new(Instant::now()));
         let stdout_writer = FakeStdoutWriter::new(last_snapshot_time.clone());
         win_sizes.insert(0, winsize); // 0 is the current terminal
-        let palette: Palette = Palette {
-            source: PaletteSource::Default,
-            theme: Theme::Dark,
-            fg: colors::BRIGHT_GRAY,
-            bg: colors::GRAY,
-            black: colors::BLACK,
-            red: colors::RED,
-            green: colors::GREEN,
-            yellow: colors::GRAY,
-            blue: colors::GRAY,
-            magenta: colors::GRAY,
-            cyan: colors::GRAY,
-            white: colors::WHITE,
-            orange: colors::ORANGE,
-        };
         FakeInputOutput {
             read_buffers: Arc::new(Mutex::new(HashMap::new())),
             stdin_writes: Arc::new(Mutex::new(HashMap::new())),
@@ -111,7 +95,6 @@ impl FakeInputOutput {
             possible_tty_inputs: get_possible_tty_inputs(),
             should_trigger_sigwinch: Arc::new((Mutex::new(false), Condvar::new())),
             sigwinch_event: None,
-            palette: Arc::new(Mutex::new(palette)),
         }
     }
     pub fn with_tty_inputs(mut self, tty_inputs: HashMap<u16, Bytes>) -> Self {
@@ -255,21 +238,6 @@ impl OsApi for FakeInputOutput {
         }
     }
     fn load_palette(&self) -> Palette {
-        let palette: Palette = Palette {
-            source: PaletteSource::Default,
-            theme: Theme::Dark,
-            fg: colors::BRIGHT_GRAY,
-            bg: colors::GRAY,
-            black: colors::BLACK,
-            red: colors::RED,
-            green: colors::GREEN,
-            yellow: colors::GRAY,
-            blue: colors::GRAY,
-            magenta: colors::GRAY,
-            cyan: colors::GRAY,
-            white: colors::WHITE,
-            orange: colors::ORANGE,
-        };
-        palette
+        default_palette()
     }
 }

--- a/zellij-tile-extra/src/lib.rs
+++ b/zellij-tile-extra/src/lib.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! rgb {
     ($a:expr) => {
-        ansi_term::Color::RGB($a.0, $a.1, $a.2)
+        ansi_term::Color::Rgb($a.0, $a.1, $a.2)
     };
 }
 
@@ -10,20 +10,12 @@ macro_rules! style {
     ($fg:expr, $bg:expr) => {
         ansi_term::Style::new()
             .fg(match $fg {
-                PaletteColor::RGB((r, g, b)) => {
-                    ansi_term::Color::RGB(r, g, b)
-                }
-                PaletteColor::EightBit(color) => {
-                    ansi_term::Color::Fixed(color)
-                }
+                PaletteColor::Rgb((r, g, b)) => ansi_term::Color::RGB(r, g, b),
+                PaletteColor::EightBit(color) => ansi_term::Color::Fixed(color),
             })
             .on(match $bg {
-                PaletteColor::RGB((r, g, b)) => {
-                    ansi_term::Color::RGB(r, g, b)
-                }
-                PaletteColor::EightBit(color) => {
-                    ansi_term::Color::Fixed(color)
-                }
+                PaletteColor::Rgb((r, g, b)) => ansi_term::Color::RGB(r, g, b),
+                PaletteColor::EightBit(color) => ansi_term::Color::Fixed(color),
             })
     };
 }

--- a/zellij-tile-extra/src/lib.rs
+++ b/zellij-tile-extra/src/lib.rs
@@ -7,9 +7,23 @@ macro_rules! rgb {
 
 #[macro_export]
 macro_rules! style {
-    ($a:expr, $b:expr) => {
+    ($fg:expr, $bg:expr) => {
         ansi_term::Style::new()
-            .fg(ansi_term::Color::RGB($a.0, $a.1, $a.2))
-            .on(ansi_term::Color::RGB($b.0, $b.1, $b.2))
+            .fg(match $fg {
+                PaletteColor::RGB((r, g, b)) => {
+                    ansi_term::Color::RGB(r, g, b)
+                }
+                PaletteColor::EightBit(color) => {
+                    ansi_term::Color::Fixed(color)
+                }
+            })
+            .on(match $bg {
+                PaletteColor::RGB((r, g, b)) => {
+                    ansi_term::Color::RGB(r, g, b)
+                }
+                PaletteColor::EightBit(color) => {
+                    ansi_term::Color::Fixed(color)
+                }
+            })
     };
 }

--- a/zellij-tile/src/data.rs
+++ b/zellij-tile/src/data.rs
@@ -79,6 +79,17 @@ impl Default for Theme {
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum PaletteColor {
+    RGB((u8, u8, u8)),
+    EightBit(u8),
+}
+impl Default for PaletteColor {
+    fn default() -> PaletteColor {
+        PaletteColor::EightBit(0)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum PaletteSource {
     Default,
     Xresources,
@@ -92,17 +103,17 @@ impl Default for PaletteSource {
 pub struct Palette {
     pub source: PaletteSource,
     pub theme: Theme,
-    pub fg: (u8, u8, u8),
-    pub bg: (u8, u8, u8),
-    pub black: (u8, u8, u8),
-    pub red: (u8, u8, u8),
-    pub green: (u8, u8, u8),
-    pub yellow: (u8, u8, u8),
-    pub blue: (u8, u8, u8),
-    pub magenta: (u8, u8, u8),
-    pub cyan: (u8, u8, u8),
-    pub white: (u8, u8, u8),
-    pub orange: (u8, u8, u8),
+    pub fg: PaletteColor,
+    pub bg: PaletteColor,
+    pub black: PaletteColor,
+    pub red: PaletteColor,
+    pub green: PaletteColor,
+    pub yellow: PaletteColor,
+    pub blue: PaletteColor,
+    pub magenta: PaletteColor,
+    pub cyan: PaletteColor,
+    pub white: PaletteColor,
+    pub orange: PaletteColor,
 }
 
 /// Represents the contents of the help message that is printed in the status bar,

--- a/zellij-tile/src/data.rs
+++ b/zellij-tile/src/data.rs
@@ -80,7 +80,7 @@ impl Default for Theme {
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum PaletteColor {
-    RGB((u8, u8, u8)),
+    Rgb((u8, u8, u8)),
     EightBit(u8),
 }
 impl Default for PaletteColor {


### PR DESCRIPTION
This includes various fixes to the new coloring system:
1. Support 8bit terminals - this is done by having the default palette being 8bit
2. Do not crash on boxes without an x11 system (this was unfortunately done by removing the automatic xrdb reading - we can find a way to re-add it later)
3. Fix the colors in the interface (the colors of some elements were wrong)
4. Fix the interface breaking in smaller sizes (the lengths and coloring of the more/less messages in the tabs and the single-letter ctrl shortcuts on the status bar were wrong and made them seem broken).