### PR TITLE
Improve handling of empty valid `yaml` files

### DIFF
--- a/zellij-utils/src/input/config.rs
+++ b/zellij-utils/src/input/config.rs
@@ -99,16 +99,21 @@ impl TryFrom<&CliArgs> for Config {
 impl Config {
     /// Uses defaults, but lets config override them.
     pub fn from_yaml(yaml_config: &str) -> ConfigResult {
-        let config_from_yaml: ConfigFromYaml = serde_yaml::from_str(yaml_config)?;
-        let keybinds = Keybinds::get_default_keybinds_with_config(config_from_yaml.keybinds);
-        let options = Options::from_yaml(config_from_yaml.options);
-        let themes = config_from_yaml.themes;
+        let config_from_yaml: Option<ConfigFromYaml> = serde_yaml::from_str(yaml_config)?;
 
-        Ok(Config {
-            keybinds,
-            options,
-            themes,
-        })
+        match config_from_yaml {
+            None => Ok(Config::default()),
+            Some(config) => {
+                let keybinds = Keybinds::get_default_keybinds_with_config(config.keybinds);
+                let options = Options::from_yaml(config.options);
+                let themes = config.themes;
+                Ok(Config {
+                    keybinds,
+                    options,
+                    themes,
+                })
+            }
+        }
     }
 
     /// Deserializes from given path.

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -103,9 +103,12 @@ impl LayoutFromYaml {
 
         let mut layout = String::new();
         layout_file.read_to_string(&mut layout)?;
-        let layout: LayoutFromYaml = serde_yaml::from_str(&layout)?;
+        let layout: Option<LayoutFromYaml> = serde_yaml::from_str(&layout)?;
 
-        Ok(layout)
+        match layout {
+            Some(layout) => Ok(layout),
+            None => Ok(LayoutFromYaml::default()),
+        }
     }
 
     // It wants to use Path here, but that doesn't compile.


### PR DESCRIPTION
Improves the way empty valid `yaml` files are handled.
When deserializing a `config` or `layout` file, that is
an empty valid `yaml` file, eg:

```
---
```

We now assume the default configuration is desired.