### PR TITLE
Add running commands to an action

### DIFF
--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -1,5 +1,6 @@
 //! Definition of the actions that can be bound to keys.
 
+use super::command::RunCommandAction;
 use serde::{Deserialize, Serialize};
 use zellij_tile::data::InputMode;
 
@@ -65,6 +66,8 @@ pub enum Action {
     CloseTab,
     GoToTab(u32),
     TabNameInput(Vec<u8>),
+    /// Run speficied command in new pane.
+    Run(RunCommandAction),
     /// Detach session and exit
     Detach,
 }

--- a/zellij-utils/src/input/command.rs
+++ b/zellij-utils/src/input/command.rs
@@ -1,4 +1,5 @@
 //! Trigger a command
+use super::actions::Direction;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -8,9 +9,28 @@ pub enum TerminalAction {
     RunCommand(RunCommand),
 }
 
-#[derive(Clone, Debug, Deserialize, Default, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Default, Serialize, PartialEq, Eq)]
 pub struct RunCommand {
     pub command: PathBuf,
     #[serde(default)]
     pub args: Vec<String>,
+}
+
+/// Intermediate representation
+#[derive(Clone, Debug, Deserialize, Default, Serialize, PartialEq, Eq)]
+pub struct RunCommandAction {
+    pub command: PathBuf,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub direction: Option<Direction>,
+}
+
+impl From<RunCommandAction> for RunCommand {
+    fn from(action: RunCommandAction) -> Self {
+        RunCommand {
+            command: action.command,
+            args: action.args,
+        }
+    }
 }


### PR DESCRIPTION
Add the ability to bind running commands to
an action.

Eg:
```
 - action: [Run: {command: "htop",},]
   key: [F: 6,]
```

Optionally the direction and arguments can be
specified:

```
 - action: [Run: {command: "htop", args: ["-C",]},]
   key: [F: 7,]
```
The directional splits are analogous to the `[NewPane]` splits.
```
- action: [Run: {command: "htop", args: ["-C",], direction: "Up"},]
  key: [F: 8,]
```