### PR TITLE
fix(unix): forkpty => openpty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,6 +352,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "close_fds"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bc416f33de9d59e79e57560f450d21ff8393adcf1cdfc3e6d8fb93d5f88a2ed"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+]
+
+[[package]]
 name = "colored"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2857,6 +2867,7 @@ dependencies = [
  "byteorder",
  "cassowary",
  "chrono",
+ "close_fds",
  "daemonize",
  "darwin-libproc",
  "highway",

--- a/zellij-server/Cargo.toml
+++ b/zellij-server/Cargo.toml
@@ -25,6 +25,7 @@ zellij-utils = { path = "../zellij-utils/", version = "0.20.0" }
 log = "0.4.14"
 typetag = "0.1.7"
 chrono = "0.4.19"
+close_fds = "0.3.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 darwin-libproc = "0.2.0"

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -1,11 +1,12 @@
 use crate::{
-    os_input_output::{AsyncReader, ChildId, ServerOsApi},
+    os_input_output::{AsyncReader, ServerOsApi},
     panes::PaneId,
     screen::ScreenInstruction,
     thread_bus::{Bus, ThreadSenders},
     wasm_vm::PluginInstruction,
     ClientId, ServerInstruction,
 };
+use zellij_utils::nix::unistd::Pid;
 use async_std::{
     future::timeout as async_timeout,
     task::{self, JoinHandle},
@@ -66,7 +67,7 @@ impl From<&PtyInstruction> for PtyContext {
 pub(crate) struct Pty {
     pub active_panes: HashMap<ClientId, PaneId>,
     pub bus: Bus<PtyInstruction>,
-    pub id_to_child_pid: HashMap<RawFd, ChildId>,
+    pub id_to_child_pid: HashMap<RawFd, RawFd>, // pty_primary => child raw fd
     debug_to_file: bool,
     task_handles: HashMap<RawFd, JoinHandle<()>>,
 }
@@ -252,15 +253,6 @@ fn stream_terminal_bytes(
                 }
             }
             async_send_to_screen(senders.clone(), ScreenInstruction::Render).await;
-
-            // we send ClosePane here so that the screen knows to close this tab if the process
-            // inside the terminal exited on its own (eg. the user typed "exit<ENTER>" inside a
-            // bash shell)
-            async_send_to_screen(
-                senders,
-                ScreenInstruction::ClosePane(PaneId::Terminal(pid), None),
-            )
-            .await;
         }
     })
 }
@@ -283,9 +275,9 @@ impl Pty {
                 .and_then(|client_id| self.active_panes.get(&client_id))
                 .and_then(|pane| match pane {
                     PaneId::Plugin(..) => None,
-                    PaneId::Terminal(id) => self.id_to_child_pid.get(id).and_then(|id| id.shell),
+                    PaneId::Terminal(id) => self.id_to_child_pid.get(id),
                 })
-                .and_then(|id| self.bus.os_input.as_ref().map(|input| input.get_cwd(id)))
+                .and_then(|id| self.bus.os_input.as_ref().map(|input| input.get_cwd(Pid::from_raw(*id))))
                 .flatten(),
         })
     }
@@ -302,12 +294,23 @@ impl Pty {
                 terminal_action.unwrap_or_else(|| self.get_default_terminal(None))
             }
         };
-        let (pid_primary, child_id): (RawFd, ChildId) = self
+        let quit_cb = Box::new({
+            let senders = self.bus
+                .senders
+                .clone();
+            move |pane_id| {
+                let _ = senders.send_to_screen(ScreenInstruction::ClosePane(
+                    pane_id,
+                    None,
+                ));
+            }
+        });
+        let (pid_primary, child_fd): (RawFd, RawFd) = self
             .bus
             .os_input
             .as_mut()
             .unwrap()
