### PR TITLE
fix(pty): use async io to avoid polling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
+name = "async-trait"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2308,6 +2319,7 @@ name = "zellij-server"
 version = "0.12.0"
 dependencies = [
  "ansi_term 0.12.1",
+ "async-trait",
  "daemonize",
  "insta",
  "serde_json",

--- a/zellij-server/Cargo.toml
+++ b/zellij-server/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 
 [dependencies]
 ansi_term = "0.12.1"
+async-trait = "0.1.50"
 daemonize = "0.4.1"
 serde_json = "1.0"
 unicode-width = "0.1.8"


### PR DESCRIPTION
This patch fixes #509 by using async read instead of polling a
non-blocking fd. This reduces CPU usage when the ptys are idle.