### PR TITLE
fix(docker-compose): Use the key-value style for environments to prevent human errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,12 @@ services:
     container_name: zellij-e2e
     hostname: zellij-e2e
     environment:
-      - PUID=1000
-      - PGID=1000
-      - TZ=Europe/Vienna
-      - PASSWORD_ACCESS=true
-      - USER_PASSWORD=test
-      - USER_NAME=test
+      PUID: 1000
+      PGID: 1000
+      TZ: Europe/Vienna
+      PASSWORD_ACCESS: true
+      USER_PASSWORD: test
+      USER_NAME: test
     volumes:
       - type: bind
         source: ./target


### PR DESCRIPTION
I suggest using the key-value style for environments to prevent human errors in `docker-compose.yml` instead of the array. YAML detects duplicate keys.

I have two more suggestions: one is removing `---` on the top, another is bumping the docker-compose file version to 3. Are there any reasons to use them? If no reasons, I would like to do them.