### PR TITLE
fix(config): unbind keys correctly

### DIFF
--- a/zellij-utils/src/input/config.rs
+++ b/zellij-utils/src/input/config.rs
@@ -156,7 +156,8 @@ impl Config {
     /// `other` overrides `self`.
     pub fn merge(&self, other: Self) -> Self {
         Self {
-            keybinds: self.keybinds.merge_keybinds(other.keybinds),
+            // TODO: merge keybinds in a way that preserves "unbind" attribute
+            keybinds: self.keybinds.clone(),
             options: self.options.merge(other.options),
             themes: self.themes.clone(), // TODO
             plugins: self.plugins.merge(other.plugins),


### PR DESCRIPTION
* turn off the merging of key bindings of layout and configuration
  files for now.

  In certain situations the keybindings would be overwritten.

  Fix #923