### PR TITLE
feat(tab): add keybind to go to last tab visited

### DIFF
--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -188,7 +188,7 @@ impl InputHandler {
             | Action::GoToPreviousTab
             | Action::CloseTab
             | Action::GoToTab(_)
-            | Action::GoToLastTab
+            | Action::ToggleTab
             | Action::MoveFocusOrTab(_) => {
                 self.command_is_executing.blocking_input_thread();
                 self.os_input

--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -188,6 +188,7 @@ impl InputHandler {
             | Action::GoToPreviousTab
             | Action::CloseTab
             | Action::GoToTab(_)
+            | Action::GoToLastTab
             | Action::MoveFocusOrTab(_) => {
                 self.command_is_executing.blocking_input_thread();
                 self.os_input

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -24,6 +24,12 @@ fn route_action(
 ) -> bool {
     let mut should_break = false;
     match action {
+        Action::GoToLastTab => {
+            session
+                .senders
+                .send_to_screen(ScreenInstruction::GoToLastTab)
+                .unwrap();
+        }
         Action::Write(val) => {
             session
                 .senders

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -24,7 +24,7 @@ fn route_action(
 ) -> bool {
     let mut should_break = false;
     match action {
-        Action::GoToLastTab => {
+        Action::ToggleTab => {
             session
                 .senders
                 .send_to_screen(ScreenInstruction::ToggleTab)

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -27,7 +27,7 @@ fn route_action(
         Action::GoToLastTab => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::GoToLastTab)
+                .send_to_screen(ScreenInstruction::ToggleTab)
                 .unwrap();
         }
         Action::Write(val) => {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -342,9 +342,7 @@ impl Screen {
     /// Consumes the last entry in tab history.
     pub fn get_previous_tab(&mut self) -> Option<&Tab> {
         let last = self.tab_history.pop();
-        if last.is_none() {
-            return None;
-        }
+        last?;
         match last.unwrap() {
             Some(tab) => self.tabs.get(&tab),
             None => None,

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -439,7 +439,7 @@ impl Screen {
     }
     pub fn toggle_tab(&mut self) {
         let active_tab_index = self.active_tab_index.unwrap();
-        if let Some(_) = self.previous_active_tab_index {
+        if self.previous_active_tab_index.is_some() {
             let position = self.get_previous_tab().unwrap().position;
             self.go_to_tab(position + 1);
         }

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -68,7 +68,7 @@ pub(crate) enum ScreenInstruction {
     ToggleActiveSyncTab,
     CloseTab,
     GoToTab(u32),
-    GoToLastTab,
+    ToggleTab,
     UpdateTabName(Vec<u8>),
     TerminalResize(PositionAndSize),
     ChangeMode(ModeInfo),
@@ -134,7 +134,7 @@ impl From<&ScreenInstruction> for ScreenContext {
             ScreenInstruction::MouseRelease(_) => ScreenContext::MouseRelease,
             ScreenInstruction::MouseHold(_) => ScreenContext::MouseHold,
             ScreenInstruction::Copy => ScreenContext::Copy,
-            ScreenInstruction::GoToLastTab => ScreenContext::GoToLastTab,
+            ScreenInstruction::ToggleTab => ScreenContext::ToggleTab,
         }
     }
 }
@@ -152,7 +152,7 @@ pub(crate) struct Screen {
     position_and_size: PositionAndSize,
     /// The index of this [`Screen`]'s active [`Tab`].
     active_tab_index: Option<usize>,
-    last_active_tab_index: Option<usize>,
+    previous_active_tab_index: Option<usize>,
     mode_info: ModeInfo,
     colors: Palette,
     session_state: Arc<RwLock<SessionState>>,
@@ -173,7 +173,7 @@ impl Screen {
             position_and_size: client_attributes.position_and_size,
             colors: client_attributes.palette,
             active_tab_index: None,
-            last_active_tab_index: None,
+            previous_active_tab_index: None,
             tabs: BTreeMap::new(),
             mode_info,
             session_state,
@@ -198,7 +198,7 @@ impl Screen {
             self.colors,
             self.session_state.clone(),
         );
-        self.last_active_tab_index = self.active_tab_index;
+        self.previous_active_tab_index = self.active_tab_index;
         self.active_tab_index = Some(tab_index);
         self.tabs.insert(tab_index, tab);
         self.update_tabs();
@@ -224,7 +224,7 @@ impl Screen {
         for tab in self.tabs.values_mut() {
             if tab.position == new_tab_pos {
                 tab.set_force_render();
-                self.last_active_tab_index = self.active_tab_index;
+                self.previous_active_tab_index = self.active_tab_index;
                 self.active_tab_index = Some(tab.index);
                 break;
             }
@@ -244,7 +244,7 @@ impl Screen {
         for tab in self.tabs.values_mut() {
             if tab.position == new_tab_pos {
                 tab.set_force_render();
-                self.last_active_tab_index = self.active_tab_index;
+                self.previous_active_tab_index = self.active_tab_index;
                 self.active_tab_index = Some(tab.index);
                 break;
             }
@@ -259,7 +259,7 @@ impl Screen {
         if let Some(t) = self.tabs.values_mut().find(|t| t.position == tab_index) {
             if t.index != active_tab_index {
                 t.set_force_render();
-                self.last_active_tab_index = self.active_tab_index;
+                self.previous_active_tab_index = self.active_tab_index;
                 self.active_tab_index = Some(t.index);
                 self.update_tabs();
                 self.render();
@@ -285,7 +285,7 @@ impl Screen {
             .unwrap();
         if self.tabs.is_empty() {
             self.active_tab_index = None;
-            self.last_active_tab_index = None;
+            self.previous_active_tab_index = None;
             if *self.session_state.read().unwrap() == SessionState::Attached {
                 self.bus
                     .senders
@@ -370,7 +370,7 @@ impl Screen {
             self.session_state.clone(),
         );
         tab.apply_layout(layout, new_pids, tab_index);
-        self.last_active_tab_index = self.active_tab_index;
+        self.previous_active_tab_index = self.active_tab_index;
         self.active_tab_index = Some(tab_index);
         self.tabs.insert(tab_index, tab);
         self.update_tabs();
@@ -429,10 +429,10 @@ impl Screen {
     }
     pub fn go_to_last_tab(&mut self) {
         let active_tab_index = self.active_tab_index.unwrap();
-        if let Some(i) = self.last_active_tab_index {
+        if let Some(i) = self.previous_active_tab_index {
             self.go_to_tab(i + 1);
         }
-        self.last_active_tab_index = Some(active_tab_index);
+        self.previous_active_tab_index = Some(active_tab_index);
         self.update_tabs();
         self.render();
     }
@@ -770,7 +770,7 @@ pub(crate) fn screen_thread_main(
             ScreenInstruction::Exit => {
                 break;
             }
-            ScreenInstruction::GoToLastTab => {
+            ScreenInstruction::ToggleTab => {
                 screen.go_to_last_tab();
                 screen
                     .bus

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -195,7 +195,7 @@ pub fn close_the_middle_tab() {
     assert_eq!(screen.tabs.len(), 2, "Two tabs left");
     assert_eq!(
         screen.get_active_tab().unwrap().position,
-        0,
+        1,
         "Active tab switched to previous tab"
     );
 }
@@ -294,11 +294,22 @@ pub fn toggle_to_previous_tab_create_tabs_only() {
     screen.new_tab(2);
     screen.new_tab(3);
 
+    assert_eq!(
+        screen.tab_history,
+        vec![None, Some(0), Some(1)],
+        "Tab history is invalid"
+    );
+
     screen.toggle_tab();
     assert_eq!(
         screen.get_active_tab().unwrap().position,
         1,
         "Active tab toggler to previous tab"
+    );
+    assert_eq!(
+        screen.tab_history,
+        vec![None, Some(0), Some(2)],
+        "Tab history is invalid"
     );
 
     screen.toggle_tab();
@@ -306,6 +317,11 @@ pub fn toggle_to_previous_tab_create_tabs_only() {
         screen.get_active_tab().unwrap().position,
         2,
         "Active tab toggler to previous tab"
+    );
+    assert_eq!(
+        screen.tab_history,
+        vec![None, Some(0), Some(1)],
+        "Tab history is invalid"
     );
 
     screen.toggle_tab();
@@ -327,48 +343,90 @@ pub fn toggle_to_previous_tab_delete() {
     };
     let mut screen = create_new_screen(position_and_size);
 
-    screen.new_tab(1);
-    screen.new_tab(2);
-    screen.new_tab(3);
+    screen.new_tab(1); // 0
+    screen.new_tab(2); // 1
+    screen.new_tab(3); // 2
+    screen.new_tab(4); // 3
+
+    assert_eq!(
+        screen.tab_history,
+        vec![None, Some(0), Some(1), Some(2)],
+        "Tab history is invalid"
+    );
+    assert_eq!(
+        screen.get_active_tab().unwrap().position,
+        3,
+        "Active tab toggler to previous tab"
+    );
 
     screen.toggle_tab();
+    assert_eq!(
+        screen.tab_history,
+        vec![None, Some(0), Some(1), Some(3)],
+        "Tab history is invalid"
+    );
+    assert_eq!(
+        screen.get_active_tab().unwrap().position,
+        2,
+        "Active tab toggler to previous tab"
+    );
+
+    screen.toggle_tab();
+    assert_eq!(
+        screen.tab_history,
+        vec![None, Some(0), Some(1), Some(2)],
+        "Tab history is invalid"
+    );
+    assert_eq!(
+        screen.get_active_tab().unwrap().position,
+        3,
+        "Active tab toggler to previous tab"
+    );
+
+    screen.switch_tab_prev();
+    assert_eq!(
+        screen.tab_history,
+        vec![None, Some(0), Some(1), Some(3)],
+        "Tab history is invalid"
+    );
+    assert_eq!(
+        screen.get_active_tab().unwrap().position,
+        2,
+        "Active tab toggler to previous tab"
+    );
+    screen.switch_tab_prev();
+    assert_eq!(
+        screen.tab_history,
+        vec![None, Some(0), Some(3), Some(2)],
+        "Tab history is invalid"
+    );
     assert_eq!(
         screen.get_active_tab().unwrap().position,
         1,
         "Active tab toggler to previous tab"
-    );
-    assert_eq!(
-        screen.get_previous_tab().unwrap().position,
-        2,
-        "Previous active tab invalid"
     );
 
     screen.close_tab();
     assert_eq!(
+        screen.tab_history,
+        vec![None, Some(0), Some(3)],
+        "Tab history is invalid"
+    );
+    assert_eq!(
         screen.get_active_tab().unwrap().position,
-        0,
-        "Active tab toggler to previous tab"
-    );
-    assert_eq!(
-        screen.get_previous_tab().unwrap().position,
         1,
-        "Previous active tab invalid"
-    );
-    assert_eq!(
-        screen.get_previous_tab().unwrap().index,
-        2,
-        "Previous active tab invalid"
+        "Active tab toggler to previous tab"
     );
 
     screen.toggle_tab();
     assert_eq!(
         screen.get_active_tab().unwrap().position,
-        1,
+        2,
         "Active tab toggler to previous tab"
     );
     assert_eq!(
-        screen.get_previous_tab().unwrap().position,
-        0,
-        "Previous active tab invalid"
+        screen.tab_history,
+        vec![None, Some(0), Some(2)],
+        "Tab history is invalid"
     );
 }

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -249,7 +249,7 @@ fn move_focus_right_at_right_screen_edge_changes_tab() {
 }
 
 #[test]
-pub fn switch_to_last_tab() {
+pub fn toggle_to_previous_tab_simple() {
     let position_and_size = PositionAndSize {
         cols: 121,
         rows: 20,
@@ -264,17 +264,111 @@ pub fn switch_to_last_tab() {
     screen.go_to_tab(1);
     screen.go_to_tab(2);
 
-    screen.go_to_last_tab();
+    screen.toggle_tab();
     assert_eq!(
         screen.get_active_tab().unwrap().position,
         0,
-        "Active tab switched to last tab"
+        "Active tab toggler to previous tab"
     );
 
-    screen.go_to_last_tab();
+    screen.toggle_tab();
     assert_eq!(
         screen.get_active_tab().unwrap().position,
         1,
-        "Active tab switched to last tab"
+        "Active tab toggler to previous tab"
+    );
+}
+
+#[test]
+pub fn toggle_to_previous_tab_create_tabs_only() {
+    let position_and_size = PositionAndSize {
+        cols: 121,
+        rows: 20,
+        x: 0,
+        y: 0,
+        ..Default::default()
+    };
+    let mut screen = create_new_screen(position_and_size);
+
+    screen.new_tab(1);
+    screen.new_tab(2);
+    screen.new_tab(3);
+
+    screen.toggle_tab();
+    assert_eq!(
+        screen.get_active_tab().unwrap().position,
+        1,
+        "Active tab toggler to previous tab"
+    );
+
+    screen.toggle_tab();
+    assert_eq!(
+        screen.get_active_tab().unwrap().position,
+        2,
+        "Active tab toggler to previous tab"
+    );
+
+    screen.toggle_tab();
+    assert_eq!(
+        screen.get_active_tab().unwrap().position,
+        1,
+        "Active tab toggler to previous tab"
+    );
+}
+
+#[test]
+pub fn toggle_to_previous_tab_delete() {
+    let position_and_size = PositionAndSize {
+        cols: 121,
+        rows: 20,
+        x: 0,
+        y: 0,
+        ..Default::default()
+    };
+    let mut screen = create_new_screen(position_and_size);
+
+    screen.new_tab(1);
+    screen.new_tab(2);
+    screen.new_tab(3);
+
+    screen.toggle_tab();
+    assert_eq!(
+        screen.get_active_tab().unwrap().position,
+        1,
+        "Active tab toggler to previous tab"
+    );
+    assert_eq!(
+        screen.get_previous_tab().unwrap().position,
+        2,
+        "Previous active tab invalid"
+    );
+
+    screen.close_tab();
+    assert_eq!(
+        screen.get_active_tab().unwrap().position,
+        0,
+        "Active tab toggler to previous tab"
+    );
+    assert_eq!(
+        screen.get_previous_tab().unwrap().position,
+        1,
+        "Previous active tab invalid"
+    );
+    assert_eq!(
+        screen.get_previous_tab().unwrap().index,
+        2,
+        "Previous active tab invalid"
+    );
+
+    screen.toggle_tab();
+    assert_eq!(
+        screen.get_active_tab().unwrap().position,
+        1,
+        "Active tab toggler to previous tab"
+    );
+    assert_eq!(
+        screen.get_previous_tab().unwrap().position,
+        0,
+        "Previous active tab invalid"
     );
 }

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -247,3 +247,34 @@ fn move_focus_right_at_right_screen_edge_changes_tab() {
         "Active tab switched to next"
     );
 }
+
+#[test]
+pub fn switch_to_last_tab() {
+    let position_and_size = PositionAndSize {
+        cols: 121,
+        rows: 20,
+        x: 0,
+        y: 0,
+        ..Default::default()
+    };
+    let mut screen = create_new_screen(position_and_size);
+
+    screen.new_tab(1);
+    screen.new_tab(2);
+    screen.go_to_tab(1);
+    screen.go_to_tab(2);
+
+    screen.go_to_last_tab();
+    assert_eq!(
+        screen.get_active_tab().unwrap().position,
+        0,
+        "Active tab switched to last tab"
+    );
+
+    screen.go_to_last_tab();
+    assert_eq!(
+        screen.get_active_tab().unwrap().position,
+        1,
+        "Active tab switched to last tab"
+    );
+}

--- a/zellij-utils/assets/config/default.yaml
+++ b/zellij-utils/assets/config/default.yaml
@@ -166,6 +166,8 @@ keybinds:
           key: [ Char: '8',]
         - action: [GoToTab: 9,]
           key: [ Char: '9',]
+        - action: [GoToLastTab]
+          key: [ Char: "\t" ]
     scroll:
         - action: [SwitchToMode: Normal,]
           key: [Ctrl: 'r', Ctrl: 's', Char: ' ',

--- a/zellij-utils/assets/config/default.yaml
+++ b/zellij-utils/assets/config/default.yaml
@@ -166,7 +166,7 @@ keybinds:
           key: [ Char: '8',]
         - action: [GoToTab: 9,]
           key: [ Char: '9',]
-        - action: [GoToLastTab]
+        - action: [ToggleTab]
           key: [ Char: "\t" ]
     scroll:
         - action: [SwitchToMode: Normal,]

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -227,6 +227,7 @@ pub enum ScreenContext {
     MouseRelease,
     MouseHold,
     Copy,
+    GoToLastTab,
 }
 
 /// Stack call representations corresponding to the different types of [`PtyInstruction`]s.

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -227,7 +227,7 @@ pub enum ScreenContext {
     MouseRelease,
     MouseHold,
     Copy,
-    GoToLastTab,
+    ToggleTab,
 }
 
 /// Stack call representations corresponding to the different types of [`PtyInstruction`]s.

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -74,6 +74,7 @@ pub enum Action {
     /// Close the current tab.
     CloseTab,
     GoToTab(u32),
+    GoToLastTab,
     TabNameInput(Vec<u8>),
     /// Run speficied command in new pane.
     Run(RunCommandAction),

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -74,7 +74,7 @@ pub enum Action {
     /// Close the current tab.
     CloseTab,
     GoToTab(u32),
-    GoToLastTab,
+    ToggleTab,
     TabNameInput(Vec<u8>),
     /// Run speficied command in new pane.
     Run(RunCommandAction),

--- a/zellij-utils/src/input/mod.rs
+++ b/zellij-utils/src/input/mod.rs
@@ -37,7 +37,7 @@ pub fn get_mode_info(
             ("x".to_string(), "Close".to_string()),
             ("r".to_string(), "Rename".to_string()),
             ("s".to_string(), "Sync".to_string()),
-            ("Tab".to_string(), "Last".to_string()),
+            ("Tab".to_string(), "Toggle".to_string()),
         ],
         InputMode::Scroll => vec![
             ("↓↑".to_string(), "Scroll".to_string()),

--- a/zellij-utils/src/input/mod.rs
+++ b/zellij-utils/src/input/mod.rs
@@ -37,6 +37,7 @@ pub fn get_mode_info(
             ("x".to_string(), "Close".to_string()),
             ("r".to_string(), "Rename".to_string()),
             ("s".to_string(), "Sync".to_string()),
+            ("Tab".to_string(), "Last".to_string()),
         ],
         InputMode::Scroll => vec![
             ("↓↑".to_string(), "Scroll".to_string()),


### PR DESCRIPTION
Fixes #398.

Tab key is used as default for the `GoToLastTab` action.

A test have been added, All other tests still pass.