### PR TITLE
feat(config): Allow empty config files

### DIFF
--- a/zellij-utils/src/input/config.rs
+++ b/zellij-utils/src/input/config.rs
@@ -99,7 +99,17 @@ impl TryFrom<&CliArgs> for Config {
 impl Config {
     /// Uses defaults, but lets config override them.
     pub fn from_yaml(yaml_config: &str) -> ConfigResult {
-        let config_from_yaml: Option<ConfigFromYaml> = serde_yaml::from_str(yaml_config)?;
+        let config_from_yaml: Option<ConfigFromYaml> = match serde_yaml::from_str(yaml_config) {
+            Err(e) => {
+                // needs direct check, as `[ErrorImpl]` is private
+                // https://github.com/dtolnay/serde-yaml/issues/121
+                if yaml_config.is_empty() {
+                    return Ok(Config::default());
+                }
+                return Err(ConfigError::Serde(e));
+            }
+            Ok(config) => config,
+        };
 
         match config_from_yaml {
             None => Ok(Config::default()),

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -103,7 +103,17 @@ impl LayoutFromYaml {
 
         let mut layout = String::new();
         layout_file.read_to_string(&mut layout)?;
-        let layout: Option<LayoutFromYaml> = serde_yaml::from_str(&layout)?;
+        let layout: Option<LayoutFromYaml> = match serde_yaml::from_str(&layout) {
+            Err(e) => {
+                // needs direct check, as `[ErrorImpl]` is private
+                // https://github.com/dtolnay/serde-yaml/issues/121
+                if layout.is_empty() {
+                    return Ok(LayoutFromYaml::default());
+                }
+                return Err(ConfigError::Serde(e));
+            }
+            Ok(config) => config,
+        };
 
         match layout {
             Some(layout) => Ok(layout),


### PR DESCRIPTION
Fix #714
Fix #756

Allow empty `config` and `layout` files

- Currently empty files are parsed as yaml documents, since they
  are empty they are invalid yaml files and a deseralization error would
  follow.

  Now we ignore the incorrect yaml on an empty document and treat it as
  an empty yaml document.

  Eg:
  ```
  ```
  and
  ```
  ---
  ```

  Are now treated equally.

Alternative: Keep treating the files as `yaml` documents.