### PR TITLE
feat(scroll): Restore scroll position on SIGINT

### DIFF
--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -127,6 +127,12 @@ fn route_action(
                 .send_to_screen(ScreenInstruction::ScrollDownAt(point))
                 .unwrap();
         }
+        Action::ScrollToBottom => {
+            session
+                .senders
+                .send_to_screen(ScreenInstruction::ScrollToBottom)
+                .unwrap();
+        }
         Action::PageScrollUp => {
             session
                 .senders

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -50,6 +50,7 @@ pub(crate) enum ScreenInstruction {
     ScrollUpAt(Position),
     ScrollDown,
     ScrollDownAt(Position),
+    ScrollToBottom,
     PageScrollUp,
     PageScrollDown,
     ClearScroll,
@@ -103,6 +104,7 @@ impl From<&ScreenInstruction> for ScreenContext {
             ScreenInstruction::Exit => ScreenContext::Exit,
             ScreenInstruction::ScrollUp => ScreenContext::ScrollUp,
             ScreenInstruction::ScrollDown => ScreenContext::ScrollDown,
+            ScreenInstruction::ScrollToBottom => ScreenContext::ScrollToBottom,
             ScreenInstruction::PageScrollUp => ScreenContext::PageScrollUp,
             ScreenInstruction::PageScrollDown => ScreenContext::PageScrollDown,
             ScreenInstruction::ClearScroll => ScreenContext::ClearScroll,
@@ -568,6 +570,12 @@ pub(crate) fn screen_thread_main(
                     .get_active_tab_mut()
                     .unwrap()
                     .scroll_terminal_down(&point, 3);
+            }
+            ScreenInstruction::ScrollToBottom => {
+                screen
+                    .get_active_tab_mut()
+                    .unwrap()
+                    .scroll_active_terminal_to_bottom();
             }
             ScreenInstruction::PageScrollUp => {
                 screen

--- a/zellij-server/src/tab.rs
+++ b/zellij-server/src/tab.rs
@@ -2280,6 +2280,16 @@ impl Tab {
             self.render();
         }
     }
+    pub fn scroll_active_terminal_to_bottom(&mut self) {
+        if let Some(active_terminal_id) = self.get_active_terminal_id() {
+            let active_terminal = self
+                .panes
+                .get_mut(&PaneId::Terminal(active_terminal_id))
+                .unwrap();
+            active_terminal.clear_scroll();
+            self.render();
+        }
+    }
     pub fn clear_active_terminal_scroll(&mut self) {
         if let Some(active_terminal_id) = self.get_active_terminal_id() {
             let active_terminal = self

--- a/zellij-utils/assets/config/default.yaml
+++ b/zellij-utils/assets/config/default.yaml
@@ -178,6 +178,8 @@ keybinds:
           key: [Ctrl: 'p',]
         - action: [SwitchToMode: Session,]
           key: [Ctrl: 'o',]
+        - action: [ScrollToBottom, SwitchToMode: Normal,]
+          key: [Ctrl: 'c',]
         - action: [Quit,]
           key: [Ctrl: 'q',]
         - action: [ScrollDown,]

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -202,6 +202,7 @@ pub enum ScreenContext {
     ScrollUpAt,
     ScrollDown,
     ScrollDownAt,
+    ScrollToBottom,
     PageScrollUp,
     PageScrollDown,
     ClearScroll,

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -48,6 +48,8 @@ pub enum Action {
     ScrollDown,
     /// Scroll down at point
     ScrollDownAt(Position),
+    /// Scroll down to bottom in focus pane.
+    ScrollToBottom,
     /// Scroll up one page in focus pane.
     PageScrollUp,
     /// Scroll down one page in focus pane.


### PR DESCRIPTION
Fixes #606

Currently scroll down to bottom then exits scroll mode.