### PR TITLE
fix(errors): Add colored crate to replace primitive color formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2906,6 +2906,7 @@ dependencies = [
  "async-std",
  "backtrace",
  "bincode",
+ "colored",
  "colorsys",
  "crossbeam",
  "directories-next",

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 [dependencies]
 backtrace = "0.3.55"
 bincode = "1.3.1"
+colored = "2.0.0"
 colorsys = "0.6.5"
 crossbeam = "0.8.0"
 directories-next = "2.0"

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -2,6 +2,7 @@
 //! the instructions that are sent between threads.
 
 use crate::channels::{SenderWithContext, ASYNCOPENCALLS, OPENCALLS};
+use colored::*;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Error, Formatter};
 use std::panic::PanicInfo;
@@ -180,24 +181,21 @@ pub enum ContextType {
     Empty,
 }
 
-// TODO use the `colored` crate for color formatting
 impl Display for ContextType {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        let purple = "\u{1b}[1;35m";
-        let green = "\u{1b}[0;32m";
-        match *self {
-            ContextType::Screen(c) => write!(f, "{}screen_thread: {}{:?}", purple, green, c),
-            ContextType::Pty(c) => write!(f, "{}pty_thread: {}{:?}", purple, green, c),
-            ContextType::Plugin(c) => write!(f, "{}plugin_thread: {}{:?}", purple, green, c),
-            ContextType::Client(c) => write!(f, "{}main_thread: {}{:?}", purple, green, c),
-            ContextType::IPCServer(c) => write!(f, "{}ipc_server: {}{:?}", purple, green, c),
-            ContextType::StdinHandler => {
-                write!(f, "{}stdin_handler_thread: {}AcceptInput", purple, green)
-            }
-            ContextType::AsyncTask => {
-                write!(f, "{}stream_terminal_bytes: {}AsyncTask", purple, green)
-            }
-            ContextType::Empty => write!(f, ""),
+        if let Some((left, right)) = match *self {
+            ContextType::Screen(c) => Some(("screen_thread:", format!("{:?}", c))),
+            ContextType::Pty(c) => Some(("pty_thread:", format!("{:?}", c))),
+            ContextType::Plugin(c) => Some(("plugin_thread:", format!("{:?}", c))),
+            ContextType::Client(c) => Some(("main_thread:", format!("{:?}", c))),
+            ContextType::IPCServer(c) => Some(("ipc_server:", format!("{:?}", c))),
+            ContextType::StdinHandler => Some(("stdin_handler_thread:", "AcceptInput".to_string())),
+            ContextType::AsyncTask => Some(("stream_terminal_bytes:", "AsyncTask".to_string())),
+            ContextType::Empty => None,
+        } {
+            write!(f, "{} {}", left.purple(), right.green())
+        } else {
+            write!(f, "")
         }
     }
 }


### PR DESCRIPTION
I completed an inline TODO in `zellij-utils/src/errors.rs` :) The `handle_panic` function has a usage of low color code, but I could not understand what the codes mean. So, I didn't touch them.