### PR TITLE
Detach session when forced close detected (handling SIGTERM and other signals)

### DIFF
--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -210,11 +210,9 @@ pub fn start_client(
                         }
                     }),
                     Box::new({
-                        let send_client_instructions = send_client_instructions.clone();
+                        let os_api = os_input.clone();
                         move || {
-                            send_client_instructions
-                                .send(ClientInstruction::Exit(ExitReason::ForceDetached))
-                                .unwrap()
+                            os_api.send_to_server(ClientToServerMsg::Action(Action::Detach));
                         }
                     }),
                 );

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -213,7 +213,7 @@ pub fn start_client(
                         let send_client_instructions = send_client_instructions.clone();
                         move || {
                             send_client_instructions
-                                .send(ClientInstruction::Exit(ExitReason::Normal))
+                                .send(ClientInstruction::Exit(ExitReason::ForceDetached))
                                 .unwrap()
                         }
                     }),


### PR DESCRIPTION
Auto detach the session when receiving a forced close signal (SIGWINCH, SIGTERM, SIGINT, SIGQUIT, SIGHUP).

The current behavior when the user manually closes Zellij (ctrl-q) remains the same and does not auto detach.

Closes #572 