### PR TITLE
fix(compatibility): do not crash when padding before wide char

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1769,12 +1769,10 @@ impl Row {
         let mut replace_with = vec![terminal_character; to + width_of_current_character];
         if to_position_accounting_for_widechars > self.columns.len() {
             self.columns.clear();
+        } else if to_position_accounting_for_widechars >= self.columns.len() {
+            drop(self.columns.drain(0..to_position_accounting_for_widechars));
         } else {
-            if to_position_accounting_for_widechars >= self.columns.len() {
-                drop(self.columns.drain(0..to_position_accounting_for_widechars));
-            } else {
-                drop(self.columns.drain(0..=to_position_accounting_for_widechars));
-            }
+            drop(self.columns.drain(0..=to_position_accounting_for_widechars));
         }
         replace_with.append(&mut self.columns);
         self.columns = replace_with;

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1770,7 +1770,11 @@ impl Row {
         if to_position_accounting_for_widechars > self.columns.len() {
             self.columns.clear();
         } else {
-            drop(self.columns.drain(0..=to_position_accounting_for_widechars));
+            if to_position_accounting_for_widechars >= self.columns.len() {
+                drop(self.columns.drain(0..to_position_accounting_for_widechars));
+            } else {
+                drop(self.columns.drain(0..=to_position_accounting_for_widechars));
+            }
         }
         replace_with.append(&mut self.columns);
         self.columns = replace_with;


### PR DESCRIPTION
This fixes a crash that happened when left-padding a line whose last character was a wide character.