### PR TITLE
fix unexpected pane closing issue with nushell

### DIFF
--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -107,6 +107,8 @@ fn handle_terminal(cmd: RunCommand, orig_termios: termios::Termios) -> (RawFd, P
                             Command::new(cmd.command)
                                 .args(&cmd.args)
                                 .pre_exec(|| -> std::io::Result<()> {
+                                    // this is the "unsafe" part, for more details please see:
+                                    // https://doc.rust-lang.org/std/os/unix/process/trait.CommandExt.html#notes-and-safety
                                     unistd::setpgid(Pid::from_raw(0), Pid::from_raw(0))
                                         .expect("failed to create a new process group");
                                     Ok(())


### PR DESCRIPTION
nushell doesn't create a new process group when spawning a process,
so all processes including the ones spawned by us are in the same
foreground group. So the kernel will send signal to every member of this
group.

This patch fixes this issue by creating a new foreground process group
when spawnning a new terminal pane.

Fix #615

Signed-off-by: Tw <tw19881113@gmail.com>