### PR TITLE
fix(envs): Unify operation of Zellij environment variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2932,6 +2932,7 @@ dependencies = [
 name = "zellij-utils"
 version = "0.20.0"
 dependencies = [
+ "anyhow",
  "async-std",
  "backtrace",
  "bincode",

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -3,6 +3,7 @@ use std::time::SystemTime;
 use std::{fs, io, process};
 use zellij_utils::{
     consts::ZELLIJ_SOCK_DIR,
+    envs,
     interprocess::local_socket::LocalSocketStream,
     ipc::{ClientToServerMsg, IpcSenderWithContext},
 };
@@ -79,7 +80,7 @@ fn assert_socket(name: &str) -> bool {
 }
 
 pub(crate) fn print_sessions(sessions: Vec<String>) {
-    let curr_session = std::env::var("ZELLIJ_SESSION_NAME").unwrap_or_else(|_| "".into());
+    let curr_session = envs::get_session_name().unwrap_or_else(|_| "".into());
     sessions.iter().for_each(|session| {
         let suffix = if curr_session == *session {
             " (current)"
@@ -91,7 +92,7 @@ pub(crate) fn print_sessions(sessions: Vec<String>) {
 }
 
 pub(crate) fn print_sessions_with_index(sessions: Vec<String>) {
-    let curr_session = std::env::var("ZELLIJ_SESSION_NAME").unwrap_or_else(|_| "".into());
+    let curr_session = envs::get_session_name().unwrap_or_else(|_| "".into());
     for (i, session) in sessions.iter().enumerate() {
         let suffix = if curr_session == *session {
             " (current)"

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -18,7 +18,8 @@ use crate::{
 use zellij_tile::data::InputMode;
 use zellij_utils::{
     channels::{self, ChannelWithContext, SenderWithContext},
-    consts::{SESSION_NAME, ZELLIJ_IPC_PIPE},
+    consts::ZELLIJ_IPC_PIPE,
+    envs,
     errors::{ClientContext, ContextType, ErrorInstruction},
     input::{actions::Action, config::Config, options::Options},
     ipc::{ClientAttributes, ClientToServerMsg, ExitReason, ServerToClientMsg},
@@ -119,7 +120,7 @@ pub fn start_client(
         .get_stdout_writer()
         .write(clear_client_terminal_attributes.as_bytes())
         .unwrap();
-    std::env::set_var(&"ZELLIJ", "0");
+    envs::set_zellij("0".to_string());
 
     let palette = config.themes.clone().map_or_else(
         || os_input.load_palette(),
@@ -137,14 +138,12 @@ pub fn start_client(
 
     let first_msg = match info {
         ClientInfo::Attach(name, config_options) => {
-            SESSION_NAME.set(name).unwrap();
-            std::env::set_var(&"ZELLIJ_SESSION_NAME", SESSION_NAME.get().unwrap());
+            envs::set_session_name(name);
 
             ClientToServerMsg::AttachClient(client_attributes, config_options)
         }
         ClientInfo::New(name) => {
-            SESSION_NAME.set(name).unwrap();
-            std::env::set_var(&"ZELLIJ_SESSION_NAME", SESSION_NAME.get().unwrap());
+            envs::set_session_name(name);
 
             spawn_server(&*ZELLIJ_IPC_PIPE).unwrap();
 

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -17,6 +17,7 @@ use std::{
     sync::{Arc, Mutex, RwLock},
     thread,
 };
+use zellij_utils::envs;
 use zellij_utils::nix::sys::stat::{umask, Mode};
 use zellij_utils::pane_size::Size;
 use zellij_utils::zellij_tile;
@@ -186,7 +187,7 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
         .start()
         .expect("could not daemonize the server process");
 
-    std::env::set_var(&"ZELLIJ", "0");
+    envs::set_zellij("0".to_string());
 
     let (to_server, server_receiver): ChannelWithContext<ServerInstruction> = channels::bounded(50);
     let to_server = SenderWithContext::new(to_server);

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.45"
 backtrace = "0.3.55"
 bincode = "1.3.1"
 colored = "2.0.0"

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -1,10 +1,10 @@
 //! Zellij program-wide constants.
 
+use crate::envs;
 use crate::shared::set_permissions;
 use directories_next::ProjectDirs;
 use lazy_static::lazy_static;
 use nix::unistd::Uid;
-use once_cell::sync::OnceCell;
 use std::path::PathBuf;
 use std::{env, fs};
 
@@ -26,11 +26,10 @@ const fn system_default_data_dir() -> &'static str {
 
 lazy_static! {
     static ref UID: Uid = Uid::current();
-    pub static ref SESSION_NAME: OnceCell<String> = OnceCell::new();
     pub static ref ZELLIJ_PROJ_DIR: ProjectDirs =
         ProjectDirs::from("org", "Zellij Contributors", "Zellij").unwrap();
     pub static ref ZELLIJ_SOCK_DIR: PathBuf = {
-        let mut ipc_dir = env::var("ZELLIJ_SOCKET_DIR").map_or_else(
+        let mut ipc_dir = envs::get_socket_dir().map_or_else(
             |_| {
                 ZELLIJ_PROJ_DIR
                     .runtime_dir()
@@ -45,7 +44,7 @@ lazy_static! {
         let mut sock_dir = ZELLIJ_SOCK_DIR.clone();
         fs::create_dir_all(&sock_dir).unwrap();
         set_permissions(&sock_dir).unwrap();
-        sock_dir.push(SESSION_NAME.get().unwrap());
+        sock_dir.push(envs::get_session_name().unwrap());
         sock_dir
     };
     pub static ref ZELLIJ_TMP_DIR: PathBuf =

--- a/zellij-utils/src/envs.rs
+++ b/zellij-utils/src/envs.rs
@@ -1,0 +1,24 @@
+/// Uniformly operates ZELLIJ* environment variables
+use anyhow::Result;
+use std::env::{set_var, var};
+
+pub const ZELLIJ_ENV_KEY: &str = "ZELLIJ";
+pub fn get_zellij() -> Result<String> {
+    Ok(var(ZELLIJ_ENV_KEY)?)
+}
+pub fn set_zellij(v: String) {
+    set_var(ZELLIJ_ENV_KEY, v);
+}
+
+pub const SESSION_NAME_ENV_KEY: &str = "ZELLIJ_SESSION_NAME";
+pub fn get_session_name() -> Result<String> {
+    Ok(var(SESSION_NAME_ENV_KEY)?)
+}
+pub fn set_session_name(v: String) {
+    set_var(SESSION_NAME_ENV_KEY, v);
+}
+
+pub const SOCKET_DIR_ENV_KEY: &str = "ZELLIJ_SOCKET_DIR";
+pub fn get_socket_dir() -> Result<String> {
+    Ok(var(SOCKET_DIR_ENV_KEY)?)
+}

--- a/zellij-utils/src/input/mod.rs
+++ b/zellij-utils/src/input/mod.rs
@@ -10,6 +10,7 @@ pub mod options;
 pub mod plugins;
 pub mod theme;
 
+use crate::envs;
 use termion::input::TermRead;
 use zellij_tile::data::{InputMode, Key, ModeInfo, Palette, PluginCapabilities};
 
@@ -56,7 +57,7 @@ pub fn get_mode_info(
         InputMode::Session => vec![("d".to_string(), "Detach".to_string())],
     };
 
-    let session_name = std::env::var("ZELLIJ_SESSION_NAME").ok();
+    let session_name = envs::get_session_name().ok();
 
     ModeInfo {
         mode,

--- a/zellij-utils/src/lib.rs
+++ b/zellij-utils/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod channels;
 pub mod cli;
 pub mod consts;
+pub mod envs;
 pub mod errors;
 pub mod input;
 pub mod ipc;


### PR DESCRIPTION
This PR aims to prevent Zellij environment variable manipulation from being scattered in various places of code and to make adding new variables such as `ZELLIJ_PANE_ID` easy.