### PR TITLE
Calculate width with unicode-width in tab-bar and utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2708,6 +2708,7 @@ dependencies = [
  "strum",
  "tempfile",
  "termion",
+ "unicode-width",
  "vte 0.10.1",
  "zellij-tile",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1981,6 +1981,7 @@ version = "0.1.0"
 dependencies = [
  "ansi_term 0.12.1",
  "colored",
+ "unicode-width",
  "zellij-tile",
  "zellij-tile-utils",
 ]

--- a/default-plugins/tab-bar/Cargo.toml
+++ b/default-plugins/tab-bar/Cargo.toml
@@ -8,5 +8,6 @@ license = "MIT"
 [dependencies]
 colored = "2"
 ansi_term = "0.12"
+unicode-width = "0.1.8"
 zellij-tile = { path = "../../zellij-tile" }
 zellij-tile-utils = { path = "../../zellij-tile-utils" }

--- a/default-plugins/tab-bar/src/line.rs
+++ b/default-plugins/tab-bar/src/line.rs
@@ -1,4 +1,5 @@
 use ansi_term::ANSIStrings;
+use unicode_width::UnicodeWidthStr;
 
 use crate::{LinePart, ARROW_SEPARATOR};
 use zellij_tile::prelude::*;
@@ -100,7 +101,7 @@ fn left_more_message(tab_count_to_the_left: usize, palette: Palette, separator: 
     };
     // 238
     // chars length plus separator length on both sides
-    let more_text_len = more_text.chars().count() + 2 * separator.chars().count();
+    let more_text_len = more_text.width() + 2 * separator.width();
     let left_separator = style!(palette.cyan, palette.orange).paint(separator);
     let more_styled_text = style!(palette.black, palette.orange)
         .bold()
@@ -130,7 +131,7 @@ fn right_more_message(
         " +many → ".to_string()
     };
     // chars length plus separator length on both sides
-    let more_text_len = more_text.chars().count() + 2 * separator.chars().count();
+    let more_text_len = more_text.width() + 2 * separator.width();
     let left_separator = style!(palette.cyan, palette.orange).paint(separator);
     let more_styled_text = style!(palette.black, palette.orange)
         .bold()
@@ -159,7 +160,7 @@ fn tab_line_prefix(session_name: Option<&str>, palette: Palette, cols: usize) ->
     }];
     if let Some(name) = session_name {
         let name_part = format!("({}) ", name);
-        let name_part_len = name_part.chars().count();
+        let name_part_len = name_part.width();
         let name_part_styled_text = style!(palette.white, palette.cyan).bold().paint(name_part);
         if cols.saturating_sub(prefix_text_len) >= name_part_len {
             parts.push(LinePart {

--- a/default-plugins/tab-bar/src/tab.rs
+++ b/default-plugins/tab-bar/src/tab.rs
@@ -1,11 +1,12 @@
 use crate::{line::tab_separator, LinePart};
 use ansi_term::ANSIStrings;
+use unicode_width::UnicodeWidthStr;
 use zellij_tile::prelude::*;
 use zellij_tile_utils::style;
 
 pub fn active_tab(text: String, palette: Palette, separator: &str) -> LinePart {
     let left_separator = style!(palette.cyan, palette.green).paint(separator);
-    let tab_text_len = text.chars().count() + 2 + separator.chars().count() * 2; // 2 for left and right separators, 2 for the text padding
+    let tab_text_len = text.width() + 2 + separator.width() * 2; // 2 for left and right separators, 2 for the text padding
     let tab_styled_text = style!(palette.black, palette.green)
         .bold()
         .paint(format!(" {} ", text));
@@ -22,7 +23,7 @@ pub fn active_tab(text: String, palette: Palette, separator: &str) -> LinePart {
 
 pub fn non_active_tab(text: String, palette: Palette, separator: &str) -> LinePart {
     let left_separator = style!(palette.cyan, palette.fg).paint(separator);
-    let tab_text_len = text.chars().count() + 2 + separator.chars().count() * 2; // 2 for left and right separators, 2 for the text padding
+    let tab_text_len = text.width() + 2 + separator.width() * 2; // 2 for left and right separators, 2 for the text padding
     let tab_styled_text = style!(palette.black, palette.fg)
         .bold()
         .paint(format!(" {} ", text));

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -30,6 +30,7 @@ vte = "0.10.1"
 zellij-tile = { path = "../zellij-tile/", version = "0.17.0" }
 log = "0.4.14"
 log4rs = "1.0.0"
+unicode-width = "0.1.8"
 
 [dependencies.async-std]
 version = "1.3.0"

--- a/zellij-utils/src/shared.rs
+++ b/zellij-utils/src/shared.rs
@@ -7,6 +7,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::{fs, io};
 use strip_ansi_escapes::strip;
+use unicode_width::UnicodeWidthStr;
 use zellij_tile::data::{Palette, PaletteColor, PaletteSource, ThemeHue};
 
 const UNIX_PERMISSIONS: u32 = 0o700;
@@ -18,10 +19,7 @@ pub fn set_permissions(path: &Path) -> io::Result<()> {
 }
 
 pub fn ansi_len(s: &str) -> usize {
-    from_utf8(&strip(s.as_bytes()).unwrap())
-        .unwrap()
-        .chars()
-        .count()
+    from_utf8(&strip(s.as_bytes()).unwrap()).unwrap().width()
 }
 
 pub fn adjust_to_size(s: &str, rows: usize, columns: usize) -> String {


### PR DESCRIPTION
In preparation for tab names from layout files #706, we need to account for wide characters.

After changing tab-bar, this was the result (notice the line below tab bar).

![screenshot-2021-09-11 16:49:13+01:00](https://user-images.githubusercontent.com/9609090/132958608-ea19dd36-9c89-4aa8-abf5-927cbc14a8e8.png)

The culprit was in zellij-utils, using unicode-width in ansi_len fixed it.