### PR TITLE
Add commands to layout

### DIFF
--- a/example/run_htop_layout.yaml
+++ b/example/run_htop_layout.yaml
@@ -1,0 +1,20 @@
+---
+direction: Vertical
+parts:
+  - direction: Horizontal
+    split_size:
+      Percent: 50
+    parts:
+      - direction: Vertical
+        split_size:
+          Percent: 50
+      - direction: Vertical
+        split_size:
+          Percent: 50
+        run:
+          command: {cmd: htop}
+  - direction: Horizontal
+    split_size:
+      Percent: 50
+    run:
+      command: {cmd: htop}

--- a/example/run_htop_layout_with_plugins.yaml
+++ b/example/run_htop_layout_with_plugins.yaml
@@ -1,0 +1,30 @@
+---
+direction: Horizontal
+parts:
+  - direction: Vertical
+    split_size:
+      Fixed: 1
+    run:
+      plugin: tab-bar
+  - direction: Vertical
+    parts:
+    - direction: Vertical
+      parts:
+      - direction: Vertical
+        split_size:
+          Percent: 50
+        run:
+          command: {cmd: htop}
+      - direction: Vertical
+        split_size:
+          Percent: 50
+        run:
+          command: {cmd: htop, args: ["-C"]}
+  - direction: Vertical
+    split_size:
+      Fixed: 5
+  - direction: Vertical
+    split_size:
+      Fixed: 2
+    run:
+      plugin: status-bar

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -1,11 +1,3 @@
-use zellij_utils::async_std;
-
-use async_std::future::timeout as async_timeout;
-use async_std::task::{self, JoinHandle};
-use std::collections::HashMap;
-use std::os::unix::io::RawFd;
-use std::time::{Duration, Instant};
-
 use crate::{
     os_input_output::{AsyncReader, Pid, ServerOsApi},
     panes::PaneId,
@@ -14,9 +6,22 @@ use crate::{
     wasm_vm::PluginInstruction,
     ServerInstruction,
 };
+use async_std::{
+    future::timeout as async_timeout,
+    task::{self, JoinHandle},
+};
+use std::{
+    collections::HashMap,
+    os::unix::io::RawFd,
+    time::{Duration, Instant},
+};
 use zellij_utils::{
+    async_std,
     errors::{get_current_ctx, ContextType, PtyContext},
-    input::{command::TerminalAction, layout::Layout},
+    input::{
+        command::TerminalAction,
+        layout::{Layout, Run},
+    },
     logging::debug_to_file,
 };
 
@@ -237,19 +242,36 @@ impl Pty {
     pub fn spawn_terminals_for_layout(
         &mut self,
         layout: Layout,
-        terminal_action: Option<TerminalAction>,
+        default_shell: Option<TerminalAction>,
     ) {
-        let total_panes = layout.total_terminal_panes();
+        let extracted_run_instructions = layout.extract_run_instructions();
         let mut new_pane_pids = vec![];
-        for _ in 0..total_panes {
-            let (pid_primary, pid_secondary): (RawFd, Pid) = self
-                .bus
-                .os_input
-                .as_mut()
-                .unwrap()
-                .spawn_terminal(terminal_action.clone());
-            self.id_to_child_pid.insert(pid_primary, pid_secondary);
-            new_pane_pids.push(pid_primary);
+        for run_instruction in extracted_run_instructions {
+            match run_instruction {
+                Some(Run::Command(command)) => {
+                    let cmd = TerminalAction::RunCommand(command);
+                    let (pid_primary, pid_secondary): (RawFd, Pid) = self
+                        .bus
+                        .os_input
+                        .as_mut()
+                        .unwrap()
+                        .spawn_terminal(Some(cmd));
+                    self.id_to_child_pid.insert(pid_primary, pid_secondary);
+                    new_pane_pids.push(pid_primary);
+                }
+                None => {
+                    let (pid_primary, pid_secondary): (RawFd, Pid) = self
+                        .bus
+                        .os_input
+                        .as_mut()
+                        .unwrap()
+                        .spawn_terminal(default_shell.clone());
+                    self.id_to_child_pid.insert(pid_primary, pid_secondary);
+                    new_pane_pids.push(pid_primary);
+                }
+                // Investigate moving plugin loading to here.
+                Some(Run::Plugin(_)) => {}
+            }
         }
         self.bus
             .senders

--- a/zellij-server/src/tab.rs
+++ b/zellij-server/src/tab.rs
@@ -26,7 +26,10 @@ use std::{
 };
 use zellij_tile::data::{Event, InputMode, ModeInfo, Palette};
 use zellij_utils::{
-    input::{layout::Layout, parse_keys},
+    input::{
+        layout::{Layout, Run},
+        parse_keys,
+    },
     pane_size::PositionAndSize,
     shared::adjust_to_size,
 };
@@ -319,7 +322,7 @@ impl Tab {
         let mut new_pids = new_pids.iter();
         for (layout, position_and_size) in positions_and_size {
             // A plugin pane
-            if let Some(plugin) = &layout.plugin {
+            if let Some(Run::Plugin(Some(plugin))) = &layout.run {
                 let (pid_tx, pid_rx) = channel();
                 self.senders
                     .send_to_plugin(PluginInstruction::Load(pid_tx, plugin.clone()))

--- a/zellij-utils/assets/layouts/default.yaml
+++ b/zellij-utils/assets/layouts/default.yaml
@@ -4,9 +4,11 @@ parts:
   - direction: Vertical
     split_size:
       Fixed: 1
-    plugin: tab-bar
+    run:
+      plugin: tab-bar
   - direction: Vertical
   - direction: Vertical
     split_size:
       Fixed: 2
-    plugin: status-bar
+    run:
+      plugin: status-bar

--- a/zellij-utils/assets/layouts/disable-status-bar.yaml
+++ b/zellij-utils/assets/layouts/disable-status-bar.yaml
@@ -4,5 +4,6 @@ parts:
   - direction: Vertical
     split_size:
       Fixed: 1
-    plugin: tab-bar
+    run:
+      plugin: tab-bar
   - direction: Vertical

--- a/zellij-utils/assets/layouts/strider.yaml
+++ b/zellij-utils/assets/layouts/strider.yaml
@@ -4,15 +4,18 @@ parts:
   - direction: Vertical
     split_size:
       Fixed: 1
-    plugin: tab-bar
+    run:
+      plugin: tab-bar
   - direction: Vertical
     parts:
       - direction: Horizontal
         split_size:
           Percent: 20
-        plugin: strider
+        run:
+          plugin: strider
       - direction: Horizontal
   - direction: Vertical
     split_size:
       Fixed: 2
-    plugin: status-bar
+    run:
+      plugin: status-bar

--- a/zellij-utils/src/input/command.rs
+++ b/zellij-utils/src/input/command.rs
@@ -11,6 +11,7 @@ pub enum TerminalAction {
 
 #[derive(Clone, Debug, Deserialize, Default, Serialize, PartialEq, Eq)]
 pub struct RunCommand {
+    #[serde(alias = "cmd")]
     pub command: PathBuf,
     #[serde(default)]
     pub args: Vec<String>,


### PR DESCRIPTION
Add the ability to run commands on loading a layout:
```
  - direction: Horizontal
    split_size:
      Percent: 50
    run:
      command: {cmd: htop}
```
or respectively:
```
  - direction: Horizontal
    split_size:
      Percent: 50
    run:
      command: {cmd: htop, args: ["-C"]}
```

In order to specify the difference of commands and
plugins now the plugins need to be under the `run` section:
```
  - direction: Vertical
    split_size:
      Fixed: 2
    run:
      plugin: status-bar
```
This also means that this is a breaking change for people
that already have a custom layout.

Example layouts:
```
---
direction: Vertical
parts:
  - direction: Horizontal
    split_size:
      Percent: 50
    parts:
      - direction: Vertical
        split_size:
          Percent: 50
      - direction: Vertical
        split_size:
          Percent: 50
        run:
          command: {cmd: htop}
  - direction: Horizontal
    split_size:
      Percent: 50
    run:
      command: {cmd: htop}
```
and:
```
---
direction: Horizontal
parts:
  - direction: Vertical
    split_size:
      Fixed: 1
    run:
      plugin: tab-bar
  - direction: Vertical
    parts:
    - direction: Vertical
      parts:
      - direction: Vertical
        split_size:
          Percent: 50
        run:
          command: {cmd: htop}
      - direction: Vertical
        split_size:
          Percent: 50
        run:
          command: {cmd: htop, args: ["-C"]}
  - direction: Vertical
    split_size:
      Fixed: 5
  - direction: Vertical
    split_size:
      Fixed: 2
    run:
      plugin: status-bar
```