### PR TITLE
feat(sessions): Suggestion for a similar session name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,6 +1175,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
+name = "lev_distance"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d234d89ecf5621c935b69a4c7266c9a634a95e465081682be47358617ce825b"
+
+[[package]]
 name = "libc"
 version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2153,6 +2159,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "suggestion"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015336207b7660be204f5012fcdb84b3ff35442b26cea77ebe6103929a56e54b"
+dependencies = [
+ "lev_distance",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2868,6 +2883,7 @@ dependencies = [
  "names",
  "rand 0.8.4",
  "ssh2",
+ "suggestion",
  "zellij-client",
  "zellij-server",
  "zellij-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ zellij-server = { path = "zellij-server/", version = "0.20.0" }
 zellij-utils = { path = "zellij-utils/", version = "0.20.0" }
 log = "0.4.14"
 dialoguer = "0.9.0"
+suggestion = "0.1.0"
 
 [dev-dependencies]
 insta = { version = "1.6.0", features = ["backtrace"] }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1,6 +1,7 @@
 use std::os::unix::fs::FileTypeExt;
 use std::time::SystemTime;
 use std::{fs, io, process};
+use suggestion::Suggest;
 use zellij_utils::{
     consts::ZELLIJ_SOCK_DIR,
     interprocess::local_socket::LocalSocketStream,
@@ -177,6 +178,9 @@ pub(crate) fn assert_session(name: &str) {
                 return;
             } else {
                 println!("No session named {:?} found.", name);
+                if let Some(sugg) = get_sessions().unwrap().suggest(name) {
+                    println!("  help: Did you mean `{}`?", sugg);
+                }
             }
         }
         Err(e) => {


### PR DESCRIPTION
I implemented a suggestion for a similar session name if the provided name does not exist.

If an invalid session name is provided, `attach` and `kill session` commands output errors:

```
$ zellij k scientific-activ
No session named "scientific-activ" found.

$ zellij a scientific-activ
No session named "scientific-activ" found.
```

This PR adds help to this using [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) as the same with [rustc implementation](https://github.com/rust-lang/rust/blob/46b8e7488eae116722196e8390c1bd2ea2e396cf/compiler/rustc_span/src/lev_distance.rs#L53):

```
No session named "scientific-activ" found.
  help: Did you mean `scientific-activity`?
```
