### PR TITLE
fix(example) Update NewTab action in example/default.yaml to new syntax

### DIFF
--- a/example/default.yaml
+++ b/example/default.yaml
@@ -129,7 +129,7 @@ keybinds:
           key: [ Char: 'j',]
         - action: [GoToPreviousTab,]
           key: [ Char: 'k',]
-        - action: [NewTab,]
+        - action: [NewTab: ,]
           key: [ Char: 'n',]
         - action: [CloseTab,]
           key: [ Char: 'x',]


### PR DESCRIPTION
The default keybind file in the examples folder has a syntax error for the NewTab action. The file is being referenced in the docs so when copy pasting it (like I did) to customize off of it, zellij won't be able to read the config on start up.