### PR TITLE
feat(ci): Support macOS build & test on CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,13 @@ env:
 jobs:
   build:
     name: Build & Test
-    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Zellij seems to support macOS as well on the release page.
I think supporting macOS CI would make Zellij more robust and prevent regression for macOS.
It would be better to support it on e2e tests as well.
