### PR TITLE
fix(tabs): force render by index rather than by position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+* Fix bug when opening new tab the new pane's viewport would sometimes be calculated incorrectly (https://github.com/zellij-org/zellij/pull/683)
+* Fix bug when in some cases closing a tab would not clear the previous pane's contents (https://github.com/zellij-org/zellij/pull/684)
 
 ## [0.16.0] - 2021-08-31
 * Plugins don't crash zellij anymore on receiving mouse events (https://github.com/zellij-org/zellij/pull/620)

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -266,7 +266,7 @@ impl Screen {
         } else {
             self.active_tab_index = self.tab_history.pop().unwrap();
             for t in self.tabs.values_mut() {
-                if t.position == self.active_tab_index.unwrap() {
+                if t.index == self.active_tab_index.unwrap() {
                     t.set_force_render()
                 }
                 if t.position > active_tab.position {


### PR DESCRIPTION
This fixes cases where sometimes on tab close the contents of the tab would stick around on the screen.

I think it's also a fix for https://github.com/zellij-org/zellij/issues/678