### PR TITLE
Add noop for mouse actions on `plugins`

### DIFF
--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -196,13 +196,13 @@ impl Pane for PluginPane {
         self.position_and_size.y -= count;
     }
     fn scroll_up(&mut self, _count: usize) {
-        unimplemented!()
+        //unimplemented!()
     }
     fn scroll_down(&mut self, _count: usize) {
-        unimplemented!()
+        //unimplemented!()
     }
     fn clear_scroll(&mut self) {
-        unimplemented!()
+        //unimplemented!()
     }
     // FIXME: This need to be reevaluated and deleted if possible.
     // `max` doesn't make sense when things are fixed...


### PR DESCRIPTION
* Comments the `unimplemented!` macro out, in favor of a noop
  The macro is still there for easy greppability.
  It is still unimplemented, but zellij doesn't need to panic once
  a plugin does get a scroll event.