### PR TITLE
Fix build on platforms with TIOCGWINSZ / ioctl() integer type mismatch.

### DIFF
--- a/zellij-client/src/os_input_output.rs
+++ b/zellij-client/src/os_input_output.rs
@@ -45,7 +45,13 @@ pub(crate) fn get_terminal_size_using_fd(fd: RawFd) -> PositionAndSize {
         ws_ypixel: 0,
     };
 
-    unsafe { ioctl(fd, TIOCGWINSZ, &mut winsize) };
+    // TIOCGWINSZ is an u32, but the second argument to ioctl is u64 on
+    // some platforms. When checked on Linux, clippy will complain about
+    // useless conversion.
+    #[allow(clippy::useless_conversion)]
+    unsafe {
+        ioctl(fd, TIOCGWINSZ.into(), &mut winsize)
+    };
     PositionAndSize::from(winsize)
 }
 

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -41,7 +41,11 @@ pub(crate) fn set_terminal_size_using_fd(fd: RawFd, columns: u16, rows: u16) {
         ws_xpixel: 0,
         ws_ypixel: 0,
     };
-    unsafe { ioctl(fd, TIOCSWINSZ, &winsize) };
+    // TIOCGWINSZ is an u32, but the second argument to ioctl is u64 on
+    // some platforms. When checked on Linux, clippy will complain about
+    // useless conversion.
+    #[allow(clippy::useless_conversion)]
+    unsafe { ioctl(fd, TIOCSWINSZ.into(), &winsize) };
 }
 
 /// Handle some signals for the child process. This will loop until the child

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -45,7 +45,9 @@ pub(crate) fn set_terminal_size_using_fd(fd: RawFd, columns: u16, rows: u16) {
     // some platforms. When checked on Linux, clippy will complain about
     // useless conversion.
     #[allow(clippy::useless_conversion)]
-    unsafe { ioctl(fd, TIOCSWINSZ.into(), &winsize) };
+    unsafe {
+        ioctl(fd, TIOCSWINSZ.into(), &winsize)
+    };
 }
 
 /// Handle some signals for the child process. This will loop until the child


### PR DESCRIPTION
As discussed in https://github.com/zellij-org/zellij/pull/539#issuecomment-850349322, provide context, comment and clippy lint hint.