### PR TITLE
fix(input): forward unknown keys to active terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Handle pasted text properly (https://github.com/zellij-org/zellij/pull/494)
 * Fix default keybinds for tab -> resize mode (https://github.com/zellij-org/zellij/pull/497)
 * Terminal compatibility: device reports (https://github.com/zellij-org/zellij/pull/500)
+* Forward unknown keys to the active terminal (https://github.com/zellij-org/zellij/pull/501)
 
 ## [0.9.0] - 2021-05-11
 * Add more functionality to unbinding the default keybindings (https://github.com/zellij-org/zellij/pull/468)

--- a/src/common/input/handler.rs
+++ b/src/common/input/handler.rs
@@ -75,6 +75,10 @@ impl InputHandler {
                                 self.pasting = true;
                             } else if unsupported_key == bracketed_paste_end {
                                 self.pasting = false;
+                            } else {
+                                // this is a hack because termion doesn't recognize certain keys
+                                // in this case we just forward it to the terminal
+                                self.handle_unknown_key(raw_bytes);
                             }
                         }
                         termion::event::Event::Mouse(_) => {
@@ -85,6 +89,12 @@ impl InputHandler {
                     Err(err) => panic!("Encountered read error: {:?}", err),
                 }
             }
+        }
+    }
+    fn handle_unknown_key(&mut self, raw_bytes: Vec<u8>) {
+        if self.mode == InputMode::Normal || self.mode == InputMode::Locked {
+            let action = Action::Write(raw_bytes);
+            self.dispatch_action(action);
         }
     }
     fn handle_key(&mut self, key: &Key, raw_bytes: Vec<u8>) {


### PR DESCRIPTION
Since termion has issues identifying certain key sequences (eg. ctrl+left arrow), this change forwards all such keys to the active terminal. This is a bit of a hack until we find a solution for this (sot hat we could also bind those keys for example).