### PR TITLE
Make session-name option in attach command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod sessions;
 mod tests;
 
 use crate::install::populate_data_dir;
-use sessions::{assert_session, assert_session_ne, list_sessions};
+use sessions::{assert_session, assert_session_ne, get_active_session, list_sessions};
 use std::convert::TryFrom;
 use std::process;
 use zellij_client::{os_input_output::get_client_os_input, start_client, ClientInfo};
@@ -54,16 +54,20 @@ pub fn main() {
             }
         };
         if let Some(Command::Sessions(Sessions::Attach {
-            session_name,
+            mut session_name,
             force,
         })) = opts.command.clone()
         {
-            assert_session(&session_name);
+            if let Some(session) = session_name.as_ref() {
+                assert_session(session);
+            } else {
+                session_name = Some(get_active_session());
+            }
             start_client(
                 Box::new(os_input),
                 opts,
                 config,
-                ClientInfo::Attach(session_name, force),
+                ClientInfo::Attach(session_name.unwrap(), force),
             );
         } else {
             let session_name = opts

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -27,8 +27,7 @@ use crate::{
 };
 use route::route_thread_main;
 use zellij_utils::{
-    channels,
-    channels::{ChannelWithContext, SenderWithContext},
+    channels::{self, ChannelWithContext, SenderWithContext},
     cli::CliArgs,
     errors::{ContextType, ErrorInstruction, ServerContext},
     input::{get_mode_info, options::Options},

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -72,7 +72,7 @@ pub enum Sessions {
     #[structopt(alias = "a")]
     Attach {
         /// Name of the session to attach to.
-        session_name: String,
+        session_name: Option<String>,
 
         /// Force attach- session will detach from the other
         /// zellij client (if any) and attach to this.


### PR DESCRIPTION
If only one session is running, attach to it. Otherwise, list the active sessions (if any).
This also fixes some exit status.