### PR TITLE
refactor(tab): close_pane returns closed pane

### DIFF
--- a/zellij-server/src/tab.rs
+++ b/zellij-server/src/tab.rs
@@ -2993,8 +2993,7 @@ impl Tab {
             if let (Some(freed_width), Some(freed_height)) =
                 (freed_space.cols.as_percent(), freed_space.rows.as_percent())
             {
-                let (panes, direction) = self.find_panes_to_grow(id);
-                if let Some(direction) = direction {
+                if let Some((panes, direction)) = self.find_panes_to_grow(id) {
                     self.grow_panes(&panes, direction, (freed_width, freed_height));
                     let pane = self.panes.remove(&id);
                     self.move_clients_out_of_pane(id);
@@ -3011,18 +3010,22 @@ impl Tab {
         }
         None
     }
-    fn find_panes_to_grow(&self, id: PaneId) -> (Vec<PaneId>, Option<Direction>) {
-        if let Some(panes) = self.panes_to_the_left_between_aligning_borders(id) {
-            (panes, Some(Direction::Horizontal))
-        } else if let Some(panes) = self.panes_to_the_right_between_aligning_borders(id) {
-            (panes, Some(Direction::Horizontal))
-        } else if let Some(panes) = self.panes_above_between_aligning_borders(id) {
-            (panes, Some(Direction::Vertical))
-        } else if let Some(panes) = self.panes_below_between_aligning_borders(id) {
-            (panes, Some(Direction::Vertical))
-        } else {
-            (vec![], None)
+    fn find_panes_to_grow(&self, id: PaneId) -> Option<(Vec<PaneId>, Direction)> {
+        if let Some(panes) = self
+            .panes_to_the_left_between_aligning_borders(id)
+            .or_else(|| self.panes_to_the_right_between_aligning_borders(id))
+        {
+            return Some((panes, Direction::Horizontal));
         }
+
+        if let Some(panes) = self
+            .panes_above_between_aligning_borders(id)
+            .or_else(|| self.panes_below_between_aligning_borders(id))
+        {
+            return Some((panes, Direction::Vertical));
+        }
+
+        None
     }
     fn grow_panes(&mut self, panes: &[PaneId], direction: Direction, (width, height): (f64, f64)) {
         match direction {

--- a/zellij-server/src/tab.rs
+++ b/zellij-server/src/tab.rs
@@ -2984,7 +2984,7 @@ impl Tab {
             }
         }
     }
-    pub fn close_pane(&mut self, id: PaneId) {
+    pub fn close_pane(&mut self, id: PaneId) -> Option<Box<dyn Pane>> {
         if self.fullscreen_is_active {
             self.unset_fullscreen();
         }
@@ -2993,49 +2993,50 @@ impl Tab {
             if let (Some(freed_width), Some(freed_height)) =
                 (freed_space.cols.as_percent(), freed_space.rows.as_percent())
             {
-                if let Some(panes) = self.panes_to_the_left_between_aligning_borders(id) {
-                    for pane_id in panes.iter() {
-                        self.increase_pane_width(pane_id, freed_width);
-                    }
-                    self.panes.remove(&id);
+                let (panes, direction) = self.find_panes_to_grow(id);
+                if let Some(direction) = direction {
+                    self.grow_panes(&panes, direction, (freed_width, freed_height));
+                    let pane = self.panes.remove(&id);
                     self.move_clients_out_of_pane(id);
-                    self.relayout_tab(Direction::Horizontal);
-                    return;
-                }
-                if let Some(panes) = self.panes_to_the_right_between_aligning_borders(id) {
-                    for pane_id in panes.iter() {
-                        self.increase_pane_width(pane_id, freed_width);
-                    }
-                    self.panes.remove(&id);
-                    self.move_clients_out_of_pane(id);
-                    self.relayout_tab(Direction::Horizontal);
-                    return;
-                }
-                if let Some(panes) = self.panes_above_between_aligning_borders(id) {
-                    for pane_id in panes.iter() {
-                        self.increase_pane_height(pane_id, freed_height);
-                    }
-                    self.panes.remove(&id);
-                    self.move_clients_out_of_pane(id);
-                    self.relayout_tab(Direction::Vertical);
-                    return;
-                }
-                if let Some(panes) = self.panes_below_between_aligning_borders(id) {
-                    for pane_id in panes.iter() {
-                        self.increase_pane_height(pane_id, freed_height);
-                    }
-                    self.panes.remove(&id);
-                    self.move_clients_out_of_pane(id);
-                    self.relayout_tab(Direction::Vertical);
-                    return;
+                    self.relayout_tab(direction);
+                    return pane;
                 }
             }
             // if we reached here, this is either the last pane or there's some sort of
             // configuration error (eg. we're trying to close a pane surrounded by fixed panes)
-            self.panes.remove(&id);
+            let pane = self.panes.remove(&id);
             self.active_panes.clear();
             self.resize_whole_tab(self.display_area);
+            return pane;
         }
+        None
+    }
+    fn find_panes_to_grow(&self, id: PaneId) -> (Vec<PaneId>, Option<Direction>) {
+        if let Some(panes) = self.panes_to_the_left_between_aligning_borders(id) {
+            (panes, Some(Direction::Horizontal))
+        } else if let Some(panes) = self.panes_to_the_right_between_aligning_borders(id) {
+            (panes, Some(Direction::Horizontal))
+        } else if let Some(panes) = self.panes_above_between_aligning_borders(id) {
+            (panes, Some(Direction::Vertical))
+        } else if let Some(panes) = self.panes_below_between_aligning_borders(id) {
+            (panes, Some(Direction::Vertical))
+        } else {
+            (vec![], None)
+        }
+    }
+    fn grow_panes(&mut self, panes: &[PaneId], direction: Direction, (width, height): (f64, f64)) {
+        match direction {
+            Direction::Horizontal => {
+                for pane_id in panes.iter() {
+                    self.increase_pane_width(pane_id, width);
+                }
+            }
+            Direction::Vertical => {
+                for pane_id in panes.iter() {
+                    self.increase_pane_height(pane_id, height);
+                }
+            }
+        };
     }
     pub fn close_focused_pane(&mut self, client_id: ClientId) {
         if let Some(active_pane_id) = self.get_active_pane_id(client_id) {


### PR DESCRIPTION
Prepare for break pane command (#196) by making close_pane return the closed
pane. Also split the function up to hopefully be more readable.