### PR TITLE
Add option to specify a default-shell

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -29,7 +29,12 @@ use zellij_utils::{
     channels::{self, ChannelWithContext, SenderWithContext},
     cli::CliArgs,
     errors::{ContextType, ErrorInstruction, ServerContext},
-    input::{get_mode_info, layout::Layout, options::Options},
+    input::{
+        command::{RunCommand, TerminalAction},
+        get_mode_info,
+        layout::Layout,
+        options::Options,
+    },
     ipc::{ClientAttributes, ClientToServerMsg, ExitReason, ServerToClientMsg},
     setup::get_default_data_dir,
 };
@@ -84,6 +89,7 @@ pub(crate) struct SessionMetaData {
     pub senders: ThreadSenders,
     pub capabilities: PluginCapabilities,
     pub palette: Palette,
+    pub default_shell: Option<TerminalAction>,
     screen_thread: Option<thread::JoinHandle<()>>,
     pty_thread: Option<thread::JoinHandle<()>>,
     wasm_thread: Option<thread::JoinHandle<()>>,
@@ -219,13 +225,21 @@ pub fn start_server(os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                 );
                 *session_data.write().unwrap() = Some(session);
                 *session_state.write().unwrap() = SessionState::Attached;
+
+                let default_shell = session_data
+                    .read()
+                    .unwrap()
+                    .as_ref()
+                    .map(|session| session.default_shell.clone())
+                    .flatten();
+
                 session_data
                     .read()
                     .unwrap()
                     .as_ref()
                     .unwrap()
                     .senders
-                    .send_to_pty(PtyInstruction::NewTab)
+                    .send_to_pty(PtyInstruction::NewTab(default_shell.clone()))
                     .unwrap();
             }
             ServerInstruction::AttachClient(attrs, _, options) => {
@@ -324,6 +338,13 @@ fn init_session(
         arrow_fonts: config_options.simplified_ui,
     };
 
+    let default_shell = config_options.default_shell.clone().map(|command| {
+        TerminalAction::RunCommand(RunCommand {
+            command,
+            ..Default::default()
+        })
+    });
+
     let pty_thread = thread::Builder::new()
         .name("pty".to_string())
         .spawn({
@@ -393,6 +414,7 @@ fn init_session(
             should_silently_fail: false,
         },
         capabilities,
+        default_shell,
         palette: client_attributes.palette,
         screen_thread: Some(screen_thread),
         pty_thread: Some(pty_thread),

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -133,13 +133,14 @@ fn route_action(
                 .unwrap();
         }
         Action::NewPane(direction) => {
+            let shell = session.default_shell.clone();
             let pty_instr = match direction {
-                Some(Direction::Left) => PtyInstruction::SpawnTerminalVertically(None),
-                Some(Direction::Right) => PtyInstruction::SpawnTerminalVertically(None),
-                Some(Direction::Up) => PtyInstruction::SpawnTerminalHorizontally(None),
-                Some(Direction::Down) => PtyInstruction::SpawnTerminalHorizontally(None),
+                Some(Direction::Left) => PtyInstruction::SpawnTerminalVertically(shell),
+                Some(Direction::Right) => PtyInstruction::SpawnTerminalVertically(shell),
+                Some(Direction::Up) => PtyInstruction::SpawnTerminalHorizontally(shell),
+                Some(Direction::Down) => PtyInstruction::SpawnTerminalHorizontally(shell),
                 // No direction specified - try to put it in the biggest available spot
-                None => PtyInstruction::SpawnTerminal(None),
+                None => PtyInstruction::SpawnTerminal(shell),
             };
             session.senders.send_to_pty(pty_instr).unwrap();
         }
@@ -150,7 +151,11 @@ fn route_action(
                 .unwrap();
         }
         Action::NewTab => {
-            session.senders.send_to_pty(PtyInstruction::NewTab).unwrap();
+            let shell = session.default_shell.clone();
+            session
+                .senders
+                .send_to_pty(PtyInstruction::NewTab(shell))
+                .unwrap();
         }
         Action::GoToNextTab => {
             session

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -20,6 +20,9 @@ pub struct Options {
     /// Set the default mode
     #[structopt(long)]
     pub default_mode: Option<InputMode>,
+    /// Set the default shell
+    #[structopt(long, parse(from_os_str))]
+    pub default_shell: Option<PathBuf>,
     /// Set the layout_dir, defaults to
     /// subdirectory of config dir
     #[structopt(long, parse(from_os_str))]
@@ -50,6 +53,11 @@ impl Options {
             other => other,
         };
 
+        let default_shell = match other.default_shell {
+            None => self.default_shell.clone(),
+            other => other,
+        };
+
         let layout_dir = match other.layout_dir {
             None => self.layout_dir.clone(),
             other => other,
@@ -64,6 +72,7 @@ impl Options {
             simplified_ui,
             theme,
             default_mode,
+            default_shell,
             layout_dir,
         }
     }


### PR DESCRIPTION
* Adds an option to specify a default shell
  either by specifying `default_shell: [PATH]`
  in the config, or running zellij with
  `zellij options --default-shell [PATH]`