### PR TITLE
Don't rename 'unnamed' tabs upon deletion of other tabs

### DIFF
--- a/default-plugins/tab-bar/src/tab.rs
+++ b/default-plugins/tab-bar/src/tab.rs
@@ -46,11 +46,7 @@ pub fn tab_style(
     capabilities: PluginCapabilities,
 ) -> LinePart {
     let separator = tab_separator(capabilities);
-    let mut tab_text = if text.is_empty() {
-        format!("Tab #{}", position + 1)
-    } else {
-        text
-    };
+    let mut tab_text = text;
     if is_sync_panes_active {
         tab_text.push_str(" (Sync)");
     }

--- a/zellij-server/src/tab.rs
+++ b/zellij-server/src/tab.rs
@@ -259,7 +259,11 @@ impl Tab {
             index,
             position,
             panes,
-            name,
+            name: if name.is_empty() {
+                format!("Tab #{} (unnamed)", position + 1)
+            } else {
+                name
+            },
             max_panes,
             panes_to_hide: HashSet::new(),
             active_terminal: pane_id,

--- a/zellij-server/src/tab.rs
+++ b/zellij-server/src/tab.rs
@@ -257,7 +257,7 @@ impl Tab {
         };
 
         let name = if name.is_empty() {
-            format!("Tab #{} (unnamed)", position + 1)
+            format!("Tab #{}", position + 1)
         } else {
             name
         };

--- a/zellij-server/src/tab.rs
+++ b/zellij-server/src/tab.rs
@@ -255,15 +255,18 @@ impl Tab {
         } else {
             BTreeMap::new()
         };
+
+        let name = if name.is_empty() {
+            format!("Tab #{} (unnamed)", position + 1)
+        } else {
+            name
+        };
+
         Tab {
             index,
             position,
             panes,
-            name: if name.is_empty() {
-                format!("Tab #{} (unnamed)", position + 1)
-            } else {
-                name
-            },
+            name,
             max_panes,
             panes_to_hide: HashSet::new(),
             active_terminal: pane_id,


### PR DESCRIPTION
This PR aims to solve issue #474.
I decided to put the logic in `Tab::new`. This approach felt the "cleanest" to me.
If this breaks any style guides or should be done differently for other reasons please let me know and I'll change it.