### PR TITLE
fix(ci): Potential vulnerability on GitHub Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,7 @@ on:
     branches: [ main ]
 
 env:
+  CACHE_VER: v1
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -23,7 +24,7 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ env.CACHE_VER }}-${{ github.ref }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Add WASM target
       run: rustup target add wasm32-wasi
     - name: Install cargo-make
@@ -46,7 +47,7 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ env.CACHE_VER }}-${{ github.ref }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Install cargo-make
       run: test -x "${HOME}/.cargo/bin/cargo-make" || cargo install --debug cargo-make
     - name: Check Format
@@ -65,7 +66,7 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ env.CACHE_VER }}-${{ github.ref }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Install cargo-make
       run: test -x "${HOME}/.cargo/bin/cargo-make" || cargo install --debug cargo-make
     - name: Check Lints


### PR DESCRIPTION
Current cache policy on GitHub Actions would potentially be vulnerable; for example, we can replace cached code with malware by opening a new PR. Even if you do not merge it, caches are still risky. Therefore, I recommend they be stored in every branch separately. Additionally, versioning caches lets us immediately drop old caches for security reasons and being stale.

What I did:
* Added [`${{ github.ref }}`](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) to cache keys
* Added cache version to cache keys