### PR TITLE
Invert Assets Installation Feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,5 +80,4 @@ assets = [
 ]
 
 [features]
-default = [ "enable_automatic_asset_installation", ]
-enable_automatic_asset_installation = []
+disable_automatic_asset_installation = []

--- a/src/common/utils/consts.rs
+++ b/src/common/utils/consts.rs
@@ -49,6 +49,6 @@ lazy_static! {
 }
 
 pub const FEATURES: &[&str] = &[
-    #[cfg(feature = "enable_automatic_asset_installation")]
-    "enable_automatic_asset_installation",
+    #[cfg(feature = "disable_automatic_asset_installation")]
+    "disable_automatic_asset_installation",
 ];

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -187,7 +187,7 @@ fn init_session(
     // Determine and initialize the data directory
     let data_dir = opts.data_dir.unwrap_or_else(get_default_data_dir);
 
-    #[cfg(enable_automatic_assets_installation)]
+    #[cfg(not(disable_automatic_assets_installation))]
     populate_data_dir(&data_dir);
 
     // Don't use default layouts in tests, but do everywhere else


### PR DESCRIPTION
* changed `enable_automatic_asset_installation` to
`disable_automatic_asset_installation`

This ensures that people by default get the
asset installation and need to opt out at
compile time, rather than opt in.

* removed default features

Not needed anymore.