### PR TITLE
support monochrome mode

### DIFF
--- a/default-plugins/status-bar/src/main.rs
+++ b/default-plugins/status-bar/src/main.rs
@@ -70,64 +70,92 @@ pub struct ColoredElements {
 // we need different colors from palette for the default theme
 // plus here we can add new sources in the future, like Theme
 // that can be defined in the config perhaps
-fn color_elements(palette: Palette) -> ColoredElements {
-    match palette.source {
-        // "cyan" here is used as a background as a dirty hack
-        // this is because the Palette struct doesn't have a "gray" section
-        // and we can't use its "bg" because that is now dynamically taken from the terminal
-        // and might often not actually fit the rest of the colorscheme
-        //
-        // to fix this, we need to restructure the Palette struct
-        PaletteSource::Default => ColoredElements {
-            selected_prefix_separator: style!(palette.cyan, palette.green),
-            selected_char_left_separator: style!(palette.black, palette.green).bold(),
-            selected_char_shortcut: style!(palette.red, palette.green).bold(),
-            selected_char_right_separator: style!(palette.black, palette.green).bold(),
-            selected_styled_text: style!(palette.black, palette.green).bold(),
-            selected_suffix_separator: style!(palette.green, palette.cyan).bold(),
-            unselected_prefix_separator: style!(palette.cyan, palette.fg),
-            unselected_char_left_separator: style!(palette.black, palette.fg).bold(),
-            unselected_char_shortcut: style!(palette.red, palette.fg).bold(),
-            unselected_char_right_separator: style!(palette.black, palette.fg).bold(),
-            unselected_styled_text: style!(palette.black, palette.fg).bold(),
-            unselected_suffix_separator: style!(palette.fg, palette.cyan),
-            disabled_prefix_separator: style!(palette.cyan, palette.fg),
-            disabled_styled_text: style!(palette.cyan, palette.fg).dimmed(),
-            disabled_suffix_separator: style!(palette.fg, palette.cyan),
-            selected_single_letter_prefix_separator: style!(palette.cyan, palette.green),
-            selected_single_letter_char_shortcut: style!(palette.red, palette.green).bold(),
-            selected_single_letter_suffix_separator: style!(palette.green, palette.cyan),
-            unselected_single_letter_prefix_separator: style!(palette.cyan, palette.fg),
-            unselected_single_letter_char_shortcut: style!(palette.red, palette.fg).bold(),
-            unselected_single_letter_suffix_separator: style!(palette.fg, palette.cyan),
-            superkey_prefix: style!(palette.white, palette.cyan).bold(),
-            superkey_suffix_separator: style!(palette.cyan, palette.cyan),
-        },
-        PaletteSource::Xresources => ColoredElements {
-            selected_prefix_separator: style!(palette.cyan, palette.green),
-            selected_char_left_separator: style!(palette.fg, palette.green).bold(),
-            selected_char_shortcut: style!(palette.red, palette.green).bold(),
-            selected_char_right_separator: style!(palette.fg, palette.green).bold(),
-            selected_styled_text: style!(palette.cyan, palette.green).bold(),
-            selected_suffix_separator: style!(palette.green, palette.cyan).bold(),
-            unselected_prefix_separator: style!(palette.cyan, palette.fg),
-            unselected_char_left_separator: style!(palette.cyan, palette.fg).bold(),
-            unselected_char_shortcut: style!(palette.red, palette.fg).bold(),
-            unselected_char_right_separator: style!(palette.cyan, palette.fg).bold(),
-            unselected_styled_text: style!(palette.cyan, palette.fg).bold(),
-            unselected_suffix_separator: style!(palette.fg, palette.cyan),
-            disabled_prefix_separator: style!(palette.cyan, palette.fg),
-            disabled_styled_text: style!(palette.cyan, palette.fg).dimmed(),
-            disabled_suffix_separator: style!(palette.fg, palette.cyan),
-            selected_single_letter_prefix_separator: style!(palette.fg, palette.green),
-            selected_single_letter_char_shortcut: style!(palette.red, palette.green).bold(),
-            selected_single_letter_suffix_separator: style!(palette.green, palette.fg),
-            unselected_single_letter_prefix_separator: style!(palette.fg, palette.cyan),
-            unselected_single_letter_char_shortcut: style!(palette.red, palette.fg).bold(),
-            unselected_single_letter_suffix_separator: style!(palette.fg, palette.cyan),
-            superkey_prefix: style!(palette.cyan, palette.fg).bold(),
-            superkey_suffix_separator: style!(palette.fg, palette.cyan),
-        },
+fn color_elements(palette: Option<Palette>) -> ColoredElements {
+    if let Some(palette) = palette {
+        match palette.source {
+            // "cyan" here is used as a background as a dirty hack
+            // this is because the Palette struct doesn't have a "gray" section
+            // and we can't use its "bg" because that is now dynamically taken from the terminal
+            // and might often not actually fit the rest of the colorscheme
+            //
+            // to fix this, we need to restructure the Palette struct
+            PaletteSource::Default => ColoredElements {
+                selected_prefix_separator: style!(palette.cyan, palette.green),
+                selected_char_left_separator: style!(palette.black, palette.green).bold(),
+                selected_char_shortcut: style!(palette.red, palette.green).bold(),
+                selected_char_right_separator: style!(palette.black, palette.green).bold(),
+                selected_styled_text: style!(palette.black, palette.green).bold(),
+                selected_suffix_separator: style!(palette.green, palette.cyan).bold(),
+                unselected_prefix_separator: style!(palette.cyan, palette.fg),
+                unselected_char_left_separator: style!(palette.black, palette.fg).bold(),
+                unselected_char_shortcut: style!(palette.red, palette.fg).bold(),
+                unselected_char_right_separator: style!(palette.black, palette.fg).bold(),
+                unselected_styled_text: style!(palette.black, palette.fg).bold(),
+                unselected_suffix_separator: style!(palette.fg, palette.cyan),
+                disabled_prefix_separator: style!(palette.cyan, palette.fg),
+                disabled_styled_text: style!(palette.cyan, palette.fg).dimmed(),
+                disabled_suffix_separator: style!(palette.fg, palette.cyan),
+                selected_single_letter_prefix_separator: style!(palette.cyan, palette.green),
+                selected_single_letter_char_shortcut: style!(palette.red, palette.green).bold(),
+                selected_single_letter_suffix_separator: style!(palette.green, palette.cyan),
+                unselected_single_letter_prefix_separator: style!(palette.cyan, palette.fg),
+                unselected_single_letter_char_shortcut: style!(palette.red, palette.fg).bold(),
+                unselected_single_letter_suffix_separator: style!(palette.fg, palette.cyan),
+                superkey_prefix: style!(palette.white, palette.cyan).bold(),
+                superkey_suffix_separator: style!(palette.cyan, palette.cyan),
+            },
+            PaletteSource::Xresources => ColoredElements {
+                selected_prefix_separator: style!(palette.cyan, palette.green),
+                selected_char_left_separator: style!(palette.fg, palette.green).bold(),
+                selected_char_shortcut: style!(palette.red, palette.green).bold(),
+                selected_char_right_separator: style!(palette.fg, palette.green).bold(),
+                selected_styled_text: style!(palette.cyan, palette.green).bold(),
+                selected_suffix_separator: style!(palette.green, palette.cyan).bold(),
+                unselected_prefix_separator: style!(palette.cyan, palette.fg),
+                unselected_char_left_separator: style!(palette.cyan, palette.fg).bold(),
+                unselected_char_shortcut: style!(palette.red, palette.fg).bold(),
+                unselected_char_right_separator: style!(palette.cyan, palette.fg).bold(),
+                unselected_styled_text: style!(palette.cyan, palette.fg).bold(),
+                unselected_suffix_separator: style!(palette.fg, palette.cyan),
+                disabled_prefix_separator: style!(palette.cyan, palette.fg),
+                disabled_styled_text: style!(palette.cyan, palette.fg).dimmed(),
+                disabled_suffix_separator: style!(palette.fg, palette.cyan),
+                selected_single_letter_prefix_separator: style!(palette.fg, palette.green),
+                selected_single_letter_char_shortcut: style!(palette.red, palette.green).bold(),
+                selected_single_letter_suffix_separator: style!(palette.green, palette.fg),
+                unselected_single_letter_prefix_separator: style!(palette.fg, palette.cyan),
+                unselected_single_letter_char_shortcut: style!(palette.red, palette.fg).bold(),
+                unselected_single_letter_suffix_separator: style!(palette.fg, palette.cyan),
+                superkey_prefix: style!(palette.cyan, palette.fg).bold(),
+                superkey_suffix_separator: style!(palette.fg, palette.cyan),
+            },
+        }
+    } else {
+        ColoredElements {
+            selected_prefix_separator: Style::new(),
+            selected_char_left_separator: Style::new(),
+            selected_char_shortcut: Style::new(),
+            selected_char_right_separator: Style::new(),
+            selected_styled_text: Style::new(),
+            selected_suffix_separator: Style::new(),
+            unselected_prefix_separator: Style::new(),
+            unselected_char_left_separator: Style::new(),
+            unselected_char_shortcut: Style::new(),
+            unselected_char_right_separator: Style::new(),
+            unselected_styled_text: Style::new(),
+            unselected_suffix_separator: Style::new(),
+            disabled_prefix_separator: Style::new(),
+            disabled_styled_text: Style::new(),
+            disabled_suffix_separator: Style::new(),
+            selected_single_letter_prefix_separator: Style::new(),
+            selected_single_letter_char_shortcut: Style::new(),
+            selected_single_letter_suffix_separator: Style::new(),
+            unselected_single_letter_prefix_separator: Style::new(),
+            unselected_single_letter_char_shortcut: Style::new(),
+            unselected_single_letter_suffix_separator: Style::new(),
+            superkey_prefix: Style::new(),
+            superkey_suffix_separator: Style::new(),
+        }
     }
 }
 
@@ -165,12 +193,21 @@ impl ZellijPlugin for State {
 
         // [48;5;238m is gray background, [0K is so that it fills the rest of the line
         // [m is background reset, [0K is so that it clears the rest of the line
-        match self.mode_info.palette.cyan {
-            PaletteColor::Rgb((r, g, b)) => {
+        match self.mode_info.palette {
+            Some(Palette {
+                cyan: PaletteColor::Rgb((r, g, b)),
+                ..
+            }) => {
                 println!("{}\u{1b}[48;2;{};{};{}m\u{1b}[0K", first_line, r, g, b);
             }
-            PaletteColor::EightBit(color) => {
+            Some(Palette {
+                cyan: PaletteColor::EightBit(color),
+                ..
+            }) => {
                 println!("{}\u{1b}[48;5;{}m\u{1b}[0K", first_line, color);
+            }
+            _ => {
+                println!("{}", first_line);
             }
         }
         println!("\u{1b}[m{}\u{1b}[0K", second_line);

--- a/default-plugins/status-bar/src/second_line.rs
+++ b/default-plugins/status-bar/src/second_line.rs
@@ -11,24 +11,38 @@ fn full_length_shortcut(
     is_first_shortcut: bool,
     letter: &str,
     description: &str,
-    palette: Palette,
+    palette: Option<Palette>,
 ) -> LinePart {
-    let white_color = match palette.white {
-        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
-        PaletteColor::EightBit(color) => Fixed(color),
+    let white_color_style = match palette {
+        Some(Palette {
+            white: PaletteColor::Rgb((r, g, b)),
+            ..
+        }) => Style::new().fg(RGB(r, g, b)),
+        Some(Palette {
+            white: PaletteColor::EightBit(color),
+            ..
+        }) => Style::new().fg(Fixed(color)),
+        _ => Style::new(),
     };
-    let green_color = match palette.green {
-        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
-        PaletteColor::EightBit(color) => Fixed(color),
+    let green_color_style = match palette {
+        Some(Palette {
+            green: PaletteColor::Rgb((r, g, b)),
+            ..
+        }) => Style::new().fg(RGB(r, g, b)),
+        Some(Palette {
+            green: PaletteColor::EightBit(color),
+            ..
+        }) => Style::new().fg(Fixed(color)),
+        _ => Style::new(),
     };
     let separator = if is_first_shortcut { " " } else { " / " };
-    let separator = Style::new().fg(white_color).paint(separator);
+    let separator = white_color_style.paint(separator);
     let shortcut_len = letter.chars().count() + 3; // 2 for <>'s around shortcut, 1 for the space
-    let shortcut_left_separator = Style::new().fg(white_color).paint("<");
-    let shortcut = Style::new().fg(green_color).bold().paint(letter);
-    let shortcut_right_separator = Style::new().fg(white_color).paint("> ");
+    let shortcut_left_separator = white_color_style.paint("<");
+    let shortcut = green_color_style.bold().paint(letter);
+    let shortcut_right_separator = white_color_style.paint("> ");
     let description_len = description.chars().count();
-    let description = Style::new().fg(white_color).bold().paint(description);
+    let description = white_color_style.bold().paint(description);
     let len = shortcut_len + description_len + separator.chars().count();
     LinePart {
         part: format!(
@@ -49,28 +63,39 @@ fn first_word_shortcut(
     is_first_shortcut: bool,
     letter: &str,
     description: &str,
-    palette: Palette,
+    palette: Option<Palette>,
 ) -> LinePart {
-    let white_color = match palette.white {
-        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
-        PaletteColor::EightBit(color) => Fixed(color),
+    let white_color_style = match palette {
+        Some(Palette {
+            white: PaletteColor::Rgb((r, g, b)),
+            ..
+        }) => Style::new().fg(RGB(r, g, b)),
+        Some(Palette {
+            white: PaletteColor::EightBit(color),
+            ..
+        }) => Style::new().fg(Fixed(color)),
+        _ => Style::new(),
     };
-    let green_color = match palette.green {
-        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
-        PaletteColor::EightBit(color) => Fixed(color),
+    let green_color_style = match palette {
+        Some(Palette {
+            green: PaletteColor::Rgb((r, g, b)),
+            ..
+        }) => Style::new().fg(RGB(r, g, b)),
+        Some(Palette {
+            green: PaletteColor::EightBit(color),
+            ..
+        }) => Style::new().fg(Fixed(color)),
+        _ => Style::new(),
     };
     let separator = if is_first_shortcut { " " } else { " / " };
-    let separator = Style::new().fg(white_color).paint(separator);
+    let separator = white_color_style.paint(separator);
     let shortcut_len = letter.chars().count() + 3; // 2 for <>'s around shortcut, 1 for the space
-    let shortcut_left_separator = Style::new().fg(white_color).paint("<");
-    let shortcut = Style::new().fg(green_color).bold().paint(letter);
-    let shortcut_right_separator = Style::new().fg(white_color).paint("> ");
+    let shortcut_left_separator = white_color_style.paint("<");
+    let shortcut = green_color_style.bold().paint(letter);
+    let shortcut_right_separator = white_color_style.paint("> ");
     let description_first_word = description.split(' ').next().unwrap_or("");
     let description_first_word_length = description_first_word.chars().count();
-    let description_first_word = Style::new()
-        .fg(white_color)
-        .bold()
-        .paint(description_first_word);
+    let description_first_word = white_color_style.bold().paint(description_first_word);
     let len = shortcut_len + description_first_word_length + separator.chars().count();
     LinePart {
         part: format!(
@@ -86,7 +111,7 @@ fn first_word_shortcut(
         len,
     }
 }
-fn quicknav_full(palette: Palette) -> LinePart {
+fn quicknav_full(palette: Option<Palette>) -> LinePart {
     let text_first_part = " Tip: ";
     let alt = "Alt";
     let text_second_part = " + ";
@@ -109,37 +134,48 @@ fn quicknav_full(palette: Palette) -> LinePart {
         + text_fifth_part.chars().count()
         + hjkl_navigation.chars().count()
         + text_sixths_part.chars().count();
-    let green_color = match palette.green {
-        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
-        PaletteColor::EightBit(color) => Fixed(color),
+    let green_color_style = match palette {
+        Some(Palette {
+            green: PaletteColor::Rgb((r, g, b)),
+            ..
+        }) => Style::new().fg(RGB(r, g, b)),
+        Some(Palette {
+            green: PaletteColor::EightBit(color),
+            ..
+        }) => Style::new().fg(Fixed(color)),
+        _ => Style::new(),
     };
-    let orange_color = match palette.orange {
-        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
-        PaletteColor::EightBit(color) => Fixed(color),
+    let orange_color_style = match palette {
+        Some(Palette {
+            orange: PaletteColor::Rgb((r, g, b)),
+            ..
+        }) => Style::new().fg(RGB(r, g, b)),
+        Some(Palette {
+            orange: PaletteColor::EightBit(color),
+            ..
+        }) => Style::new().fg(Fixed(color)),
+        _ => Style::new(),
     };
     LinePart {
         part: format!(
             "{}{}{}{}{}{}{}{}{}{}{}",
             text_first_part,
-            Style::new().fg(orange_color).bold().paint(alt),
+            orange_color_style.bold().paint(alt),
             text_second_part,
-            Style::new().fg(green_color).bold().paint(new_pane_shortcut),
+            green_color_style.bold().paint(new_pane_shortcut),
             text_third_part,
-            Style::new().fg(orange_color).bold().paint(second_alt),
+            orange_color_style.bold().paint(second_alt),
             text_fourth_part,
-            Style::new()
-                .fg(green_color)
-                .bold()
-                .paint(brackets_navigation),
+            green_color_style.bold().paint(brackets_navigation),
             text_fifth_part,
-            Style::new().fg(green_color).bold().paint(hjkl_navigation),
+            green_color_style.bold().paint(hjkl_navigation),
             text_sixths_part,
         ),
         len,
     }
 }
 
-fn quicknav_medium(palette: Palette) -> LinePart {
+fn quicknav_medium(palette: Option<Palette>) -> LinePart {
     let text_first_part = " Tip: ";
     let alt = "Alt";
     let text_second_part = " + ";
@@ -162,37 +198,48 @@ fn quicknav_medium(palette: Palette) -> LinePart {
         + text_fifth_part.chars().count()
         + hjkl_navigation.chars().count()
         + text_sixths_part.chars().count();
-    let green_color = match palette.green {
-        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
-        PaletteColor::EightBit(color) => Fixed(color),
+    let green_color_style = match palette {
+        Some(Palette {
+            green: PaletteColor::Rgb((r, g, b)),
+            ..
+        }) => Style::new().fg(RGB(r, g, b)),
+        Some(Palette {
+            green: PaletteColor::EightBit(color),
+            ..
+        }) => Style::new().fg(Fixed(color)),
+        _ => Style::new(),
     };
-    let orange_color = match palette.orange {
-        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
-        PaletteColor::EightBit(color) => Fixed(color),
+    let orange_color_style = match palette {
+        Some(Palette {
+            orange: PaletteColor::Rgb((r, g, b)),
+            ..
+        }) => Style::new().fg(RGB(r, g, b)),
+        Some(Palette {
+            orange: PaletteColor::EightBit(color),
+            ..
+        }) => Style::new().fg(Fixed(color)),
+        _ => Style::new(),
     };
     LinePart {
         part: format!(
             "{}{}{}{}{}{}{}{}{}{}{}",
             text_first_part,
-            Style::new().fg(orange_color).bold().paint(alt),
+            orange_color_style.bold().paint(alt),
             text_second_part,
-            Style::new().fg(green_color).bold().paint(new_pane_shortcut),
+            green_color_style.bold().paint(new_pane_shortcut),
             text_third_part,
-            Style::new().fg(orange_color).bold().paint(second_alt),
+            orange_color_style.bold().paint(second_alt),
             text_fourth_part,
-            Style::new()
-                .fg(green_color)
-                .bold()
-                .paint(brackets_navigation),
+            green_color_style.bold().paint(brackets_navigation),
             text_fifth_part,
-            Style::new().fg(green_color).bold().paint(hjkl_navigation),
+            green_color_style.bold().paint(hjkl_navigation),
             text_sixths_part,
         ),
         len,
     }
 }
 
-fn quicknav_short(palette: Palette) -> LinePart {
+fn quicknav_short(palette: Option<Palette>) -> LinePart {
     let text_first_part = " QuickNav: ";
     let alt = "Alt";
     let text_second_part = " + ";
@@ -209,66 +256,98 @@ fn quicknav_short(palette: Palette) -> LinePart {
         + brackets_navigation.chars().count()
         + text_fifth_part.chars().count()
         + hjkl_navigation.chars().count();
-    let green_color = match palette.green {
-        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
-        PaletteColor::EightBit(color) => Fixed(color),
+    let green_color_style = match palette {
+        Some(Palette {
+            green: PaletteColor::Rgb((r, g, b)),
+            ..
+        }) => Style::new().fg(RGB(r, g, b)),
+        Some(Palette {
+            green: PaletteColor::EightBit(color),
+            ..
+        }) => Style::new().fg(Fixed(color)),
+        _ => Style::new(),
     };
-    let orange_color = match palette.orange {
-        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
-        PaletteColor::EightBit(color) => Fixed(color),
+    let orange_color_style = match palette {
+        Some(Palette {
+            orange: PaletteColor::Rgb((r, g, b)),
+            ..
+        }) => Style::new().fg(RGB(r, g, b)),
+        Some(Palette {
+            orange: PaletteColor::EightBit(color),
+            ..
+        }) => Style::new().fg(Fixed(color)),
+        _ => Style::new(),
     };
     LinePart {
         part: format!(
             "{}{}{}{}{}{}{}{}",
             text_first_part,
-            Style::new().fg(orange_color).bold().paint(alt),
+            orange_color_style.bold().paint(alt),
             text_second_part,
-            Style::new().fg(green_color).bold().paint(new_pane_shortcut),
+            green_color_style.bold().paint(new_pane_shortcut),
             text_third_part,
-            Style::new()
-                .fg(green_color)
-                .bold()
-                .paint(brackets_navigation),
+            green_color_style.bold().paint(brackets_navigation),
             text_fifth_part,
-            Style::new().fg(green_color).bold().paint(hjkl_navigation),
+            green_color_style.bold().paint(hjkl_navigation),
         ),
         len,
     }
 }
 
-fn locked_interface_indication(palette: Palette) -> LinePart {
+fn locked_interface_indication(palette: Option<Palette>) -> LinePart {
     let locked_text = " -- INTERFACE LOCKED -- ";
     let locked_text_len = locked_text.chars().count();
-    let white_color = match palette.white {
-        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
-        PaletteColor::EightBit(color) => Fixed(color),
+    let white_color_style = match palette {
+        Some(Palette {
+            white: PaletteColor::Rgb((r, g, b)),
+            ..
+        }) => Style::new().fg(RGB(r, g, b)),
+        Some(Palette {
+            white: PaletteColor::EightBit(color),
+            ..
+        }) => Style::new().fg(Fixed(color)),
+        _ => Style::new(),
     };
-    let locked_styled_text = Style::new().fg(white_color).bold().paint(locked_text);
+    let locked_styled_text = white_color_style.bold().paint(locked_text);
     LinePart {
         part: format!("{}", locked_styled_text),
         len: locked_text_len,
     }
 }
 
-fn select_pane_shortcut(is_first_shortcut: bool, palette: Palette) -> LinePart {
+fn select_pane_shortcut(is_first_shortcut: bool, palette: Option<Palette>) -> LinePart {
     let shortcut = "ENTER";
     let description = "Select pane";
     let separator = if is_first_shortcut { " " } else { " / " };
-    let white_color = match palette.white {
-        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
-        PaletteColor::EightBit(color) => Fixed(color),
+    let white_color_style = match palette {
+        Some(Palette {
+            white: PaletteColor::Rgb((r, g, b)),
+            ..
+        }) => Style::new().fg(RGB(r, g, b)),
+        Some(Palette {
+            white: PaletteColor::EightBit(color),
+            ..
+        }) => Style::new().fg(Fixed(color)),
+        _ => Style::new(),
     };
-    let orange_color = match palette.orange {
-        PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
-        PaletteColor::EightBit(color) => Fixed(color),
+    let orange_color_style = match palette {
+        Some(Palette {
+            orange: PaletteColor::Rgb((r, g, b)),
+            ..
+        }) => Style::new().fg(RGB(r, g, b)),
+        Some(Palette {
+            orange: PaletteColor::EightBit(color),
+            ..
+        }) => Style::new().fg(Fixed(color)),
+        _ => Style::new(),
     };
-    let separator = Style::new().fg(white_color).paint(separator);
+    let separator = white_color_style.paint(separator);
     let shortcut_len = shortcut.chars().count() + 3; // 2 for <>'s around shortcut, 1 for the space
-    let shortcut_left_separator = Style::new().fg(white_color).paint("<");
-    let shortcut = Style::new().fg(orange_color).bold().paint(shortcut);
-    let shortcut_right_separator = Style::new().fg(white_color).paint("> ");
+    let shortcut_left_separator = white_color_style.paint("<");
+    let shortcut = orange_color_style.bold().paint(shortcut);
+    let shortcut_right_separator = white_color_style.paint("> ");
     let description_len = description.chars().count();
-    let description = Style::new().fg(white_color).bold().paint(description);
+    let description = white_color_style.bold().paint(description);
     let len = shortcut_len + description_len + separator.chars().count();
     LinePart {
         part: format!(

--- a/default-plugins/tab-bar/src/line.rs
+++ b/default-plugins/tab-bar/src/line.rs
@@ -1,4 +1,4 @@
-use ansi_term::ANSIStrings;
+use ansi_term::{ANSIStrings, Style};
 
 use crate::{LinePart, ARROW_SEPARATOR};
 use zellij_tile::prelude::*;
@@ -48,7 +48,11 @@ fn populate_tabs_in_tab_line(
     }
 }
 
-fn left_more_message(tab_count_to_the_left: usize, palette: Palette, separator: &str) -> LinePart {
+fn left_more_message(
+    tab_count_to_the_left: usize,
+    palette: Option<Palette>,
+    separator: &str,
+) -> LinePart {
     if tab_count_to_the_left == 0 {
         return LinePart {
             part: String::new(),
@@ -62,11 +66,24 @@ fn left_more_message(tab_count_to_the_left: usize, palette: Palette, separator: 
     };
     // 238
     let more_text_len = more_text.chars().count() + 2; // 2 for the arrows
-    let left_separator = style!(palette.cyan, palette.orange).paint(separator);
-    let more_styled_text = style!(palette.black, palette.orange)
-        .bold()
-        .paint(more_text);
-    let right_separator = style!(palette.orange, palette.cyan).paint(separator);
+    let left_separator_style = if let Some(palette) = palette {
+        style!(palette.cyan, palette.orange)
+    } else {
+        Style::new()
+    };
+    let left_separator = left_separator_style.paint(separator);
+    let more_style = if let Some(palette) = palette {
+        style!(palette.black, palette.orange)
+    } else {
+        Style::new()
+    };
+    let more_styled_text = more_style.bold().paint(more_text);
+    let right_separator_style = if let Some(palette) = palette {
+        style!(palette.orange, palette.cyan)
+    } else {
+        Style::new()
+    };
+    let right_separator = right_separator_style.paint(separator);
     let more_styled_text = format!(
         "{}",
         ANSIStrings(&[left_separator, more_styled_text, right_separator,])
@@ -79,7 +96,7 @@ fn left_more_message(tab_count_to_the_left: usize, palette: Palette, separator: 
 
 fn right_more_message(
     tab_count_to_the_right: usize,
-    palette: Palette,
+    palette: Option<Palette>,
     separator: &str,
 ) -> LinePart {
     if tab_count_to_the_right == 0 {
@@ -94,11 +111,24 @@ fn right_more_message(
         " +many → ".to_string()
     };
     let more_text_len = more_text.chars().count() + 1; // 2 for the arrow
-    let left_separator = style!(palette.cyan, palette.orange).paint(separator);
-    let more_styled_text = style!(palette.black, palette.orange)
-        .bold()
-        .paint(more_text);
-    let right_separator = style!(palette.orange, palette.cyan).paint(separator);
+    let left_separator_style = if let Some(palette) = palette {
+        style!(palette.cyan, palette.orange)
+    } else {
+        Style::new()
+    };
+    let left_separator = left_separator_style.paint(separator);
+    let more_style = if let Some(palette) = palette {
+        style!(palette.black, palette.orange)
+    } else {
+        Style::new()
+    };
+    let more_styled_text = more_style.bold().paint(more_text);
+    let right_separator_style = if let Some(palette) = palette {
+        style!(palette.orange, palette.cyan)
+    } else {
+        Style::new()
+    };
+    let right_separator = right_separator_style.paint(separator);
     let more_styled_text = format!(
         "{}",
         ANSIStrings(&[left_separator, more_styled_text, right_separator,])
@@ -114,7 +144,7 @@ fn add_previous_tabs_msg(
     tabs_to_render: &mut Vec<LinePart>,
     title_bar: &mut Vec<LinePart>,
     cols: usize,
-    palette: Palette,
+    palette: Option<Palette>,
     separator: &str,
 ) {
     while get_current_title_len(tabs_to_render)
@@ -131,7 +161,7 @@ fn add_next_tabs_msg(
     tabs_after_active: &mut Vec<LinePart>,
     title_bar: &mut Vec<LinePart>,
     cols: usize,
-    palette: Palette,
+    palette: Option<Palette>,
     separator: &str,
 ) {
     while get_current_title_len(title_bar)
@@ -144,16 +174,19 @@ fn add_next_tabs_msg(
     title_bar.push(right_more_message);
 }
 
-fn tab_line_prefix(session_name: Option<&str>, palette: Palette) -> LinePart {
+fn tab_line_prefix(session_name: Option<&str>, palette: Option<Palette>) -> LinePart {
     let mut prefix_text = " Zellij ".to_string();
     if let Some(name) = session_name {
         prefix_text.push_str(&format!("({}) ", name));
     }
 
     let prefix_text_len = prefix_text.chars().count();
-    let prefix_styled_text = style!(palette.white, palette.cyan)
-        .bold()
-        .paint(prefix_text);
+    let prefix_style = if let Some(palette) = palette {
+        style!(palette.white, palette.cyan)
+    } else {
+        Style::new()
+    };
+    let prefix_styled_text = prefix_style.bold().paint(prefix_text);
     LinePart {
         part: format!("{}", prefix_styled_text),
         len: prefix_text_len,
@@ -173,7 +206,7 @@ pub fn tab_line(
     mut all_tabs: Vec<LinePart>,
     active_tab_index: usize,
     cols: usize,
-    palette: Palette,
+    palette: Option<Palette>,
     capabilities: PluginCapabilities,
 ) -> Vec<LinePart> {
     let mut tabs_to_render: Vec<LinePart> = vec![];

--- a/default-plugins/tab-bar/src/main.rs
+++ b/default-plugins/tab-bar/src/main.rs
@@ -75,12 +75,21 @@ impl ZellijPlugin for State {
         for bar_part in tab_line {
             s = format!("{}{}", s, bar_part.part);
         }
-        match self.mode_info.palette.cyan {
-            PaletteColor::Rgb((r, g, b)) => {
+        match self.mode_info.palette {
+            Some(Palette {
+                cyan: PaletteColor::Rgb((r, g, b)),
+                ..
+            }) => {
                 println!("{}\u{1b}[48;2;{};{};{}m\u{1b}[0K", s, r, g, b);
             }
-            PaletteColor::EightBit(color) => {
+            Some(Palette {
+                cyan: PaletteColor::EightBit(color),
+                ..
+            }) => {
                 println!("{}\u{1b}[48;5;{}m\u{1b}[0K", s, color);
+            }
+            _ => {
+                println!("{}", s);
             }
         }
     }

--- a/default-plugins/tab-bar/src/tab.rs
+++ b/default-plugins/tab-bar/src/tab.rs
@@ -1,15 +1,28 @@
 use crate::{line::tab_separator, LinePart};
-use ansi_term::ANSIStrings;
+use ansi_term::{ANSIStrings, Style};
 use zellij_tile::prelude::*;
 use zellij_tile_utils::style;
 
-pub fn active_tab(text: String, palette: Palette, separator: &str) -> LinePart {
-    let left_separator = style!(palette.cyan, palette.green).paint(separator);
+pub fn active_tab(text: String, palette: Option<Palette>, separator: &str) -> LinePart {
+    let left_separator_style = if let Some(palette) = palette {
+        style!(palette.cyan, palette.green)
+    } else {
+        Style::new()
+    };
+    let left_separator = left_separator_style.paint(separator);
     let tab_text_len = text.chars().count() + 4; // 2 for left and right separators, 2 for the text padding
-    let tab_styled_text = style!(palette.black, palette.green)
-        .bold()
-        .paint(format!(" {} ", text));
-    let right_separator = style!(palette.green, palette.cyan).paint(separator);
+    let tab_style = if let Some(palette) = palette {
+        style!(palette.black, palette.green)
+    } else {
+        Style::new()
+    };
+    let tab_styled_text = tab_style.bold().paint(format!(" {} ", text));
+    let right_separator_style = if let Some(palette) = palette {
+        style!(palette.green, palette.cyan)
+    } else {
+        Style::new()
+    };
+    let right_separator = right_separator_style.paint(separator);
     let tab_styled_text = format!(
         "{}",
         ANSIStrings(&[left_separator, tab_styled_text, right_separator,])
@@ -20,13 +33,26 @@ pub fn active_tab(text: String, palette: Palette, separator: &str) -> LinePart {
     }
 }
 
-pub fn non_active_tab(text: String, palette: Palette, separator: &str) -> LinePart {
-    let left_separator = style!(palette.cyan, palette.fg).paint(separator);
+pub fn non_active_tab(text: String, palette: Option<Palette>, separator: &str) -> LinePart {
+    let left_separator_style = if let Some(palette) = palette {
+        style!(palette.cyan, palette.fg)
+    } else {
+        Style::new()
+    };
+    let left_separator = left_separator_style.paint(separator);
     let tab_text_len = text.chars().count() + 4; // 2 for left and right separators, 2 for the padding
-    let tab_styled_text = style!(palette.black, palette.fg)
-        .bold()
-        .paint(format!(" {} ", text));
-    let right_separator = style!(palette.fg, palette.cyan).paint(separator);
+    let tab_style = if let Some(palette) = palette {
+        style!(palette.black, palette.fg)
+    } else {
+        Style::new()
+    };
+    let tab_styled_text = tab_style.bold().paint(format!(" {} ", text));
+    let right_separator_style = if let Some(palette) = palette {
+        style!(palette.fg, palette.cyan)
+    } else {
+        Style::new()
+    };
+    let right_separator = right_separator_style.paint(separator);
     let tab_styled_text = format!(
         "{}",
         ANSIStrings(&[left_separator, tab_styled_text, right_separator,])
@@ -41,7 +67,7 @@ pub fn tab_style(
     text: String,
     is_active_tab: bool,
     is_sync_panes_active: bool,
-    palette: Palette,
+    palette: Option<Palette>,
     capabilities: PluginCapabilities,
 ) -> LinePart {
     let separator = tab_separator(capabilities);

--- a/src/tests/e2e/remote_runner.rs
+++ b/src/tests/e2e/remote_runner.rs
@@ -216,7 +216,7 @@ impl RemoteRunner {
         let sess = ssh_connect();
         let mut channel = sess.channel_session().unwrap();
         let vte_parser = vte::Parser::new();
-        let terminal_output = TerminalPane::new(0, win_size, Palette::default(), 0); // 0 is the pane index
+        let terminal_output = TerminalPane::new(0, win_size, Some(Palette::default()), 0); // 0 is the pane index
         setup_remote_environment(&mut channel, win_size);
         start_zellij(&mut channel, session_name.as_ref());
         RemoteRunner {
@@ -242,7 +242,7 @@ impl RemoteRunner {
         let sess = ssh_connect();
         let mut channel = sess.channel_session().unwrap();
         let vte_parser = vte::Parser::new();
-        let terminal_output = TerminalPane::new(0, win_size, Palette::default(), 0); // 0 is the pane index
+        let terminal_output = TerminalPane::new(0, win_size, Some(Palette::default()), 0); // 0 is the pane index
         setup_remote_environment(&mut channel, win_size);
         start_zellij_without_frames(&mut channel);
         RemoteRunner {
@@ -270,7 +270,7 @@ impl RemoteRunner {
         let sess = ssh_connect();
         let mut channel = sess.channel_session().unwrap();
         let vte_parser = vte::Parser::new();
-        let terminal_output = TerminalPane::new(0, win_size, Palette::default(), 0); // 0 is the pane index
+        let terminal_output = TerminalPane::new(0, win_size, Some(Palette::default()), 0); // 0 is the pane index
         setup_remote_environment(&mut channel, win_size);
         start_zellij_with_layout(
             &mut channel,

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -106,13 +106,17 @@ pub fn start_client(
     std::env::set_var(&"ZELLIJ", "0");
 
     let config_options = Options::from_cli(&config.options, opts.command.clone());
-    let palette = config.themes.clone().map_or_else(
-        || os_input.load_palette(),
-        |t| {
-            t.theme_config(&config_options)
-                .unwrap_or_else(|| os_input.load_palette())
-        },
-    );
+    let palette = if config_options.monochrome {
+        None
+    } else {
+        Some(config.themes.clone().map_or_else(
+            || os_input.load_palette(),
+            |t| {
+                t.theme_config(&config_options)
+                    .unwrap_or_else(|| os_input.load_palette())
+            },
+        ))
+    };
 
     let full_screen_ws = os_input.get_terminal_size_using_fd(0);
     let client_attributes = ClientAttributes {

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -90,7 +90,7 @@ impl ErrorInstruction for ServerInstruction {
 pub(crate) struct SessionMetaData {
     pub senders: ThreadSenders,
     pub capabilities: PluginCapabilities,
-    pub palette: Palette,
+    pub palette: Option<Palette>,
     pub default_shell: Option<TerminalAction>,
     screen_thread: Option<thread::JoinHandle<()>>,
     pty_thread: Option<thread::JoinHandle<()>>,

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -288,7 +288,7 @@ pub struct Grid {
     scroll_region: Option<(usize, usize)>,
     active_charset: CharsetIndex,
     preceding_char: Option<TerminalCharacter>,
-    colors: Palette,
+    colors: Option<Palette>,
     output_buffer: OutputBuffer,
     title_stack: Vec<String>,
     pub changed_colors: [Option<AnsiCode>; 256],
@@ -319,7 +319,7 @@ impl Debug for Grid {
 }
 
 impl Grid {
-    pub fn new(rows: usize, columns: usize, colors: Palette) -> Self {
+    pub fn new(rows: usize, columns: usize, colors: Option<Palette>) -> Self {
         Grid {
             lines_above: VecDeque::with_capacity(SCROLL_BACK),
             viewport: vec![Row::new(columns).canonical()],
@@ -1404,8 +1404,11 @@ impl Perform for Grid {
                             // currently only getting the color sequence is supported,
                             // setting still isn't
                             if param == b"?" {
-                                let color_response_message = match self.colors.bg {
-                                    PaletteColor::Rgb((r, g, b)) => {
+                                let color_response_message = match self.colors {
+                                    Some(Palette {
+                                        bg: PaletteColor::Rgb((r, g, b)),
+                                        ..
+                                    }) => {
                                         format!(
                                             "\u{1b}]{};rgb:{1:02x}{1:02x}/{2:02x}{2:02x}/{3:02x}{3:02x}{4}",
                                             // dynamic_code, color.r, color.g, color.b, terminator

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -16,7 +16,7 @@ fn read_fixture(fixture_name: &str) -> Vec<u8> {
 #[test]
 fn vttest1_0() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest1-0";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -28,7 +28,7 @@ fn vttest1_0() {
 #[test]
 fn vttest1_1() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest1-1";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -40,7 +40,7 @@ fn vttest1_1() {
 #[test]
 fn vttest1_2() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest1-2";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -52,7 +52,7 @@ fn vttest1_2() {
 #[test]
 fn vttest1_3() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest1-3";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -64,7 +64,7 @@ fn vttest1_3() {
 #[test]
 fn vttest1_4() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest1-4";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -76,7 +76,7 @@ fn vttest1_4() {
 #[test]
 fn vttest1_5() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest1-5";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -88,7 +88,7 @@ fn vttest1_5() {
 #[test]
 fn vttest2_0() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest2-0";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -100,7 +100,7 @@ fn vttest2_0() {
 #[test]
 fn vttest2_1() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest2-1";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -112,7 +112,7 @@ fn vttest2_1() {
 #[test]
 fn vttest2_2() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest2-2";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -124,7 +124,7 @@ fn vttest2_2() {
 #[test]
 fn vttest2_3() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest2-3";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -136,7 +136,7 @@ fn vttest2_3() {
 #[test]
 fn vttest2_4() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest2-4";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -148,7 +148,7 @@ fn vttest2_4() {
 #[test]
 fn vttest2_5() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest2-5";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -160,7 +160,7 @@ fn vttest2_5() {
 #[test]
 fn vttest2_6() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest2-6";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -172,7 +172,7 @@ fn vttest2_6() {
 #[test]
 fn vttest2_7() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest2-7";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -184,7 +184,7 @@ fn vttest2_7() {
 #[test]
 fn vttest2_8() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest2-8";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -196,7 +196,7 @@ fn vttest2_8() {
 #[test]
 fn vttest2_9() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest2-9";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -208,7 +208,7 @@ fn vttest2_9() {
 #[test]
 fn vttest2_10() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest2-10";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -220,7 +220,7 @@ fn vttest2_10() {
 #[test]
 fn vttest2_11() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest2-11";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -232,7 +232,7 @@ fn vttest2_11() {
 #[test]
 fn vttest2_12() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest2-12";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -244,7 +244,7 @@ fn vttest2_12() {
 #[test]
 fn vttest2_13() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest2-13";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -256,7 +256,7 @@ fn vttest2_13() {
 #[test]
 fn vttest2_14() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest2-14";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -268,7 +268,7 @@ fn vttest2_14() {
 #[test]
 fn vttest3_0() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(41, 110, Palette::default());
+    let mut grid = Grid::new(41, 110, Some(Palette::default()));
     let fixture_name = "vttest3-0";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -280,7 +280,7 @@ fn vttest3_0() {
 #[test]
 fn vttest8_0() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(51, 97, Palette::default());
+    let mut grid = Grid::new(51, 97, Some(Palette::default()));
     let fixture_name = "vttest8-0";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -292,7 +292,7 @@ fn vttest8_0() {
 #[test]
 fn vttest8_1() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(51, 97, Palette::default());
+    let mut grid = Grid::new(51, 97, Some(Palette::default()));
     let fixture_name = "vttest8-1";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -304,7 +304,7 @@ fn vttest8_1() {
 #[test]
 fn vttest8_2() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(51, 97, Palette::default());
+    let mut grid = Grid::new(51, 97, Some(Palette::default()));
     let fixture_name = "vttest8-2";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -316,7 +316,7 @@ fn vttest8_2() {
 #[test]
 fn vttest8_3() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(51, 97, Palette::default());
+    let mut grid = Grid::new(51, 97, Some(Palette::default()));
     let fixture_name = "vttest8-3";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -328,7 +328,7 @@ fn vttest8_3() {
 #[test]
 fn vttest8_4() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(51, 97, Palette::default());
+    let mut grid = Grid::new(51, 97, Some(Palette::default()));
     let fixture_name = "vttest8-4";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -340,7 +340,7 @@ fn vttest8_4() {
 #[test]
 fn vttest8_5() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(51, 97, Palette::default());
+    let mut grid = Grid::new(51, 97, Some(Palette::default()));
     let fixture_name = "vttest8-5";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -352,7 +352,7 @@ fn vttest8_5() {
 #[test]
 fn csi_b() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(51, 97, Palette::default());
+    let mut grid = Grid::new(51, 97, Some(Palette::default()));
     let fixture_name = "csi-b";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -364,7 +364,7 @@ fn csi_b() {
 #[test]
 fn csi_capital_i() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(51, 97, Palette::default());
+    let mut grid = Grid::new(51, 97, Some(Palette::default()));
     let fixture_name = "csi-capital-i";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -376,7 +376,7 @@ fn csi_capital_i() {
 #[test]
 fn csi_capital_z() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(51, 97, Palette::default());
+    let mut grid = Grid::new(51, 97, Some(Palette::default()));
     let fixture_name = "csi-capital-z";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -388,7 +388,7 @@ fn csi_capital_z() {
 #[test]
 fn terminal_reports() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(51, 97, Palette::default());
+    let mut grid = Grid::new(51, 97, Some(Palette::default()));
     let fixture_name = "terminal_reports";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -400,7 +400,7 @@ fn terminal_reports() {
 #[test]
 fn wide_characters() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(21, 104, Palette::default());
+    let mut grid = Grid::new(21, 104, Some(Palette::default()));
     let fixture_name = "wide_characters";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -412,7 +412,7 @@ fn wide_characters() {
 #[test]
 fn wide_characters_line_wrap() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(21, 104, Palette::default());
+    let mut grid = Grid::new(21, 104, Some(Palette::default()));
     let fixture_name = "wide_characters_line_wrap";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -424,7 +424,7 @@ fn wide_characters_line_wrap() {
 #[test]
 fn fish_wide_characters_override_clock() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(21, 104, Palette::default());
+    let mut grid = Grid::new(21, 104, Some(Palette::default()));
     let fixture_name = "fish_wide_characters_override_clock";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -436,7 +436,7 @@ fn fish_wide_characters_override_clock() {
 #[test]
 fn bash_delete_wide_characters() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(21, 104, Palette::default());
+    let mut grid = Grid::new(21, 104, Some(Palette::default()));
     let fixture_name = "bash_delete_wide_characters";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -448,7 +448,7 @@ fn bash_delete_wide_characters() {
 #[test]
 fn delete_wide_characters_before_cursor() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(21, 104, Palette::default());
+    let mut grid = Grid::new(21, 104, Some(Palette::default()));
     let fixture_name = "delete_wide_characters_before_cursor";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -460,7 +460,7 @@ fn delete_wide_characters_before_cursor() {
 #[test]
 fn delete_wide_characters_before_cursor_when_cursor_is_on_wide_character() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(21, 104, Palette::default());
+    let mut grid = Grid::new(21, 104, Some(Palette::default()));
     let fixture_name = "delete_wide_characters_before_cursor_when_cursor_is_on_wide_character";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -472,7 +472,7 @@ fn delete_wide_characters_before_cursor_when_cursor_is_on_wide_character() {
 #[test]
 fn delete_wide_character_under_cursor() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(21, 104, Palette::default());
+    let mut grid = Grid::new(21, 104, Some(Palette::default()));
     let fixture_name = "delete_wide_character_under_cursor";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -484,7 +484,7 @@ fn delete_wide_character_under_cursor() {
 #[test]
 fn replace_wide_character_under_cursor() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(21, 104, Palette::default());
+    let mut grid = Grid::new(21, 104, Some(Palette::default()));
     let fixture_name = "replace_wide_character_under_cursor";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -496,7 +496,7 @@ fn replace_wide_character_under_cursor() {
 #[test]
 fn wrap_wide_characters() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(21, 90, Palette::default());
+    let mut grid = Grid::new(21, 90, Some(Palette::default()));
     let fixture_name = "wide_characters_full";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -508,7 +508,7 @@ fn wrap_wide_characters() {
 #[test]
 fn wrap_wide_characters_on_size_change() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(21, 93, Palette::default());
+    let mut grid = Grid::new(21, 93, Some(Palette::default()));
     let fixture_name = "wide_characters_full";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -521,7 +521,7 @@ fn wrap_wide_characters_on_size_change() {
 #[test]
 fn unwrap_wide_characters_on_size_change() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(21, 93, Palette::default());
+    let mut grid = Grid::new(21, 93, Some(Palette::default()));
     let fixture_name = "wide_characters_full";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -535,7 +535,7 @@ fn unwrap_wide_characters_on_size_change() {
 #[test]
 fn wrap_wide_characters_in_the_middle_of_the_line() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(21, 91, Palette::default());
+    let mut grid = Grid::new(21, 91, Some(Palette::default()));
     let fixture_name = "wide_characters_line_middle";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -547,7 +547,7 @@ fn wrap_wide_characters_in_the_middle_of_the_line() {
 #[test]
 fn wrap_wide_characters_at_the_end_of_the_line() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(21, 90, Palette::default());
+    let mut grid = Grid::new(21, 90, Some(Palette::default()));
     let fixture_name = "wide_characters_line_end";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -559,7 +559,7 @@ fn wrap_wide_characters_at_the_end_of_the_line() {
 #[test]
 fn copy_selected_text_from_viewport() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(27, 125, Palette::default());
+    let mut grid = Grid::new(27, 125, Some(Palette::default()));
     let fixture_name = "grid_copy";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -579,7 +579,7 @@ fn copy_selected_text_from_viewport() {
 #[test]
 fn copy_selected_text_from_lines_above() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(27, 125, Palette::default());
+    let mut grid = Grid::new(27, 125, Some(Palette::default()));
     let fixture_name = "grid_copy";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -599,7 +599,7 @@ fn copy_selected_text_from_lines_above() {
 #[test]
 fn copy_selected_text_from_lines_below() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(27, 125, Palette::default());
+    let mut grid = Grid::new(27, 125, Some(Palette::default()));
     let fixture_name = "grid_copy";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -627,7 +627,7 @@ fn copy_selected_text_from_lines_below() {
 #[test]
 fn run_bandwhich_from_fish_shell() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(28, 116, Palette::default());
+    let mut grid = Grid::new(28, 116, Some(Palette::default()));
     let fixture_name = "fish_and_bandwhich";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -639,7 +639,7 @@ fn run_bandwhich_from_fish_shell() {
 #[test]
 fn fish_tab_completion_options() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(28, 116, Palette::default());
+    let mut grid = Grid::new(28, 116, Some(Palette::default()));
     let fixture_name = "fish_tab_completion_options";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -656,7 +656,7 @@ pub fn fish_select_tab_completion_options() {
     // this is not clearly seen in the snapshot because it does not include styles,
     // but we can see the command line change and the cursor staying in place
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(28, 116, Palette::default());
+    let mut grid = Grid::new(28, 116, Some(Palette::default()));
     let fixture_name = "fish_select_tab_completion_options";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -676,7 +676,7 @@ pub fn vim_scroll_region_down() {
     // this tests also has other steps afterwards that fills the line with the next line in the
     // file
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(28, 116, Palette::default());
+    let mut grid = Grid::new(28, 116, Some(Palette::default()));
     let fixture_name = "vim_scroll_region_down";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -694,7 +694,7 @@ pub fn vim_ctrl_d() {
     // end of the scroll region
     // vim makes sure to fill these empty lines with the rest of the file
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(28, 116, Palette::default());
+    let mut grid = Grid::new(28, 116, Some(Palette::default()));
     let fixture_name = "vim_ctrl_d";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -711,7 +711,7 @@ pub fn vim_ctrl_u() {
     // this causes the effect of scrolling up X lines (vim replaces the lines with the ones in the
     // file above the current content)
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(28, 116, Palette::default());
+    let mut grid = Grid::new(28, 116, Some(Palette::default()));
     let fixture_name = "vim_ctrl_u";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -723,7 +723,7 @@ pub fn vim_ctrl_u() {
 #[test]
 pub fn htop() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(28, 116, Palette::default());
+    let mut grid = Grid::new(28, 116, Some(Palette::default()));
     let fixture_name = "htop";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -735,7 +735,7 @@ pub fn htop() {
 #[test]
 pub fn htop_scrolling() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(28, 116, Palette::default());
+    let mut grid = Grid::new(28, 116, Some(Palette::default()));
     let fixture_name = "htop_scrolling";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -747,7 +747,7 @@ pub fn htop_scrolling() {
 #[test]
 pub fn htop_right_scrolling() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(28, 116, Palette::default());
+    let mut grid = Grid::new(28, 116, Some(Palette::default()));
     let fixture_name = "htop_right_scrolling";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -767,7 +767,7 @@ pub fn vim_overwrite() {
     // * confirm you would like to change the file by pressing 'y' and then ENTER
     // * if everything looks fine, this test passed :)
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(28, 116, Palette::default());
+    let mut grid = Grid::new(28, 116, Some(Palette::default()));
     let fixture_name = "vim_overwrite";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -781,7 +781,7 @@ pub fn clear_scroll_region() {
     // this is actually a test of 1049h/l (alternative buffer)
     // @imsnif - the name is a monument to the time I didn't fully understand this mechanism :)
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(28, 116, Palette::default());
+    let mut grid = Grid::new(28, 116, Some(Palette::default()));
     let fixture_name = "clear_scroll_region";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -793,7 +793,7 @@ pub fn clear_scroll_region() {
 #[test]
 pub fn display_tab_characters_properly() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(28, 116, Palette::default());
+    let mut grid = Grid::new(28, 116, Some(Palette::default()));
     let fixture_name = "tab_characters";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -805,7 +805,7 @@ pub fn display_tab_characters_properly() {
 #[test]
 pub fn neovim_insert_mode() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(28, 116, Palette::default());
+    let mut grid = Grid::new(28, 116, Some(Palette::default()));
     let fixture_name = "nvim_insert";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -817,7 +817,7 @@ pub fn neovim_insert_mode() {
 #[test]
 pub fn bash_cursor_linewrap() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(28, 116, Palette::default());
+    let mut grid = Grid::new(28, 116, Some(Palette::default()));
     let fixture_name = "bash_cursor_linewrap";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -831,7 +831,7 @@ pub fn fish_paste_multiline() {
     // here we paste a multiline command in fish shell, making sure we support it
     // going up and changing the colors of our line-wrapped pasted text
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(28, 149, Palette::default());
+    let mut grid = Grid::new(28, 149, Some(Palette::default()));
     let fixture_name = "fish_paste_multiline";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -843,7 +843,7 @@ pub fn fish_paste_multiline() {
 #[test]
 pub fn git_log() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(28, 149, Palette::default());
+    let mut grid = Grid::new(28, 149, Some(Palette::default()));
     let fixture_name = "git_log";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -857,7 +857,7 @@ pub fn git_diff_scrollup() {
     // this tests makes sure that when we have a git diff that exceeds the screen size
     // we are able to scroll up
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(28, 149, Palette::default());
+    let mut grid = Grid::new(28, 149, Some(Palette::default()));
     let fixture_name = "git_diff_scrollup";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -869,7 +869,7 @@ pub fn git_diff_scrollup() {
 #[test]
 pub fn emacs_longbuf() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(60, 284, Palette::default());
+    let mut grid = Grid::new(60, 284, Some(Palette::default()));
     let fixture_name = "emacs_longbuf_tutorial";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -881,7 +881,7 @@ pub fn emacs_longbuf() {
 #[test]
 pub fn top_and_quit() {
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(56, 235, Palette::default());
+    let mut grid = Grid::new(56, 235, Some(Palette::default()));
     let fixture_name = "top_and_quit";
     let content = read_fixture(fixture_name);
     for byte in content {
@@ -899,7 +899,7 @@ pub fn exa_plus_omf_theme() {
     // over existing on-screen content without deleting it, so we must
     // convert it to spaces
     let mut vte_parser = vte::Parser::new();
-    let mut grid = Grid::new(56, 235, Palette::default());
+    let mut grid = Grid::new(56, 235, Some(Palette::default()));
     let fixture_name = "exa_plus_omf_theme";
     let content = read_fixture(fixture_name);
     for byte in content {

--- a/zellij-server/src/panes/unit/snapshots/zellij_server__panes__terminal_pane__grid_tests__monochrome_pane.snap
+++ b/zellij-server/src/panes/unit/snapshots/zellij_server__panes__terminal_pane__grid_tests__monochrome_pane.snap
@@ -1,0 +1,6 @@
+---
+source: zellij-server/src/panes/./unit/terminal_pane_tests.rs
+expression: "format!(\"{:?}\", terminal_pane.render().unwrap())"
+
+---
+"\u{1b}[1;1H\u{1b}[m\u{1b}[1mHi Zellij\u{1b}[29m\u{1b}[28m\u{1b}[27m\u{1b}[25m\u{1b}[25m\u{1b}[22m\u{1b}[24m\u{1b}[24m\u{1b}[22m\u{1b}[23m "

--- a/zellij-server/src/panes/unit/terminal_pane_tests.rs
+++ b/zellij-server/src/panes/unit/terminal_pane_tests.rs
@@ -1,6 +1,7 @@
 use super::super::TerminalPane;
 use crate::tab::Pane;
-use ::insta::assert_snapshot;
+use ansi_term::Color::{Fixed, RGB};
+use insta::assert_snapshot;
 use zellij_utils::pane_size::PositionAndSize;
 use zellij_utils::zellij_tile::data::Palette;
 
@@ -14,8 +15,8 @@ pub fn scrolling_inside_a_pane() {
         ..Default::default()
     };
     let pid = 1;
-    let palette = Palette::default();
-    let mut terminal_pane = TerminalPane::new(pid, fake_win_size, Some(palette), 0); // 0 is the pane index
+    let palette = Some(Palette::default());
+    let mut terminal_pane = TerminalPane::new(pid, fake_win_size, palette, 0); // 0 is the pane index
     let mut text_to_fill_pane = String::new();
     for i in 0..30 {
         text_to_fill_pane.push_str(&format!("\rline {}\n", i + 1));
@@ -27,4 +28,26 @@ pub fn scrolling_inside_a_pane() {
     assert_snapshot!(format!("{:?}", terminal_pane.grid));
     terminal_pane.clear_scroll();
     assert_snapshot!(format!("{:?}", terminal_pane.grid));
+}
+
+#[test]
+pub fn monochrome_pane() {
+    let fake_win_size = PositionAndSize {
+        cols: 10,
+        rows: 1,
+        x: 0,
+        y: 0,
+        ..Default::default()
+    };
+    let pid = 1;
+    let palette = None;
+    let mut terminal_pane = TerminalPane::new(pid, fake_win_size, palette, 0);
+    let text_style = ansi_term::Style::new()
+        .fg(Fixed(77))
+        .on(RGB(7, 7, 7))
+        .bold(); // styles other than colors should not be stripped
+    let text_to_fill_pane = format!("{}", text_style.paint("Hi Zellij"));
+
+    terminal_pane.handle_pty_bytes(dbg!(text_to_fill_pane).as_bytes().to_vec());
+    assert_snapshot!(format!("{:?}", terminal_pane.render().unwrap()));
 }

--- a/zellij-server/src/panes/unit/terminal_pane_tests.rs
+++ b/zellij-server/src/panes/unit/terminal_pane_tests.rs
@@ -15,7 +15,7 @@ pub fn scrolling_inside_a_pane() {
     };
     let pid = 1;
     let palette = Palette::default();
-    let mut terminal_pane = TerminalPane::new(pid, fake_win_size, palette, 0); // 0 is the pane index
+    let mut terminal_pane = TerminalPane::new(pid, fake_win_size, Some(palette), 0); // 0 is the pane index
     let mut text_to_fill_pane = String::new();
     for i in 0..30 {
         text_to_fill_pane.push_str(&format!("\rline {}\n", i + 1));

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -153,7 +153,7 @@ pub(crate) struct Screen {
     /// The index of this [`Screen`]'s active [`Tab`].
     active_tab_index: Option<usize>,
     mode_info: ModeInfo,
-    colors: Palette,
+    colors: Option<Palette>,
     session_state: Arc<RwLock<SessionState>>,
     draw_pane_frames: bool,
 }

--- a/zellij-server/src/tab.rs
+++ b/zellij-server/src/tab.rs
@@ -108,7 +108,7 @@ pub(crate) struct Tab {
     should_clear_display_before_rendering: bool,
     session_state: Arc<RwLock<SessionState>>,
     pub mode_info: ModeInfo,
-    pub colors: Palette,
+    pub colors: Option<Palette>,
     draw_pane_frames: bool,
 }
 
@@ -296,7 +296,7 @@ impl Tab {
         max_panes: Option<usize>,
         pane_id: Option<PaneId>,
         mode_info: ModeInfo,
-        colors: Palette,
+        colors: Option<Palette>,
         session_state: Arc<RwLock<SessionState>>,
         draw_pane_frames: bool,
     ) -> Self {
@@ -1035,18 +1035,14 @@ impl Tab {
                         pane.set_active_at(Instant::now());
                         match self.mode_info.mode {
                             InputMode::Normal | InputMode::Locked => {
-                                pane.set_boundary_color(Some(self.colors.green));
+                                pane.set_boundary_color(self.colors.map(|colors| colors.green));
                             }
                             _ => {
-                                pane.set_boundary_color(Some(self.colors.orange));
+                                pane.set_boundary_color(self.colors.map(|colors| colors.orange));
                             }
                         }
                         if !self.draw_pane_frames {
-                            boundaries.add_rect(
-                                pane.as_ref(),
-                                self.mode_info.mode,
-                                Some(self.colors),
-                            )
+                            boundaries.add_rect(pane.as_ref(), self.mode_info.mode, self.colors)
                         }
                     }
                     false => {

--- a/zellij-server/src/unit/tab_tests.rs
+++ b/zellij-server/src/unit/tab_tests.rs
@@ -82,7 +82,7 @@ fn create_new_tab(position_and_size: PositionAndSize) -> Tab {
     let max_panes = None;
     let first_pane_id = Some(PaneId::Terminal(1));
     let mode_info = ModeInfo::default();
-    let colors = Palette::default();
+    let colors = Some(Palette::default());
     let session_state = Arc::new(RwLock::new(SessionState::Attached));
     Tab::new(
         index,

--- a/zellij-tile/src/data.rs
+++ b/zellij-tile/src/data.rs
@@ -146,7 +146,7 @@ pub struct ModeInfo {
     pub mode: InputMode,
     // FIXME: This should probably return Keys and Actions, then sort out strings plugin-side
     pub keybinds: Vec<(String, String)>, // <shortcut> => <shortcut description>
-    pub palette: Palette,
+    pub palette: Option<Palette>,
     pub capabilities: PluginCapabilities,
     pub session_name: Option<String>,
 }

--- a/zellij-utils/src/input/mod.rs
+++ b/zellij-utils/src/input/mod.rs
@@ -16,7 +16,7 @@ use zellij_tile::data::{InputMode, Key, ModeInfo, Palette, PluginCapabilities};
 /// (as pairs of [`String`]s).
 pub fn get_mode_info(
     mode: InputMode,
-    palette: Palette,
+    palette: Option<Palette>,
     capabilities: PluginCapabilities,
 ) -> ModeInfo {
     let keybinds = match mode {

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -64,6 +64,10 @@ pub struct Options {
     /// Set behaviour on force close (quit or detach)
     #[structopt(long)]
     pub on_force_close: Option<OnForceClose>,
+    #[structopt(long)]
+    #[serde(default)]
+    /// Strip out all colors
+    pub monochrome: bool,
 }
 
 impl Options {
@@ -84,6 +88,7 @@ impl Options {
         let simplified_ui = merge_bool(other.simplified_ui, self.simplified_ui);
         let disable_mouse_mode = merge_bool(other.disable_mouse_mode, self.disable_mouse_mode);
         let no_pane_frames = merge_bool(other.no_pane_frames, self.no_pane_frames);
+        let monochrome = merge_bool(other.monochrome, self.monochrome);
 
         let default_mode = other.default_mode.or(self.default_mode);
         let default_shell = other.default_shell.or_else(|| self.default_shell.clone());
@@ -100,6 +105,7 @@ impl Options {
             disable_mouse_mode,
             no_pane_frames,
             on_force_close,
+            monochrome,
         }
     }
 

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -38,7 +38,7 @@ pub enum ClientType {
 #[derive(Default, Serialize, Deserialize, Debug, Clone, Copy)]
 pub struct ClientAttributes {
     pub position_and_size: PositionAndSize,
-    pub palette: Palette,
+    pub palette: Option<Palette>,
 }
 
 // Types of messages sent from the client to the server


### PR DESCRIPTION
When in monochrome mode, all color related escape sequences are stripped.

Fixes #614

Signed-off-by: Tw <wei.tan@intel.com>