### PR TITLE
feat(update): integrate dependabot for gh actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
* dependabot will check weekly, if the gh actions have new versions
  available and will open a pr, if necessary