### PR TITLE
Ignore the position number for now

### DIFF
--- a/default-plugins/tab-bar/src/tab.rs
+++ b/default-plugins/tab-bar/src/tab.rs
@@ -40,7 +40,7 @@ pub fn non_active_tab(text: String, palette: Palette, separator: &str) -> LinePa
 pub fn tab_style(
     text: String,
     is_active_tab: bool,
-    position: usize,
+    _position: usize,
     is_sync_panes_active: bool,
     palette: Palette,
     capabilities: PluginCapabilities,


### PR DESCRIPTION
* It will become useful in the near future again,
and makes no sense to remove atm.