### PR TITLE
fix(compatibility): do not remove frame when clearing viewport

### DIFF
--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -193,8 +193,8 @@ impl Pane for TerminalPane {
             let mut character_styles = CharacterStyles::new();
             if self.grid.clear_viewport_before_rendering {
                 for line_index in 0..self.grid.height {
-                    let x = self.get_x();
-                    let y = self.get_y();
+                    let x = self.get_content_x();
+                    let y = self.get_content_y();
                     vte_output.push_str(&format!(
                         "\u{1b}[{};{}H\u{1b}[m",
                         y + line_index + 1,


### PR DESCRIPTION
This fixes an issue in the new pane UI where when we switched to an alternative grid (eg. when opening nvim or htop) the frame around the pane was sometimes erased.