### PR TITLE
Fix prompt line overflowing when resizing panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Improve handling of empty valid `yaml` files (https://github.com/zellij-org/zellij/pull/716)
 * Add options subcommand to attach (https://github.com/zellij-org/zellij/pull/718)
 * Fix: do not pad empty pane frame title (https://github.com/zellij-org/zellij/pull/724)
+* Fix: Do not overflow empty lines when resizing panes (https://github.com/zellij-org/zellij/pull/725)
 
 
 ## [0.16.0] - 2021-08-31

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -2218,19 +2218,6 @@ impl Row {
     pub fn is_empty(&self) -> bool {
         self.columns.is_empty()
     }
-    pub fn is_blank(&self) -> bool {
-        self.columns.iter().fold(true, |is_empty, character| {
-            if !is_empty {
-                return false;
-            } else {
-                if character.character == EMPTY_TERMINAL_CHARACTER.character {
-                    return true;
-                } else {
-                    return false;
-                }
-            }
-        })
-    }
     pub fn delete_and_return_character(&mut self, x: usize) -> Option<TerminalCharacter> {
         if x < self.columns.len() {
             Some(self.columns.remove(x))

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -665,6 +665,19 @@ impl Grid {
                 }
                 new_viewport_rows.append(&mut canonical_line_parts);
             }
+            let mut last_blank_row_index = None;
+            for (i, row) in new_viewport_rows.iter().enumerate() {
+                if row.is_blank() {
+                    if last_blank_row_index.is_none() {
+                        last_blank_row_index = Some(i);
+                    }
+                } else {
+                    last_blank_row_index = None;
+                }
+            }
+            if let Some(last_blank_row_index) = last_blank_row_index {
+                new_viewport_rows.truncate(std::cmp::max(last_blank_row_index, self.cursor.y));
+            }
             self.viewport = new_viewport_rows;
 
             let mut new_cursor_y = self.canonical_line_y_coordinates(cursor_canonical_line_index);

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -527,8 +527,8 @@ impl Grid {
         for (i, line) in self.viewport.iter().enumerate() {
             if line.is_canonical {
                 canonical_lines_traversed += 1;
+                y_coordinates = i;
                 if canonical_lines_traversed == canonical_line_index + 1 {
-                    y_coordinates = i;
                     break;
                 }
             }
@@ -628,6 +628,13 @@ impl Grid {
                     }
                 }
             }
+            for line in viewport_canonical_lines.iter_mut() {
+                if line.is_blank() {
+                    if line.columns.len() > new_columns {
+                        line.columns.drain(..new_columns);
+                    }
+                }
+            }
             let mut new_viewport_rows = vec![];
             for mut canonical_line in viewport_canonical_lines {
                 let mut canonical_line_parts: Vec<Row> = vec![];
@@ -661,6 +668,7 @@ impl Grid {
             self.viewport = new_viewport_rows;
 
             let mut new_cursor_y = self.canonical_line_y_coordinates(cursor_canonical_line_index);
+
             let new_cursor_x = (cursor_index_in_canonical_line / new_columns)
                 + (cursor_index_in_canonical_line % new_columns);
             let current_viewport_row_count = self.viewport.len();
@@ -2198,6 +2206,19 @@ impl Row {
     }
     pub fn is_empty(&self) -> bool {
         self.columns.is_empty()
+    }
+    pub fn is_blank(&self) -> bool {
+        self.columns.iter().fold(true, |is_empty, character| {
+            if !is_empty {
+                return false;
+            } else {
+                if character.character == EMPTY_TERMINAL_CHARACTER.character {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+        })
     }
     pub fn delete_and_return_character(&mut self, x: usize) -> Option<TerminalCharacter> {
         if x < self.columns.len() {

--- a/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__clear_scroll_region.snap
+++ b/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__clear_scroll_region.snap
@@ -3,7 +3,7 @@ source: zellij-server/src/panes/./unit/grid_tests.rs
 expression: "format!(\"{:?}\", grid)"
 
 ---
-00 (C): Welcome to fish, the friendly interactive shell                                                                     
+00 (C): Welcome to fish, the friendly interactive shell
 01 (C): ⋊> ~/c/mosaic on main ⨯ vim some-file                                                                       15:07:22
 02 (C): ⋊> ~/c/mosaic on main ⨯                                                                                     15:07:29
 

--- a/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__emacs_longbuf.snap
+++ b/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__emacs_longbuf.snap
@@ -3,8 +3,8 @@ source: zellij-server/src/panes/./unit/grid_tests.rs
 expression: "format!(\"{:?}\", grid)"
 
 ---
-00 (C): ➜  mosaic git:(mosaic#130) emacs                                                                                                                                                                                                                                                            
-01 (C): ➜  mosaic git:(mosaic#130) emacs -nw                                                                                                                                                                                                                                                        
+00 (C): ➜  mosaic git:(mosaic#130) emacs
+01 (C): ➜  mosaic git:(mosaic#130) emacs -nw
 02 (C): ➜  mosaic git:(mosaic#130) exit                                                                                                                                                                                                                                                             
 03 (C): 
 


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/321

This makes sure we do not wrap empty lines when resizing panes.