### PR TITLE
fix(compatibility): properly paste multilines

### DIFF
--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -91,8 +91,10 @@ impl InputHandler {
                                 self.handle_key(&key, raw_bytes);
                             } else if unsupported_key == bracketed_paste_start {
                                 self.pasting = true;
+                                self.handle_unknown_key(raw_bytes);
                             } else if unsupported_key == bracketed_paste_end {
                                 self.pasting = false;
+                                self.handle_unknown_key(raw_bytes);
                             } else {
                                 // this is a hack because termion doesn't recognize certain keys
                                 // in this case we just forward it to the terminal

--- a/zellij-client/src/unit/input_handler_tests.rs
+++ b/zellij-client/src/unit/input_handler_tests.rs
@@ -259,7 +259,9 @@ pub fn bracketed_paste() {
         default_mode,
     ));
     let expected_actions_sent_to_server = vec![
+        Action::Write(commands::BRACKETED_PASTE_START.to_vec()),
         Action::Write(commands::MOVE_FOCUS_LEFT_IN_NORMAL_MODE.to_vec()), // keys were directly written to server and not interpreted
+        Action::Write(commands::BRACKETED_PASTE_END.to_vec()),
         Action::Quit,
     ];
     let received_actions = extract_actions_sent_to_server(events_sent_to_server);


### PR DESCRIPTION
Fixes: https://github.com/zellij-org/zellij/issues/560

This was happening because while we were properly dealing with bracketed paste, we weren't forwarding the instructions to the active terminal. Now we are.