### PR TITLE
Fix build on platforms with TIOCGWINSZ / ioctl() integer type mismatch.

### DIFF
--- a/zellij-client/src/os_input_output.rs
+++ b/zellij-client/src/os_input_output.rs
@@ -45,7 +45,7 @@ pub(crate) fn get_terminal_size_using_fd(fd: RawFd) -> PositionAndSize {
         ws_ypixel: 0,
     };
 
-    unsafe { ioctl(fd, TIOCGWINSZ, &mut winsize) };
+    unsafe { ioctl(fd, TIOCGWINSZ.into(), &mut winsize) };
     PositionAndSize::from(winsize)
 }
 

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -41,7 +41,7 @@ pub(crate) fn set_terminal_size_using_fd(fd: RawFd, columns: u16, rows: u16) {
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
-    unsafe { ioctl(fd, TIOCSWINSZ, &winsize) };
+    unsafe { ioctl(fd, TIOCSWINSZ.into(), &winsize) };
 }
 
 /// Handle some signals for the child process. This will loop until the child


### PR DESCRIPTION
The conversion is required e.g. on 64 bit FreeBSD to convert `TIOCGWINSZ` (hard coded to `u32`) into an `u64` which is expected by `ioctl()`. It might be an issue on other platforms as well.