-            .spawn_terminal(terminal_action);
+            .spawn_terminal(terminal_action, quit_cb);
         let task_handle = stream_terminal_bytes(
             pid_primary,
             self.bus.senders.clone(),
@@ -315,7 +318,7 @@ impl Pty {
             self.debug_to_file,
         );
         self.task_handles.insert(pid_primary, task_handle);
-        self.id_to_child_pid.insert(pid_primary, child_id);
+        self.id_to_child_pid.insert(pid_primary, child_fd);
         pid_primary
     }
     pub fn spawn_terminals_for_layout(
@@ -329,22 +332,33 @@ impl Pty {
         let extracted_run_instructions = layout.extract_run_instructions();
         let mut new_pane_pids = vec![];
         for run_instruction in extracted_run_instructions {
+            let quit_cb = Box::new({
+                let senders = self.bus
+                    .senders
+                    .clone();
+                move |pane_id| {
+                    let _ = senders.send_to_screen(ScreenInstruction::ClosePane(
+                        pane_id,
+                        None,
+                    ));
+                }
+            });
             match run_instruction {
                 Some(Run::Command(command)) => {
                     let cmd = TerminalAction::RunCommand(command);
-                    let (pid_primary, child_id): (RawFd, ChildId) =
-                        self.bus.os_input.as_mut().unwrap().spawn_terminal(cmd);
-                    self.id_to_child_pid.insert(pid_primary, child_id);
+                    let (pid_primary, child_fd): (RawFd, RawFd) =
+                        self.bus.os_input.as_mut().unwrap().spawn_terminal(cmd, quit_cb);
+                    self.id_to_child_pid.insert(pid_primary, child_fd);
                     new_pane_pids.push(pid_primary);
                 }
                 None => {
-                    let (pid_primary, child_id): (RawFd, ChildId) = self
+                    let (pid_primary, child_fd): (RawFd, RawFd) = self
                         .bus
                         .os_input
                         .as_mut()
                         .unwrap()
-                        .spawn_terminal(default_shell.clone());
-                    self.id_to_child_pid.insert(pid_primary, child_id);
+                        .spawn_terminal(default_shell.clone(), quit_cb);
+                    self.id_to_child_pid.insert(pid_primary, child_fd);
                     new_pane_pids.push(pid_primary);
                 }
                 // Investigate moving plugin loading to here.
@@ -372,27 +386,15 @@ impl Pty {
     pub fn close_pane(&mut self, id: PaneId) {
         match id {
             PaneId::Terminal(id) => {
-                let pids = self.id_to_child_pid.remove(&id).unwrap();
-                let handle = self.task_handles.remove(&id).unwrap();
+                let child_fd= self.id_to_child_pid.remove(&id).unwrap();
+                self.task_handles.remove(&id).unwrap();
                 task::block_on(async {
                     self.bus
                         .os_input
                         .as_mut()
                         .unwrap()
-                        .kill(pids.primary)
+                        .kill(Pid::from_raw(child_fd))
                         .unwrap();
-                    let timeout = Duration::from_millis(100);
-                    match async_timeout(timeout, handle.cancel()).await {
-                        Ok(_) => {}
-                        _ => {
-                            self.bus
-                                .os_input
-                                .as_mut()
-                                .unwrap()
-                                .force_kill(pids.primary)
-                                .unwrap();
-                        }
-                    };
                 });
             }
             PaneId::Plugin(pid) => drop(

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -30,7 +30,11 @@ impl ServerOsApi for FakeInputOutput {
     fn set_terminal_size_using_fd(&self, _fd: RawFd, _cols: u16, _rows: u16) {
         // noop
     }
-    fn spawn_terminal(&self, _file_to_open: TerminalAction, _quit_db: Box<dyn Fn(PaneId) + Send>) -> (RawFd, RawFd) {
+    fn spawn_terminal(
+        &self,
+        _file_to_open: TerminalAction,
+        _quit_db: Box<dyn Fn(PaneId) + Send>,
+    ) -> (RawFd, RawFd) {
         unimplemented!()
     }
     fn read_from_tty_stdout(&self, _fd: RawFd, _buf: &mut [u8]) -> Result<usize, nix::Error> {

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -1,7 +1,8 @@
 use super::{Screen, ScreenInstruction};
+use crate::panes::PaneId;
 use crate::zellij_tile::data::{ModeInfo, Palette};
 use crate::{
-    os_input_output::{AsyncReader, ChildId, Pid, ServerOsApi},
+    os_input_output::{AsyncReader, Pid, ServerOsApi},
     thread_bus::Bus,
     ClientId,
 };
@@ -29,7 +30,7 @@ impl ServerOsApi for FakeInputOutput {
     fn set_terminal_size_using_fd(&self, _fd: RawFd, _cols: u16, _rows: u16) {
         // noop
     }
-    fn spawn_terminal(&self, _file_to_open: TerminalAction) -> (RawFd, ChildId) {
+    fn spawn_terminal(&self, _file_to_open: TerminalAction, _quit_db: Box<dyn Fn(PaneId) + Send>) -> (RawFd, RawFd) {
         unimplemented!()
     }
     fn read_from_tty_stdout(&self, _fd: RawFd, _buf: &mut [u8]) -> Result<usize, nix::Error> {

--- a/zellij-server/src/unit/tab_tests.rs
+++ b/zellij-server/src/unit/tab_tests.rs
@@ -1,7 +1,7 @@
 use super::Tab;
 use crate::zellij_tile::data::{ModeInfo, Palette};
 use crate::{
-    os_input_output::{AsyncReader, ChildId, Pid, ServerOsApi},
+    os_input_output::{AsyncReader, Pid, ServerOsApi},
     panes::PaneId,
     thread_bus::ThreadSenders,
     ClientId,
@@ -29,7 +29,7 @@ impl ServerOsApi for FakeInputOutput {
     fn set_terminal_size_using_fd(&self, _fd: RawFd, _cols: u16, _rows: u16) {
         // noop
     }
-    fn spawn_terminal(&self, _file_to_open: TerminalAction) -> (RawFd, ChildId) {
+    fn spawn_terminal(&self, _file_to_open: TerminalAction, _quit_cb: Box<dyn Fn(PaneId) + Send>) -> (RawFd, RawFd) {
         unimplemented!()
     }
     fn read_from_tty_stdout(&self, _fd: RawFd, _buf: &mut [u8]) -> Result<usize, nix::Error> {

--- a/zellij-server/src/unit/tab_tests.rs
+++ b/zellij-server/src/unit/tab_tests.rs
@@ -29,7 +29,11 @@ impl ServerOsApi for FakeInputOutput {
     fn set_terminal_size_using_fd(&self, _fd: RawFd, _cols: u16, _rows: u16) {
         // noop
     }
-    fn spawn_terminal(&self, _file_to_open: TerminalAction, _quit_cb: Box<dyn Fn(PaneId) + Send>) -> (RawFd, RawFd) {
+    fn spawn_terminal(
+        &self,
+        _file_to_open: TerminalAction,
+        _quit_cb: Box<dyn Fn(PaneId) + Send>,
+    ) -> (RawFd, RawFd) {
         unimplemented!()
     }
     fn read_from_tty_stdout(&self, _fd: RawFd, _buf: &mut [u8]) -> Result<usize, nix::Error> {


### PR DESCRIPTION
This is a fix for both https://github.com/zellij-org/zellij/issues/803 and https://github.com/zellij-org/zellij/issues/796

The major user facing effects are that this should significantly improve our resource utilization in regards to process count and memory usage. It also means child processes are not exposed to the open FDs of the main Zellij process.

The major changes:
1. Instead of creating new terminals with `forkpty` we now use `openpty` and do the forking ourselves with Rust's `Command` - which we were doing anyway. This saves considerable amounts of RAM and actually makes a lot of stuff simpler (eg. we don't need to set the process group of the forked process because `Command` does it for us. We also need to do the acrobatics we were doing to find out the shell's pid because it's now the child process itself).
2. We now explicitly reap both parts of the pty on child process end (after `wait`ing for it). I'm not sure if this was implicitly done before, but now its explicit.
3. As pointed out by @tailhook, we now close all fds before forking the child process so as not to leak. For now I elected not to also set the `CLOEXEC` flag every time we open an fd (eg. with our unix pipes) because quite honestly I've been down this rabbit hole for longer than I intended and this is a redundancy in this case. Would be nice to follow up and do this later though.