### PR TITLE
feat(keybinding): Introduce a pseudo `All` mode to define keybindings for all real input modes

### DIFF
--- a/default-plugins/status-bar/src/first_line.rs
+++ b/default-plugins/status-bar/src/first_line.rs
@@ -246,6 +246,7 @@ pub fn superkey(palette: ColoredElements, separator: &str) -> LinePart {
 pub fn ctrl_keys(help: &ModeInfo, max_len: usize, separator: &str) -> LinePart {
     let colored_elements = color_elements(help.palette);
     match &help.mode {
+        InputMode::All => Default::default(),
         InputMode::Locked => key_indicators(
             max_len,
             &[

--- a/zellij-tile/src/data.rs
+++ b/zellij-tile/src/data.rs
@@ -40,6 +40,10 @@ pub enum Event {
 /// Describes the different input modes, which change the way that keystrokes will be interpreted.
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, EnumIter, Serialize, Deserialize)]
 pub enum InputMode {
+    /// `All` is a pseudo mode, any key bindings in this mode will be added to other real modes.
+    /// This is usually used for common key binding definition.
+    #[serde(alias = "all")]
+    All,
     /// In `Normal` mode, input is always written to the terminal, except for the shortcuts leading
     /// to other modes
     #[serde(alias = "normal")]

--- a/zellij-utils/src/input/keybinds.rs
+++ b/zellij-utils/src/input/keybinds.rs
@@ -247,6 +247,14 @@ impl From<KeybindsFromYaml> for Keybinds {
             }
             keybinds.0.insert(mode, mode_keybinds);
         }
+
+        // Apply `all` keybinds to all the other modes if any
+        if let Some(all) = keybinds.0.remove(&InputMode::All) {
+            for mode_keybinds in keybinds.0.values_mut() {
+                mode_keybinds.0.extend(all.clone().0);
+            }
+        }
+
         keybinds
     }
 }

--- a/zellij-utils/src/input/mod.rs
+++ b/zellij-utils/src/input/mod.rs
@@ -20,7 +20,7 @@ pub fn get_mode_info(
     capabilities: PluginCapabilities,
 ) -> ModeInfo {
     let keybinds = match mode {
-        InputMode::Normal | InputMode::Locked => Vec::new(),
+        InputMode::Normal | InputMode::Locked | InputMode::All => Vec::new(),
         InputMode::Resize => vec![("←↓↑→".to_string(), "Resize".to_string())],
         InputMode::Pane => vec![
             ("←↓↑→".to_string(), "Move focus".to_string()),


### PR DESCRIPTION
With this patch you could define some sort of global key bindings, they'll be used no matter which mode you're in currently.
