### PR TITLE
fix(warning): Fix an unused import warning of std::fs on macOS

### DIFF
--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -3,8 +3,10 @@ use std::collections::HashMap;
 #[cfg(target_os = "macos")]
 use darwin_libproc;
 
-use std::env;
+#[cfg(target_os = "linux")]
 use std::fs;
+
+use std::env;
 use std::os::unix::io::RawFd;
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;


### PR DESCRIPTION
Building zellij on macOS shows a warning in `zellij-server/src/os_input_output.rs`:

```sh
warning: unused import: `std::fs`
 --> zellij-server/src/os_input_output.rs:7:5
  |
7 | use std::fs;
  |     ^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: `zellij-server` (lib) generated 1 warning
```

`std::fs` is only used when `target_os` is Linux:
https://github.com/zellij-org/zellij/blob/03e62eb91c4f53a5be1548fecacc1fd5173adf47/zellij-server/src/os_input_output.rs#L364-L367