### PR TITLE
fix(compatibility): only send bracketed paste to terminals requesting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Fix various shells (eg. nushell) unexpectedly exiting when the user presses ctrl-c (https://github.com/zellij-org/zellij/pull/648)
 * Fix line wrapping while scrolling (https://github.com/zellij-org/zellij/pull/650)
 * Indicate to the user when text is copied to the clipboard with the mouse (https://github.com/zellij-org/zellij/pull/642)
+* Terminal compatibility: properly paste multilines (https://github.com/zellij-org/zellij/pull/653 + https://github.com/zellij-org/zellij/pull/658)
 
 ## [0.15.0] - 2021-07-19
 * Kill children properly (https://github.com/zellij-org/zellij/pull/601)

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -352,7 +352,7 @@ pub struct Grid {
     pub should_render: bool,
     pub cursor_key_mode: bool, // DECCKM - when set, cursor keys should send ANSI direction codes (eg. "OD") instead of the arrow keys (eg. "[D")
     pub bracketed_paste_mode: bool, // when set, paste instructions to the terminal should be escaped with a special sequence
-    pub erasure_mode: bool,    // ERM
+    pub erasure_mode: bool,         // ERM
     pub insert_mode: bool,
     pub disable_linewrap: bool,
     pub clear_viewport_before_rendering: bool,

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -351,6 +351,7 @@ pub struct Grid {
     pub changed_colors: Option<[Option<AnsiCode>; 256]>,
     pub should_render: bool,
     pub cursor_key_mode: bool, // DECCKM - when set, cursor keys should send ANSI direction codes (eg. "OD") instead of the arrow keys (eg. "[D")
+    pub bracketed_paste_mode: bool, // when set, paste instructions to the terminal should be escaped with a special sequence
     pub erasure_mode: bool,    // ERM
     pub insert_mode: bool,
     pub disable_linewrap: bool,
@@ -390,6 +391,7 @@ impl Grid {
             height: rows,
             should_render: true,
             cursor_key_mode: false,
+            bracketed_paste_mode: false,
             erasure_mode: false,
             insert_mode: false,
             disable_linewrap: false,
@@ -1638,6 +1640,9 @@ impl Perform for Grid {
             };
             if first_intermediate_is_questionmark {
                 match params_iter.next().map(|param| param[0]) {
+                    Some(2004) => {
+                        self.bracketed_paste_mode = false;
+                    }
                     Some(1049) => {
                         if let Some((
                             alternative_lines_above,
@@ -1690,6 +1695,9 @@ impl Perform for Grid {
                     Some(25) => {
                         self.show_cursor();
                         self.mark_for_rerender();
+                    }
+                    Some(2004) => {
+                        self.bracketed_paste_mode = true;
                     }
                     Some(1049) => {
                         let current_lines_above = std::mem::replace(

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -144,6 +144,15 @@ impl Pane for TerminalPane {
                     return "OB".as_bytes().to_vec();
                 }
             }
+            [27, 91, 50, 48, 48, 126] | [27, 91, 50, 48, 49, 126] => {
+                if !self.grid.bracketed_paste_mode {
+                    // Zellij itself operates in bracketed paste mode, so the terminal sends these
+                    // instructions (bracketed paste start and bracketed paste end respectively)
+                    // when pasting input. We only need to make sure not to send them to terminal
+                    // panes who do not work in this mode
+                    return vec![];
+                }
+            }
             _ => {}
         };
         input_bytes


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/zellij-org/zellij/pull/653
We would be sending the bracketed paste instructions to terminals regarding of whether they requested them or not, which was causing some issues in eg. vim.