### PR TITLE
add: `WriteChars` action

### DIFF
--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -50,6 +50,17 @@ fn route_action(
                 .send_to_screen(ScreenInstruction::WriteCharacter(val, client_id))
                 .unwrap();
         }
+        Action::WriteChars(val) => {
+            session
+                .senders
+                .send_to_screen(ScreenInstruction::ClearScroll(client_id))
+                .unwrap();
+            let val = Vec::from(val.as_bytes());
+            session
+                .senders
+                .send_to_screen(ScreenInstruction::WriteCharacter(val, client_id))
+                .unwrap();
+        }
         Action::SwitchToMode(mode) => {
             let palette = session.palette;
             // TODO: use the palette from the client and remove it from the server os api

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -28,6 +28,8 @@ pub enum Action {
     Quit,
     /// Write to the terminal.
     Write(Vec<u8>),
+    /// Write Characters to the terminal.
+    WriteChars(String),
     /// Switch to the specified input mode.
     SwitchToMode(InputMode),
     /// Resize focus pane in specified direction.


### PR DESCRIPTION
* Behaves like the `Write` action, but one can specify
  strings themselves instead of their bytecodes.

  Usage:

  WriteChars: "cargo make test",