### PR TITLE
Make macOS and potentially Windows sessions permanent

### DIFF
--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -29,14 +29,8 @@ lazy_static! {
     pub static ref ZELLIJ_PROJ_DIR: ProjectDirs =
         ProjectDirs::from("org", "Zellij Contributors", "Zellij").unwrap();
     pub static ref ZELLIJ_SOCK_DIR: PathBuf = {
-        let mut ipc_dir = env::var("ZELLIJ_SOCKET_DIR").map_or_else(
-            |_| {
-                ZELLIJ_PROJ_DIR
-                    .runtime_dir()
-                    .map_or_else(|| ZELLIJ_TMP_DIR.clone(), |p| p.to_owned())
-            },
-            PathBuf::from,
-        );
+        let mut ipc_dir = env::var("ZELLIJ_SOCKET_DIR")
+            .map_or_else(|_| ZELLIJ_PROJ_DIR.data_dir().to_path_buf(), PathBuf::from);
         ipc_dir.push(VERSION);
         ipc_dir
     };


### PR DESCRIPTION
When using sessions in macOS, I found them getting removed without explicit removal.

Turns out the session info was getting stored in the temp directory, potentially because [runtime_dir](https://docs.rs/directories-next/2.0.0/directories_next/struct.ProjectDirs.html#method.runtime_dir) method returns nothing for macOS and Windows and Zellij falls back to a temp directory.

This PR replaces [runtime_dir](https://docs.rs/directories-next/2.0.0/directories_next/struct.ProjectDirs.html#method.runtime_dir) with [data_dir](https://docs.rs/directories-next/2.0.0/directories_next/struct.ProjectDirs.html#method.data_dir), which I felt was suitable.

In macOS now the session gets stored in `$HOME/Library/Application Support/org.Zellij-Contributors.Zellij/<VERSION>/`. I am not plenty familiar with this codebase, so hope things like configs that get stored here don't get affected.