### PR TITLE
simplify .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
-/target
+target/
 *.new
 .vscode
 .vim
 .DS_Store 
 /assets/man/zellij.1
-**/target


### PR DESCRIPTION
`/target` is useless when there's already `**/target`.

And `**/target` should be written just `target`.

And to be more precise, what's really wanted here is
to match the "target" *directory* everywhere so the
best rule is `target/`.