### PR TITLE
Simplify deserialization for layouts, config

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,16 +5,14 @@ mod tests;
 
 use crate::install::populate_data_dir;
 use sessions::{assert_session, assert_session_ne, get_active_session, list_sessions};
-use std::convert::TryFrom;
 use std::process;
 use zellij_client::{os_input_output::get_client_os_input, start_client, ClientInfo};
 use zellij_server::{os_input_output::get_server_os_input, start_server};
 use zellij_utils::{
     cli::{CliArgs, Command, Sessions},
     consts::{ZELLIJ_TMP_DIR, ZELLIJ_TMP_LOG_DIR},
-    input::{config::Config, layout::Layout, options::Options},
     logging::*,
-    setup::{find_default_config_dir, get_default_data_dir, get_layout_dir, Setup},
+    setup::{get_default_data_dir, Setup},
     structopt::StructOpt,
 };
 
@@ -26,23 +24,12 @@ pub fn main() {
         list_sessions();
     }
 
-    let config = match Config::try_from(&opts) {
-        Ok(config) => config,
+    let (config, layout, config_options) = match Setup::from_options(&opts) {
+        Ok(results) => results,
         Err(e) => {
-            eprintln!("There was an error in the config file:\n{}", e);
+            eprintln!("{}", e);
             process::exit(1);
         }
-    };
-    let config_options = Options::from_cli(&config.options, opts.command.clone());
-
-    if let Some(Command::Setup(ref setup)) = opts.command {
-        Setup::from_cli(setup, &opts, &config_options).map_or_else(
-            |e| {
-                eprintln!("{:?}", e);
-                process::exit(1);
-            },
-            |_| {},
-        );
     };
 
     atomic_create_dir(&*ZELLIJ_TMP_DIR).unwrap();
@@ -93,15 +80,6 @@ pub fn main() {
             let data_dir = opts.data_dir.clone().unwrap_or_else(get_default_data_dir);
             #[cfg(not(disable_automatic_asset_installation))]
             populate_data_dir(&data_dir);
-
-            let layout_dir = config_options.layout_dir.or_else(|| {
-                get_layout_dir(opts.config_dir.clone().or_else(find_default_config_dir))
-            });
-            let layout = Layout::from_path_or_default(
-                opts.layout.as_ref(),
-                opts.layout_path.as_ref(),
-                layout_dir,
-            );
 
             start_client(
                 Box::new(os_input),

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -80,8 +80,8 @@ impl Layout {
         layout: Option<&PathBuf>,
         layout_path: Option<&PathBuf>,
         layout_dir: Option<PathBuf>,
-    ) -> Option<Layout> {
-        let layout_result = layout
+    ) -> Option<Result<Layout, ConfigError>> {
+        layout
             .map(|p| Layout::from_dir(p, layout_dir.as_ref()))
             .or_else(|| layout_path.map(|p| Layout::new(p)))
             .or_else(|| {
@@ -89,16 +89,7 @@ impl Layout {
                     &std::path::PathBuf::from("default"),
                     layout_dir.as_ref(),
                 ))
-            });
-
-        match layout_result {
-            None => None,
-            Some(Ok(layout)) => Some(layout),
-            Some(Err(e)) => {
-                eprintln!("There was an error in the layout file:\n{}", e);
-                std::process::exit(1);
-            }
-        }
+            })
     }
 
     // Currently still needed but on nightly


### PR DESCRIPTION
Simplify deserialzation for layouts, config and config options.

Move the logic responsible to `Setup::from_options()` in order
to be able to parse `main.rs` as well as adding new command easier.