### PR TITLE
fix(tabs): use tab index for tab name

### DIFF
--- a/zellij-server/src/tab.rs
+++ b/zellij-server/src/tab.rs
@@ -268,7 +268,7 @@ impl Tab {
         let panes = BTreeMap::new();
 
         let name = if name.is_empty() {
-            format!("Tab #{}", position + 1)
+            format!("Tab #{}", index + 1)
         } else {
             name
         };


### PR DESCRIPTION
This PR fixes a small visual bug that causes tab names to have the same name if we close any tab that is not the last and create a new tab.

Previously, if we had tabs 2, 3, and created a new tab, we would end up with tabs 2, 3, 3. Now we get 2, 3, 4.

