### PR TITLE
fix: mismatch JSON format on `get_zellij_version`

### DIFF
--- a/zellij-server/src/wasm_vm.rs
+++ b/zellij-server/src/wasm_vm.rs
@@ -313,7 +313,7 @@ fn host_get_plugin_ids(plugin_env: &PluginEnv) {
 }
 
 fn host_get_zellij_version(plugin_env: &PluginEnv) {
-    wasi_write_object(&plugin_env.wasi_env, &VERSION.to_string());
+    wasi_write_object(&plugin_env.wasi_env, VERSION);
 }
 
 fn host_open_file(plugin_env: &PluginEnv) {
@@ -397,7 +397,7 @@ pub fn wasi_write_string(wasi_env: &WasiEnv, buf: &str) {
     writeln!(wasi_file, "{}\r", buf).unwrap();
 }
 
-pub fn wasi_write_object(wasi_env: &WasiEnv, object: &impl Serialize) {
+pub fn wasi_write_object(wasi_env: &WasiEnv, object: &(impl Serialize + ?Sized)) {
     wasi_write_string(wasi_env, &serde_json::to_string(&object).unwrap());
 }
 


### PR DESCRIPTION
This PR related #848 #894

@TheLostLambda 
Previously, we added the `get_zellij_version` function to provide the zellij version to the plugin.
I founded a bug during development after this feature was merged.

`object_from_stdin` is serialized through serde. However, `host_get_zellij_version()` writes only `String` values ​​through the `wasi_write_string` function. This causes a ["trailing characters"](https://github.com/serde-rs/json/issues/549) error because it's not in normal JSON format.

So, Here we have two choices.

1. Re-implement `string_from_stdin`
2. The `host_get_zellij_version` function returns a object that can be serialized, not a String (`VERSION` const value).

I look fine either way.
I'd love to hear your opinions :)