### PR TITLE
add support for osc 8 escape code

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1490,8 +1490,7 @@ impl Perform for Grid {
                 if params.len() < 3 {
                     return;
                 }
-                self.link_handler
-                    .dispatch_osc8(params, bell_terminated, &mut self.cursor);
+                self.cursor.pending_styles.link_anchor = self.link_handler.dispatch_osc8(params);
             }
 
             // Get/set Foreground, Background, Cursor colors.

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1424,7 +1424,6 @@ impl Perform for Grid {
             }
             13 => {
                 // 0d, carriage return
-
                 self.move_cursor_to_beginning_of_line();
             }
             14 => {

--- a/zellij-server/src/panes/link_handler.rs
+++ b/zellij-server/src/panes/link_handler.rs
@@ -1,41 +1,15 @@
 use std::collections::HashMap;
 
-use super::{AnsiCode, CharacterStyles, LinkAnchor, TerminalCharacter};
+use super::{Cursor, LinkAnchor};
 
-pub const ANCHOR_END_TERMINAL_CHARACTER: TerminalCharacter = TerminalCharacter {
-    character: '\u{0000}',
-    width: 0,
-    styles: CharacterStyles {
-        foreground: Some(AnsiCode::Reset),
-        background: Some(AnsiCode::Reset),
-        strike: Some(AnsiCode::Reset),
-        hidden: Some(AnsiCode::Reset),
-        reverse: Some(AnsiCode::Reset),
-        slow_blink: Some(AnsiCode::Reset),
-        fast_blink: Some(AnsiCode::Reset),
-        underline: Some(AnsiCode::Reset),
-        bold: Some(AnsiCode::Reset),
-        dim: Some(AnsiCode::Reset),
-        italic: Some(AnsiCode::Reset),
-    },
-    link_anchor: Some(LinkAnchor::End),
-};
+const TERMINATOR: &str = "\x1b\\";
 
 #[derive(Debug, Clone)]
 pub struct LinkHandler {
-    status: Status,
+    pending_link_anchor: Option<LinkAnchor>,
     links: HashMap<u16, Link>,
     link_index: u16,
-    bell_terminated: bool,
 }
-
-#[derive(Debug, Clone)]
-enum Status {
-    Empty,
-    Started,
-    Ended,
-}
-
 #[derive(Debug, Clone)]
 struct Link {
     id: Option<String>,
@@ -45,71 +19,47 @@ struct Link {
 impl LinkHandler {
     pub fn new() -> Self {
         Self {
-            status: Status::Empty,
+            pending_link_anchor: None,
             links: HashMap::new(),
             link_index: 0,
-            bell_terminated: false,
         }
     }
 
-    pub fn dispatch_osc8(&mut self, params: &[u8], uri: &[u8], bell_terminated: bool) {
+    pub fn dispatch_osc8(&mut self, params: &[&[u8]], _bell_terminated: bool, cursor: &mut Cursor) {
+        let (link_params, uri) = (params[1], params[2]);
         log::info!(
             "dispatching osc8, params: {:?}, uri: {:?}",
-            std::str::from_utf8(params),
+            std::str::from_utf8(link_params),
             std::str::from_utf8(uri)
         );
-        self.bell_terminated = bell_terminated;
 
         if !uri.is_empty() {
-            self.start(params, uri)
+            self.start(link_params, uri)
         } else {
-            self.status = Status::Ended;
+            self.pending_link_anchor = Some(LinkAnchor::End);
         }
+        cursor.pending_styles.link_anchor = self.pending_link_anchor();
     }
 
     pub fn pending_link_anchor(&mut self) -> Option<LinkAnchor> {
-        match self.status {
-            Status::Started => {
-                let current_link_index = self.link_index;
-                self.status = Status::Empty;
-                self.link_index += 1;
-                Some(LinkAnchor::Start(current_link_index))
-            }
-            Status::Ended => {
-                self.status = Status::Empty;
-                Some(LinkAnchor::End)
-            }
-            _ => None,
+        let pending_link_anchor = self.pending_link_anchor;
+        if let Some(LinkAnchor::End) = self.pending_link_anchor {
+            self.pending_link_anchor = None;
         }
+        pending_link_anchor
     }
 
-    pub fn insert_anchor_end(&mut self) -> Option<TerminalCharacter> {
-        if let Status::Ended = self.status {
-            self.status = Status::Empty;
-            Some(ANCHOR_END_TERMINAL_CHARACTER)
-        } else {
-            None
-        }
-    }
-
-    pub fn output_osc8(&self, t_character: TerminalCharacter) -> Option<String> {
-        t_character.link_anchor.map(|link| {
-            let terminator = if self.bell_terminated {
-                "\x07"
-            } else {
-                "\x1b\\"
-            };
-            match link {
-                LinkAnchor::Start(index) => {
-                    let link = self.links.get(&index).unwrap();
-                    let id = link
-                        .id
-                        .as_ref()
-                        .map_or("".to_string(), |id| format!("id={}", id));
-                    format!("\u{1b}]8;{};{}{}", id, link.uri, terminator)
-                }
-                LinkAnchor::End => format!("\u{1b}]8;;{}", terminator),
+    pub fn output_osc8(&self, link_anchor: Option<LinkAnchor>) -> String {
+        link_anchor.map_or("".to_string(), |link| match link {
+            LinkAnchor::Start(index) => {
+                let link = self.links.get(&index).unwrap();
+                let id = link
+                    .id
+                    .as_ref()
+                    .map_or("".to_string(), |id| format!("id={}", id));
+                format!("\u{1b}]8;{};{}{}", id, link.uri, TERMINATOR)
             }
+            LinkAnchor::End => format!("\u{1b}]8;;{}", TERMINATOR),
         })
     }
 
@@ -119,8 +69,9 @@ impl LinkHandler {
                 .split(|&b| b == b':')
                 .find(|kv| kv.starts_with(b"id="))
                 .and_then(|kv| String::from_utf8(kv[3..].to_vec()).ok());
-            self.status = Status::Started;
+            self.pending_link_anchor = Some(LinkAnchor::Start(self.link_index));
             self.links.insert(self.link_index, Link { id, uri });
+            self.link_index += 1;
         }
     }
 }

--- a/zellij-server/src/panes/link_handler.rs
+++ b/zellij-server/src/panes/link_handler.rs
@@ -1,0 +1,132 @@
+use std::collections::HashMap;
+
+use super::{AnsiCode, CharacterStyles, LinkAnchor, TerminalCharacter};
+
+pub const ANCHOR_END_TERMINAL_CHARACTER: TerminalCharacter = TerminalCharacter {
+    character: '\u{0000}',
+    width: 0,
+    styles: CharacterStyles {
+        foreground: Some(AnsiCode::Reset),
+        background: Some(AnsiCode::Reset),
+        strike: Some(AnsiCode::Reset),
+        hidden: Some(AnsiCode::Reset),
+        reverse: Some(AnsiCode::Reset),
+        slow_blink: Some(AnsiCode::Reset),
+        fast_blink: Some(AnsiCode::Reset),
+        underline: Some(AnsiCode::Reset),
+        bold: Some(AnsiCode::Reset),
+        dim: Some(AnsiCode::Reset),
+        italic: Some(AnsiCode::Reset),
+    },
+    link_anchor: Some(LinkAnchor::End),
+};
+
+#[derive(Debug, Clone)]
+pub struct LinkHandler {
+    status: Status,
+    links: HashMap<u16, Link>,
+    link_index: u16,
+    bell_terminated: bool,
+}
+
+#[derive(Debug, Clone)]
+enum Status {
+    Empty,
+    Started,
+    Ended,
+}
+
+#[derive(Debug, Clone)]
+struct Link {
+    id: Option<String>,
+    uri: String,
+}
+
+impl LinkHandler {
+    pub fn new() -> Self {
+        Self {
+            status: Status::Empty,
+            links: HashMap::new(),
+            link_index: 0,
+            bell_terminated: false,
+        }
+    }
+
+    pub fn dispatch_osc8(&mut self, params: &[u8], uri: &[u8], bell_terminated: bool) {
+        log::info!(
+            "dispatching osc8, params: {:?}, uri: {:?}",
+            std::str::from_utf8(params),
+            std::str::from_utf8(uri)
+        );
+        self.bell_terminated = bell_terminated;
+
+        if !uri.is_empty() {
+            self.start(params, uri)
+        } else {
+            self.status = Status::Ended;
+        }
+    }
+
+    pub fn pending_link_anchor(&mut self) -> Option<LinkAnchor> {
+        match self.status {
+            Status::Started => {
+                let current_link_index = self.link_index;
+                self.status = Status::Empty;
+                self.link_index += 1;
+                Some(LinkAnchor::Start(current_link_index))
+            }
+            Status::Ended => {
+                self.status = Status::Empty;
+                Some(LinkAnchor::End)
+            }
+            _ => None,
+        }
+    }
+
+    pub fn insert_anchor_end(&mut self) -> Option<TerminalCharacter> {
+        if let Status::Ended = self.status {
+            self.status = Status::Empty;
+            Some(ANCHOR_END_TERMINAL_CHARACTER)
+        } else {
+            None
+        }
+    }
+
+    pub fn output_osc8(&self, t_character: TerminalCharacter) -> Option<String> {
+        t_character.link_anchor.map(|link| {
+            let terminator = if self.bell_terminated {
+                "\x07"
+            } else {
+                "\x1b\\"
+            };
+            match link {
+                LinkAnchor::Start(index) => {
+                    let link = self.links.get(&index).unwrap();
+                    let id = link
+                        .id
+                        .as_ref()
+                        .map_or("".to_string(), |id| format!("id={}", id));
+                    format!("\u{1b}]8;{};{}{}", id, link.uri, terminator)
+                }
+                LinkAnchor::End => format!("\u{1b}]8;;{}", terminator),
+            }
+        })
+    }
+
+    fn start(&mut self, params: &[u8], uri: &[u8]) {
+        if let Ok(uri) = String::from_utf8(uri.to_vec()) {
+            let id = params
+                .split(|&b| b == b':')
+                .find(|kv| kv.starts_with(b"id="))
+                .and_then(|kv| String::from_utf8(kv[3..].to_vec()).ok());
+            self.status = Status::Started;
+            self.links.insert(self.link_index, Link { id, uri });
+        }
+    }
+}
+
+impl Default for LinkHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/zellij-server/src/panes/mod.rs
+++ b/zellij-server/src/panes/mod.rs
@@ -1,5 +1,6 @@
 mod alacritty_functions;
 mod grid;
+mod link_handler;
 mod plugin_pane;
 mod selection;
 mod terminal_character;

--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -20,8 +20,8 @@ pub const EMPTY_TERMINAL_CHARACTER: TerminalCharacter = TerminalCharacter {
         bold: Some(AnsiCode::Reset),
         dim: Some(AnsiCode::Reset),
         italic: Some(AnsiCode::Reset),
+        link_anchor: Some(LinkAnchor::End),
     },
-    link_anchor: None,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -109,6 +109,7 @@ pub struct CharacterStyles {
     pub bold: Option<AnsiCode>,
     pub dim: Option<AnsiCode>,
     pub italic: Option<AnsiCode>,
+    pub link_anchor: Option<LinkAnchor>,
 }
 
 impl Default for CharacterStyles {
@@ -125,6 +126,7 @@ impl Default for CharacterStyles {
             bold: None,
             dim: None,
             italic: None,
+            link_anchor: None,
         }
     }
 }
@@ -177,6 +179,10 @@ impl CharacterStyles {
         self.strike = strike_code;
         self
     }
+    pub fn link_anchor(mut self, link_anchor: Option<LinkAnchor>) -> Self {
+        self.link_anchor = link_anchor;
+        self
+    }
     pub fn clear(&mut self) {
         self.foreground = None;
         self.background = None;
@@ -189,6 +195,7 @@ impl CharacterStyles {
         self.bold = None;
         self.dim = None;
         self.italic = None;
+        self.link_anchor = None;
     }
     pub fn update_and_return_diff(
         &mut self,
@@ -208,6 +215,7 @@ impl CharacterStyles {
             && new_styles.bold == Some(AnsiCode::Reset)
             && new_styles.dim == Some(AnsiCode::Reset)
             && new_styles.italic == Some(AnsiCode::Reset)
+            && new_styles.link_anchor == Some(LinkAnchor::End)
         {
             self.foreground = Some(AnsiCode::Reset);
             self.background = Some(AnsiCode::Reset);
@@ -220,6 +228,7 @@ impl CharacterStyles {
             self.bold = Some(AnsiCode::Reset);
             self.dim = Some(AnsiCode::Reset);
             self.italic = Some(AnsiCode::Reset);
+            self.link_anchor = Some(LinkAnchor::End);
             return Some(*new_styles);
         };
 
@@ -310,6 +319,14 @@ impl CharacterStyles {
                 diff = Some(CharacterStyles::new().italic(new_styles.italic));
             }
             self.italic = new_styles.italic;
+        }
+        if self.link_anchor != new_styles.link_anchor {
+            if let Some(new_diff) = diff.as_mut() {
+                diff = Some(new_diff.link_anchor(new_styles.link_anchor))
+            } else {
+                diff = Some(CharacterStyles::new().link_anchor(new_styles.link_anchor))
+            }
+            self.link_anchor = new_styles.link_anchor;
         }
 
         if let Some(changed_colors) = changed_colors {
@@ -623,7 +640,7 @@ impl Display for CharacterStyles {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum LinkAnchor {
     Start(u16),
     End,
@@ -762,7 +779,6 @@ pub struct TerminalCharacter {
     pub character: char,
     pub styles: CharacterStyles,
     pub width: usize,
-    pub link_anchor: Option<LinkAnchor>,
 }
 
 impl ::std::fmt::Debug for TerminalCharacter {

--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -21,6 +21,7 @@ pub const EMPTY_TERMINAL_CHARACTER: TerminalCharacter = TerminalCharacter {
         dim: Some(AnsiCode::Reset),
         italic: Some(AnsiCode::Reset),
     },
+    link_anchor: None,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -622,6 +623,12 @@ impl Display for CharacterStyles {
     }
 }
 
+#[derive(Clone, Copy)]
+pub enum LinkAnchor {
+    Start(u16),
+    End,
+}
+
 #[derive(Clone, Copy, Debug)]
 pub enum CharsetIndex {
     G0,
@@ -755,6 +762,7 @@ pub struct TerminalCharacter {
     pub character: char,
     pub styles: CharacterStyles,
     pub width: usize,
+    pub link_anchor: Option<LinkAnchor>,
 }
 
 impl ::std::fmt::Debug for TerminalCharacter {

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -237,6 +237,11 @@ impl Pane for TerminalPane {
                     {
                         vte_output.push_str(&new_styles.to_string());
                     }
+
+                    if let Some(osc8_seq) = self.grid.link_handler.output_osc8(t_character) {
+                        vte_output.push_str(&osc8_seq);
+                    }
+
                     vte_output.push(t_character.character);
                 }
                 character_styles.clear();

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -236,10 +236,8 @@ impl Pane for TerminalPane {
                         .update_and_return_diff(&t_character.styles, self.grid.changed_colors)
                     {
                         vte_output.push_str(&new_styles.to_string());
-                    }
-
-                    if let Some(osc8_seq) = self.grid.link_handler.output_osc8(t_character) {
-                        vte_output.push_str(&osc8_seq);
+                        vte_output
+                            .push_str(&self.grid.link_handler.output_osc8(new_styles.link_anchor))
                     }
 
                     vte_output.push(t_character.character);


### PR DESCRIPTION
This adds support for osc8, for a quick idea of how it works see: https://iterm2.com/documentation-escape-codes.html, while this [gist](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) has a lot more details covered. 

The case of a newline immediately after a link ends, for example
```shell
printf '\e]8;;\n\nhttp/example.com\e\\LINK1\e]8;;\e\\\n
```
 was  a bit problematic, since the line gets padded with empty characters up to the width of the row:

![screenshot-2021-10-31T17:23:28](https://user-images.githubusercontent.com/7355179/139594931-c664d067-7ab0-4d36-8205-98437cba6bc7.png)

I handled this by adding a zero width null character to end the link in this situation, not quite sure if that's a reasonable solution though. 


