### PR TITLE
fix(compatibility): docker-compose progress bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Fix various shells (eg. nushell) unexpectedly exiting when the user presses ctrl-c (https://github.com/zellij-org/zellij/pull/648)
 * Fix line wrapping while scrolling (https://github.com/zellij-org/zellij/pull/650)
 * Indicate to the user when text is copied to the clipboard with the mouse (https://github.com/zellij-org/zellij/pull/642)
+* Terminal compatibility: fix progress bar line overflow (http://github.com/zellij-org/zellij/pull/656)
 
 ## [0.15.0] - 2021-07-19
 * Kill children properly (https://github.com/zellij-org/zellij/pull/601)

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1068,26 +1068,14 @@ impl Grid {
         }
         self.output_buffer.update_all_lines();
     }
-    pub fn move_cursor_down(&mut self, count: usize, pad_character: TerminalCharacter) {
+    pub fn move_cursor_down_until_edge_of_screen(&mut self, count: usize, pad_character: TerminalCharacter) {
         if let Some((scroll_region_top, scroll_region_bottom)) = self.scroll_region {
             if self.cursor.y >= scroll_region_top && self.cursor.y <= scroll_region_bottom {
                 self.cursor.y = std::cmp::min(self.cursor.y + count, scroll_region_bottom);
                 return;
             }
         }
-        let lines_to_add = if self.cursor.y + count > self.height - 1 {
-            (self.cursor.y + count) - (self.height - 1)
-        } else {
-            0
-        };
-        self.cursor.y = if self.cursor.y + count > self.height - 1 {
-            self.height - 1
-        } else {
-            self.cursor.y + count
-        };
-        for _ in 0..lines_to_add {
-            self.add_canonical_line();
-        }
+        self.cursor.y = std::cmp::min(self.cursor.y + count, self.height - 1);
         self.pad_lines_until(self.cursor.y, pad_character);
     }
     pub fn move_cursor_back(&mut self, count: usize) {
@@ -1626,7 +1614,7 @@ impl Perform for Grid {
             // move cursor down until edge of screen
             let move_down_count = next_param_or(1);
             let pad_character = EMPTY_TERMINAL_CHARACTER;
-            self.move_cursor_down(move_down_count as usize, pad_character);
+            self.move_cursor_down_until_edge_of_screen(move_down_count as usize, pad_character);
         } else if c == 'D' {
             let move_back_count = next_param_or(1);
             self.move_cursor_back(move_back_count);
@@ -1806,7 +1794,7 @@ impl Perform for Grid {
         } else if c == 'E' {
             let count = next_param_or(1);
             let pad_character = EMPTY_TERMINAL_CHARACTER;
-            self.move_cursor_down(count, pad_character);
+            self.move_cursor_down_until_edge_of_screen(count, pad_character);
         } else if c == 'F' {
             let count = next_param_or(1);
             self.move_cursor_up(count);

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1068,7 +1068,11 @@ impl Grid {
         }
         self.output_buffer.update_all_lines();
     }
-    pub fn move_cursor_down_until_edge_of_screen(&mut self, count: usize, pad_character: TerminalCharacter) {
+    pub fn move_cursor_down_until_edge_of_screen(
+        &mut self,
+        count: usize,
+        pad_character: TerminalCharacter,
+    ) {
         if let Some((scroll_region_top, scroll_region_bottom)) = self.scroll_region {
             if self.cursor.y >= scroll_region_top && self.cursor.y <= scroll_region_bottom {
                 self.cursor.y = std::cmp::min(self.cursor.y + count, scroll_region_bottom);


### PR DESCRIPTION
This fixes docker-compose progress bars, and might also be a fix for https://github.com/zellij-org/zellij/issues/353 (but I'm not 100% sure it's the same bug).

It fixes them by properly treating the 'B' CSI signal when on the edge of the screen. Before we would add newlines where we should just stop instead.