### PR TITLE
add: `rust-version` (msrv) field to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/zellij-org/zellij"
 homepage = "https://zellij.dev"
 include = ["src/**/*", "assets/plugins/*", "assets/layouts/*", "assets/config/*", "LICENSE.md", "README.md", "!**/*_test.*", "!**/tests/**/*"]
 resolver = "2"
+rust-version = "1.56"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
* specifies the minimum version the package can be compiled with,
  may be ignored with `--ignore-rust-version` option

  ref: https://doc.rust-lang.org/nightly/cargo/reference/manifest.html#the-rust-version-field