### PR TITLE
Change Ordering of the Default Config Directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+* Change Switch default config loading order of `HOME` and system (https://github.com/zellij-org/zellij/pull/488)
 
 ## [0.9.0] - 2021-05-11
 * Add more functionality to unbinding the default keybindings (https://github.com/zellij-org/zellij/pull/468)

--- a/src/common/setup.rs
+++ b/src/common/setup.rs
@@ -53,8 +53,8 @@ pub mod install {
 #[cfg(not(test))]
 pub fn find_default_config_dir() -> Option<PathBuf> {
     vec![
-        Some(xdg_config_dir()),
         home_config_dir(),
+        Some(xdg_config_dir()),
         Some(Path::new(SYSTEM_DEFAULT_CONFIG_DIR).to_path_buf()),
     ]
     .into_iter()


### PR DESCRIPTION
closes #485

* since darwin doesn't have distinct data and config
  directories, assumptions that we had were invalid

* now the `HOME` config directory is loaded before the
  system config directory, in this case populating the
  data directory doesn't invalidate possible user configuration,
  because the configuration directory now exists