### PR TITLE
fix(os): attempt to stop children with SIGTERM before SIGKILL

### DIFF
--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -277,10 +277,15 @@ impl Pty {
                     self.bus.os_input.as_mut().unwrap().kill(child_pid).unwrap();
                     let timeout = Duration::from_millis(100);
                     match async_timeout(timeout, handle.cancel()).await {
-                        Ok(_) => {},
+                        Ok(_) => {}
                         _ => {
-                            self.bus.os_input.as_mut().unwrap().force_kill(child_pid).unwrap();
-                        },
+                            self.bus
+                                .os_input
+                                .as_mut()
+                                .unwrap()
+                                .force_kill(child_pid)
+                                .unwrap();
+                        }
                     };
                 });
             }

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -273,9 +273,15 @@ impl Pty {
             PaneId::Terminal(id) => {
                 let child_pid = self.id_to_child_pid.remove(&id).unwrap();
                 let handle = self.task_handles.remove(&id).unwrap();
-                self.bus.os_input.as_mut().unwrap().kill(child_pid).unwrap();
                 task::block_on(async {
-                    handle.cancel().await;
+                    self.bus.os_input.as_mut().unwrap().kill(child_pid).unwrap();
+                    let timeout = Duration::from_millis(100);
+                    match async_timeout(timeout, handle.cancel()).await {
+                        Ok(_) => {},
+                        _ => {
+                            self.bus.os_input.as_mut().unwrap().force_kill(child_pid).unwrap();
+                        },
+                    };
                 });
             }
             PaneId::Plugin(pid) => drop(

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -44,6 +44,9 @@ impl ServerOsApi for FakeInputOutput {
     fn box_clone(&self) -> Box<dyn ServerOsApi> {
         Box::new((*self).clone())
     }
+    fn force_kill(&self, _pid: Pid) -> Result<(), nix::Error> {
+        unimplemented!()
+    }
     fn kill(&self, _pid: Pid) -> Result<(), nix::Error> {
         unimplemented!()
     }

--- a/zellij-server/src/unit/tab_tests.rs
+++ b/zellij-server/src/unit/tab_tests.rs
@@ -44,6 +44,9 @@ impl ServerOsApi for FakeInputOutput {
     fn box_clone(&self) -> Box<dyn ServerOsApi> {
         unimplemented!()
     }
+    fn force_kill(&self, _pid: Pid) -> Result<(), nix::Error> {
+        unimplemented!()
+    }
     fn kill(&self, _pid: Pid) -> Result<(), nix::Error> {
         unimplemented!()
     }


### PR DESCRIPTION
This is a fix for https://github.com/zellij-org/zellij/issues/597 (and likely some other issues).

Previously we sent a `SIGKILL` to a child process whenever we wanted to kill it (eg. closing a pane).
Not only is this overkill (pun intended) but in some cases the children get stuck (likely if they have some critical cleanup to do that we're not giving them a chance to).

Now we make 3 attempts to send a `SIGTERM`, and then send a `SIGKILL`. This has a super minor performance implication when closing Zellij with several dozen panes open, but it's (at least on my machine) a question of +1-2 seconds, and it's just on exit in this edge case. So I think it's bearable.