### PR TITLE
Fix plugin attribute update on inactive tab

### DIFF
--- a/zellij-server/src/tab.rs
+++ b/zellij-server/src/tab.rs
@@ -301,7 +301,7 @@ impl Tab {
         }
     }
 
-    pub fn apply_layout(&mut self, layout: Layout, new_pids: Vec<RawFd>) {
+    pub fn apply_layout(&mut self, layout: Layout, new_pids: Vec<RawFd>, tab_index: usize) {
         // TODO: this should be an attribute on Screen instead of full_screen_ws
         let free_space = PositionAndSize {
             x: 0,
@@ -340,7 +340,7 @@ impl Tab {
             if let Some(Run::Plugin(Some(plugin))) = &layout.run {
                 let (pid_tx, pid_rx) = channel();
                 self.senders
-                    .send_to_plugin(PluginInstruction::Load(pid_tx, plugin.clone()))
+                    .send_to_plugin(PluginInstruction::Load(pid_tx, plugin.clone(), tab_index))
                     .unwrap();
                 let pid = pid_rx.recv().unwrap();
                 let new_plugin = PluginPane::new(


### PR DESCRIPTION
Fixes #621

* `ScreenInstruction::SetSelectable` etc.
  were not updating correctly, if a NewTab was spawned, before
  the plugin was finished setting the attributes.

  Now the `tab_index` is used to send the instructions to
  their respective tabs and plugins.