### PR TITLE
Add support for scroll mode persistence

### DIFF
--- a/src/tests/e2e/remote_runner.rs
+++ b/src/tests/e2e/remote_runner.rs
@@ -2,7 +2,10 @@ use zellij_tile::data::Palette;
 
 use zellij_server::panes::TerminalPane;
 use zellij_utils::pane_size::{Dimension, PaneGeom, Size};
-use zellij_utils::{vte, zellij_tile};
+use zellij_utils::{
+    vte,
+    zellij_tile::{self, data::ModeInfo},
+};
 
 use ssh2::Session;
 use std::io::prelude::*;
@@ -207,7 +210,8 @@ impl RemoteRunner {
             rows,
             cols,
         };
-        let terminal_output = TerminalPane::new(0, pane_geom, Palette::default(), 0); // 0 is the pane index
+        let terminal_output =
+            TerminalPane::new(0, pane_geom, Palette::default(), 0, ModeInfo::default()); // 0 is the pane index
         setup_remote_environment(&mut channel, win_size);
         start_zellij(&mut channel);
         RemoteRunner {
@@ -238,7 +242,8 @@ impl RemoteRunner {
             rows,
             cols,
         };
-        let terminal_output = TerminalPane::new(0, pane_geom, Palette::default(), 0); // 0 is the pane index
+        let terminal_output =
+            TerminalPane::new(0, pane_geom, Palette::default(), 0, ModeInfo::default()); // 0 is the pane index
         setup_remote_environment(&mut channel, win_size);
         start_zellij_without_frames(&mut channel);
         RemoteRunner {
@@ -274,7 +279,8 @@ impl RemoteRunner {
             rows,
             cols,
         };
-        let terminal_output = TerminalPane::new(0, pane_geom, Palette::default(), 0); // 0 is the pane index
+        let terminal_output =
+            TerminalPane::new(0, pane_geom, Palette::default(), 0, ModeInfo::default()); // 0 is the pane index
         setup_remote_environment(&mut channel, win_size);
         start_zellij_with_layout(&mut channel, &remote_path.to_string_lossy());
         RemoteRunner {

--- a/zellij-client/src/unit/input_handler_tests.rs
+++ b/zellij-client/src/unit/input_handler_tests.rs
@@ -180,7 +180,7 @@ pub fn quit_breaks_input_loop() {
         options,
         command_is_executing,
         send_client_instructions,
-        default_mode,
+        Arc::new(Mutex::new(default_mode)),
     ));
     let expected_actions_sent_to_server = vec![Action::Quit];
     let received_actions = extract_actions_sent_to_server(events_sent_to_server);
@@ -216,7 +216,7 @@ pub fn move_focus_left_in_pane_mode() {
         options,
         command_is_executing,
         send_client_instructions,
-        default_mode,
+        Arc::new(Mutex::new(default_mode)),
     ));
     let expected_actions_sent_to_server =
         vec![Action::MoveFocusOrTab(Direction::Left), Action::Quit];
@@ -256,7 +256,7 @@ pub fn bracketed_paste() {
         options,
         command_is_executing,
         send_client_instructions,
-        default_mode,
+        Arc::new(Mutex::new(default_mode)),
     ));
     let expected_actions_sent_to_server = vec![
         Action::Write(commands::BRACKETED_PASTE_START.to_vec()),

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -15,7 +15,7 @@ use zellij_utils::{
     pane_size::{Dimension, PaneGeom},
     position::Position,
     vte,
-    zellij_tile::data::{Palette, PaletteColor},
+    zellij_tile::data::{ModeInfo, Palette, PaletteColor},
 };
 
 pub const SELECTION_SCROLL_INTERVAL_MS: u64 = 10;
@@ -45,6 +45,7 @@ pub struct TerminalPane {
     frame: Option<PaneFrame>,
     frame_color: Option<PaletteColor>,
     borderless: bool,
+    mode_info: ModeInfo,
 }
 
 impl Pane for TerminalPane {
@@ -89,6 +90,12 @@ impl Pane for TerminalPane {
     fn get_geom_override(&mut self, pane_geom: PaneGeom) {
         self.geom_override = Some(pane_geom);
         self.reflow_lines();
+    }
+    fn set_mode_info(&mut self, mode_info: ModeInfo) {
+        self.mode_info = mode_info;
+    }
+    fn get_mode_info(&self) -> Option<&ModeInfo> {
+        Some(&self.mode_info)
     }
     fn handle_pty_bytes(&mut self, bytes: VteBytes) {
         for byte in bytes.iter() {
@@ -407,6 +414,7 @@ impl TerminalPane {
         position_and_size: PaneGeom,
         palette: Palette,
         pane_index: usize,
+        mode_info: ModeInfo,
     ) -> TerminalPane {
         let initial_pane_title = format!("Pane #{}", pane_index);
         let grid = Grid::new(
@@ -415,6 +423,7 @@ impl TerminalPane {
             palette,
         );
         TerminalPane {
+            mode_info,
             frame: None,
             frame_color: None,
             content_offset: Offset::default(),

--- a/zellij-server/src/panes/unit/terminal_pane_tests.rs
+++ b/zellij-server/src/panes/unit/terminal_pane_tests.rs
@@ -2,7 +2,7 @@ use super::super::TerminalPane;
 use crate::tab::Pane;
 use ::insta::assert_snapshot;
 use zellij_utils::pane_size::PaneGeom;
-use zellij_utils::zellij_tile::data::Palette;
+use zellij_utils::zellij_tile::data::{ModeInfo, Palette};
 
 #[test]
 pub fn scrolling_inside_a_pane() {
@@ -12,7 +12,7 @@ pub fn scrolling_inside_a_pane() {
 
     let pid = 1;
     let palette = Palette::default();
-    let mut terminal_pane = TerminalPane::new(pid, fake_win_size, palette, 0); // 0 is the pane index
+    let mut terminal_pane = TerminalPane::new(pid, fake_win_size, palette, 0, ModeInfo::default()); // 0 is the pane index
     let mut text_to_fill_pane = String::new();
     for i in 0..30 {
         text_to_fill_pane.push_str(&format!("\rline {}\n", i + 1));

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -51,22 +51,11 @@ fn route_action(
             // to allow for this
             session
                 .senders
-                .send_to_plugin(PluginInstruction::Update(
-                    None,
-                    Event::ModeUpdate(get_mode_info(mode, palette, session.capabilities)),
-                ))
-                .unwrap();
-            session
-                .senders
                 .send_to_screen(ScreenInstruction::ChangeMode(get_mode_info(
                     mode,
                     palette,
                     session.capabilities,
                 )))
-                .unwrap();
-            session
-                .senders
-                .send_to_screen(ScreenInstruction::Render)
                 .unwrap();
         }
         Action::Resize(direction) => {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -435,16 +435,19 @@ impl Screen {
         let current_mode = active_tab.mode_info.mode;
 
         if current_mode != InputMode::Normal {
-            return
+            return;
         }
 
         let new_mode = active_tab.get_active_pane().and_then(|pane| {
-            pane.get_mode_info()
-                .and_then(|info| matches.iter().find_map(|test| if test == &info.mode {
-                    Some(info.clone())
-                } else {
-                    None
-                }))
+            pane.get_mode_info().and_then(|info| {
+                matches.iter().find_map(|test| {
+                    if test == &info.mode {
+                        Some(info.clone())
+                    } else {
+                        None
+                    }
+                })
+            })
         });
 
         if let Some(mode_info) = new_mode {
@@ -792,9 +795,7 @@ pub(crate) fn screen_thread_main(
     }
 }
 
-const DEFAULT_STICKY_MODES: &[InputMode; 1] = &[
-    InputMode::Scroll,
-];
+const DEFAULT_STICKY_MODES: &[InputMode; 1] = &[InputMode::Scroll];
 
 #[cfg(test)]
 #[path = "./unit/screen_tests.rs"]

--- a/zellij-server/src/tab.rs
+++ b/zellij-server/src/tab.rs
@@ -541,6 +541,17 @@ impl Tab {
         self.get_active_pane_id()
             .and_then(|ap| self.panes.get(&ap).map(Box::as_ref))
     }
+    pub fn get_active_pane_mut(&mut self) -> Option<&mut dyn Pane> {
+        let active = self
+            .get_active_pane_id()
+            .and_then(move |id| self.panes.get_mut(&id));
+
+        if let Some(pane) = active {
+            Some(pane.as_mut())
+        } else {
+            None
+        }
+    }
     fn get_active_pane_id(&self) -> Option<PaneId> {
         self.active_terminal
     }

--- a/zellij-server/src/tab.rs
+++ b/zellij-server/src/tab.rs
@@ -139,6 +139,10 @@ pub trait Pane {
     fn set_geom(&mut self, position_and_size: PaneGeom);
     fn get_geom_override(&mut self, pane_geom: PaneGeom);
     fn handle_pty_bytes(&mut self, bytes: VteBytes);
+    fn set_mode_info(&mut self, _mode_info: ModeInfo) {}
+    fn get_mode_info(&self) -> Option<&ModeInfo> {
+        None
+    }
     fn cursor_coordinates(&self) -> Option<(usize, usize)>;
     fn adjust_input_to_terminal(&self, input_bytes: Vec<u8>) -> Vec<u8>;
     fn position_and_size(&self) -> PaneGeom;
@@ -353,6 +357,7 @@ impl Tab {
                     *position_and_size,
                     self.colors,
                     next_terminal_position,
+                    self.mode_info.clone(),
                 );
                 new_pane.set_borderless(layout.borderless);
                 self.panes
@@ -438,6 +443,7 @@ impl Tab {
                         bottom_winsize,
                         self.colors,
                         next_terminal_position,
+                        self.mode_info.clone(),
                     );
                     terminal_to_split.set_geom(top_winsize);
                     self.panes.insert(pid, Box::new(new_terminal));
@@ -454,6 +460,7 @@ impl Tab {
                         right_winsize,
                         self.colors,
                         next_terminal_position,
+                        self.mode_info.clone(),
                     );
                     terminal_to_split.set_geom(left_winsize);
                     self.panes.insert(pid, Box::new(new_terminal));
@@ -487,6 +494,7 @@ impl Tab {
                     bottom_winsize,
                     self.colors,
                     next_terminal_position,
+                    self.mode_info.clone(),
                 );
                 active_pane.set_geom(top_winsize);
                 self.panes.insert(pid, Box::new(new_terminal));
@@ -514,8 +522,13 @@ impl Tab {
             }
             let terminal_ws = active_pane.position_and_size();
             if let Some((left_winsize, right_winsize)) = split(Direction::Vertical, &terminal_ws) {
-                let new_terminal =
-                    TerminalPane::new(term_pid, right_winsize, self.colors, next_terminal_position);
+                let new_terminal = TerminalPane::new(
+                    term_pid,
+                    right_winsize,
+                    self.colors,
+                    next_terminal_position,
+                    self.mode_info.clone(),
+                );
                 active_pane.set_geom(left_winsize);
                 self.panes.insert(pid, Box::new(new_terminal));
             }

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -56,7 +56,7 @@ impl ServerOsApi for FakeInputOutput {
         unimplemented!()
     }
     fn send_to_client(&self, _msg: ServerToClientMsg) {
-        unimplemented!()
+        //unimplemented!()
     }
     fn add_client_sender(&self) {
         unimplemented!()

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -261,6 +261,7 @@ pub enum ClientContext {
     UnblockInputThread,
     Render,
     ServerError,
+    SetInputMode,
 }
 
 /// Stack call representations corresponding to the different types of [`ServerInstruction`]s.

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -16,7 +16,7 @@ use std::{
     os::unix::io::{AsRawFd, FromRawFd},
 };
 
-use zellij_tile::data::Palette;
+use zellij_tile::data::{InputMode, Palette};
 
 type SessionId = u64;
 
@@ -71,6 +71,7 @@ pub enum ServerToClientMsg {
     SessionInfo(Session),
     // A list of sessions
     SessionList(HashSet<Session>),*/
+    SetInputMode(InputMode),
     Render(String),
     UnblockInputThread,
     Exit(ExitReason),


### PR DESCRIPTION
This PR implements persisting the scroll mode for a pane after focusing a different pane and then moving back into it.

This resolves issue #638.