### PR TITLE
fix(performance): do not hang when resizing large line wraps

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -2207,21 +2207,13 @@ impl Row {
     pub fn drain_until(&mut self, x: usize) -> VecDeque<TerminalCharacter> {
         let mut drained_part: VecDeque<TerminalCharacter> = VecDeque::new();
         let mut drained_part_len = 0;
-        loop {
-            match self.columns.remove(0) {
-                Some(next_character) => {
-                    if drained_part_len + next_character.width <= x {
-                        drained_part.push_back(next_character);
-                        drained_part_len += next_character.width;
-                    } else {
-                        self.columns.push_front(next_character); // put it back
-                        break;
-                    }
-                }
-                None => {
-                    // columns is empty
-                    break;
-                }
+        while let Some(next_character) = self.columns.remove(0) {
+            if drained_part_len + next_character.width <= x {
+                drained_part.push_back(next_character);
+                drained_part_len += next_character.width;
+            } else {
+                self.columns.push_front(next_character); // put it back
+                break;
             }
         }
         drained_part


### PR DESCRIPTION
Before this fix, Zellij would sometimes hang when resizing or scrolling through extremely large line wraps (eg. large one-line css files). This fixes the issue by (among other things) using a `VecDeque` instead of a `Vec` to keep track of the columns in a row. That way when we remove/add a character from their beginning (which we do often in this scenario) the complexity is O(1) instead of O(n).