### PR TITLE
Fix: move `colors_transform` to `colorsys`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,10 +363,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "colors-transform"
-version = "0.2.11"
+name = "colorsys"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9226dbc05df4fb986f48d730b001532580883c4c06c5d1c213f4b34c1c157178"
+checksum = "4dfdf9179d546b55ff3f88c9d93ecfaa3e9760163da5a1080af5243230dbbb70"
 
 [[package]]
 name = "concurrent-queue"
@@ -2895,7 +2895,7 @@ dependencies = [
  "async-std",
  "backtrace",
  "bincode",
- "colors-transform",
+ "colorsys",
  "crossbeam",
  "directories-next",
  "interprocess",

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [dependencies]
 backtrace = "0.3.55"
 bincode = "1.3.1"
-colors-transform = "0.2.5"
+colorsys = "0.6.5"
 crossbeam = "0.8.0"
 directories-next = "2.0"
 interprocess = "1.1.1"

--- a/zellij-utils/src/shared.rs
+++ b/zellij-utils/src/shared.rs
@@ -2,7 +2,7 @@
 
 use std::{iter, str::from_utf8};
 
-use colors_transform::{Color, Rgb};
+use colorsys::Rgb;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::{fs, io};
@@ -52,10 +52,9 @@ pub mod colors {
 }
 
 pub fn _hex_to_rgb(hex: &str) -> (u8, u8, u8) {
-    let rgb = Rgb::from_hex_str(hex)
+    Rgb::from_hex_str(hex)
         .expect("The passed argument must be a valid hex color")
-        .as_tuple();
-    (rgb.0 as u8, rgb.1 as u8, rgb.2 as u8)
+        .into()
 }
 
 pub fn default_palette() -> Palette {


### PR DESCRIPTION
* `colors_transform` is deprecated and superceded by `colorsys`

  ref: https://crates.io/crates/colors-transform