### PR TITLE
feat(ui): Implement 'attach --create' so attach would never fail

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,6 @@ pub fn main() {
             force,
         })) = opts.command.clone()
         {
-
             let mut sessions = get_sessions();
             let mut start_new_session = false;
 
@@ -114,28 +113,25 @@ pub fn main() {
                     print_sessions(sessions);
                     process::exit(1);
                 }
-
-            } else {
-                if sessions
+            } else if sessions
                     .iter()
                     .any(|s| s.to_string() == session_name.as_deref().unwrap())
-                {
-                    // If a session name was given, and it exists, attach to it
-                } else if create {
-                    // If a session name was given, but does not exist while --create was used,
-                    // attach a new session using that name
-                    start_new_session = true;
-                    println!(
-                        "Creating new session {:?} to attach",
-                        session_name.clone().unwrap()
-                    );
-                    opts.session = session_name.clone();
-                } else {
-                    // If a session name was given, but does not exist and will not be created,
-                    // just list sessions and exit
-                    eprintln!("ERROR: No session named {:?} found", session_name.unwrap());
-                    process::exit(1);
-                }
+            {
+                // If a session name was given, and it exists, attach to it
+            } else if create {
+                // If a session name was given, but does not exist while --create was used,
+                // attach a new session using that name
+                start_new_session = true;
+                println!(
+                    "Creating new session {:?} to attach",
+                    session_name.clone().unwrap()
+                );
+                opts.session = session_name.clone();
+            } else {
+                // If a session name was given, but does not exist and will not be created,
+                // just list sessions and exit
+                eprintln!("ERROR: No session named {:?} found", session_name.unwrap());
+                process::exit(1);
             }
 
             if start_new_session {

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -74,8 +74,12 @@ pub enum Sessions {
         /// Name of the session to attach to.
         session_name: Option<String>,
 
-        /// Force attach- session will detach from the other
-        /// zellij client (if any) and attach to this.
+        /// If session does not exist, create it to ensure that the
+        /// attach command will always succeed.
+        #[structopt(long, short)]
+        create: bool,
+
+        /// Detach session from other Zellij client (if any) and attach to this.
         #[structopt(long, short)]
         force: bool,
     },


### PR DESCRIPTION
Add support for `--create` in subcommand `attach` to enable similar use as in `tmux new-session -A -s Foo` where attaching a session will always result in a session, either re-using the old or creating a new.

This allows me to have a Zellij session open "forever", even across remote host reboots when the session otherwise dies. For example I can have `while ! ssh host -t 'zellij attach --create workspace'; do echo $?; sleep 3; done` and that window will forever be an open terminal to my remote machine with my previous session open as far as possible.

Closes: zellij-org/zellij#541

![zellij-attach-create](https://user-images.githubusercontent.com/668724/123556133-2f147900-d792-11eb-8373-12dba5eee454.gif)
