### PR TITLE
fix(strider): do not descend into host folder

### DIFF
--- a/default-plugins/strider/src/main.rs
+++ b/default-plugins/strider/src/main.rs
@@ -35,8 +35,14 @@ impl ZellijPlugin for State {
                     }
                 }
                 Key::Left | Key::Char('h') => {
-                    self.path.pop();
-                    refresh_directory(self);
+                    if self.path.components().count() > 2 {
+                        // don't descend into /host
+                        // the reason this is a hard-coded number (2) and not "== ROOT"
+                        // or some such is that there are certain cases in which self.path
+                        // is empty and this will work then too
+                        self.path.pop();
+                        refresh_directory(self);
+                    }
                 }
 
                 Key::Char('.') => {


### PR DESCRIPTION
This prevents strider from descending into the /host folder, which was causing it to display an irrecoverable blank screen