### PR TITLE
Add various refactorings

### DIFF
--- a/default-plugins/status-bar/src/first_line.rs
+++ b/default-plugins/status-bar/src/first_line.rs
@@ -93,7 +93,7 @@ fn selected_mode_shortcut(
 ) -> LinePart {
     let prefix_separator = palette.selected_prefix_separator.paint(separator);
     let char_left_separator = palette.selected_char_left_separator.paint(" <".to_string());
-    let char_shortcut = palette.selected_char_shortcut.paint(format!("{}", letter));
+    let char_shortcut = palette.selected_char_shortcut.paint(letter.to_string());
     let char_right_separator = palette.selected_char_right_separator.paint(">".to_string());
     let styled_text = palette.selected_styled_text.paint(format!("{} ", text));
     let suffix_separator = palette.selected_suffix_separator.paint(separator);

--- a/default-plugins/status-bar/src/main.rs
+++ b/default-plugins/status-bar/src/main.rs
@@ -176,7 +176,7 @@ impl ZellijPlugin for State {
         let first_line = format!("{}{}", superkey, ctrl_keys);
 
         let mut second_line = LinePart::default();
-        for t in self.tabs.iter_mut() {
+        for t in &mut self.tabs {
             if t.active {
                 match self.mode_info.mode {
                     InputMode::Normal => {

--- a/default-plugins/status-bar/src/second_line.rs
+++ b/default-plugins/status-bar/src/second_line.rs
@@ -31,16 +31,14 @@ fn full_length_shortcut(
     let description = Style::new().fg(white_color).bold().paint(description);
     let len = shortcut_len + description_len + separator.chars().count();
     LinePart {
-        part: format!(
-            "{}",
-            ANSIStrings(&[
-                separator,
-                shortcut_left_separator,
-                shortcut,
-                shortcut_right_separator,
-                description
-            ])
-        ),
+        part: ANSIStrings(&[
+            separator,
+            shortcut_left_separator,
+            shortcut,
+            shortcut_right_separator,
+            description,
+        ])
+        .to_string(),
         len,
     }
 }
@@ -73,16 +71,14 @@ fn first_word_shortcut(
         .paint(description_first_word);
     let len = shortcut_len + description_first_word_length + separator.chars().count();
     LinePart {
-        part: format!(
-            "{}",
-            ANSIStrings(&[
-                separator,
-                shortcut_left_separator,
-                shortcut,
-                shortcut_right_separator,
-                description_first_word,
-            ])
-        ),
+        part: ANSIStrings(&[
+            separator,
+            shortcut_left_separator,
+            shortcut,
+            shortcut_right_separator,
+            description_first_word,
+        ])
+        .to_string(),
         len,
     }
 }
@@ -284,7 +280,7 @@ fn locked_interface_indication(palette: Palette) -> LinePart {
     };
     let locked_styled_text = Style::new().fg(white_color).bold().paint(locked_text);
     LinePart {
-        part: format!("{}", locked_styled_text),
+        part: locked_styled_text.to_string(),
         len: locked_text_len,
     }
 }
@@ -310,16 +306,14 @@ fn select_pane_shortcut(is_first_shortcut: bool, palette: Palette) -> LinePart {
     let description = Style::new().fg(white_color).bold().paint(description);
     let len = shortcut_len + description_len + separator.chars().count();
     LinePart {
-        part: format!(
-            "{}",
-            ANSIStrings(&[
-                separator,
-                shortcut_left_separator,
-                shortcut,
-                shortcut_right_separator,
-                description
-            ])
-        ),
+        part: ANSIStrings(&[
+            separator,
+            shortcut_left_separator,
+            shortcut,
+            shortcut_right_separator,
+            description,
+        ])
+        .to_string(),
         len,
     }
 }
@@ -422,7 +416,7 @@ pub fn text_copied_hint(palette: &Palette) -> LinePart {
         PaletteColor::EightBit(color) => Fixed(color),
     };
     LinePart {
-        part: format!("{}", Style::new().fg(green_color).bold().paint(hint)),
+        part: Style::new().fg(green_color).bold().paint(hint).to_string(),
         len: hint.len(),
     }
 }

--- a/default-plugins/tab-bar/src/line.rs
+++ b/default-plugins/tab-bar/src/line.rs
@@ -107,10 +107,8 @@ fn left_more_message(tab_count_to_the_left: usize, palette: Palette, separator: 
         .bold()
         .paint(more_text);
     let right_separator = style!(palette.orange, palette.gray).paint(separator);
-    let more_styled_text = format!(
-        "{}",
-        ANSIStrings(&[left_separator, more_styled_text, right_separator,])
-    );
+    let more_styled_text =
+        ANSIStrings(&[left_separator, more_styled_text, right_separator]).to_string();
     LinePart {
         part: more_styled_text,
         len: more_text_len,
@@ -137,10 +135,8 @@ fn right_more_message(
         .bold()
         .paint(more_text);
     let right_separator = style!(palette.orange, palette.gray).paint(separator);
-    let more_styled_text = format!(
-        "{}",
-        ANSIStrings(&[left_separator, more_styled_text, right_separator,])
-    );
+    let more_styled_text =
+        ANSIStrings(&[left_separator, more_styled_text, right_separator]).to_string();
     LinePart {
         part: more_styled_text,
         len: more_text_len,
@@ -155,7 +151,7 @@ fn tab_line_prefix(session_name: Option<&str>, palette: Palette, cols: usize) ->
         .bold()
         .paint(prefix_text);
     let mut parts = vec![LinePart {
-        part: format!("{}", prefix_styled_text),
+        part: prefix_styled_text.to_string(),
         len: prefix_text_len,
     }];
     if let Some(name) = session_name {
@@ -164,7 +160,7 @@ fn tab_line_prefix(session_name: Option<&str>, palette: Palette, cols: usize) ->
         let name_part_styled_text = style!(palette.white, palette.gray).bold().paint(name_part);
         if cols.saturating_sub(prefix_text_len) >= name_part_len {
             parts.push(LinePart {
-                part: format!("{}", name_part_styled_text),
+                part: name_part_styled_text.to_string(),
                 len: name_part_len,
             })
         }

--- a/default-plugins/tab-bar/src/main.rs
+++ b/default-plugins/tab-bar/src/main.rs
@@ -43,7 +43,7 @@ impl ZellijPlugin for State {
             Event::ModeUpdate(mode_info) => self.mode_info = mode_info,
             Event::TabUpdate(tabs) => {
                 // tabs are indexed starting from 1 so we need to add 1
-                self.active_tab_idx = (&tabs).iter().position(|t| t.active).unwrap() + 1;
+                self.active_tab_idx = tabs.iter().position(|t| t.active).unwrap() + 1;
                 self.tabs = tabs;
             }
             Event::Mouse(me) => match me {
@@ -69,7 +69,7 @@ impl ZellijPlugin for State {
         }
         let mut all_tabs: Vec<LinePart> = vec![];
         let mut active_tab_index = 0;
-        for t in self.tabs.iter_mut() {
+        for t in &mut self.tabs {
             let mut tabname = t.name.clone();
             if t.active && self.mode_info.mode == InputMode::RenameTab {
                 if tabname.is_empty() {

--- a/default-plugins/tab-bar/src/tab.rs
+++ b/default-plugins/tab-bar/src/tab.rs
@@ -11,10 +11,8 @@ pub fn active_tab(text: String, palette: Palette, separator: &str) -> LinePart {
         .bold()
         .paint(format!(" {} ", text));
     let right_separator = style!(palette.green, palette.gray).paint(separator);
-    let tab_styled_text = format!(
-        "{}",
-        ANSIStrings(&[left_separator, tab_styled_text, right_separator,])
-    );
+    let tab_styled_text =
+        ANSIStrings(&[left_separator, tab_styled_text, right_separator]).to_string();
     LinePart {
         part: tab_styled_text,
         len: tab_text_len,
@@ -28,10 +26,8 @@ pub fn non_active_tab(text: String, palette: Palette, separator: &str) -> LinePa
         .bold()
         .paint(format!(" {} ", text));
     let right_separator = style!(palette.fg, palette.gray).paint(separator);
-    let tab_styled_text = format!(
-        "{}",
-        ANSIStrings(&[left_separator, tab_styled_text, right_separator,])
-    );
+    let tab_styled_text =
+        ANSIStrings(&[left_separator, tab_styled_text, right_separator]).to_string();
     LinePart {
         part: tab_styled_text,
         len: tab_text_len,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -40,7 +40,7 @@ pub(crate) fn kill_all_sessions(yes: bool) {
                     process::exit(1);
                 }
             }
-            for session in sessions.iter() {
+            for session in &sessions {
                 kill_session_impl(session);
             }
             process::exit(0);
@@ -131,7 +131,7 @@ fn attach_with_session_name(
     config_options: Options,
     create: bool,
 ) -> ClientInfo {
-    match session_name.as_ref() {
+    match &session_name {
         Some(session) if create => {
             if !session_exists(session).unwrap() {
                 ClientInfo::New(session_name.unwrap())

--- a/src/tests/e2e/cases.rs
+++ b/src/tests/e2e/cases.rs
@@ -5,6 +5,7 @@ use zellij_utils::{pane_size::Size, position::Position};
 
 use rand::Rng;
 
+use std::fmt::Write;
 use std::path::Path;
 
 use super::remote_runner::{RemoteRunner, RemoteTerminal, Step};
@@ -231,26 +232,26 @@ pub fn scrolling_inside_a_pane() {
                     if remote_terminal.cursor_position_is(63, 2) && remote_terminal.tip_appears() {
                         // cursor is in the newly opened second pane
                         let mut content_to_send = String::new();
-                        content_to_send.push_str(&format!("{:0<56}", "line1 "));
-                        content_to_send.push_str(&format!("{:0<58}", "line2 "));
-                        content_to_send.push_str(&format!("{:0<58}", "line3 "));
-                        content_to_send.push_str(&format!("{:0<58}", "line4 "));
-                        content_to_send.push_str(&format!("{:0<58}", "line5 "));
-                        content_to_send.push_str(&format!("{:0<58}", "line6 "));
-                        content_to_send.push_str(&format!("{:0<58}", "line7 "));
-                        content_to_send.push_str(&format!("{:0<58}", "line8 "));
-                        content_to_send.push_str(&format!("{:0<58}", "line9 "));
-                        content_to_send.push_str(&format!("{:0<58}", "line10 "));
-                        content_to_send.push_str(&format!("{:0<58}", "line11 "));
-                        content_to_send.push_str(&format!("{:0<58}", "line12 "));
-                        content_to_send.push_str(&format!("{:0<58}", "line13 "));
-                        content_to_send.push_str(&format!("{:0<58}", "line14 "));
-                        content_to_send.push_str(&format!("{:0<58}", "line15 "));
-                        content_to_send.push_str(&format!("{:0<58}", "line16 "));
-                        content_to_send.push_str(&format!("{:0<58}", "line17 "));
-                        content_to_send.push_str(&format!("{:0<58}", "line18 "));
-                        content_to_send.push_str(&format!("{:0<58}", "line19 "));
-                        content_to_send.push_str(&format!("{:0<57}", "line20 "));
+                        write!(&mut content_to_send, "{:0<56}", "line1 ").unwrap();
+                        write!(&mut content_to_send, "{:0<58}", "line2 ").unwrap();
+                        write!(&mut content_to_send, "{:0<58}", "line3 ").unwrap();
+                        write!(&mut content_to_send, "{:0<58}", "line4 ").unwrap();
+                        write!(&mut content_to_send, "{:0<58}", "line5 ").unwrap();
+                        write!(&mut content_to_send, "{:0<58}", "line6 ").unwrap();
+                        write!(&mut content_to_send, "{:0<58}", "line7 ").unwrap();
+                        write!(&mut content_to_send, "{:0<58}", "line8 ").unwrap();
+                        write!(&mut content_to_send, "{:0<58}", "line9 ").unwrap();
+                        write!(&mut content_to_send, "{:0<58}", "line10 ").unwrap();
+                        write!(&mut content_to_send, "{:0<58}", "line11 ").unwrap();
+                        write!(&mut content_to_send, "{:0<58}", "line12 ").unwrap();
+                        write!(&mut content_to_send, "{:0<58}", "line13 ").unwrap();
+                        write!(&mut content_to_send, "{:0<58}", "line14 ").unwrap();
+                        write!(&mut content_to_send, "{:0<58}", "line15 ").unwrap();
+                        write!(&mut content_to_send, "{:0<58}", "line16 ").unwrap();
+                        write!(&mut content_to_send, "{:0<58}", "line17 ").unwrap();
+                        write!(&mut content_to_send, "{:0<58}", "line18 ").unwrap();
+                        write!(&mut content_to_send, "{:0<58}", "line19 ").unwrap();
+                        write!(&mut content_to_send, "{:0<57}", "line20 ").unwrap();
 
                         remote_terminal.send_key(content_to_send.as_bytes());
 

--- a/src/tests/e2e/remote_runner.rs
+++ b/src/tests/e2e/remote_runner.rs
@@ -45,14 +45,12 @@ fn setup_remote_environment(channel: &mut ssh2::Channel, win_size: Size) {
         .request_pty("xterm", None, Some((columns, rows, 0, 0)))
         .unwrap();
     channel.shell().unwrap();
-    channel.write_all("export PS1=\"$ \"\n".as_bytes()).unwrap();
+    channel.write_all(b"export PS1=\"$ \"\n").unwrap();
     channel.flush().unwrap();
 }
 
 fn stop_zellij(channel: &mut ssh2::Channel) {
-    channel
-        .write_all("killall -KILL zellij\n".as_bytes())
-        .unwrap();
+    channel.write_all(b"killall -KILL zellij\n").unwrap();
 }
 
 fn start_zellij(channel: &mut ssh2::Channel) {

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -299,9 +299,9 @@ pub fn start_client(
                 os_input.send_to_server(ClientToServerMsg::ClientExited);
 
                 if let ExitReason::Error(_) = reason {
-                    handle_error(format!("{}", reason));
+                    handle_error(reason.to_string());
                 }
-                exit_msg = format!("{}", reason);
+                exit_msg = reason.to_string();
                 break;
             }
             ClientInstruction::Error(backtrace) => {

--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -66,14 +66,14 @@ pub(crate) fn stdin_loop(
                 && stdin_buffer
                     .iter()
                     .take(bracketed_paste_start.len())
-                    .eq(bracketed_paste_start.iter()))
+                    .eq(&bracketed_paste_start))
         {
             match bracketed_paste_end_position(&stdin_buffer) {
                 Some(paste_end_position) => {
                     let starts_with_bracketed_paste_start = stdin_buffer
                         .iter()
                         .take(bracketed_paste_start.len())
-                        .eq(bracketed_paste_start.iter());
+                        .eq(&bracketed_paste_start);
 
                     let ends_with_bracketed_paste_end = true;
 
@@ -97,7 +97,7 @@ pub(crate) fn stdin_loop(
                     let starts_with_bracketed_paste_start = stdin_buffer
                         .iter()
                         .take(bracketed_paste_start.len())
-                        .eq(bracketed_paste_start.iter());
+                        .eq(&bracketed_paste_start);
                     if starts_with_bracketed_paste_start {
                         drop(stdin_buffer.drain(..6)); // bracketed paste start
                     }

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -451,9 +451,8 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                 // Here the output is of the type Option<String> sent by screen thread.
                 // If `Some(_)`- unwrap it and forward it to the clients to render.
                 // If `None`- Send an exit instruction. This is the case when a user closes the last Tab/Pane.
-                if let Some(op) = output.as_mut() {
-                    for (client_id, client_render_instruction) in
-                        op.client_render_instructions.iter_mut()
+                if let Some(op) = &mut output {
+                    for (client_id, client_render_instruction) in &mut op.client_render_instructions
                     {
                         os_input.send_to_client(
                             *client_id,

--- a/zellij-server/src/logging_pipe.rs
+++ b/zellij-server/src/logging_pipe.rs
@@ -147,7 +147,7 @@ mod logging_pipe_test {
     fn write_without_endl_does_not_consume_buffer_after_flush() {
         let mut pipe = LoggingPipe::new("TestPipe", 0);
 
-        let test_buffer = "Testing write".as_bytes();
+        let test_buffer = b"Testing write";
 
         pipe.write_all(test_buffer).expect("Err write");
         pipe.flush().expect("Err flush");
@@ -159,7 +159,7 @@ mod logging_pipe_test {
     fn write_with_single_endl_at_the_end_consumes_whole_buffer_after_flush() {
         let mut pipe = LoggingPipe::new("TestPipe", 0);
 
-        let test_buffer = "Testing write \n".as_bytes();
+        let test_buffer = b"Testing write \n";
 
         pipe.write_all(test_buffer).expect("Err write");
         pipe.flush().expect("Err flush");
@@ -171,8 +171,8 @@ mod logging_pipe_test {
     fn write_with_endl_in_the_middle_consumes_buffer_up_to_endl_after_flush() {
         let mut pipe = LoggingPipe::new("TestPipe", 0);
 
-        let test_buffer = "Testing write \n".as_bytes();
-        let test_buffer2 = "And the rest".as_bytes();
+        let test_buffer = b"Testing write \n";
+        let test_buffer2: &[_] = b"And the rest";
 
         pipe.write_all(
             [
@@ -195,7 +195,7 @@ mod logging_pipe_test {
     fn write_with_many_endl_consumes_whole_buffer_after_flush() {
         let mut pipe = LoggingPipe::new("TestPipe", 0);
 
-        let test_buffer = "Testing write \n".as_bytes();
+        let test_buffer: &[_] = b"Testing write \n";
 
         pipe.write_all(
             [
@@ -235,7 +235,7 @@ mod logging_pipe_test {
     #[test]
     fn write_with_many_endls_consumes_everything_after_flush() {
         let mut pipe = LoggingPipe::new("TestPipe", 0);
-        let test_buffer = "Testing write \n".as_bytes();
+        let test_buffer: &[_] = b"Testing write \n";
 
         pipe.write_all(
             [test_buffer, test_buffer, b"\n", b"\n", b"\n"]

--- a/zellij-server/src/panes/link_handler.rs
+++ b/zellij-server/src/panes/link_handler.rs
@@ -99,7 +99,7 @@ mod tests {
     #[test]
     fn dispatch_osc8_link_end() {
         let mut link_handler = LinkHandler::default();
-        let params = vec!["8".as_bytes(), &[], &[]];
+        let params: Vec<&[_]> = vec![b"8", b"", b""];
 
         let anchor = link_handler.dispatch_osc8(&params);
 

--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use std::sync::mpsc::channel;
 use std::time::Instant;
 use std::unimplemented;
@@ -165,12 +166,14 @@ impl Pane for PluginPane {
                     .concat()
                 };
 
-                vte_output.push_str(&format!(
+                write!(
+                    &mut vte_output,
                     "\u{1b}[{};{}H\u{1b}[m{}",
                     self.get_content_y() + 1 + index,
                     self.get_content_x() + 1,
                     line_to_print,
-                )); // goto row/col and reset styles
+                )
+                .unwrap(); // goto row/col and reset styles
                 let line_len = line_to_print.len();
                 if line_len < self.get_content_columns() {
                     // pad line
@@ -185,11 +188,13 @@ impl Pane for PluginPane {
                 for line_index in total_line_count..self.get_content_rows() {
                     let x = self.get_content_x();
                     let y = self.get_content_y();
-                    vte_output.push_str(&format!(
+                    write!(
+                        &mut vte_output,
                         "\u{1b}[{};{}H\u{1b}[m",
                         y + line_index + 1,
                         x + 1
-                    )); // goto row/col and reset styles
+                    )
+                    .unwrap(); // goto row/col and reset styles
                     for _col_index in 0..self.get_content_columns() {
                         vte_output.push(' ');
                     }

--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -68,44 +68,48 @@ pub enum NamedColor {
 
 impl NamedColor {
     fn to_foreground_ansi_code(self) -> String {
-        match self {
-            NamedColor::Black => format!("{}", 30),
-            NamedColor::Red => format!("{}", 31),
-            NamedColor::Green => format!("{}", 32),
-            NamedColor::Yellow => format!("{}", 33),
-            NamedColor::Blue => format!("{}", 34),
-            NamedColor::Magenta => format!("{}", 35),
-            NamedColor::Cyan => format!("{}", 36),
-            NamedColor::White => format!("{}", 37),
-            NamedColor::BrightBlack => format!("{}", 90),
-            NamedColor::BrightRed => format!("{}", 91),
-            NamedColor::BrightGreen => format!("{}", 92),
-            NamedColor::BrightYellow => format!("{}", 93),
-            NamedColor::BrightBlue => format!("{}", 94),
-            NamedColor::BrightMagenta => format!("{}", 95),
-            NamedColor::BrightCyan => format!("{}", 96),
-            NamedColor::BrightWhite => format!("{}", 97),
-        }
+        let v = match self {
+            NamedColor::Black => 30,
+            NamedColor::Red => 31,
+            NamedColor::Green => 32,
+            NamedColor::Yellow => 33,
+            NamedColor::Blue => 34,
+            NamedColor::Magenta => 35,
+            NamedColor::Cyan => 36,
+            NamedColor::White => 37,
+            NamedColor::BrightBlack => 90,
+            NamedColor::BrightRed => 91,
+            NamedColor::BrightGreen => 92,
+            NamedColor::BrightYellow => 93,
+            NamedColor::BrightBlue => 94,
+            NamedColor::BrightMagenta => 95,
+            NamedColor::BrightCyan => 96,
+            NamedColor::BrightWhite => 97,
+        };
+
+        v.to_string()
     }
     fn to_background_ansi_code(self) -> String {
-        match self {
-            NamedColor::Black => format!("{}", 40),
-            NamedColor::Red => format!("{}", 41),
-            NamedColor::Green => format!("{}", 42),
-            NamedColor::Yellow => format!("{}", 43),
-            NamedColor::Blue => format!("{}", 44),
-            NamedColor::Magenta => format!("{}", 45),
-            NamedColor::Cyan => format!("{}", 46),
-            NamedColor::White => format!("{}", 47),
-            NamedColor::BrightBlack => format!("{}", 100),
-            NamedColor::BrightRed => format!("{}", 101),
-            NamedColor::BrightGreen => format!("{}", 102),
-            NamedColor::BrightYellow => format!("{}", 103),
-            NamedColor::BrightBlue => format!("{}", 104),
-            NamedColor::BrightMagenta => format!("{}", 105),
-            NamedColor::BrightCyan => format!("{}", 106),
-            NamedColor::BrightWhite => format!("{}", 107),
-        }
+        let v = match self {
+            NamedColor::Black => 40,
+            NamedColor::Red => 41,
+            NamedColor::Green => 42,
+            NamedColor::Yellow => 43,
+            NamedColor::Blue => 44,
+            NamedColor::Magenta => 45,
+            NamedColor::Cyan => 46,
+            NamedColor::White => 47,
+            NamedColor::BrightBlack => 100,
+            NamedColor::BrightRed => 101,
+            NamedColor::BrightGreen => 102,
+            NamedColor::BrightYellow => 103,
+            NamedColor::BrightBlue => 104,
+            NamedColor::BrightMagenta => 105,
+            NamedColor::BrightCyan => 106,
+            NamedColor::BrightWhite => 107,
+        };
+
+        v.to_string()
     }
 }
 

--- a/zellij-server/src/panes/unit/terminal_pane_tests.rs
+++ b/zellij-server/src/panes/unit/terminal_pane_tests.rs
@@ -4,6 +4,8 @@ use ::insta::assert_snapshot;
 use zellij_utils::pane_size::PaneGeom;
 use zellij_utils::zellij_tile::data::Palette;
 
+use std::fmt::Write;
+
 #[test]
 pub fn scrolling_inside_a_pane() {
     let mut fake_win_size = PaneGeom::default();
@@ -15,9 +17,9 @@ pub fn scrolling_inside_a_pane() {
     let mut terminal_pane = TerminalPane::new(pid, fake_win_size, palette, 0); // 0 is the pane index
     let mut text_to_fill_pane = String::new();
     for i in 0..30 {
-        text_to_fill_pane.push_str(&format!("\rline {}\n", i + 1));
+        writeln!(&mut text_to_fill_pane, "\rline {}", i + 1).unwrap();
     }
-    terminal_pane.handle_pty_bytes(text_to_fill_pane.as_bytes().to_vec());
+    terminal_pane.handle_pty_bytes(text_to_fill_pane.into_bytes());
     terminal_pane.scroll_up(10);
     assert_snapshot!(format!("{:?}", terminal_pane.grid));
     terminal_pane.scroll_down(3);

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -284,13 +284,12 @@ impl Pty {
                         PaneId::Plugin(..) => None,
                         PaneId::Terminal(id) => self.id_to_child_pid.get(id),
                     })
-                    .and_then(|id| {
+                    .and_then(|&id| {
                         self.bus
                             .os_input
                             .as_ref()
-                            .map(|input| input.get_cwd(Pid::from_raw(*id)))
-                    })
-                    .flatten();
+                            .and_then(|input| input.get_cwd(Pid::from_raw(id)))
+                    });
             };
         };
     }

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -55,7 +55,7 @@ fn route_action(
                 .senders
                 .send_to_screen(ScreenInstruction::ClearScroll(client_id))
                 .unwrap();
-            let val = Vec::from(val.as_bytes());
+            let val = val.into_bytes();
             session
                 .senders
                 .send_to_screen(ScreenInstruction::WriteCharacter(val, client_id))

--- a/zellij-server/src/tab.rs
+++ b/zellij-server/src/tab.rs
@@ -360,7 +360,7 @@ impl Tab {
         let positions_in_layout = layout.position_panes_in_space(&free_space);
 
         let mut positions_and_size = positions_in_layout.iter();
-        for (pane_kind, terminal_pane) in self.panes.iter_mut() {
+        for (pane_kind, terminal_pane) in &mut self.panes {
             // for now the layout only supports terminal panes
             if let PaneId::Terminal(pid) = pane_kind {
                 match positions_and_size.next() {
@@ -774,7 +774,7 @@ impl Tab {
         if self.fullscreen_is_active {
             let first_client_id = self.connected_clients.iter().next().unwrap(); // this is a temporary hack until we fix the ui for multiple clients
             let active_pane_id = self.active_panes.get(first_client_id).unwrap();
-            for terminal_id in self.panes_to_hide.iter() {
+            for terminal_id in &self.panes_to_hide {
                 let pane = self.panes.get_mut(terminal_id).unwrap();
                 pane.set_should_render(true);
                 pane.set_should_render_boundaries(true);
@@ -908,11 +908,11 @@ impl Tab {
     fn update_active_panes_in_pty_thread(&self) {
         // this is a bit hacky and we should ideally not keep this state in two different places at
         // some point
-        for connected_client in self.connected_clients.iter() {
+        for &connected_client in &self.connected_clients {
             self.senders
                 .send_to_pty(PtyInstruction::UpdateActivePane(
-                    self.active_panes.get(connected_client).copied(),
-                    *connected_client,
+                    self.active_panes.get(&connected_client).copied(),
+                    connected_client,
                 ))
                 .unwrap();
         }
@@ -936,28 +936,27 @@ impl Tab {
                     self.mode_info.mode,
                 );
                 pane_contents_and_ui.render_pane_contents_for_all_clients();
-                for client_id in self.connected_clients.iter() {
+                for &client_id in &self.connected_clients {
                     if self.draw_pane_frames {
-                        pane_contents_and_ui
-                            .render_pane_frame(*client_id, self.session_is_mirrored);
+                        pane_contents_and_ui.render_pane_frame(client_id, self.session_is_mirrored);
                     } else {
                         let boundaries = client_id_to_boundaries
-                            .entry(*client_id)
+                            .entry(client_id)
                             .or_insert_with(|| Boundaries::new(self.viewport));
                         pane_contents_and_ui.render_pane_boundaries(
-                            *client_id,
+                            client_id,
                             boundaries,
                             self.session_is_mirrored,
                         );
                     }
                     // this is done for panes that don't have their own cursor (eg. panes of
                     // another user)
-                    pane_contents_and_ui.render_fake_cursor_if_needed(*client_id);
+                    pane_contents_and_ui.render_fake_cursor_if_needed(client_id);
                 }
             }
         }
         // render boundaries if needed
-        for (client_id, boundaries) in client_id_to_boundaries.iter_mut() {
+        for (client_id, boundaries) in &mut client_id_to_boundaries {
             output.push_to_client(*client_id, &boundaries.vte_output());
         }
         // FIXME: Once clients can be distinguished
@@ -976,24 +975,24 @@ impl Tab {
         }
     }
     fn render_cursor(&self, output: &mut Output) {
-        for client_id in self.connected_clients.iter() {
-            match self.get_active_terminal_cursor_position(*client_id) {
+        for &client_id in &self.connected_clients {
+            match self.get_active_terminal_cursor_position(client_id) {
                 Some((cursor_position_x, cursor_position_y)) => {
                     let show_cursor = "\u{1b}[?25h";
                     let change_cursor_shape =
-                        self.get_active_pane(*client_id).unwrap().cursor_shape_csi();
+                        self.get_active_pane(client_id).unwrap().cursor_shape_csi();
                     let goto_cursor_position = &format!(
                         "\u{1b}[{};{}H\u{1b}[m{}",
                         cursor_position_y + 1,
                         cursor_position_x + 1,
                         change_cursor_shape
                     ); // goto row/col
-                    output.push_to_client(*client_id, show_cursor);
-                    output.push_to_client(*client_id, goto_cursor_position);
+                    output.push_to_client(client_id, show_cursor);
+                    output.push_to_client(client_id, goto_cursor_position);
                 }
                 None => {
                     let hide_cursor = "\u{1b}[?25l";
-                    output.push_to_client(*client_id, hide_cursor);
+                    output.push_to_client(client_id, hide_cursor);
                 }
             }
         }
@@ -1509,10 +1508,7 @@ impl Tab {
 
         // FIXME: This checks that we aren't violating the resize constraints of the aligned panes
         // above and below this one. This should be moved to a `can_resize` function eventually.
-        for terminal_id in terminals_to_the_left
-            .iter()
-            .chain(terminals_to_the_right.iter())
-        {
+        for terminal_id in terminals_to_the_left.iter().chain(&terminals_to_the_right) {
             let pane = self.panes.get(terminal_id).unwrap();
             if pane.current_geom().rows.as_percent().unwrap() - percent < RESIZE_PERCENT {
                 return;
@@ -1523,10 +1519,7 @@ impl Tab {
         for terminal_id in terminals_below {
             self.increase_pane_height(&terminal_id, percent);
         }
-        for terminal_id in terminals_to_the_left
-            .iter()
-            .chain(terminals_to_the_right.iter())
-        {
+        for terminal_id in terminals_to_the_left.iter().chain(&terminals_to_the_right) {
             self.reduce_pane_height(terminal_id, percent);
         }
     }
@@ -1548,10 +1541,7 @@ impl Tab {
 
         // FIXME: This checks that we aren't violating the resize constraints of the aligned panes
         // above and below this one. This should be moved to a `can_resize` function eventually.
-        for terminal_id in terminals_to_the_left
-            .iter()
-            .chain(terminals_to_the_right.iter())
-        {
+        for terminal_id in terminals_to_the_left.iter().chain(&terminals_to_the_right) {
             let pane = self.panes.get(terminal_id).unwrap();
             if pane.current_geom().rows.as_percent().unwrap() - percent < RESIZE_PERCENT {
                 return;
@@ -1562,10 +1552,7 @@ impl Tab {
         for terminal_id in terminals_above {
             self.increase_pane_height(&terminal_id, percent);
         }
-        for terminal_id in terminals_to_the_left
-            .iter()
-            .chain(terminals_to_the_right.iter())
-        {
+        for terminal_id in terminals_to_the_left.iter().chain(&terminals_to_the_right) {
             self.reduce_pane_height(terminal_id, percent);
         }
     }
@@ -1587,7 +1574,7 @@ impl Tab {
 
         // FIXME: This checks that we aren't violating the resize constraints of the aligned panes
         // above and below this one. This should be moved to a `can_resize` function eventually.
-        for terminal_id in terminals_above.iter().chain(terminals_below.iter()) {
+        for terminal_id in terminals_above.iter().chain(&terminals_below) {
             let pane = self.panes.get(terminal_id).unwrap();
             if pane.current_geom().cols.as_percent().unwrap() - percent < RESIZE_PERCENT {
                 return;
@@ -1598,7 +1585,7 @@ impl Tab {
         for terminal_id in terminals_to_the_left {
             self.increase_pane_width(&terminal_id, percent);
         }
-        for terminal_id in terminals_above.iter().chain(terminals_below.iter()) {
+        for terminal_id in terminals_above.iter().chain(&terminals_below) {
             self.reduce_pane_width(terminal_id, percent);
         }
     }
@@ -1620,7 +1607,7 @@ impl Tab {
 
         // FIXME: This checks that we aren't violating the resize constraints of the aligned panes
         // above and below this one. This should be moved to a `can_resize` function eventually.
-        for terminal_id in terminals_above.iter().chain(terminals_below.iter()) {
+        for terminal_id in terminals_above.iter().chain(&terminals_below) {
             let pane = self.panes.get(terminal_id).unwrap();
             if pane.current_geom().cols.as_percent().unwrap() - percent < RESIZE_PERCENT {
                 return;
@@ -1631,7 +1618,7 @@ impl Tab {
         for terminal_id in terminals_to_the_right {
             self.increase_pane_width(&terminal_id, percent);
         }
-        for terminal_id in terminals_above.iter().chain(terminals_below.iter()) {
+        for terminal_id in terminals_above.iter().chain(&terminals_below) {
             self.reduce_pane_width(terminal_id, percent);
         }
     }
@@ -1654,10 +1641,7 @@ impl Tab {
         for terminal_id in terminals_above {
             self.reduce_pane_height(&terminal_id, percent);
         }
-        for terminal_id in terminals_to_the_left
-            .iter()
-            .chain(terminals_to_the_right.iter())
-        {
+        for terminal_id in terminals_to_the_left.iter().chain(&terminals_to_the_right) {
             self.increase_pane_height(terminal_id, percent);
         }
     }
@@ -1680,10 +1664,7 @@ impl Tab {
         for terminal_id in terminals_below {
             self.reduce_pane_height(&terminal_id, percent);
         }
-        for terminal_id in terminals_to_the_left
-            .iter()
-            .chain(terminals_to_the_right.iter())
-        {
+        for terminal_id in terminals_to_the_left.iter().chain(&terminals_to_the_right) {
             self.increase_pane_height(terminal_id, percent);
         }
     }
@@ -1708,7 +1689,7 @@ impl Tab {
         for terminal_id in terminals_to_the_right {
             self.reduce_pane_width(&terminal_id, percent);
         }
-        for terminal_id in terminals_above.iter().chain(terminals_below.iter()) {
+        for terminal_id in terminals_above.iter().chain(&terminals_below) {
             self.increase_pane_width(terminal_id, percent);
         }
     }
@@ -1731,7 +1712,7 @@ impl Tab {
         for terminal_id in terminals_to_the_left {
             self.reduce_pane_width(&terminal_id, percent);
         }
-        for terminal_id in terminals_above.iter().chain(terminals_below.iter()) {
+        for terminal_id in terminals_above.iter().chain(&terminals_below) {
             self.increase_pane_width(terminal_id, percent);
         }
     }
@@ -2180,7 +2161,7 @@ impl Tab {
             })
     }
     pub fn relayout_tab(&mut self, direction: Direction) {
-        let mut resizer = PaneResizer::new(self.panes.iter_mut());
+        let mut resizer = PaneResizer::new(&mut self.panes);
         let result = match direction {
             Direction::Horizontal => resizer.layout(direction, self.display_area.cols),
             Direction::Vertical => resizer.layout(direction, self.display_area.rows),
@@ -3119,12 +3100,12 @@ impl Tab {
     fn grow_panes(&mut self, panes: &[PaneId], direction: Direction, (width, height): (f64, f64)) {
         match direction {
             Direction::Horizontal => {
-                for pane_id in panes.iter() {
+                for pane_id in panes {
                     self.increase_pane_width(pane_id, width);
                 }
             }
             Direction::Vertical => {
-                for pane_id in panes.iter() {
+                for pane_id in panes {
                     self.increase_pane_height(pane_id, height);
                 }
             }

--- a/zellij-server/src/ui/boundaries.rs
+++ b/zellij-server/src/ui/boundaries.rs
@@ -3,6 +3,7 @@ use zellij_utils::{pane_size::Viewport, zellij_tile};
 use crate::tab::Pane;
 use ansi_term::Colour::{Fixed, RGB};
 use std::collections::HashMap;
+use std::fmt::Write;
 use zellij_tile::data::PaletteColor;
 use zellij_utils::shared::colors;
 
@@ -513,12 +514,14 @@ impl Boundaries {
     pub fn vte_output(&self) -> String {
         let mut vte_output = String::new();
         for (coordinates, boundary_character) in &self.boundary_characters {
-            vte_output.push_str(&format!(
+            write!(
+                &mut vte_output,
                 "\u{1b}[{};{}H\u{1b}[m{}",
                 coordinates.y + 1,
                 coordinates.x + 1,
                 boundary_character
-            )); // goto row/col + boundary character
+            )
+            .unwrap(); // goto row/col + boundary character
         }
         vte_output
     }

--- a/zellij-server/src/ui/overlay/prompt.rs
+++ b/zellij-server/src/ui/overlay/prompt.rs
@@ -3,6 +3,8 @@ use zellij_utils::pane_size::Size;
 use super::{Overlay, OverlayType, Overlayable};
 use crate::{ClientId, ServerInstruction};
 
+use std::fmt::Write;
+
 #[derive(Clone, Debug)]
 pub struct Prompt {
     pub message: String,
@@ -37,7 +39,14 @@ impl Overlayable for Prompt {
         let mut vte_output = self.message.clone();
         Overlay::pad_cols(&mut vte_output, size.cols);
         for (x, h) in vte_output.chars().enumerate() {
-            output.push_str(&format!("\u{1b}[{};{}H\u{1b}[48;5;238m{}", rows, x + 1, h,));
+            write!(
+                &mut output,
+                "\u{1b}[{};{}H\u{1b}[48;5;238m{}",
+                rows,
+                x + 1,
+                h,
+            )
+            .unwrap();
         }
         output
     }

--- a/zellij-server/src/ui/pane_contents_and_ui.rs
+++ b/zellij-server/src/ui/pane_contents_and_ui.rs
@@ -55,14 +55,14 @@ impl<'a> PaneContentsAndUi<'a> {
         let pane_focused_for_different_client = self
             .focused_clients
             .iter()
-            .filter(|c_id| **c_id != client_id)
+            .filter(|&&c_id| c_id != client_id)
             .count()
             > 0;
         if pane_focused_for_different_client && !pane_focused_for_client_id {
             let fake_cursor_client_id = self
                 .focused_clients
                 .iter()
-                .find(|c_id| **c_id != client_id)
+                .find(|&&c_id| c_id != client_id)
                 .unwrap();
             if let Some(colors) = client_id_to_colors(*fake_cursor_client_id, self.colors) {
                 if let Some(vte_output) = self.pane.render_fake_cursor(colors.0, colors.1) {
@@ -84,7 +84,7 @@ impl<'a> PaneContentsAndUi<'a> {
         let other_focused_clients: Vec<ClientId> = self
             .focused_clients
             .iter()
-            .filter(|c_id| **c_id != client_id)
+            .filter(|&&c_id| c_id != client_id)
             .copied()
             .collect();
         let pane_focused_for_differet_client = !other_focused_clients.is_empty();

--- a/zellij-server/src/ui/pane_resizer.rs
+++ b/zellij-server/src/ui/pane_resizer.rs
@@ -30,8 +30,8 @@ struct Span {
 type Grid = Vec<Vec<Span>>;
 
 impl<'a> PaneResizer<'a> {
-    pub fn new(panes: impl Iterator<Item = (&'a PaneId, &'a mut Box<dyn Pane>)>) -> Self {
-        let panes: HashMap<_, _> = panes.collect();
+    pub fn new(panes: impl IntoIterator<Item = (&'a PaneId, &'a mut Box<dyn Pane>)>) -> Self {
+        let panes: HashMap<_, _> = panes.into_iter().collect();
         let mut vars = HashMap::new();
         for &&k in panes.keys() {
             vars.insert(k, Variable::new());
@@ -84,7 +84,7 @@ impl<'a> PaneResizer<'a> {
 
         // Round f64 pane sizes to usize without gaps or overlap
         let mut finalised = Vec::new();
-        for spans in grid.iter_mut() {
+        for spans in &mut grid {
             let rounded_size: isize = spans.iter().map(|s| rounded_sizes[&s.size_var]).sum();
             let mut error = space as isize - rounded_size;
             let mut flex_spans: Vec<_> = spans
@@ -105,9 +105,9 @@ impl<'a> PaneResizer<'a> {
         }
 
         // Update span positions based on their rounded sizes
-        for spans in grid.iter_mut() {
+        for spans in &mut grid {
             let mut offset = 0;
-            for span in spans.iter_mut() {
+            for span in spans {
                 span.pos = offset;
                 let sz = rounded_sizes[&span.size_var];
                 if sz < 1 {

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -307,7 +307,7 @@ pub fn toggle_to_previous_tab_create_tabs_only() {
 
     assert_eq!(
         screen.tab_history.get(&1).unwrap(),
-        &vec![0, 1],
+        &[0, 1],
         "Tab history is invalid"
     );
 
@@ -319,7 +319,7 @@ pub fn toggle_to_previous_tab_create_tabs_only() {
     );
     assert_eq!(
         screen.tab_history.get(&1).unwrap(),
-        &vec![0, 2],
+        &[0, 2],
         "Tab history is invalid"
     );
 
@@ -331,7 +331,7 @@ pub fn toggle_to_previous_tab_create_tabs_only() {
     );
     assert_eq!(
         screen.tab_history.get(&1).unwrap(),
-        &vec![0, 1],
+        &[0, 1],
         "Tab history is invalid"
     );
 
@@ -358,7 +358,7 @@ pub fn toggle_to_previous_tab_delete() {
 
     assert_eq!(
         screen.tab_history.get(&1).unwrap(),
-        &vec![0, 1, 2],
+        &[0, 1, 2],
         "Tab history is invalid"
     );
     assert_eq!(
@@ -370,7 +370,7 @@ pub fn toggle_to_previous_tab_delete() {
     screen.toggle_tab(1);
     assert_eq!(
         screen.tab_history.get(&1).unwrap(),
-        &vec![0, 1, 3],
+        &[0, 1, 3],
         "Tab history is invalid"
     );
     assert_eq!(
@@ -382,7 +382,7 @@ pub fn toggle_to_previous_tab_delete() {
     screen.toggle_tab(1);
     assert_eq!(
         screen.tab_history.get(&1).unwrap(),
-        &vec![0, 1, 2],
+        &[0, 1, 2],
         "Tab history is invalid"
     );
     assert_eq!(
@@ -394,7 +394,7 @@ pub fn toggle_to_previous_tab_delete() {
     screen.switch_tab_prev(1);
     assert_eq!(
         screen.tab_history.get(&1).unwrap(),
-        &vec![0, 1, 3],
+        &[0, 1, 3],
         "Tab history is invalid"
     );
     assert_eq!(
@@ -405,7 +405,7 @@ pub fn toggle_to_previous_tab_delete() {
     screen.switch_tab_prev(1);
     assert_eq!(
         screen.tab_history.get(&1).unwrap(),
-        &vec![0, 3, 2],
+        &[0, 3, 2],
         "Tab history is invalid"
     );
     assert_eq!(
@@ -417,7 +417,7 @@ pub fn toggle_to_previous_tab_delete() {
     screen.close_tab(1);
     assert_eq!(
         screen.tab_history.get(&1).unwrap(),
-        &vec![0, 3],
+        &[0, 3],
         "Tab history is invalid"
     );
     assert_eq!(
@@ -434,7 +434,7 @@ pub fn toggle_to_previous_tab_delete() {
     );
     assert_eq!(
         screen.tab_history.get(&1).unwrap(),
-        &vec![0, 2],
+        &[0, 2],
         "Tab history is invalid"
     );
 }

--- a/zellij-server/src/wasm_vm.rs
+++ b/zellij-server/src/wasm_vm.rs
@@ -83,7 +83,7 @@ pub(crate) fn wasm_thread_main(
     let mut plugin_map = HashMap::new();
     let plugin_dir = data_dir.join("plugins/");
     let plugin_global_data_dir = plugin_dir.join("data");
-    fs::create_dir_all(plugin_global_data_dir.as_path()).unwrap();
+    fs::create_dir_all(&plugin_global_data_dir).unwrap();
 
     for plugin in plugins.iter() {
         if let PluginType::Headless = plugin.run {
@@ -160,7 +160,7 @@ pub(crate) fn wasm_thread_main(
         }
     }
     info!("wasm main thread exits");
-    fs::remove_dir_all(plugin_global_data_dir.as_path()).unwrap();
+    fs::remove_dir_all(&plugin_global_data_dir).unwrap();
 }
 
 fn start_plugin(
@@ -210,7 +210,7 @@ fn start_plugin(
         .env("CLICOLOR_FORCE", "1")
         .map_dir("/host", ".")
         .unwrap()
-        .map_dir("/data", plugin_own_data_dir.as_path())
+        .map_dir("/data", &plugin_own_data_dir)
         .unwrap()
         .stdin(Box::new(input))
         .stdout(Box::new(output))

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -47,8 +47,7 @@ lazy_static! {
         sock_dir.push(envs::get_session_name().unwrap());
         sock_dir
     };
-    pub static ref ZELLIJ_TMP_DIR: PathBuf =
-        PathBuf::from("/tmp/zellij-".to_string() + &format!("{}", *UID));
+    pub static ref ZELLIJ_TMP_DIR: PathBuf = PathBuf::from(format!("/tmp/zellij-{}", *UID));
     pub static ref ZELLIJ_TMP_LOG_DIR: PathBuf = ZELLIJ_TMP_DIR.join("zellij-log");
     pub static ref ZELLIJ_TMP_LOG_FILE: PathBuf = ZELLIJ_TMP_LOG_DIR.join("zellij.log");
 }

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -121,8 +121,8 @@ impl ErrorContext {
 
     /// Adds a call to this [`ErrorContext`]'s call stack representation.
     pub fn add_call(&mut self, call: ContextType) {
-        for ctx in self.calls.iter_mut() {
-            if *ctx == ContextType::Empty {
+        for ctx in &mut self.calls {
+            if let ContextType::Empty = ctx {
                 *ctx = call;
                 break;
             }

--- a/zellij-utils/src/input/config.rs
+++ b/zellij-utils/src/input/config.rs
@@ -149,7 +149,7 @@ impl Config {
     // once serde-yaml supports zero-copy
     pub fn from_default_assets() -> ConfigResult {
         let cfg = String::from_utf8(setup::DEFAULT_CONFIG.to_vec())?;
-        Self::from_yaml(cfg.as_str())
+        Self::from_yaml(&cfg)
     }
 
     /// Merges two Config structs into one Config struct

--- a/zellij-utils/src/input/keybinds.rs
+++ b/zellij-utils/src/input/keybinds.rs
@@ -109,7 +109,7 @@ impl Keybinds {
 
         for mode in InputMode::iter() {
             if let Some(keybinds) = keybinds_from_yaml.get(&mode) {
-                for keybind in keybinds.iter() {
+                for keybind in keybinds {
                     match keybind {
                         KeyActionUnbind::Unbind(unbind) => {
                             unbind_config.insert(mode, unbind.unbind.clone());
@@ -242,8 +242,8 @@ impl From<KeybindsFromYaml> for Keybinds {
 
         for mode in InputMode::iter() {
             let mut mode_keybinds = ModeKeybinds::new();
-            for key_action in keybinds_from_yaml.keybinds.get(&mode).iter() {
-                for keybind in key_action.iter() {
+            if let Some(key_action) = keybinds_from_yaml.keybinds.get(&mode) {
+                for keybind in key_action {
                     mode_keybinds = mode_keybinds.merge(ModeKeybinds::from(keybind.clone()));
                 }
             }

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -254,8 +254,8 @@ impl LayoutFromYamlIntermediate {
     ) -> LayoutFromYamlIntermediateResult {
         match layout_dir {
             Some(dir) => Self::from_path(&dir.join(layout))
-                .or_else(|_| LayoutFromYamlIntermediate::from_default_assets(layout.as_path())),
-            None => LayoutFromYamlIntermediate::from_default_assets(layout.as_path()),
+                .or_else(|_| LayoutFromYamlIntermediate::from_default_assets(layout)),
+            None => LayoutFromYamlIntermediate::from_default_assets(layout),
         }
     }
     // Currently still needed but on nightly
@@ -277,19 +277,19 @@ impl LayoutFromYamlIntermediate {
     // once serde-yaml supports zero-copy
     pub fn default_from_assets() -> LayoutFromYamlIntermediateResult {
         let layout: LayoutFromYamlIntermediate =
-            serde_yaml::from_str(String::from_utf8(setup::DEFAULT_LAYOUT.to_vec())?.as_str())?;
+            serde_yaml::from_str(&String::from_utf8(setup::DEFAULT_LAYOUT.to_vec())?)?;
         Ok(layout)
     }
 
     pub fn strider_from_assets() -> LayoutFromYamlIntermediateResult {
         let layout: LayoutFromYamlIntermediate =
-            serde_yaml::from_str(String::from_utf8(setup::STRIDER_LAYOUT.to_vec())?.as_str())?;
+            serde_yaml::from_str(&String::from_utf8(setup::STRIDER_LAYOUT.to_vec())?)?;
         Ok(layout)
     }
 
     pub fn disable_status_from_assets() -> LayoutFromYamlIntermediateResult {
         let layout: LayoutFromYamlIntermediate =
-            serde_yaml::from_str(String::from_utf8(setup::NO_STATUS_LAYOUT.to_vec())?.as_str())?;
+            serde_yaml::from_str(&String::from_utf8(setup::NO_STATUS_LAYOUT.to_vec())?)?;
         Ok(layout)
     }
 }
@@ -331,9 +331,10 @@ impl LayoutFromYaml {
     #[allow(clippy::ptr_arg)]
     pub fn from_dir(layout: &PathBuf, layout_dir: Option<&PathBuf>) -> LayoutFromYamlResult {
         match layout_dir {
-            Some(dir) => Self::new(&dir.join(layout))
-                .or_else(|_| Self::from_default_assets(layout.as_path())),
-            None => Self::from_default_assets(layout.as_path()),
+            Some(dir) => {
+                Self::new(&dir.join(layout)).or_else(|_| Self::from_default_assets(layout))
+            }
+            None => Self::from_default_assets(layout),
         }
     }
 
@@ -372,19 +373,19 @@ impl LayoutFromYaml {
     // once serde-yaml supports zero-copy
     pub fn default_from_assets() -> LayoutFromYamlResult {
         let layout: LayoutFromYaml =
-            serde_yaml::from_str(String::from_utf8(setup::DEFAULT_LAYOUT.to_vec())?.as_str())?;
+            serde_yaml::from_str(&String::from_utf8(setup::DEFAULT_LAYOUT.to_vec())?)?;
         Ok(layout)
     }
 
     pub fn strider_from_assets() -> LayoutFromYamlResult {
         let layout: LayoutFromYaml =
-            serde_yaml::from_str(String::from_utf8(setup::STRIDER_LAYOUT.to_vec())?.as_str())?;
+            serde_yaml::from_str(&String::from_utf8(setup::STRIDER_LAYOUT.to_vec())?)?;
         Ok(layout)
     }
 
     pub fn disable_status_from_assets() -> LayoutFromYamlResult {
         let layout: LayoutFromYaml =
-            serde_yaml::from_str(String::from_utf8(setup::NO_STATUS_LAYOUT.to_vec())?.as_str())?;
+            serde_yaml::from_str(&String::from_utf8(setup::NO_STATUS_LAYOUT.to_vec())?)?;
         Ok(layout)
     }
 }
@@ -465,7 +466,7 @@ pub struct TabLayout {
 
 impl TabLayout {
     fn check(&self) -> Result<TabLayout, ConfigError> {
-        for part in self.parts.iter() {
+        for part in &self.parts {
             part.check()?;
             if !part.name.is_empty() {
                 return Err(ConfigError::LayoutNameInTab(LayoutNameInTabError));
@@ -479,7 +480,7 @@ impl Layout {
     pub fn total_terminal_panes(&self) -> usize {
         let mut total_panes = 0;
         total_panes += self.parts.len();
-        for part in self.parts.iter() {
+        for part in &self.parts {
             match part.run {
                 Some(Run::Command(_)) | None => {
                     total_panes += part.total_terminal_panes();
@@ -493,7 +494,7 @@ impl Layout {
     pub fn total_borderless_panes(&self) -> usize {
         let mut total_borderless_panes = 0;
         total_borderless_panes += self.parts.iter().filter(|p| p.borderless).count();
-        for part in self.parts.iter() {
+        for part in &self.parts {
             total_borderless_panes += part.total_borderless_panes();
         }
         total_borderless_panes
@@ -503,7 +504,7 @@ impl Layout {
         if self.parts.is_empty() {
             run_instructions.push(self.run.clone());
         }
-        for part in self.parts.iter() {
+        for part in &self.parts {
             let mut current_runnables = part.extract_run_instructions();
             run_instructions.append(&mut current_runnables);
         }
@@ -549,7 +550,7 @@ fn layout_size(direction: Direction, layout: &Layout) -> usize {
                 .parts
                 .iter()
                 .map(|p| child_layout_size(direction, layout.direction, p))
-                .sum::<usize>();
+                .sum();
             max(size, children_size)
         }
     }

--- a/zellij-utils/src/input/plugins.rs
+++ b/zellij-utils/src/input/plugins.rs
@@ -18,7 +18,7 @@ pub use zellij_tile::data::PluginTag;
 lazy_static! {
     static ref DEFAULT_CONFIG_PLUGINS: PluginsConfig = {
         let cfg = String::from_utf8(setup::DEFAULT_CONFIG.to_vec()).unwrap();
-        let cfg_yaml: ConfigFromYaml = serde_yaml::from_str(cfg.as_str()).unwrap();
+        let cfg_yaml: ConfigFromYaml = serde_yaml::from_str(&cfg).unwrap();
         PluginsConfig::try_from(cfg_yaml.plugins).unwrap()
     };
 }
@@ -271,7 +271,7 @@ mod tests {
         )?;
         let plugins = PluginsConfig::get_plugins_with_default(plugins.try_into()?);
 
-        assert_eq!(plugins.iter().collect::<Vec<_>>().len(), 4);
+        assert_eq!(plugins.iter().count(), 4);
         Ok(())
     }
 

--- a/zellij-utils/src/logging.rs
+++ b/zellij-utils/src/logging.rs
@@ -92,7 +92,7 @@ pub fn atomic_create_dir(dir_name: &Path) -> io::Result<()> {
 pub fn debug_to_file(message: &[u8], pid: RawFd) -> io::Result<()> {
     let mut path = PathBuf::new();
     path.push(&*ZELLIJ_TMP_LOG_DIR);
-    path.push(format!("zellij-{}.log", pid.to_string()));
+    path.push(format!("zellij-{}.log", pid));
 
     let mut file = fs::OpenOptions::new()
         .append(true)

--- a/zellij-utils/src/shared.rs
+++ b/zellij-utils/src/shared.rs
@@ -19,7 +19,7 @@ pub fn set_permissions(path: &Path) -> io::Result<()> {
 }
 
 pub fn ansi_len(s: &str) -> usize {
-    from_utf8(&strip(s.as_bytes()).unwrap()).unwrap().width()
+    from_utf8(&strip(s).unwrap()).unwrap().width()
 }
 
 pub fn adjust_to_size(s: &str, rows: usize, columns: usize) -> String {


### PR DESCRIPTION
Highlights:

- Change `format!("{}", ...)` to `.to_string()`
- Change `s.push_str(&format!(...))` to `write!(s, ...)`
- Use shorter reference form in `for` loops and pattern matches
- Use `Deref` and `IntoIterator` to shorten some function calls
- Use byte string literals (`b"..."`) where applicable