### PR TITLE
fix(makefile): build-plugins on building dev-dir

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -47,13 +47,15 @@ args = ["build"]
 args = ["build", "--release"]
 
 [tasks.build-dev-data-dir]
+dependencies = ["build-plugins"]
 script_runner = "@duckscript"
 script = '''
-asset_dir = set ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/assets
 target_dir = set ${CARGO_TARGET_DIR}
 data_dir = set ${target_dir}/dev-data
 rm -r ${data_dir}
 plugins = glob_array ${target_dir}/wasm32-wasi/debug/*.wasm
+mkdir ${data_dir}
+mkdir ${data_dir}/plugins
 for plugin in ${plugins}
     plugin_name = basename ${plugin}
     cp ${plugin} ${data_dir}/plugins/${plugin_name}


### PR DESCRIPTION
- add building plugins `build-plugins` as a dependency for the task
  `build-dev-data-dir`