### PR TITLE
fix(typo): fix setup --check

### DIFF
--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -335,7 +335,7 @@ impl Setup {
         if let Some(layout_dir) = layout_dir {
             message.push_str(&format!("[LAYOUT DIR]: {:?}\n", layout_dir));
         } else {
-            message.push_str("[CONFIG FILE]: Not Found\n");
+            message.push_str("[LAYOUT DIR]: Not Found\n");
         }
         message.push_str(&format!("[SYSTEM DATA DIR]: {:?}\n", system_data_dir));
 


### PR DESCRIPTION
Fixing a typo in `setup --check`.