### PR TITLE
fix(input): properly query bracketed paste mode in terminals

### DIFF
--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -95,10 +95,29 @@ impl InputHandler {
                         }
                     }
                 }
-                Ok((InputInstruction::PastedText(raw_bytes), _error_context)) => {
+                Ok((
+                    InputInstruction::PastedText((
+                        send_bracketed_paste_start,
+                        raw_bytes,
+                        send_bracketed_paste_end,
+                    )),
+                    _error_context,
+                )) => {
                     if self.mode == InputMode::Normal || self.mode == InputMode::Locked {
-                        let action = Action::Write(raw_bytes);
-                        self.dispatch_action(action);
+                        if send_bracketed_paste_start {
+                            let bracketed_paste_start = vec![27, 91, 50, 48, 48, 126]; // \u{1b}[200~
+                            let paste_start_action = Action::Write(bracketed_paste_start);
+                            self.dispatch_action(paste_start_action);
+                        }
+
+                        let pasted_text_action = Action::Write(raw_bytes);
+                        self.dispatch_action(pasted_text_action);
+
+                        if send_bracketed_paste_end {
+                            let bracketed_paste_end = vec![27, 91, 50, 48, 49, 126]; // \u{1b}[201~
+                            let paste_end_action = Action::Write(bracketed_paste_end);
+                            self.dispatch_action(paste_end_action);
+                        }
                     }
                 }
                 Ok((InputInstruction::SwitchToMode(input_mode), _error_context)) => {

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -95,7 +95,7 @@ pub enum ClientInfo {
 pub(crate) enum InputInstruction {
     KeyEvent(termion::event::Event, Vec<u8>),
     SwitchToMode(InputMode),
-    PastedText(Vec<u8>),
+    PastedText((bool, Vec<u8>, bool)), // (send_brackted_paste_start, pasted_text, send_bracketed_paste_end)
 }
 
 pub fn start_client(


### PR DESCRIPTION
When fixing some paste issues in https://github.com/zellij-org/zellij/pull/810 I accidentally broke querying panes for whether they have bracketed paste on or not (oops!). This resulted in several issues.

Here this is fixed by sending the bracketed paste instructions separately to the backend so that it can recognize them and do the right thing depending on the terminal pane.

This should fix https://github.com/zellij-org/zellij/issues/854 and https://github.com/zellij-org/zellij/issues/856