### PR TITLE
Fix `clean` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Restructuring cargo workspace: Separate client, server and utils into separate crates (https://github.com/zellij-org/zellij/pull/515)
 * Terminal compatibility: handle most OSC sequences (https://github.com/zellij-org/zellij/pull/517)
 * Split `layout` flag into `layout` and `layout-path` (https://github.com/zellij-org/zellij/pull/514)
+* Fix behaviour of the `clean` flag (https://github.com/zellij-org/zellij/pull/519)
 
 ## [0.11.0] - 2021-05-15
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,36 +17,35 @@ pub fn main() {
     let opts = CliArgs::from_args();
 
     if let Some(ConfigCli::Setup(setup)) = opts.option.clone() {
-        Setup::from_cli(&setup, opts).expect("Failed to print to stdout");
-        std::process::exit(0);
-    } else {
-        let config = match Config::try_from(&opts) {
-            Ok(config) => config,
+        Setup::from_cli(&setup, &opts).expect("Failed to print to stdout");
+    }
+
+    let config = match Config::try_from(&opts) {
+        Ok(config) => config,
+        Err(e) => {
+            eprintln!("There was an error in the config file:\n{}", e);
+            std::process::exit(1);
+        }
+    };
+    atomic_create_dir(&*ZELLIJ_TMP_DIR).unwrap();
+    atomic_create_dir(&*ZELLIJ_TMP_LOG_DIR).unwrap();
+    if let Some(path) = opts.server {
+        let os_input = match get_server_os_input() {
+            Ok(server_os_input) => server_os_input,
             Err(e) => {
-                eprintln!("There was an error in the config file:\n{}", e);
+                eprintln!("failed to open terminal:\n{}", e);
                 std::process::exit(1);
             }
         };
-        atomic_create_dir(&*ZELLIJ_TMP_DIR).unwrap();
-        atomic_create_dir(&*ZELLIJ_TMP_LOG_DIR).unwrap();
-        if let Some(path) = opts.server {
-            let os_input = match get_server_os_input() {
-                Ok(server_os_input) => server_os_input,
-                Err(e) => {
-                    eprintln!("failed to open terminal:\n{}", e);
-                    std::process::exit(1);
-                }
-            };
-            start_server(Box::new(os_input), path);
-        } else {
-            let os_input = match get_client_os_input() {
-                Ok(os_input) => os_input,
-                Err(e) => {
-                    eprintln!("failed to open terminal:\n{}", e);
-                    std::process::exit(1);
-                }
-            };
-            start_client(Box::new(os_input), opts, config);
-        }
+        start_server(Box::new(os_input), path);
+    } else {
+        let os_input = match get_client_os_input() {
+            Ok(os_input) => os_input,
+            Err(e) => {
+                eprintln!("failed to open terminal:\n{}", e);
+                std::process::exit(1);
+            }
+        };
+        start_client(Box::new(os_input), opts, config);
     }
 }

--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -146,30 +146,38 @@ pub struct Setup {
 
 impl Setup {
     /// Entrypoint from main
-    pub fn from_cli(&self, opts: CliArgs) -> std::io::Result<()> {
+    pub fn from_cli(&self, opts: &CliArgs) -> std::io::Result<()> {
+        if self.clean {
+            return Ok(());
+        }
+
         if self.dump_config {
             dump_default_config()?;
+            std::process::exit(0);
         }
 
         if self.check {
-            Setup::check_defaults_config(opts)?;
+            Setup::check_defaults_config(&opts)?;
+            std::process::exit(0);
         }
 
         if let Some(shell) = &self.generate_completion {
             Self::generate_completion(shell.into());
+            std::process::exit(0);
         }
 
         Ok(())
     }
 
-    pub fn check_defaults_config(opts: CliArgs) -> std::io::Result<()> {
-        let data_dir = opts.data_dir.unwrap_or_else(get_default_data_dir);
-        let config_dir = opts.config_dir.or_else(find_default_config_dir);
+    pub fn check_defaults_config(opts: &CliArgs) -> std::io::Result<()> {
+        let data_dir = opts.data_dir.clone().unwrap_or_else(get_default_data_dir);
+        let config_dir = opts.config_dir.clone().or_else(find_default_config_dir);
         let plugin_dir = data_dir.join("plugins");
         let layout_dir = data_dir.join("layouts");
         let system_data_dir = PathBuf::from(SYSTEM_DEFAULT_DATA_DIR_PREFIX).join("share/zellij");
         let config_file = opts
             .config
+            .clone()
             .or_else(|| config_dir.clone().map(|p| p.join(CONFIG_NAME)));
 
         let mut message = String::new();


### PR DESCRIPTION
* The setup subcommand was exiting the programm no matter what,
   even if the `clean` flag was provided.
   Now it returns to the main function on encountering the clean flag.