### PR TITLE
fix(typo): Correct typo from `occured` to `occurred`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ pub fn main() {
                 }
             }
             Err(e) => {
-                eprintln!("Error occured: {:?}", e);
+                eprintln!("Error occurred: {:?}", e);
                 process::exit(1);
             }
         }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -78,7 +78,7 @@ pub(crate) fn get_active_session() -> ActiveSession {
             }
         }
         Err(e) => {
-            eprintln!("Error occured: {:?}", e);
+            eprintln!("Error occurred: {:?}", e);
             process::exit(1);
         }
     }
@@ -91,7 +91,7 @@ pub(crate) fn kill_session(name: &str) {
             IpcSenderWithContext::new(stream).send(ClientToServerMsg::KillSession);
         }
         Err(e) => {
-            eprintln!("Error occured: {:?}", e);
+            eprintln!("Error occurred: {:?}", e);
             process::exit(1);
         }
     };
@@ -108,7 +108,7 @@ pub(crate) fn list_sessions() {
             0
         }
         Err(e) => {
-            eprintln!("Error occured: {:?}", e);
+            eprintln!("Error occurred: {:?}", e);
             1
         }
     };
@@ -137,7 +137,7 @@ pub(crate) fn assert_session(name: &str) {
             }
         }
         Err(e) => {
-            eprintln!("Error occured: {:?}", e);
+            eprintln!("Error occurred: {:?}", e);
         }
     };
     process::exit(1);
@@ -151,7 +151,7 @@ pub(crate) fn assert_session_ne(name: &str) {
             }
             println!("Session with name {:?} aleady exists. Use attach command to connect to it or specify a different name.", name);
         }
-        Err(e) => eprintln!("Error occured: {:?}", e),
+        Err(e) => eprintln!("Error occurred: {:?}", e),
     };
     process::exit(1);
 }

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -104,7 +104,7 @@ impl Display for ExitReason {
                 f,
                 "Session attached to another client. Use --force flag to force connect."
             ),
-            Self::Error(e) => write!(f, "Error occured in server:\n{}", e),
+            Self::Error(e) => write!(f, "Error occurred in server:\n{}", e),
         }
     }
 }


### PR DESCRIPTION
I am working on another work on zellij, but during this, I found typos. `occured` should be replaced `occurred`.

Ref: https://www.grammarly.com/blog/occurred-occured-ocurred/