### PR TITLE
Random fixes

### DIFF
--- a/src/tests/fakes.rs
+++ b/src/tests/fakes.rs
@@ -127,7 +127,7 @@ impl FakeInputOutput {
         }
         self.stdin_commands = Arc::new(Mutex::new(stdin_commands));
     }
-    pub fn add_terminal(&mut self, fd: RawFd) {
+    pub fn add_terminal(&self, fd: RawFd) {
         self.stdin_writes.lock().unwrap().insert(fd, vec![]);
     }
     pub fn add_sigwinch_event(&mut self, new_position_and_size: PositionAndSize) {
@@ -225,7 +225,7 @@ impl ClientOsApi for FakeInputOutput {
 }
 
 impl ServerOsApi for FakeInputOutput {
-    fn set_terminal_size_using_fd(&mut self, pid: RawFd, cols: u16, rows: u16) {
+    fn set_terminal_size_using_fd(&self, pid: RawFd, cols: u16, rows: u16) {
         let terminal_input = self
             .possible_tty_inputs
             .get(&cols)
@@ -239,7 +239,7 @@ impl ServerOsApi for FakeInputOutput {
             .unwrap()
             .push(IoEvent::SetTerminalSizeUsingFd(pid, cols, rows));
     }
-    fn spawn_terminal(&mut self, _file_to_open: Option<PathBuf>) -> (RawFd, Pid) {
+    fn spawn_terminal(&self, _file_to_open: Option<PathBuf>) -> (RawFd, Pid) {
         let next_terminal_id = self.stdin_writes.lock().unwrap().keys().len() as RawFd + 1;
         self.add_terminal(next_terminal_id);
         (
@@ -247,7 +247,7 @@ impl ServerOsApi for FakeInputOutput {
             Pid::from_raw(next_terminal_id + 1000),
         ) // secondary number is arbitrary here
     }
-    fn write_to_tty_stdin(&mut self, pid: RawFd, buf: &mut [u8]) -> Result<usize, nix::Error> {
+    fn write_to_tty_stdin(&self, pid: RawFd, buf: &[u8]) -> Result<usize, nix::Error> {
         let mut stdin_writes = self.stdin_writes.lock().unwrap();
         let write_buffer = stdin_writes.get_mut(&pid).unwrap();
         let mut bytes_written = 0;
@@ -257,7 +257,7 @@ impl ServerOsApi for FakeInputOutput {
         }
         Ok(bytes_written)
     }
-    fn read_from_tty_stdout(&mut self, pid: RawFd, buf: &mut [u8]) -> Result<usize, nix::Error> {
+    fn read_from_tty_stdout(&self, pid: RawFd, buf: &mut [u8]) -> Result<usize, nix::Error> {
         let mut read_buffers = self.read_buffers.lock().unwrap();
         let mut bytes_read = 0;
         match read_buffers.get_mut(&pid) {
@@ -274,14 +274,14 @@ impl ServerOsApi for FakeInputOutput {
             None => Err(nix::Error::Sys(nix::errno::Errno::EAGAIN)),
         }
     }
-    fn tcdrain(&mut self, pid: RawFd) -> Result<(), nix::Error> {
+    fn tcdrain(&self, pid: RawFd) -> Result<(), nix::Error> {
         self.io_events.lock().unwrap().push(IoEvent::TcDrain(pid));
         Ok(())
     }
     fn box_clone(&self) -> Box<dyn ServerOsApi> {
         Box::new((*self).clone())
     }
-    fn kill(&mut self, pid: Pid) -> Result<(), nix::Error> {
+    fn kill(&self, pid: Pid) -> Result<(), nix::Error> {
         self.io_events.lock().unwrap().push(IoEvent::Kill(pid));
         Ok(())
     }
@@ -295,7 +295,7 @@ impl ServerOsApi for FakeInputOutput {
     fn send_to_client(&self, msg: ServerToClientMsg) {
         self.send_instructions_to_client.send(msg).unwrap();
     }
-    fn add_client_sender(&mut self) {}
+    fn add_client_sender(&self) {}
     fn update_receiver(&mut self, _stream: LocalSocketStream) {}
     fn load_palette(&self) -> Palette {
         default_palette()

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -177,9 +177,7 @@ fn stream_terminal_bytes(
             while let Some(bytes) = terminal_bytes.next().await {
                 let bytes_is_empty = bytes.is_empty();
                 if debug {
-                    for byte in bytes.iter() {
-                        debug_to_file(*byte, pid).unwrap();
-                    }
+                    debug_to_file(&bytes, pid).unwrap();
                 }
                 if !bytes_is_empty {
                     let _ = senders.send_to_screen(ScreenInstruction::PtyBytes(pid, bytes));

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -8,7 +8,7 @@ use std::pin::*;
 use std::time::{Duration, Instant};
 
 use crate::{
-    os_input_output::ServerOsApi,
+    os_input_output::{Pid, ServerOsApi},
     panes::PaneId,
     screen::ScreenInstruction,
     thread_bus::{Bus, ThreadSenders},
@@ -97,7 +97,7 @@ impl From<&PtyInstruction> for PtyContext {
 
 pub(crate) struct Pty {
     pub bus: Bus<PtyInstruction>,
-    pub id_to_child_pid: HashMap<RawFd, RawFd>,
+    pub id_to_child_pid: HashMap<RawFd, Pid>,
     debug_to_file: bool,
     task_handles: HashMap<RawFd, JoinHandle<()>>,
 }
@@ -235,7 +235,7 @@ impl Pty {
         }
     }
     pub fn spawn_terminal(&mut self, file_to_open: Option<PathBuf>) -> RawFd {
-        let (pid_primary, pid_secondary): (RawFd, RawFd) = self
+        let (pid_primary, pid_secondary): (RawFd, Pid) = self
             .bus
             .os_input
             .as_mut()
@@ -255,7 +255,7 @@ impl Pty {
         let total_panes = layout.total_terminal_panes();
         let mut new_pane_pids = vec![];
         for _ in 0..total_panes {
-            let (pid_primary, pid_secondary): (RawFd, RawFd) =
+            let (pid_primary, pid_secondary): (RawFd, Pid) =
                 self.bus.os_input.as_mut().unwrap().spawn_terminal(None);
             self.id_to_child_pid.insert(pid_primary, pid_secondary);
             new_pane_pids.push(pid_primary);

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -37,7 +37,7 @@ impl ReadFromPid {
 
 impl Stream for ReadFromPid {
     type Item = Vec<u8>;
-    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut read_buffer = [0; 65535];
         let pid = self.pid;
         let read_result = &self.os_input.read_from_tty_stdout(pid, &mut read_buffer);

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -189,7 +189,7 @@ fn route_action(action: Action, session: &SessionMetaData, os_input: &dyn Server
 
 pub(crate) fn route_thread_main(
     sessions: Arc<RwLock<Option<SessionMetaData>>>,
-    mut os_input: Box<dyn ServerOsApi>,
+    os_input: Box<dyn ServerOsApi>,
     to_server: SenderWithContext<ServerInstruction>,
 ) {
     loop {

--- a/zellij-server/src/tab.rs
+++ b/zellij-server/src/tab.rs
@@ -232,7 +232,7 @@ impl Tab {
         position: usize,
         name: String,
         full_screen_ws: &PositionAndSize,
-        mut os_api: Box<dyn ServerOsApi>,
+        os_api: Box<dyn ServerOsApi>,
         senders: ThreadSenders,
         max_panes: Option<usize>,
         pane_id: Option<PaneId>,
@@ -624,9 +624,9 @@ impl Tab {
         match pane_id {
             PaneId::Terminal(active_terminal_id) => {
                 let active_terminal = self.panes.get(&pane_id).unwrap();
-                let mut adjusted_input = active_terminal.adjust_input_to_terminal(input_bytes);
+                let adjusted_input = active_terminal.adjust_input_to_terminal(input_bytes);
                 self.os_api
-                    .write_to_tty_stdin(active_terminal_id, &mut adjusted_input)
+                    .write_to_tty_stdin(active_terminal_id, &adjusted_input)
                     .expect("failed to write to terminal");
                 self.os_api
                     .tcdrain(active_terminal_id)

--- a/zellij-utils/src/logging.rs
+++ b/zellij-utils/src/logging.rs
@@ -71,7 +71,7 @@ pub fn _delete_log_dir() -> io::Result<()> {
     }
 }
 
-pub fn debug_to_file(message: u8, pid: RawFd) -> io::Result<()> {
+pub fn debug_to_file(message: &[u8], pid: RawFd) -> io::Result<()> {
     let mut path = PathBuf::new();
     path.push(&*ZELLIJ_TMP_LOG_DIR);
     path.push(format!("zellij-{}.log", pid.to_string()));
@@ -81,5 +81,5 @@ pub fn debug_to_file(message: u8, pid: RawFd) -> io::Result<()> {
         .create(true)
         .open(&path)?;
     set_permissions(&path)?;
-    file.write_all(&[message])
+    file.write_all(message)
 }


### PR DESCRIPTION
Assorted refactors and fixes:
* use Pid instead of RawFd for processes in ServerOsApi
* improve debug performance by writing entire buffers instead of per-byte
* remove muts where not needed

They should have no user-visible impact (except for faster debug output on heavy workloads).