### PR TITLE
Add on_force_close config option

### DIFF
--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -164,6 +164,8 @@ pub fn start_client(
         })
     });
 
+    let on_force_close = config_options.on_force_close.unwrap_or_default();
+
     let _stdin_thread = thread::Builder::new()
         .name("stdin_handler".to_string())
         .spawn({
@@ -200,7 +202,7 @@ pub fn start_client(
                     Box::new({
                         let os_api = os_input.clone();
                         move || {
-                            os_api.send_to_server(ClientToServerMsg::Action(Action::Detach));
+                            os_api.send_to_server(ClientToServerMsg::Action(on_force_close.into()));
                         }
                     }),
                 );

--- a/zellij-utils/assets/config/default.yaml
+++ b/zellij-utils/assets/config/default.yaml
@@ -240,3 +240,10 @@ keybinds:
           key: [Ctrl: 'q',]
         - action: [Detach,]
           key: [Char: 'd',]
+
+# Choose what to do when zellij receives SIGTERM, SIGINT, SIGQUIT or SIGHUP
+# eg. when terminal window with an active zellij session is closed
+# Options:
+#   - Detach (Default)
+#   - Quit
+#on_force_close: Quit

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -1,6 +1,7 @@
 //! Definition of the actions that can be bound to keys.
 
 use super::command::RunCommandAction;
+use crate::input::options::OnForceClose;
 use serde::{Deserialize, Serialize};
 use zellij_tile::data::InputMode;
 
@@ -80,4 +81,13 @@ pub enum Action {
     MouseRelease(Position),
     MouseHold(Position),
     Copy,
+}
+
+impl From<OnForceClose> for Action {
+    fn from(ofc: OnForceClose) -> Action {
+        match ofc {
+            OnForceClose::Quit => Action::Quit,
+            OnForceClose::Detach => Action::Detach,
+        }
+    }
 }

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -2,8 +2,33 @@
 use crate::cli::Command;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::str::FromStr;
 use structopt::StructOpt;
 use zellij_tile::data::InputMode;
+
+#[derive(Copy, Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub enum OnForceClose {
+    Quit,
+    Detach,
+}
+
+impl Default for OnForceClose {
+    fn default() -> Self {
+        Self::Detach
+    }
+}
+
+impl FromStr for OnForceClose {
+    type Err = Box<dyn std::error::Error>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "quit" => Ok(Self::Quit),
+            "detach" => Ok(Self::Detach),
+            e => Err(e.to_string().into()),
+        }
+    }
+}
 
 #[derive(Clone, Default, Debug, PartialEq, Deserialize, Serialize, StructOpt)]
 /// Options that can be set either through the config file,
@@ -30,6 +55,8 @@ pub struct Options {
     #[structopt(long)]
     #[serde(default)]
     pub disable_mouse_mode: bool,
+    #[structopt(long)]
+    pub on_force_close: Option<OnForceClose>,
 }
 
 impl Options {
@@ -77,6 +104,11 @@ impl Options {
             self.disable_mouse_mode
         };
 
+        let on_force_close = match other.on_force_close {
+            None => self.on_force_close,
+            other => other,
+        };
+
         Options {
             simplified_ui,
             theme,
@@ -84,6 +116,7 @@ impl Options {
             default_shell,
             layout_dir,
             disable_mouse_mode,
+            on_force_close,
         }
     }
 

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -55,6 +55,7 @@ pub struct Options {
     #[structopt(long)]
     #[serde(default)]
     pub disable_mouse_mode: bool,
+    /// Set behaviour on force close (quit or detach)
     #[structopt(long)]
     pub on_force_close: Option<OnForceClose>,
 }


### PR DESCRIPTION
This allows the user to configure the behaviour for when zellij receives `SIGTERM, SIGINT, SIGQUIT or SIGHUP`. User can choose between quit and detach.