### PR TITLE
fix(docs): fix wrong arguments for `cargo make run` given in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ cargo make build
 cargo make test
 # Run Zellij (optionally with additional arguments)
 cargo make run
-cargo make run -- -l strider
+cargo make run -l strider
 # Run Clippy (potentially with additional options)
 cargo make clippy
 cargo make clippy -W clippy::pedantic


### PR DESCRIPTION
This PR brings a fix for arguments of `cargo make run` command in `CONTRIBUTING.md`.

When I tried the command before this change, I got the error below:
```sh
$ cargo make run -- -l strider
[cargo-make] ...
...

    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/zellij --data-dir /tmp/zellij-org/zellij/target/dev-data/ -- -l strider`
error: Found argument '-l' which wasn't expected, or isn't valid in this context

USAGE:
    zellij --data-dir <data-dir>

For more information try --help
[cargo-make] ERROR - Error while executing command, exit code: 1
[cargo-make] WARN - Build Failed.
```

This is because `cargo make run` just passes all subsequent arguments to zellij binary. Therefore, I suggest that `--` argument be removed from the example shown in `CONTRIBUTING.md`. The result for the change I brought is shown below.

```sh
$ cargo make run -l strider
[cargo-make] ...
...

    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/zellij --data-dir /tmp/zellij-org/zellij/target/dev-data/ -l strider`
Bye from Zellij!
```