### PR TITLE
Feature attach options

### DIFF
--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -86,6 +86,7 @@ pub fn start_client(
     mut os_input: Box<dyn ClientOsApi>,
     opts: CliArgs,
     config: Config,
+    config_options: Options,
     info: ClientInfo,
     layout: Option<LayoutFromYaml>,
 ) {
@@ -105,7 +106,6 @@ pub fn start_client(
         .unwrap();
     std::env::set_var(&"ZELLIJ", "0");
 
-    let config_options = Options::from_cli(&config.options, opts.command.clone());
     let palette = config.themes.clone().map_or_else(
         || os_input.load_palette(),
         |t| {

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -63,6 +63,13 @@ pub enum Command {
 }
 
 #[derive(Debug, StructOpt, Clone, Serialize, Deserialize)]
+pub enum SessionCommand {
+    /// Change the behaviour of zellij
+    #[structopt(name = "options")]
+    Options(Options),
+}
+
+#[derive(Debug, StructOpt, Clone, Serialize, Deserialize)]
 pub enum Sessions {
     /// List active sessions
     #[structopt(alias = "ls")]
@@ -78,5 +85,8 @@ pub enum Sessions {
         /// zellij client (if any) and attach to this.
         #[structopt(long, short)]
         force: bool,
+        /// Change the behaviour of zellij
+        #[structopt(subcommand, name = "options")]
+        options: Option<SessionCommand>,
     },
 }


### PR DESCRIPTION
 Add options subcommand to attach

fixes #688

- the `options` subcommand of `attach` functions the same,
  as the `options` subcommand of creating the normal session,
  but not every option will have an effect on reattaching,
  for example the `default_mode` setting would make no sense
  to switch.

  In the future it would make sense to be able to hot swap some
  of the options on reattach, but we are not able to do that yet,
  for example the `default_shell` one.

  Eg:

  ```
  zellij attach <session-name> options --theme <theme>
  ```