### PR TITLE
fix(compatibility): support changing index colors with osc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Simplify deserialization slightly (https://github.com/zellij-org/zellij/pull/633)
 * Fix update plugin attributes on inactive tab (https://github.com/zellij-org/zellij/pull/634)
 * New pane UI: draw pane frames - can be disabled with ctrl-p + z, or through configuration (https://github.com/zellij-org/zellij/pull/643)
+* Terminal compatibility: support changing index colors through OSC 4 and similar (https://github.com/zellij-org/zellij/pull/646)
 
 ## [0.15.0] - 2021-07-19
 * Kill children properly (https://github.com/zellij-org/zellij/pull/601)

--- a/src/tests/e2e/remote_runner.rs
+++ b/src/tests/e2e/remote_runner.rs
@@ -144,8 +144,6 @@ impl<'a> RemoteTerminal<'a> {
     }
     pub fn status_bar_appears(&self) -> bool {
         self.current_snapshot.contains("Ctrl +")
-        // self.current_snapshot.contains("Ctrl +") && !self.current_snapshot.contains("─────")
-        // this is a bug that happens because the app draws borders around the status bar momentarily on first render
     }
     pub fn snapshot_contains(&self, text: &str) -> bool {
         self.current_snapshot.contains(text)

--- a/zellij-server/src/panes/alacritty_functions.rs
+++ b/zellij-server/src/panes/alacritty_functions.rs
@@ -2,8 +2,8 @@ use zellij_utils::position::Position;
 use zellij_utils::zellij_tile::prelude::PaletteColor;
 use zellij_utils::{vte, zellij_tile};
 
-use std::fmt::Debug;
 use std::convert::TryFrom;
+use std::fmt::Debug;
 use std::os::unix::io::RawFd;
 use std::time::{self, Instant};
 use zellij_tile::data::Palette;
@@ -45,7 +45,10 @@ pub fn xparse_color(color: &[u8]) -> Option<AnsiCode> {
 
 /// Parse colors in `rgb:r(rrr)/g(ggg)/b(bbb)` format.
 pub fn parse_rgb_color(color: &[u8]) -> Option<AnsiCode> {
-    let colors = std::str::from_utf8(color).ok()?.split('/').collect::<Vec<_>>();
+    let colors = std::str::from_utf8(color)
+        .ok()?
+        .split('/')
+        .collect::<Vec<_>>();
 
     if colors.len() != 3 {
         return None;
@@ -62,7 +65,11 @@ pub fn parse_rgb_color(color: &[u8]) -> Option<AnsiCode> {
         }
     };
 
-    Some(AnsiCode::RgbCode((scale(colors[0])?, scale(colors[1])?, scale(colors[2])?)))
+    Some(AnsiCode::RgbCode((
+        scale(colors[0])?,
+        scale(colors[1])?,
+        scale(colors[2])?,
+    )))
 }
 
 /// Parse colors in `#r(rrr)g(ggg)b(bbb)` format.
@@ -101,8 +108,6 @@ pub fn parse_number(input: &[u8]) -> Option<u8> {
     Some(num)
 }
 
-
-
 // these functions are copied verbatim (with slight modifications) from alacritty, mainly in order
 // to be able to use the VTE API provided by their great package of the same name more easily
 // The following license refers to this file and the functions
@@ -111,17 +116,17 @@ pub fn parse_number(input: &[u8]) -> Option<u8> {
 //                               Apache License
 //                         Version 2.0, January 2004
 //                      http://www.apache.org/licenses/
-// 
+//
 // TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-// 
+//
 // 1. Definitions.
-// 
+//
 //    "License" shall mean the terms and conditions for use, reproduction,
 //    and distribution as defined by Sections 1 through 9 of this document.
-// 
+//
 //    "Licensor" shall mean the copyright owner or entity authorized by
 //    the copyright owner that is granting the License.
-// 
+//
 //    "Legal Entity" shall mean the union of the acting entity and all
 //    other entities that control, are controlled by, or are under common
 //    control with that entity. For the purposes of this definition,
@@ -129,24 +134,24 @@ pub fn parse_number(input: &[u8]) -> Option<u8> {
 //    direction or management of such entity, whether by contract or
 //    otherwise, or (ii) ownership of fifty percent (50%) or more of the
 //    outstanding shares, or (iii) beneficial ownership of such entity.
-// 
+//
 //    "You" (or "Your") shall mean an individual or Legal Entity
 //    exercising permissions granted by this License.
-// 
+//
 //    "Source" form shall mean the preferred form for making modifications,
 //    including but not limited to software source code, documentation
 //    source, and configuration files.
-// 
+//
 //    "Object" form shall mean any form resulting from mechanical
 //    transformation or translation of a Source form, including but
 //    not limited to compiled object code, generated documentation,
 //    and conversions to other media types.
-// 
+//
 //    "Work" shall mean the work of authorship, whether in Source or
 //    Object form, made available under the License, as indicated by a
 //    copyright notice that is included in or attached to the work
 //    (an example is provided in the Appendix below).
-// 
+//
 //    "Derivative Works" shall mean any work, whether in Source or Object
 //    form, that is based on (or derived from) the Work and for which the
 //    editorial revisions, annotations, elaborations, or other modifications
@@ -154,7 +159,7 @@ pub fn parse_number(input: &[u8]) -> Option<u8> {
 //    of this License, Derivative Works shall not include works that remain
 //    separable from, or merely link (or bind by name) to the interfaces of,
 //    the Work and Derivative Works thereof.
-// 
+//
 //    "Contribution" shall mean any work of authorship, including
 //    the original version of the Work and any modifications or additions
 //    to that Work or Derivative Works thereof, that is intentionally
@@ -168,18 +173,18 @@ pub fn parse_number(input: &[u8]) -> Option<u8> {
 //    Licensor for the purpose of discussing and improving the Work, but
 //    excluding communication that is conspicuously marked or otherwise
 //    designated in writing by the copyright owner as "Not a Contribution."
-// 
+//
 //    "Contributor" shall mean Licensor and any individual or Legal Entity
 //    on behalf of whom a Contribution has been received by Licensor and
 //    subsequently incorporated within the Work.
-// 
+//
 // 2. Grant of Copyright License. Subject to the terms and conditions of
 //    this License, each Contributor hereby grants to You a perpetual,
 //    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
 //    copyright license to reproduce, prepare Derivative Works of,
 //    publicly display, publicly perform, sublicense, and distribute the
 //    Work and such Derivative Works in Source or Object form.
-// 
+//
 // 3. Grant of Patent License. Subject to the terms and conditions of
 //    this License, each Contributor hereby grants to You a perpetual,
 //    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
@@ -195,24 +200,24 @@ pub fn parse_number(input: &[u8]) -> Option<u8> {
 //    or contributory patent infringement, then any patent licenses
 //    granted to You under this License for that Work shall terminate
 //    as of the date such litigation is filed.
-// 
+//
 // 4. Redistribution. You may reproduce and distribute copies of the
 //    Work or Derivative Works thereof in any medium, with or without
 //    modifications, and in Source or Object form, provided that You
 //    meet the following conditions:
-// 
+//
 //    (a) You must give any other recipients of the Work or
 //        Derivative Works a copy of this License; and
-// 
+//
 //    (b) You must cause any modified files to carry prominent notices
 //        stating that You changed the files; and
-// 
+//
 //    (c) You must retain, in the Source form of any Derivative Works
 //        that You distribute, all copyright, patent, trademark, and
 //        attribution notices from the Source form of the Work,
 //        excluding those notices that do not pertain to any part of
 //        the Derivative Works; and
-// 
+//
 //    (d) If the Work includes a "NOTICE" text file as part of its
 //        distribution, then any Derivative Works that You distribute must
 //        include a readable copy of the attribution notices contained
@@ -229,14 +234,14 @@ pub fn parse_number(input: &[u8]) -> Option<u8> {
 //        or as an addendum to the NOTICE text from the Work, provided
 //        that such additional attribution notices cannot be construed
 //        as modifying the License.
-// 
+//
 //    You may add Your own copyright statement to Your modifications and
 //    may provide additional or different license terms and conditions
 //    for use, reproduction, or distribution of Your modifications, or
 //    for any such Derivative Works as a whole, provided Your use,
 //    reproduction, and distribution of the Work otherwise complies with
 //    the conditions stated in this License.
-// 
+//
 // 5. Submission of Contributions. Unless You explicitly state otherwise,
 //    any Contribution intentionally submitted for inclusion in the Work
 //    by You to the Licensor shall be under the terms and conditions of
@@ -244,12 +249,12 @@ pub fn parse_number(input: &[u8]) -> Option<u8> {
 //    Notwithstanding the above, nothing herein shall supersede or modify
 //    the terms of any separate license agreement you may have executed
 //    with Licensor regarding such Contributions.
-// 
+//
 // 6. Trademarks. This License does not grant permission to use the trade
 //    names, trademarks, service marks, or product names of the Licensor,
 //    except as required for reasonable and customary use in describing the
 //    origin of the Work and reproducing the content of the NOTICE file.
-// 
+//
 // 7. Disclaimer of Warranty. Unless required by applicable law or
 //    agreed to in writing, Licensor provides the Work (and each
 //    Contributor provides its Contributions) on an "AS IS" BASIS,
@@ -259,7 +264,7 @@ pub fn parse_number(input: &[u8]) -> Option<u8> {
 //    PARTICULAR PURPOSE. You are solely responsible for determining the
 //    appropriateness of using or redistributing the Work and assume any
 //    risks associated with Your exercise of permissions under this License.
-// 
+//
 // 8. Limitation of Liability. In no event and under no legal theory,
 //    whether in tort (including negligence), contract, or otherwise,
 //    unless required by applicable law (such as deliberate and grossly
@@ -271,7 +276,7 @@ pub fn parse_number(input: &[u8]) -> Option<u8> {
 //    work stoppage, computer failure or malfunction, or any and all
 //    other commercial damages or losses), even if such Contributor
 //    has been advised of the possibility of such damages.
-// 
+//
 // 9. Accepting Warranty or Additional Liability. While redistributing
 //    the Work or Derivative Works thereof, You may choose to offer,
 //    and charge a fee for, acceptance of support, warranty, indemnity,
@@ -282,11 +287,11 @@ pub fn parse_number(input: &[u8]) -> Option<u8> {
 //    defend, and hold each Contributor harmless for any liability
 //    incurred by, or claims asserted against, such Contributor by reason
 //    of your accepting any such warranty or additional liability.
-// 
+//
 // END OF TERMS AND CONDITIONS
-// 
+//
 // APPENDIX: How to apply the Apache License to your work.
-// 
+//
 //    To apply the Apache License to your work, attach the following
 //    boilerplate notice, with the fields enclosed by brackets "[]"
 //    replaced with your own identifying information. (Don't include
@@ -295,18 +300,18 @@ pub fn parse_number(input: &[u8]) -> Option<u8> {
 //    file or class name and description of purpose be included on the
 //    same "printed page" as the copyright notice for easier
 //    identification within third-party archives.
-// 
+//
 // Copyright 2020 The Alacritty Project
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //    http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//

--- a/zellij-server/src/panes/alacritty_functions.rs
+++ b/zellij-server/src/panes/alacritty_functions.rs
@@ -1,0 +1,312 @@
+use zellij_utils::position::Position;
+use zellij_utils::zellij_tile::prelude::PaletteColor;
+use zellij_utils::{vte, zellij_tile};
+
+use std::fmt::Debug;
+use std::convert::TryFrom;
+use std::os::unix::io::RawFd;
+use std::time::{self, Instant};
+use zellij_tile::data::Palette;
+
+use zellij_utils::pane_size::PositionAndSize;
+
+use crate::panes::AnsiCode;
+use crate::panes::{
+    grid::Grid,
+    terminal_character::{
+        CharacterStyles, CursorShape, TerminalCharacter, EMPTY_TERMINAL_CHARACTER,
+    },
+};
+use crate::pty::VteBytes;
+use crate::tab::Pane;
+
+pub fn parse_sgr_color(params: &mut dyn Iterator<Item = u16>) -> Option<AnsiCode> {
+    match params.next() {
+        Some(2) => Some(AnsiCode::RgbCode((
+            u8::try_from(params.next()?).ok()?,
+            u8::try_from(params.next()?).ok()?,
+            u8::try_from(params.next()?).ok()?,
+        ))),
+        Some(5) => Some(AnsiCode::ColorIndex(u8::try_from(params.next()?).ok()?)),
+        _ => None,
+    }
+}
+
+/// Parse colors in XParseColor format.
+pub fn xparse_color(color: &[u8]) -> Option<AnsiCode> {
+    if !color.is_empty() && color[0] == b'#' {
+        parse_legacy_color(&color[1..])
+    } else if color.len() >= 4 && &color[..4] == b"rgb:" {
+        parse_rgb_color(&color[4..])
+    } else {
+        None
+    }
+}
+
+/// Parse colors in `rgb:r(rrr)/g(ggg)/b(bbb)` format.
+pub fn parse_rgb_color(color: &[u8]) -> Option<AnsiCode> {
+    let colors = std::str::from_utf8(color).ok()?.split('/').collect::<Vec<_>>();
+
+    if colors.len() != 3 {
+        return None;
+    }
+
+    // Scale values instead of filling with `0`s.
+    let scale = |input: &str| {
+        if input.len() > 4 {
+            None
+        } else {
+            let max = u32::pow(16, input.len() as u32) - 1;
+            let value = u32::from_str_radix(input, 16).ok()?;
+            Some((255 * value / max) as u8)
+        }
+    };
+
+    Some(AnsiCode::RgbCode((scale(colors[0])?, scale(colors[1])?, scale(colors[2])?)))
+}
+
+/// Parse colors in `#r(rrr)g(ggg)b(bbb)` format.
+pub fn parse_legacy_color(color: &[u8]) -> Option<AnsiCode> {
+    let item_len = color.len() / 3;
+
+    // Truncate/Fill to two byte precision.
+    let color_from_slice = |slice: &[u8]| {
+        let col = usize::from_str_radix(std::str::from_utf8(slice).ok()?, 16).ok()? << 4;
+        Some((col >> (4 * slice.len().saturating_sub(1))) as u8)
+    };
+
+    Some(AnsiCode::RgbCode((
+        color_from_slice(&color[0..item_len])?,
+        color_from_slice(&color[item_len..item_len * 2])?,
+        color_from_slice(&color[item_len * 2..])?,
+    )))
+}
+
+pub fn parse_number(input: &[u8]) -> Option<u8> {
+    if input.is_empty() {
+        return None;
+    }
+    let mut num: u8 = 0;
+    for c in input {
+        let c = *c as char;
+        if let Some(digit) = c.to_digit(10) {
+            num = match num.checked_mul(10).and_then(|v| v.checked_add(digit as u8)) {
+                Some(v) => v,
+                None => return None,
+            }
+        } else {
+            return None;
+        }
+    }
+    Some(num)
+}
+
+
+
+// these functions are copied verbatim (with slight modifications) from alacritty, mainly in order
+// to be able to use the VTE API provided by their great package of the same name more easily
+// The following license refers to this file and the functions
+// within it only
+//
+//                               Apache License
+//                         Version 2.0, January 2004
+//                      http://www.apache.org/licenses/
+// 
+// TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+// 
+// 1. Definitions.
+// 
+//    "License" shall mean the terms and conditions for use, reproduction,
+//    and distribution as defined by Sections 1 through 9 of this document.
+// 
+//    "Licensor" shall mean the copyright owner or entity authorized by
+//    the copyright owner that is granting the License.
+// 
+//    "Legal Entity" shall mean the union of the acting entity and all
+//    other entities that control, are controlled by, or are under common
+//    control with that entity. For the purposes of this definition,
+//    "control" means (i) the power, direct or indirect, to cause the
+//    direction or management of such entity, whether by contract or
+//    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+//    outstanding shares, or (iii) beneficial ownership of such entity.
+// 
+//    "You" (or "Your") shall mean an individual or Legal Entity
+//    exercising permissions granted by this License.
+// 
+//    "Source" form shall mean the preferred form for making modifications,
+//    including but not limited to software source code, documentation
+//    source, and configuration files.
+// 
+//    "Object" form shall mean any form resulting from mechanical
+//    transformation or translation of a Source form, including but
+//    not limited to compiled object code, generated documentation,
+//    and conversions to other media types.
+// 
+//    "Work" shall mean the work of authorship, whether in Source or
+//    Object form, made available under the License, as indicated by a
+//    copyright notice that is included in or attached to the work
+//    (an example is provided in the Appendix below).
+// 
+//    "Derivative Works" shall mean any work, whether in Source or Object
+//    form, that is based on (or derived from) the Work and for which the
+//    editorial revisions, annotations, elaborations, or other modifications
+//    represent, as a whole, an original work of authorship. For the purposes
+//    of this License, Derivative Works shall not include works that remain
+//    separable from, or merely link (or bind by name) to the interfaces of,
+//    the Work and Derivative Works thereof.
+// 
+//    "Contribution" shall mean any work of authorship, including
+//    the original version of the Work and any modifications or additions
+//    to that Work or Derivative Works thereof, that is intentionally
+//    submitted to Licensor for inclusion in the Work by the copyright owner
+//    or by an individual or Legal Entity authorized to submit on behalf of
+//    the copyright owner. For the purposes of this definition, "submitted"
+//    means any form of electronic, verbal, or written communication sent
+//    to the Licensor or its representatives, including but not limited to
+//    communication on electronic mailing lists, source code control systems,
+//    and issue tracking systems that are managed by, or on behalf of, the
+//    Licensor for the purpose of discussing and improving the Work, but
+//    excluding communication that is conspicuously marked or otherwise
+//    designated in writing by the copyright owner as "Not a Contribution."
+// 
+//    "Contributor" shall mean Licensor and any individual or Legal Entity
+//    on behalf of whom a Contribution has been received by Licensor and
+//    subsequently incorporated within the Work.
+// 
+// 2. Grant of Copyright License. Subject to the terms and conditions of
+//    this License, each Contributor hereby grants to You a perpetual,
+//    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+//    copyright license to reproduce, prepare Derivative Works of,
+//    publicly display, publicly perform, sublicense, and distribute the
+//    Work and such Derivative Works in Source or Object form.
+// 
+// 3. Grant of Patent License. Subject to the terms and conditions of
+//    this License, each Contributor hereby grants to You a perpetual,
+//    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+//    (except as stated in this section) patent license to make, have made,
+//    use, offer to sell, sell, import, and otherwise transfer the Work,
+//    where such license applies only to those patent claims licensable
+//    by such Contributor that are necessarily infringed by their
+//    Contribution(s) alone or by combination of their Contribution(s)
+//    with the Work to which such Contribution(s) was submitted. If You
+//    institute patent litigation against any entity (including a
+//    cross-claim or counterclaim in a lawsuit) alleging that the Work
+//    or a Contribution incorporated within the Work constitutes direct
+//    or contributory patent infringement, then any patent licenses
+//    granted to You under this License for that Work shall terminate
+//    as of the date such litigation is filed.
+// 
+// 4. Redistribution. You may reproduce and distribute copies of the
+//    Work or Derivative Works thereof in any medium, with or without
+//    modifications, and in Source or Object form, provided that You
+//    meet the following conditions:
+// 
+//    (a) You must give any other recipients of the Work or
+//        Derivative Works a copy of this License; and
+// 
+//    (b) You must cause any modified files to carry prominent notices
+//        stating that You changed the files; and
+// 
+//    (c) You must retain, in the Source form of any Derivative Works
+//        that You distribute, all copyright, patent, trademark, and
+//        attribution notices from the Source form of the Work,
+//        excluding those notices that do not pertain to any part of
+//        the Derivative Works; and
+// 
+//    (d) If the Work includes a "NOTICE" text file as part of its
+//        distribution, then any Derivative Works that You distribute must
+//        include a readable copy of the attribution notices contained
+//        within such NOTICE file, excluding those notices that do not
+//        pertain to any part of the Derivative Works, in at least one
+//        of the following places: within a NOTICE text file distributed
+//        as part of the Derivative Works; within the Source form or
+//        documentation, if provided along with the Derivative Works; or,
+//        within a display generated by the Derivative Works, if and
+//        wherever such third-party notices normally appear. The contents
+//        of the NOTICE file are for informational purposes only and
+//        do not modify the License. You may add Your own attribution
+//        notices within Derivative Works that You distribute, alongside
+//        or as an addendum to the NOTICE text from the Work, provided
+//        that such additional attribution notices cannot be construed
+//        as modifying the License.
+// 
+//    You may add Your own copyright statement to Your modifications and
+//    may provide additional or different license terms and conditions
+//    for use, reproduction, or distribution of Your modifications, or
+//    for any such Derivative Works as a whole, provided Your use,
+//    reproduction, and distribution of the Work otherwise complies with
+//    the conditions stated in this License.
+// 
+// 5. Submission of Contributions. Unless You explicitly state otherwise,
+//    any Contribution intentionally submitted for inclusion in the Work
+//    by You to the Licensor shall be under the terms and conditions of
+//    this License, without any additional terms or conditions.
+//    Notwithstanding the above, nothing herein shall supersede or modify
+//    the terms of any separate license agreement you may have executed
+//    with Licensor regarding such Contributions.
+// 
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor,
+//    except as required for reasonable and customary use in describing the
+//    origin of the Work and reproducing the content of the NOTICE file.
+// 
+// 7. Disclaimer of Warranty. Unless required by applicable law or
+//    agreed to in writing, Licensor provides the Work (and each
+//    Contributor provides its Contributions) on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//    implied, including, without limitation, any warranties or conditions
+//    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+//    PARTICULAR PURPOSE. You are solely responsible for determining the
+//    appropriateness of using or redistributing the Work and assume any
+//    risks associated with Your exercise of permissions under this License.
+// 
+// 8. Limitation of Liability. In no event and under no legal theory,
+//    whether in tort (including negligence), contract, or otherwise,
+//    unless required by applicable law (such as deliberate and grossly
+//    negligent acts) or agreed to in writing, shall any Contributor be
+//    liable to You for damages, including any direct, indirect, special,
+//    incidental, or consequential damages of any character arising as a
+//    result of this License or out of the use or inability to use the
+//    Work (including but not limited to damages for loss of goodwill,
+//    work stoppage, computer failure or malfunction, or any and all
+//    other commercial damages or losses), even if such Contributor
+//    has been advised of the possibility of such damages.
+// 
+// 9. Accepting Warranty or Additional Liability. While redistributing
+//    the Work or Derivative Works thereof, You may choose to offer,
+//    and charge a fee for, acceptance of support, warranty, indemnity,
+//    or other liability obligations and/or rights consistent with this
+//    License. However, in accepting such obligations, You may act only
+//    on Your own behalf and on Your sole responsibility, not on behalf
+//    of any other Contributor, and only if You agree to indemnify,
+//    defend, and hold each Contributor harmless for any liability
+//    incurred by, or claims asserted against, such Contributor by reason
+//    of your accepting any such warranty or additional liability.
+// 
+// END OF TERMS AND CONDITIONS
+// 
+// APPENDIX: How to apply the Apache License to your work.
+// 
+//    To apply the Apache License to your work, attach the following
+//    boilerplate notice, with the fields enclosed by brackets "[]"
+//    replaced with your own identifying information. (Don't include
+//    the brackets!)  The text should be enclosed in the appropriate
+//    comment syntax for the file format. We also recommend that a
+//    file or class name and description of purpose be included on the
+//    same "printed page" as the copyright notice for easier
+//    identification within third-party archives.
+// 
+// Copyright 2020 The Alacritty Project
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// 

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -18,31 +18,11 @@ use zellij_tile::data::{Palette, PaletteColor};
 use zellij_utils::{consts::VERSION, logging::debug_log_to_file, shared::version_number};
 
 use crate::panes::terminal_character::{
-    CharacterStyles, CharsetIndex, Cursor, CursorShape, StandardCharset, TerminalCharacter,
-    EMPTY_TERMINAL_CHARACTER,
+    CharacterStyles, CharsetIndex, Cursor, CursorShape, StandardCharset, TerminalCharacter, AnsiCode, EMPTY_TERMINAL_CHARACTER,
 };
+use crate::panes::alacritty_functions::{parse_number, xparse_color};
 
 use super::selection::Selection;
-
-// this was copied verbatim from alacritty
-fn parse_number(input: &[u8]) -> Option<u8> {
-    if input.is_empty() {
-        return None;
-    }
-    let mut num: u8 = 0;
-    for c in input {
-        let c = *c as char;
-        if let Some(digit) = c.to_digit(10) {
-            num = match num.checked_mul(10).and_then(|v| v.checked_add(digit as u8)) {
-                Some(v) => v,
-                None => return None,
-            }
-        } else {
-            return None;
-        }
-    }
-    Some(num)
-}
 
 fn get_top_non_canonical_rows(rows: &mut Vec<Row>) -> Vec<Row> {
     let mut index_of_last_non_canonical_row = None;
@@ -310,6 +290,7 @@ pub struct Grid {
     colors: Palette,
     output_buffer: OutputBuffer,
     title_stack: Vec<String>,
+    pub changed_colors: [Option<AnsiCode>; 256],
     pub should_render: bool,
     pub cursor_key_mode: bool, // DECCKM - when set, cursor keys should send ANSI direction codes (eg. "OD") instead of the arrow keys (eg. "[D")
     pub erasure_mode: bool,    // ERM
@@ -363,6 +344,7 @@ impl Grid {
             selection: Default::default(),
             title_stack: vec![],
             title: None,
+            changed_colors: [None; 256],
         }
     }
     pub fn render_full_viewport(&mut self) {
@@ -506,8 +488,6 @@ impl Grid {
                 Some(self.width),
             );
 
-            //             let line_to_insert_at_viewport_top = self.lines_above.pop_back().unwrap();
-            //             self.viewport.insert(0, line_to_insert_at_viewport_top);
             self.selection.move_down(1);
         }
         self.output_buffer.update_all_lines();
@@ -1189,6 +1169,7 @@ impl Grid {
         self.disable_linewrap = false;
         self.cursor.change_shape(CursorShape::Block);
         self.output_buffer.update_all_lines();
+        self.changed_colors = [None; 256];
     }
     fn set_preceding_character(&mut self, terminal_character: TerminalCharacter) {
         self.preceding_char = Some(terminal_character);
@@ -1316,12 +1297,20 @@ impl Grid {
 impl Perform for Grid {
     fn print(&mut self, c: char) {
         let c = self.cursor.charsets[self.active_charset].map(c);
+
+        // we add the changed_colors here instead of changing the actual colors on the
+        // TerminalCharacter in real time because these changed colors also affect the area around
+        // the character (eg. empty space after it)
+        // on the other hand, we must do it here and not at render-time because then it would be
+        // wiped out when one scrolls
+        let styles = self.cursor.pending_styles.changed_colors(self.changed_colors);
+
         // apparently, building TerminalCharacter like this without a "new" method
         // is a little faster
         let terminal_character = TerminalCharacter {
             character: c,
             width: c.width().unwrap_or(0),
-            styles: self.cursor.pending_styles,
+            styles,
         };
         self.set_preceding_character(terminal_character);
         self.add_character(terminal_character);
@@ -1387,18 +1376,20 @@ impl Perform for Grid {
                         .join(";")
                         .trim()
                         .to_owned();
-                    // TBD: do something with title?
                     self.set_title(title);
                 }
             }
 
             // Set color index.
             b"4" => {
-                // TBD: set color index - currently unsupported
-                //
-                // this changes a terminal color index to something else
-                // meaning anything set to that index will be changed
-                // during rendering
+                for chunk in params[1..].chunks(2) {
+                    let index = parse_number(chunk[0]);
+                    let color = xparse_color(chunk[1]);
+                    if let (Some(i), Some(c)) = (index, color) {
+                        self.changed_colors[i as usize] = Some(c);
+                        return;
+                    }
+                }
             }
 
             // Get/set Foreground, Background, Cursor colors.
@@ -1472,6 +1463,27 @@ impl Perform for Grid {
 
             // Reset color index.
             b"104" => {
+
+                // Reset all color indexes when no parameters are given.
+                if params.len() == 1 {
+                    for i in 0..256 {
+                        self.changed_colors[i] = None;
+                    }
+                    return;
+                }
+
+                // Reset color indexes given as parameters.
+                for param in &params[1..] {
+                    match parse_number(param) {
+                        Some(index) => {
+                            self.changed_colors[index as usize] = None
+                        }
+                        None => {}
+                    }
+                }
+
+
+
                 // Reset all color indexes when no parameters are given.
                 if params.len() == 1 {
                     // TBD - reset all color changes - currently unsupported

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -17,11 +17,10 @@ use vte::{Params, Perform};
 use zellij_tile::data::{Palette, PaletteColor};
 use zellij_utils::{consts::VERSION, logging::debug_log_to_file, shared::version_number};
 
-use crate::panes::alacritty_functions::{parse_number, xparse_color};
 use crate::panes::terminal_character::{
-    AnsiCode, CharacterStyles, CharsetIndex, Cursor, CursorShape, StandardCharset,
-    TerminalCharacter, EMPTY_TERMINAL_CHARACTER,
+    CharacterStyles, CharsetIndex, Cursor, CursorShape, StandardCharset, TerminalCharacter, AnsiCode, EMPTY_TERMINAL_CHARACTER,
 };
+use crate::panes::alacritty_functions::{parse_number, xparse_color};
 
 use super::selection::Selection;
 
@@ -1304,10 +1303,7 @@ impl Perform for Grid {
         // the character (eg. empty space after it)
         // on the other hand, we must do it here and not at render-time because then it would be
         // wiped out when one scrolls
-        let styles = self
-            .cursor
-            .pending_styles
-            .changed_colors(self.changed_colors);
+        let styles = self.cursor.pending_styles.changed_colors(self.changed_colors);
 
         // apparently, building TerminalCharacter like this without a "new" method
         // is a little faster
@@ -1467,6 +1463,7 @@ impl Perform for Grid {
 
             // Reset color index.
             b"104" => {
+
                 // Reset all color indexes when no parameters are given.
                 if params.len() == 1 {
                     for i in 0..256 {
@@ -1477,11 +1474,12 @@ impl Perform for Grid {
 
                 // Reset color indexes given as parameters.
                 for param in &params[1..] {
-                    match parse_number(param) {
-                        Some(index) => self.changed_colors[index as usize] = None,
-                        None => {}
+                    if let Some(index) = parse_number(param) {
+                        self.changed_colors[index as usize] = None
                     }
                 }
+
+
 
                 // Reset all color indexes when no parameters are given.
                 if params.len() == 1 {

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -17,10 +17,11 @@ use vte::{Params, Perform};
 use zellij_tile::data::{Palette, PaletteColor};
 use zellij_utils::{consts::VERSION, logging::debug_log_to_file, shared::version_number};
 
-use crate::panes::terminal_character::{
-    CharacterStyles, CharsetIndex, Cursor, CursorShape, StandardCharset, TerminalCharacter, AnsiCode, EMPTY_TERMINAL_CHARACTER,
-};
 use crate::panes::alacritty_functions::{parse_number, xparse_color};
+use crate::panes::terminal_character::{
+    AnsiCode, CharacterStyles, CharsetIndex, Cursor, CursorShape, StandardCharset,
+    TerminalCharacter, EMPTY_TERMINAL_CHARACTER,
+};
 
 use super::selection::Selection;
 
@@ -1303,7 +1304,10 @@ impl Perform for Grid {
         // the character (eg. empty space after it)
         // on the other hand, we must do it here and not at render-time because then it would be
         // wiped out when one scrolls
-        let styles = self.cursor.pending_styles.changed_colors(self.changed_colors);
+        let styles = self
+            .cursor
+            .pending_styles
+            .changed_colors(self.changed_colors);
 
         // apparently, building TerminalCharacter like this without a "new" method
         // is a little faster
@@ -1463,7 +1467,6 @@ impl Perform for Grid {
 
             // Reset color index.
             b"104" => {
-
                 // Reset all color indexes when no parameters are given.
                 if params.len() == 1 {
                     for i in 0..256 {
@@ -1475,14 +1478,10 @@ impl Perform for Grid {
                 // Reset color indexes given as parameters.
                 for param in &params[1..] {
                     match parse_number(param) {
-                        Some(index) => {
-                            self.changed_colors[index as usize] = None
-                        }
+                        Some(index) => self.changed_colors[index as usize] = None,
                         None => {}
                     }
                 }
-
-
 
                 // Reset all color indexes when no parameters are given.
                 if params.len() == 1 {

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -17,10 +17,11 @@ use vte::{Params, Perform};
 use zellij_tile::data::{Palette, PaletteColor};
 use zellij_utils::{consts::VERSION, logging::debug_log_to_file, shared::version_number};
 
-use crate::panes::terminal_character::{
-    CharacterStyles, CharsetIndex, Cursor, CursorShape, StandardCharset, TerminalCharacter, AnsiCode, EMPTY_TERMINAL_CHARACTER,
-};
 use crate::panes::alacritty_functions::{parse_number, xparse_color};
+use crate::panes::terminal_character::{
+    AnsiCode, CharacterStyles, CharsetIndex, Cursor, CursorShape, StandardCharset,
+    TerminalCharacter, EMPTY_TERMINAL_CHARACTER,
+};
 
 use super::selection::Selection;
 
@@ -1303,7 +1304,10 @@ impl Perform for Grid {
         // the character (eg. empty space after it)
         // on the other hand, we must do it here and not at render-time because then it would be
         // wiped out when one scrolls
-        let styles = self.cursor.pending_styles.changed_colors(self.changed_colors);
+        let styles = self
+            .cursor
+            .pending_styles
+            .changed_colors(self.changed_colors);
 
         // apparently, building TerminalCharacter like this without a "new" method
         // is a little faster
@@ -1463,7 +1467,6 @@ impl Perform for Grid {
 
             // Reset color index.
             b"104" => {
-
                 // Reset all color indexes when no parameters are given.
                 if params.len() == 1 {
                     for i in 0..256 {
@@ -1478,8 +1481,6 @@ impl Perform for Grid {
                         self.changed_colors[index as usize] = None
                     }
                 }
-
-
 
                 // Reset all color indexes when no parameters are given.
                 if params.len() == 1 {

--- a/zellij-server/src/panes/mod.rs
+++ b/zellij-server/src/panes/mod.rs
@@ -1,12 +1,12 @@
+mod alacritty_functions;
 mod grid;
 mod plugin_pane;
 mod selection;
 mod terminal_character;
 mod terminal_pane;
-mod alacritty_functions;
 
+pub use alacritty_functions::*;
 pub use grid::*;
 pub(crate) use plugin_pane::*;
 pub use terminal_character::*;
 pub use terminal_pane::*;
-pub use alacritty_functions::*;

--- a/zellij-server/src/panes/mod.rs
+++ b/zellij-server/src/panes/mod.rs
@@ -3,8 +3,10 @@ mod plugin_pane;
 mod selection;
 mod terminal_character;
 mod terminal_pane;
+mod alacritty_functions;
 
 pub use grid::*;
 pub(crate) use plugin_pane::*;
 pub use terminal_character::*;
 pub use terminal_pane::*;
+pub use alacritty_functions::*;

--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -498,18 +498,11 @@ impl Display for CharacterStyles {
                     write!(f, "\u{1b}[38;2;{};{};{}m", r, g, b)?;
                 }
                 AnsiCode::ColorIndex(color_index) => {
-                    match self
-                        .changed_colors
-                        .and_then(|changed_colors| changed_colors[color_index as usize])
-                    {
-                        Some(changed_color_index) => {
-                            if let AnsiCode::RgbCode((r, g, b)) = changed_color_index {
-                                write!(f, "\u{1b}[38;2;{};{};{}m", r, g, b)?;
-                            } else {
-                                write!(f, "\u{1b}[38;5;{}m", color_index)?;
-                            }
+                    match self.changed_colors.and_then(|changed_colors| changed_colors[color_index as usize]) {
+                        Some(AnsiCode::RgbCode((r, g, b))) => {
+                            write!(f, "\u{1b}[38;2;{};{};{}m", r, g, b)?;
                         }
-                        None => {
+                        _ => {
                             write!(f, "\u{1b}[38;5;{}m", color_index)?;
                         }
                     }
@@ -529,18 +522,11 @@ impl Display for CharacterStyles {
                     write!(f, "\u{1b}[48;2;{};{};{}m", r, g, b)?;
                 }
                 AnsiCode::ColorIndex(color_index) => {
-                    match self
-                        .changed_colors
-                        .and_then(|changed_colors| changed_colors[color_index as usize])
-                    {
-                        Some(changed_color_index) => {
-                            if let AnsiCode::RgbCode((r, g, b)) = changed_color_index {
-                                write!(f, "\u{1b}[48;2;{};{};{}m", r, g, b)?;
-                            } else {
-                                write!(f, "\u{1b}[48;5;{}m", color_index)?;
-                            }
+                    match self.changed_colors.and_then(|changed_colors| changed_colors[color_index as usize]) {
+                        Some(AnsiCode::RgbCode((r, g, b))) => {
+                            write!(f, "\u{1b}[48;2;{};{};{}m", r, g, b)?;
                         }
-                        None => {
+                        _ => {
                             write!(f, "\u{1b}[48;5;{}m", color_index)?;
                         }
                     }

--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -498,7 +498,10 @@ impl Display for CharacterStyles {
                     write!(f, "\u{1b}[38;2;{};{};{}m", r, g, b)?;
                 }
                 AnsiCode::ColorIndex(color_index) => {
-                    match self.changed_colors.and_then(|changed_colors| changed_colors[color_index as usize]) {
+                    match self
+                        .changed_colors
+                        .and_then(|changed_colors| changed_colors[color_index as usize])
+                    {
                         Some(AnsiCode::RgbCode((r, g, b))) => {
                             write!(f, "\u{1b}[38;2;{};{};{}m", r, g, b)?;
                         }
@@ -522,7 +525,10 @@ impl Display for CharacterStyles {
                     write!(f, "\u{1b}[48;2;{};{};{}m", r, g, b)?;
                 }
                 AnsiCode::ColorIndex(color_index) => {
-                    match self.changed_colors.and_then(|changed_colors| changed_colors[color_index as usize]) {
+                    match self
+                        .changed_colors
+                        .and_then(|changed_colors| changed_colors[color_index as usize])
+                    {
                         Some(AnsiCode::RgbCode((r, g, b))) => {
                             write!(f, "\u{1b}[48;2;{};{};{}m", r, g, b)?;
                         }

--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -498,14 +498,17 @@ impl Display for CharacterStyles {
                     write!(f, "\u{1b}[38;2;{};{};{}m", r, g, b)?;
                 }
                 AnsiCode::ColorIndex(color_index) => {
-                    match self.changed_colors.and_then(|changed_colors| changed_colors[color_index as usize]) {
+                    match self
+                        .changed_colors
+                        .and_then(|changed_colors| changed_colors[color_index as usize])
+                    {
                         Some(changed_color_index) => {
                             if let AnsiCode::RgbCode((r, g, b)) = changed_color_index {
                                 write!(f, "\u{1b}[38;2;{};{};{}m", r, g, b)?;
                             } else {
                                 write!(f, "\u{1b}[38;5;{}m", color_index)?;
                             }
-                        },
+                        }
                         None => {
                             write!(f, "\u{1b}[38;5;{}m", color_index)?;
                         }
@@ -526,14 +529,17 @@ impl Display for CharacterStyles {
                     write!(f, "\u{1b}[48;2;{};{};{}m", r, g, b)?;
                 }
                 AnsiCode::ColorIndex(color_index) => {
-                    match self.changed_colors.and_then(|changed_colors| changed_colors[color_index as usize]) {
+                    match self
+                        .changed_colors
+                        .and_then(|changed_colors| changed_colors[color_index as usize])
+                    {
                         Some(changed_color_index) => {
                             if let AnsiCode::RgbCode((r, g, b)) = changed_color_index {
                                 write!(f, "\u{1b}[48;2;{};{};{}m", r, g, b)?;
                             } else {
                                 write!(f, "\u{1b}[48;5;{}m", color_index)?;
                             }
-                        },
+                        }
                         None => {
                             write!(f, "\u{1b}[48;5;{}m", color_index)?;
                         }

--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -1,8 +1,10 @@
-use std::convert::TryFrom;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::ops::{Index, IndexMut};
+
 use zellij_utils::logging::debug_log_to_file;
 use zellij_utils::vte::ParamsIter;
+
+use crate::panes::alacritty_functions::parse_sgr_color;
 
 pub const EMPTY_TERMINAL_CHARACTER: TerminalCharacter = TerminalCharacter {
     character: ' ',
@@ -19,6 +21,7 @@ pub const EMPTY_TERMINAL_CHARACTER: TerminalCharacter = TerminalCharacter {
         bold: Some(AnsiCode::Reset),
         dim: Some(AnsiCode::Reset),
         italic: Some(AnsiCode::Reset),
+        changed_colors: None,
     },
 };
 
@@ -107,6 +110,7 @@ pub struct CharacterStyles {
     pub bold: Option<AnsiCode>,
     pub dim: Option<AnsiCode>,
     pub italic: Option<AnsiCode>,
+    pub changed_colors: Option<[Option<AnsiCode>; 256]>,
 }
 
 impl Default for CharacterStyles {
@@ -123,6 +127,7 @@ impl Default for CharacterStyles {
             bold: None,
             dim: None,
             italic: None,
+            changed_colors: None,
         }
     }
 }
@@ -173,6 +178,10 @@ impl CharacterStyles {
     }
     pub fn strike(mut self, strike_code: Option<AnsiCode>) -> Self {
         self.strike = strike_code;
+        self
+    }
+    pub fn changed_colors(mut self, changed_colors: [Option<AnsiCode>; 256]) -> Self {
+        self.changed_colors = Some(changed_colors);
         self
     }
     pub fn clear(&mut self) {
@@ -317,6 +326,16 @@ impl CharacterStyles {
             } else {
                 diff = Some(CharacterStyles::new().italic(new_styles.italic));
                 self.italic = new_styles.italic;
+            }
+        }
+
+        if let Some(changed_colors) = new_styles.changed_colors {
+            if let Some(new_diff) = diff.as_mut() {
+                diff = Some(new_diff.changed_colors(changed_colors));
+                self.changed_colors = new_styles.changed_colors;
+            } else {
+                diff = Some(CharacterStyles::new().changed_colors(changed_colors));
+                self.changed_colors = new_styles.changed_colors;
             }
         }
         diff
@@ -479,7 +498,18 @@ impl Display for CharacterStyles {
                     write!(f, "\u{1b}[38;2;{};{};{}m", r, g, b)?;
                 }
                 AnsiCode::ColorIndex(color_index) => {
-                    write!(f, "\u{1b}[38;5;{}m", color_index)?;
+                    match self.changed_colors.and_then(|changed_colors| changed_colors[color_index as usize]) {
+                        Some(changed_color_index) => {
+                            if let AnsiCode::RgbCode((r, g, b)) = changed_color_index {
+                                write!(f, "\u{1b}[38;2;{};{};{}m", r, g, b)?;
+                            } else {
+                                write!(f, "\u{1b}[38;5;{}m", color_index)?;
+                            }
+                        },
+                        None => {
+                            write!(f, "\u{1b}[38;5;{}m", color_index)?;
+                        }
+                    }
                 }
                 AnsiCode::Reset => {
                     write!(f, "\u{1b}[39m")?;
@@ -496,7 +526,18 @@ impl Display for CharacterStyles {
                     write!(f, "\u{1b}[48;2;{};{};{}m", r, g, b)?;
                 }
                 AnsiCode::ColorIndex(color_index) => {
-                    write!(f, "\u{1b}[48;5;{}m", color_index)?;
+                    match self.changed_colors.and_then(|changed_colors| changed_colors[color_index as usize]) {
+                        Some(changed_color_index) => {
+                            if let AnsiCode::RgbCode((r, g, b)) = changed_color_index {
+                                write!(f, "\u{1b}[48;2;{};{};{}m", r, g, b)?;
+                            } else {
+                                write!(f, "\u{1b}[48;5;{}m", color_index)?;
+                            }
+                        },
+                        None => {
+                            write!(f, "\u{1b}[48;5;{}m", color_index)?;
+                        }
+                    }
                 }
                 AnsiCode::Reset => {
                     write!(f, "\u{1b}[49m")?;
@@ -755,17 +796,5 @@ pub struct TerminalCharacter {
 impl ::std::fmt::Debug for TerminalCharacter {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.character)
-    }
-}
-
-fn parse_sgr_color(params: &mut dyn Iterator<Item = u16>) -> Option<AnsiCode> {
-    match params.next() {
-        Some(2) => Some(AnsiCode::RgbCode((
-            u8::try_from(params.next()?).ok()?,
-            u8::try_from(params.next()?).ok()?,
-            u8::try_from(params.next()?).ok()?,
-        ))),
-        Some(5) => Some(AnsiCode::ColorIndex(u8::try_from(params.next()?).ok()?)),
-        _ => None,
     }
 }


### PR DESCRIPTION
This adds support for OSC 4 (and friends) which enables temporarily changing the index colors of the terminal to an arbitrary RGB color.

This should solve (among other things): https://github.com/zellij-org/zellij/issues/613