### PR TITLE
Fix missing `layout-dir` in makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   `layout-dir` one can switch either the layouts to
   the new dir, or set the `layout-dir` to be the current
   `layout-dir`
+* Fix `Makefile.toml` because of missing directory (https://github.com/zellij-org/zellij/pull/580)
 
 ## [0.13.0] - 2021-06-04
 * Fix crash when padding before widechar (https://github.com/zellij-org/zellij/pull/540)

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -51,7 +51,6 @@ asset_dir = set ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/assets
 target_dir = set ${CARGO_TARGET_DIR}
 data_dir = set ${target_dir}/dev-data
 rm -r ${data_dir}
-cp ${asset_dir}/layouts ${data_dir}/
 plugins = glob_array ${target_dir}/wasm32-wasi/debug/*.wasm
 for plugin in ${plugins}
     plugin_name = basename ${plugin}


### PR DESCRIPTION
The `layout-dir` got removed, but the
make action depended on the `dir`.