### PR TITLE
fix(compatibility): do not duplicate bracketed paste in chunked stdin input

### DIFF
--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -61,6 +61,7 @@ pub(crate) fn stdin_loop(
     let adjusted_keys = keys_to_adjust();
     loop {
         let mut stdin_buffer = os_input.read_from_stdin();
+        log::info!("stdin_buffer is: {:?}", String::from_utf8(stdin_buffer.clone()).unwrap());
         if pasting
             || (stdin_buffer.len() > bracketed_paste_start.len()
                 && stdin_buffer

--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -61,7 +61,6 @@ pub(crate) fn stdin_loop(
     let adjusted_keys = keys_to_adjust();
     loop {
         let mut stdin_buffer = os_input.read_from_stdin();
-        log::info!("stdin_buffer is: {:?}", String::from_utf8(stdin_buffer.clone()).unwrap());
         if pasting
             || (stdin_buffer.len() > bracketed_paste_start.len()
                 && stdin_buffer

--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -95,6 +95,14 @@ pub(crate) fn stdin_loop(
                     pasting = false;
                 }
                 None => {
+                    let starts_with_bracketed_paste_start = stdin_buffer
+                        .iter()
+                        .take(bracketed_paste_start.len())
+                        .eq(bracketed_paste_start.iter());
+                    if starts_with_bracketed_paste_start {
+                        drop(stdin_buffer.drain(..6)); // bracketed paste start
+                    }
+
                     send_input_instructions
                         .send(InputInstruction::PastedText((true, stdin_buffer, false)))
                         .unwrap();

--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -104,7 +104,7 @@ pub(crate) fn stdin_loop(
                     }
 
                     send_input_instructions
-                        .send(InputInstruction::PastedText((true, stdin_buffer, false)))
+                        .send(InputInstruction::PastedText((starts_with_bracketed_paste_start, stdin_buffer, false)))
                         .unwrap();
                     pasting = true;
                     continue;

--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -103,7 +103,11 @@ pub(crate) fn stdin_loop(
                     }
 
                     send_input_instructions
-                        .send(InputInstruction::PastedText((starts_with_bracketed_paste_start, stdin_buffer, false)))
+                        .send(InputInstruction::PastedText((
+                            starts_with_bracketed_paste_start,
+                            stdin_buffer,
+                            false,
+                        )))
                         .unwrap();
                     pasting = true;
                     continue;

--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -109,7 +109,7 @@ impl NamedColor {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
 pub struct CharacterStyles {
     pub foreground: Option<AnsiCode>,
     pub background: Option<AnsiCode>,
@@ -123,25 +123,6 @@ pub struct CharacterStyles {
     pub dim: Option<AnsiCode>,
     pub italic: Option<AnsiCode>,
     pub link_anchor: Option<LinkAnchor>,
-}
-
-impl Default for CharacterStyles {
-    fn default() -> Self {
-        Self {
-            foreground: None,
-            background: None,
-            strike: None,
-            hidden: None,
-            reverse: None,
-            slow_blink: None,
-            fast_blink: None,
-            underline: None,
-            bold: None,
-            dim: None,
-            italic: None,
-            link_anchor: None,
-        }
-    }
 }
 
 impl CharacterStyles {

--- a/zellij-server/src/tab.rs
+++ b/zellij-server/src/tab.rs
@@ -946,7 +946,7 @@ impl Tab {
                             .or_insert_with(|| Boundaries::new(self.viewport));
                         pane_contents_and_ui.render_pane_boundaries(
                             *client_id,
-                            &mut boundaries,
+                            boundaries,
                             self.session_is_mirrored,
                         );
                     }

--- a/zellij-server/src/ui/overlay/mod.rs
+++ b/zellij-server/src/ui/overlay/mod.rs
@@ -44,17 +44,9 @@ impl Overlayable for OverlayType {
 /// Entrypoint from [`Screen`], which holds the context in which
 /// the overlays are being rendered.
 /// The most recent overlays draw over the previous overlays.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct OverlayWindow {
     pub overlay_stack: Vec<Overlay>,
-}
-
-impl Default for OverlayWindow {
-    fn default() -> Self {
-        Self {
-            overlay_stack: vec![],
-        }
-    }
 }
 
 impl Overlayable for OverlayWindow {

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -162,7 +162,7 @@ pub struct LayoutFromYamlIntermediate {
 
 // The struct that is used to deserialize the layout from
 // a yaml configuration file
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 #[serde(crate = "self::serde")]
 #[serde(default)]
 pub struct LayoutFromYaml {
@@ -771,17 +771,6 @@ impl Default for LayoutTemplate {
             }],
             split_size: None,
             run: None,
-        }
-    }
-}
-
-impl Default for LayoutFromYaml {
-    fn default() -> Self {
-        Self {
-            session: SessionFromYaml::default(),
-            template: LayoutTemplate::default(),
-            borderless: false,
-            tabs: vec![],
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/885

Windows terminal apparently chunks stdin quite a bit, also when pasting. We detect bracketed paste in Zellij and interpret it for performance reasons (we chunk it up to reduce traffic between Zellij's client/server). There were certain cases in which we didn't handle this correctly and ended up duplicating the bracketed paste instruction and so it appeared on screen.

This fixes that.

Thanks @tranzystorek-io for the hand in debugging this!

EDIT: also a bunch of clippy fixes because a new stable rust came in the middle :)