### PR TITLE
Change name of `Run` binding for actions

### DIFF
--- a/zellij-utils/src/input/command.rs
+++ b/zellij-utils/src/input/command.rs
@@ -19,6 +19,7 @@ pub struct RunCommand {
 /// Intermediate representation
 #[derive(Clone, Debug, Deserialize, Default, Serialize, PartialEq, Eq)]
 pub struct RunCommandAction {
+    #[serde(rename = "cmd")]
     pub command: PathBuf,
     #[serde(default)]
     pub args: Vec<String>,


### PR DESCRIPTION
Change
```
Run: {command: <path>, args: [ARGS], direction: <direction> }
```
into
```
Run: {cmd: <path>, args: [ARGS], direction: <direction> }
```