### PR TITLE
Fix(scroll): Prevent scroll buffer overwrite

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -361,6 +361,7 @@ pub struct Grid {
     pub pending_messages_to_pty: Vec<Vec<u8>>,
     pub selection: Selection,
     pub title: Option<String>,
+    pub is_scrolled: bool,
 }
 
 impl Debug for Grid {
@@ -405,6 +406,7 @@ impl Grid {
             title_stack: vec![],
             title: None,
             changed_colors: None,
+            is_scrolled: false,
         }
     }
     pub fn render_full_viewport(&mut self) {
@@ -537,6 +539,7 @@ impl Grid {
     }
     pub fn scroll_up_one_line(&mut self) {
         if !self.lines_above.is_empty() && self.viewport.len() == self.height {
+            self.is_scrolled = true;
             let line_to_push_down = self.viewport.pop().unwrap();
             self.lines_below.insert(0, line_to_push_down);
 
@@ -571,6 +574,9 @@ impl Grid {
 
             self.selection.move_up(1);
             self.output_buffer.update_all_lines();
+        }
+        if self.lines_below.is_empty() {
+            self.is_scrolled = false;
         }
     }
     fn force_change_size(&mut self, new_rows: usize, new_columns: usize) {

--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -263,6 +263,9 @@ impl Pane for PluginPane {
     fn clear_scroll(&mut self) {
         //unimplemented!()
     }
+    fn is_scrolled(&self) -> bool {
+        false
+    }
 
     fn active_at(&self) -> Instant {
         self.active_at

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -320,6 +320,9 @@ impl Pane for TerminalPane {
         self.grid.reset_viewport();
         self.set_should_render(true);
     }
+    fn is_scrolled(&self) -> bool {
+        self.grid.is_scrolled
+    }
 
     fn active_at(&self) -> Instant {
         self.active_at

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -406,7 +406,9 @@ impl Screen {
         self.update_tabs();
     }
     pub fn change_mode(&mut self, mode_info: ModeInfo) {
-        if self.mode_info.mode == InputMode::Scroll {
+        if self.mode_info.mode == InputMode::Scroll
+            && (mode_info.mode == InputMode::Normal || mode_info.mode == InputMode::Locked)
+        {
             self.get_active_tab_mut()
                 .unwrap()
                 .clear_active_terminal_scroll();

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -16,7 +16,7 @@ use crate::{
     wasm_vm::PluginInstruction,
     ServerInstruction, SessionState,
 };
-use zellij_tile::data::{Event, ModeInfo, Palette, PluginCapabilities, TabInfo};
+use zellij_tile::data::{Event, InputMode, ModeInfo, Palette, PluginCapabilities, TabInfo};
 use zellij_utils::{
     errors::{ContextType, ScreenContext},
     input::{get_mode_info, options::Options},
@@ -406,6 +406,11 @@ impl Screen {
         self.update_tabs();
     }
     pub fn change_mode(&mut self, mode_info: ModeInfo) {
+        if self.mode_info.mode == InputMode::Scroll {
+            self.get_active_tab_mut()
+                .unwrap()
+                .clear_active_terminal_scroll();
+        }
         self.colors = mode_info.palette;
         self.mode_info = mode_info;
         for tab in self.tabs.values_mut() {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -205,6 +205,12 @@ impl Screen {
             new_tab.visible(true);
 
             let old_active_index = self.active_tab_index.replace(new_tab_index);
+            if let Some(ref i) = old_active_index {
+                if let Some(t) = self.tabs.get_mut(i) {
+                    t.is_active = false;
+                }
+            }
+            self.tabs.get_mut(&new_tab_index).unwrap().is_active = true;
             self.tab_history.retain(|&e| e != Some(new_tab_pos));
             self.tab_history.push(old_active_index);
 
@@ -264,6 +270,7 @@ impl Screen {
             for t in self.tabs.values_mut() {
                 if t.index == self.active_tab_index.unwrap() {
                     t.set_force_render();
+                    t.is_active = true;
                     t.visible(true);
                 }
                 if t.position > active_tab.position {
@@ -351,8 +358,9 @@ impl Screen {
             self.draw_pane_frames,
         );
         tab.apply_layout(layout, new_pids, tab_index);
-        if let Some(active_tab) = self.get_active_tab() {
+        if let Some(active_tab) = self.get_active_tab_mut() {
             active_tab.visible(false);
+            active_tab.is_active = false;
         }
         self.tab_history
             .push(self.active_tab_index.replace(tab_index));

--- a/zellij-server/src/tab.rs
+++ b/zellij-server/src/tab.rs
@@ -40,7 +40,7 @@ const MIN_TERMINAL_WIDTH: usize = 5;
 const RESIZE_PERCENT: f64 = 5.0;
 
 const MAX_PENDING_VTE_EVENTS: usize = 7000;
-const PENDING_EVENTS_SET_SIZE: usize = 100;
+const PENDING_EVENTS_SET_SIZE: usize = 200;
 
 type BorderAndPaneIds = (usize, Vec<PaneId>);
 


### PR DESCRIPTION
Fix #306 
Currently, if a command is producing output (eg `tail`), then scrolling up causes the command to overwrite the scroll buffer.
This PR fixes it. Now when a pane is scrolled up, new vte events are buffered and when we exit scroll, the events are played at once.