### PR TITLE
Various clippy fixes

### DIFF
--- a/src/tests/e2e/cases.rs
+++ b/src/tests/e2e/cases.rs
@@ -157,7 +157,7 @@ pub fn cannot_split_terminals_vertically_when_active_terminal_is_too_small() {
         instruction: |mut remote_terminal: RemoteTerminal| -> bool {
             // this is just normal input that should be sent into the one terminal so that we can make
             // sure we silently failed to split in the previous step
-            remote_terminal.send_key(&"Hi!".as_bytes());
+            remote_terminal.send_key("Hi!".as_bytes());
             true
         },
     })
@@ -205,26 +205,26 @@ pub fn scrolling_inside_a_pane() {
                 let mut step_is_complete = false;
                 if remote_terminal.cursor_position_is(63, 2) && remote_terminal.tip_appears() {
                     // cursor is in the newly opened second pane
-                    remote_terminal.send_key(&format!("{:0<56}", "line1 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line2 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line3 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line4 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line5 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line6 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line7 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line8 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line9 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line10 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line11 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line12 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line13 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line14 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line15 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line16 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line17 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line18 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line19 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<57}", "line20 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<56}", "line1 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line2 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line3 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line4 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line5 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line6 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line7 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line8 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line9 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line10 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line11 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line12 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line13 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line14 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line15 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line16 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line17 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line18 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line19 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<57}", "line20 ").as_bytes());
                     step_is_complete = true;
                 }
                 step_is_complete
@@ -574,7 +574,7 @@ pub fn lock_mode() {
                 if remote_terminal.snapshot_contains("INTERFACE LOCKED") {
                     remote_terminal.send_key(&TAB_MODE);
                     remote_terminal.send_key(&NEW_TAB_IN_TAB_MODE);
-                    remote_terminal.send_key(&"abc".as_bytes());
+                    remote_terminal.send_key("abc".as_bytes());
                     step_is_complete = true;
                 }
                 step_is_complete
@@ -675,7 +675,7 @@ pub fn detach_and_attach_session() {
                 let mut step_is_complete = false;
                 if remote_terminal.cursor_position_is(63, 2) && remote_terminal.tip_appears() {
                     // new pane has been opened and focused
-                    remote_terminal.send_key(&"I am some text".as_bytes());
+                    remote_terminal.send_key("I am some text".as_bytes());
                     step_is_complete = true;
                 }
                 step_is_complete
@@ -825,26 +825,26 @@ pub fn scrolling_inside_a_pane_with_mouse() {
                 let mut step_is_complete = false;
                 if remote_terminal.cursor_position_is(63, 2) && remote_terminal.tip_appears() {
                     // cursor is in the newly opened second pane
-                    remote_terminal.send_key(&format!("{:0<56}", "line1 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line2 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line3 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line4 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line5 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line6 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line7 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line8 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line9 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line10 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line11 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line12 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line13 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line14 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line15 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line16 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line17 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line18 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<58}", "line19 ").as_bytes());
-                    remote_terminal.send_key(&format!("{:0<57}", "line20 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<56}", "line1 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line2 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line3 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line4 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line5 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line6 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line7 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line8 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line9 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line10 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line11 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line12 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line13 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line14 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line15 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line16 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line17 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line18 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<58}", "line19 ").as_bytes());
+                    remote_terminal.send_key(format!("{:0<57}", "line20 ").as_bytes());
                     step_is_complete = true;
                 }
                 step_is_complete

--- a/src/tests/e2e/remote_runner.rs
+++ b/src/tests/e2e/remote_runner.rs
@@ -34,9 +34,7 @@ fn setup_remote_environment(channel: &mut ssh2::Channel, win_size: Size) {
         .request_pty("xterm", None, Some((columns, rows, 0, 0)))
         .unwrap();
     channel.shell().unwrap();
-    channel
-        .write_all(format!("export PS1=\"$ \"\n").as_bytes())
-        .unwrap();
+    channel.write_all("export PS1=\"$ \"\n".as_bytes()).unwrap();
     channel.flush().unwrap();
 }
 

--- a/src/tests/e2e/remote_runner.rs
+++ b/src/tests/e2e/remote_runner.rs
@@ -154,7 +154,7 @@ impl<'a> RemoteTerminal<'a> {
         format!("x: {}, y: {}", self.cursor_x, self.cursor_y)
     }
     pub fn send_key(&mut self, key: &[u8]) {
-        self.channel.write(key).unwrap();
+        self.channel.write_all(key).unwrap();
         self.channel.flush().unwrap();
     }
     pub fn change_size(&mut self, cols: u32, rows: u32) {

--- a/zellij-client/src/unit/input_handler_tests.rs
+++ b/zellij-client/src/unit/input_handler_tests.rs
@@ -110,8 +110,7 @@ impl ClientOsApi for FakeClientOsApi {
         if stdin_events.is_empty() {
             panic!("ran out of stdin events!");
         }
-        let next_event = stdin_events.remove(0);
-        next_event
+        stdin_events.remove(0)
     }
     fn box_clone(&self) -> Box<dyn ClientOsApi> {
         unimplemented!()
@@ -174,14 +173,14 @@ pub fn quit_breaks_input_loop() {
     let send_client_instructions = SenderWithContext::new(send_client_instructions);
 
     let default_mode = InputMode::Normal;
-    drop(input_loop(
+    input_loop(
         client_os_api,
         config,
         options,
         command_is_executing,
         send_client_instructions,
         default_mode,
-    ));
+    );
     let expected_actions_sent_to_server = vec![Action::Quit];
     let received_actions = extract_actions_sent_to_server(events_sent_to_server);
     assert_eq!(
@@ -192,8 +191,7 @@ pub fn quit_breaks_input_loop() {
 
 #[test]
 pub fn move_focus_left_in_pane_mode() {
-    let mut stdin_events = vec![];
-    stdin_events.push(commands::MOVE_FOCUS_LEFT_IN_NORMAL_MODE.to_vec());
+    let stdin_events = vec![commands::MOVE_FOCUS_LEFT_IN_NORMAL_MODE.to_vec()];
     let events_sent_to_server = Arc::new(Mutex::new(vec![]));
     let command_is_executing = CommandIsExecuting::new();
     let client_os_api = Box::new(FakeClientOsApi::new(
@@ -210,14 +208,14 @@ pub fn move_focus_left_in_pane_mode() {
     let send_client_instructions = SenderWithContext::new(send_client_instructions);
 
     let default_mode = InputMode::Normal;
-    drop(input_loop(
+    input_loop(
         client_os_api,
         config,
         options,
         command_is_executing,
         send_client_instructions,
         default_mode,
-    ));
+    );
     let expected_actions_sent_to_server =
         vec![Action::MoveFocusOrTab(Direction::Left), Action::Quit];
     let received_actions = extract_actions_sent_to_server(events_sent_to_server);
@@ -250,14 +248,14 @@ pub fn bracketed_paste() {
     let send_client_instructions = SenderWithContext::new(send_client_instructions);
 
     let default_mode = InputMode::Normal;
-    drop(input_loop(
+    input_loop(
         client_os_api,
         config,
         options,
         command_is_executing,
         send_client_instructions,
         default_mode,
-    ));
+    );
     let expected_actions_sent_to_server = vec![
         Action::Write(commands::BRACKETED_PASTE_START.to_vec()),
         Action::Write(commands::MOVE_FOCUS_LEFT_IN_NORMAL_MODE.to_vec()), // keys were directly written to server and not interpreted

--- a/zellij-server/src/logging_pipe.rs
+++ b/zellij-server/src/logging_pipe.rs
@@ -149,7 +149,7 @@ mod logging_pipe_test {
 
         let test_buffer = "Testing write".as_bytes();
 
-        pipe.write(test_buffer).expect("Err write");
+        pipe.write_all(test_buffer).expect("Err write");
         pipe.flush().expect("Err flush");
 
         assert_eq!(pipe.buffer.len(), test_buffer.len());
@@ -161,7 +161,7 @@ mod logging_pipe_test {
 
         let test_buffer = "Testing write \n".as_bytes();
 
-        pipe.write(test_buffer).expect("Err write");
+        pipe.write_all(test_buffer).expect("Err write");
         pipe.flush().expect("Err flush");
 
         assert_eq!(pipe.buffer.len(), 0);
@@ -174,7 +174,7 @@ mod logging_pipe_test {
         let test_buffer = "Testing write \n".as_bytes();
         let test_buffer2 = "And the rest".as_bytes();
 
-        pipe.write(
+        pipe.write_all(
             [
                 test_buffer,
                 test_buffer,
@@ -197,7 +197,7 @@ mod logging_pipe_test {
 
         let test_buffer = "Testing write \n".as_bytes();
 
-        pipe.write(
+        pipe.write_all(
             [
                 test_buffer,
                 test_buffer,
@@ -223,7 +223,7 @@ mod logging_pipe_test {
         // make sure it's not valid utf-8 string if we drop last symbol
         assert!(std::str::from_utf8(&test_buffer[..test_buffer.len() - 1]).is_err());
 
-        pipe.write(&test_buffer[..test_buffer.len() - 1])
+        pipe.write_all(&test_buffer[..test_buffer.len() - 1])
             .expect("Err write");
         pipe.flush().expect("Err flush");
 
@@ -237,7 +237,7 @@ mod logging_pipe_test {
         let mut pipe = LoggingPipe::new("TestPipe", 0);
         let test_buffer = "Testing write \n".as_bytes();
 
-        pipe.write(
+        pipe.write_all(
             [test_buffer, test_buffer, b"\n", b"\n", b"\n"]
                 .concat()
                 .as_slice(),

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -8,9 +8,8 @@ fn read_fixture(fixture_name: &str) -> Vec<u8> {
     path_to_file.push("tests");
     path_to_file.push("fixtures");
     path_to_file.push(fixture_name);
-    let content = std::fs::read(path_to_file)
-        .unwrap_or_else(|_| panic!("could not read fixture {:?}", &fixture_name));
-    content
+    std::fs::read(path_to_file)
+        .unwrap_or_else(|_| panic!("could not read fixture {:?}", &fixture_name))
 }
 
 #[test]

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -79,8 +79,10 @@ fn create_new_screen(size: Size) -> Screen {
     let mut bus: Bus<ScreenInstruction> = Bus::empty();
     let fake_os_input = FakeInputOutput {};
     bus.os_input = Some(Box::new(fake_os_input));
-    let mut client_attributes = ClientAttributes::default();
-    client_attributes.size = size;
+    let client_attributes = ClientAttributes {
+        size,
+        ..Default::default()
+    };
     let max_panes = None;
     let mode_info = ModeInfo::default();
     let session_state = Arc::new(RwLock::new(SessionState::Attached));

--- a/zellij-utils/src/input/config.rs
+++ b/zellij-utils/src/input/config.rs
@@ -275,8 +275,10 @@ mod config_test {
     #[test]
     fn try_from_cli_args_with_config() {
         let arbitrary_config = PathBuf::from("nonexistent.yaml");
-        let mut opts = CliArgs::default();
-        opts.config = Some(arbitrary_config);
+        let opts = CliArgs {
+            config: Some(arbitrary_config),
+            ..Default::default()
+        };
         println!("OPTS= {:?}", opts);
         let result = Config::try_from(&opts);
         assert!(result.is_err());
@@ -285,11 +287,13 @@ mod config_test {
     #[test]
     fn try_from_cli_args_with_option_clean() {
         use crate::setup::Setup;
-        let mut opts = CliArgs::default();
-        opts.command = Some(Command::Setup(Setup {
-            clean: true,
-            ..Setup::default()
-        }));
+        let opts = CliArgs {
+            command: Some(Command::Setup(Setup {
+                clean: true,
+                ..Setup::default()
+            })),
+            ..Default::default()
+        };
         let result = Config::try_from(&opts);
         assert!(result.is_ok());
     }

--- a/zellij-utils/src/input/unit/keybinds_test.rs
+++ b/zellij-utils/src/input/unit/keybinds_test.rs
@@ -92,7 +92,7 @@ fn merge_keybinds_overwrites_same_keys() {
     let mut keybinds_self = Keybinds::new();
     keybinds_self
         .0
-        .insert(InputMode::Normal, mode_keybinds_self.clone());
+        .insert(InputMode::Normal, mode_keybinds_self);
     let mut keybinds_other = Keybinds::new();
     keybinds_other
         .0
@@ -152,7 +152,7 @@ fn no_unbind_unbinds_none() {
 fn last_keybind_is_taken() {
     let actions_1 = vec![Action::NoOp, Action::NewTab(None)];
     let keyaction_1 = KeyActionFromYaml {
-        action: actions_1.clone(),
+        action: actions_1,
         key: vec![Key::F(1), Key::Backspace, Key::Char('t')],
     };
     let actions_2 = vec![Action::GoToTab(1)];
@@ -184,7 +184,7 @@ fn last_keybind_overwrites() {
 
     let mut expected = ModeKeybinds::new();
     expected.0.insert(Key::F(1), actions_2.clone());
-    expected.0.insert(Key::Backspace, actions_1.clone());
+    expected.0.insert(Key::Backspace, actions_1);
     expected.0.insert(Key::Char('t'), actions_2);
 
     assert_eq!(expected, ModeKeybinds::from(vec![keyaction_1, keyaction_2]));


### PR DESCRIPTION
I split this into two commits, as unused_io_amount is a correctness fix while the others are mostly style.

Fixes unusused_io_amount, needless_borrow, let_and_return, vec_init_then_push, unit_arg, useless_format, field_reassign_with_default, redundant_clone.