### PR TITLE
fix(compatibility): maintain original cursor shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Terminal compatibility: properly paste multilines (https://github.com/zellij-org/zellij/pull/653 + https://github.com/zellij-org/zellij/pull/658)
 * Terminal compatibility: fix progress bar line overflow (http://github.com/zellij-org/zellij/pull/656)
 * Add action to toggle between tabs `ToggleTab`, bound by default to [TAB] in tab mode (https://github.com/zellij-org/zellij/pull/622)
+* Terminal compatibility: properly handle cursor shape changes in eg. Neovim (https://github.com/zellij-org/zellij/pull/659)
 
 
 ## [0.15.0] - 2021-07-19

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1219,7 +1219,7 @@ impl Grid {
         self.active_charset = Default::default();
         self.erasure_mode = false;
         self.disable_linewrap = false;
-        self.cursor.change_shape(CursorShape::Block);
+        self.cursor.change_shape(CursorShape::Initial);
         self.output_buffer.update_all_lines();
         self.changed_colors = None;
     }
@@ -1821,7 +1821,8 @@ impl Perform for Grid {
                 // DECSCUSR (CSI Ps SP q) -- Set Cursor Style.
                 let cursor_style_id = next_param_or(0);
                 let shape = match cursor_style_id {
-                    0 | 2 => Some(CursorShape::Block),
+                    0 => Some(CursorShape::Initial),
+                    2 => Some(CursorShape::Block),
                     1 => Some(CursorShape::BlinkingBlock),
                     3 => Some(CursorShape::BlinkingUnderline),
                     4 => Some(CursorShape::Underline),

--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -724,6 +724,7 @@ impl IndexMut<CharsetIndex> for Charsets {
 
 #[derive(Clone, Copy, Debug)]
 pub enum CursorShape {
+    Initial,
     Block,
     BlinkingBlock,
     Underline,
@@ -750,7 +751,7 @@ impl Cursor {
             is_hidden: false,
             pending_styles: CharacterStyles::new(),
             charsets: Default::default(),
-            shape: CursorShape::Block,
+            shape: CursorShape::Initial,
         }
     }
     pub fn change_shape(&mut self, shape: CursorShape) {

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -344,7 +344,8 @@ impl Pane for TerminalPane {
     }
     fn cursor_shape_csi(&self) -> String {
         match self.grid.cursor_shape() {
-            CursorShape::Block => "\u{1b}[0 q".to_string(),
+            CursorShape::Initial => "\u{1b}[0 q".to_string(),
+            CursorShape::Block => "\u{1b}[2 q".to_string(),
             CursorShape::BlinkingBlock => "\u{1b}[1 q".to_string(),
             CursorShape::Underline => "\u{1b}[4 q".to_string(),
             CursorShape::BlinkingUnderline => "\u{1b}[3 q".to_string(),


### PR DESCRIPTION
Previously we treated the "block" cursor shape as the default, changing to it every time we received the `[0 q` CSI. But this is not the correct behaviour, as in some terminals the default shape is another one. This fixes the issue.

Fixes: https://github.com/zellij-org/zellij/issues/552