### PR TITLE
fix(options): handling and overwriting cli opts

### DIFF
--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -63,7 +63,7 @@ impl InputHandler {
         let mut err_ctx = OPENCALLS.with(|ctx| *ctx.borrow());
         err_ctx.add_call(ContextType::StdinHandler);
         let alt_left_bracket = vec![27, 91];
-        if !self.options.disable_mouse_mode.unwrap_or_default() {
+        if self.options.mouse_mode.unwrap_or(true) {
             self.os_input.enable_mouse();
         }
         loop {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -560,7 +560,7 @@ pub(crate) fn screen_thread_main(
     config_options: Box<Options>,
 ) {
     let capabilities = config_options.simplified_ui;
-    let draw_pane_frames = !config_options.no_pane_frames.unwrap_or_default();
+    let draw_pane_frames = config_options.pane_frames.unwrap_or(true);
 
     let mut screen = Screen::new(
         bus,

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -155,10 +155,10 @@ impl Options {
 /// boolean flags end up toggling boolean options in `Options`
 pub struct CliOptions {
     /// Disable handling of mouse events
-    #[structopt(long)]
+    #[structopt(long, conflicts_with("mouse-mode"))]
     pub disable_mouse_mode: bool,
     /// Disable display of pane frames
-    #[structopt(long)]
+    #[structopt(long, conflicts_with("pane-frames"))]
     pub no_pane_frames: bool,
     #[structopt(flatten)]
     options: Options,

--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -270,7 +270,7 @@ impl Setup {
         // https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
         let hyperlink_start = "\u{1b}]8;;";
         let hyperlink_mid = "\u{1b}\\";
-        let hyperlink_end = "\u{1b}]8;;\u{1b}\\\n'";
+        let hyperlink_end = "\u{1b}]8;;\u{1b}\\";
 
         let mut message = String::new();
 
@@ -315,7 +315,7 @@ impl Setup {
 
         message.push_str(&format!("[ARROW SEPARATOR]: {}\n", ARROW_SEPARATOR));
         message.push_str(" Is the [ARROW_SEPARATOR] displayed correctly?\n");
-        message.push_str(" If not you may want to either start zellij with a compatible mode 'zellij options --simplified-ui'\n");
+        message.push_str(" If not you may want to either start zellij with a compatible mode: 'zellij options --simplified-ui true'\n");
         let mut hyperlink_compat = String::new();
         hyperlink_compat.push_str(hyperlink_start);
         hyperlink_compat.push_str("https://zellij.dev/documentation/compatibility.html#the-status-bar-fonts-dont-render-correctly");
@@ -326,6 +326,9 @@ impl Setup {
             " Or check the font that is in use:\n {}\n",
             hyperlink_compat
         ));
+        message.push_str("[MOUSE INTERACTION]: \n");
+        message.push_str(" Can be temporarily disabled through pressing the [SHIFT] key.\n");
+        message.push_str(" If that doesn't fix any issues consider to disable the mouse handling of zellij: 'zellij options --disable-mouse-mode'\n");
 
         message.push_str(&format!("[FEATURES]: {:?}\n", FEATURES));
         let mut hyperlink = String::new();
@@ -334,7 +337,7 @@ impl Setup {
         hyperlink.push_str(hyperlink_mid);
         hyperlink.push_str("zellij.dev/documentation");
         hyperlink.push_str(hyperlink_end);
-        message.push_str(&format!("[DOCUMENTATION]: {}", hyperlink));
+        message.push_str(&format!("[DOCUMENTATION]: {}\n", hyperlink));
         //printf '\e]8;;http://example.com\e\\This is a link\e]8;;\e\\\n'
 
         std::io::stdout().write_all(message.as_bytes())?;


### PR DESCRIPTION
* previously it was only possible to turn off certain features with a
  command line option, now it is possible to also overwrite this
  behavior in a sane way, for that some breaking changes happened:

  following options got renamed and inverted:
  ```
  disable_mouse_mode -> mouse_mode
  no_pane_frames -> pane_frames
  ```

  following cli options got added:
  ```
  mouse-mode [bool]
  pane-frames [bool]
  simplified-ui [bool]
  ```

  the following cli flag got removed:
  ```
  simplified-ui
  ```

  They can be specified in the following way:
  ```
  zellij options --mouse-mode true
  ```
  in order to enable the mouse mode, even if it is turned off in the
  config file:
  ```
  mouse_mode: false
  ```

  The order is now as follows:
  1. corresponding flag (`disable-mouse-mode`)
  2. corresponding option (`mouse-mode`)
  3. corresponding config option (`mouse_mode`)