### PR TITLE
Fix(plugins): support multiple users

### DIFF
--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__mirrored_sessions.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__mirrored_sessions.snap
@@ -26,4 +26,4 @@ expression: first_runner_snapshot
 │                                                          ││                                                          │
 └──────────────────────────────────────────────────────────┘└──────────────────────────────────────────────────────────┘
  Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SCROLL  <o> SESSION  <q> QUIT           
- <←↓↑→> Move focus / <n> New / <x> Close / <r> Rename / <s> Sync / <Tab> Toggle / <ENTER> Select pane                   
+ Tip: Alt + <n> => new pane. Alt + <[] or hjkl> => navigate. Alt + <+-> => resize pane.                                 

--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -130,7 +130,12 @@ impl Pane for PluginPane {
     fn set_selectable(&mut self, selectable: bool) {
         self.selectable = selectable;
     }
-    fn render(&mut self) -> Option<String> {
+    fn render(&mut self, client_id: Option<ClientId>) -> Option<String> {
+        if client_id.is_none() {
+            // this is a bit of a hack but works in a pinch
+            return None;
+        }
+        let client_id = client_id.unwrap();
         // if self.should_render {
         if true {
             // while checking should_render rather than rendering each pane every time
@@ -144,6 +149,7 @@ impl Pane for PluginPane {
                 .send(PluginInstruction::Render(
                     buf_tx,
                     self.pid,
+                    client_id,
                     self.get_content_rows(),
                     self.get_content_columns(),
                 ))
@@ -269,6 +275,7 @@ impl Pane for PluginPane {
         self.send_plugin_instructions
             .send(PluginInstruction::Update(
                 Some(self.pid),
+                None,
                 Event::Mouse(Mouse::ScrollUp(count)),
             ))
             .unwrap();
@@ -277,6 +284,7 @@ impl Pane for PluginPane {
         self.send_plugin_instructions
             .send(PluginInstruction::Update(
                 Some(self.pid),
+                None,
                 Event::Mouse(Mouse::ScrollDown(count)),
             ))
             .unwrap();
@@ -288,6 +296,7 @@ impl Pane for PluginPane {
         self.send_plugin_instructions
             .send(PluginInstruction::Update(
                 Some(self.pid),
+                None,
                 Event::Mouse(Mouse::LeftClick(start.line.0, start.column.0)),
             ))
             .unwrap();
@@ -296,6 +305,7 @@ impl Pane for PluginPane {
         self.send_plugin_instructions
             .send(PluginInstruction::Update(
                 Some(self.pid),
+                None,
                 Event::Mouse(Mouse::Hold(position.line.0, position.column.0)),
             ))
             .unwrap();
@@ -304,6 +314,7 @@ impl Pane for PluginPane {
         self.send_plugin_instructions
             .send(PluginInstruction::Update(
                 Some(self.pid),
+                None,
                 Event::Mouse(Mouse::Release(
                     end.map(|Position { line, column }| (line.0, column.0)),
                 )),
@@ -337,6 +348,7 @@ impl Pane for PluginPane {
         self.send_plugin_instructions
             .send(PluginInstruction::Update(
                 Some(self.pid),
+                None,
                 Event::Mouse(Mouse::RightClick(to.line.0, to.column.0)),
             ))
             .unwrap();

--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -131,10 +131,8 @@ impl Pane for PluginPane {
         self.selectable = selectable;
     }
     fn render(&mut self, client_id: Option<ClientId>) -> Option<String> {
-        if client_id.is_none() {
-            // this is a bit of a hack but works in a pinch
-            return None;
-        }
+        // this is a bit of a hack but works in a pinch
+        client_id?;
         let client_id = client_id.unwrap();
         // if self.should_render {
         if true {

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -183,7 +183,8 @@ impl Pane for TerminalPane {
     fn set_selectable(&mut self, selectable: bool) {
         self.selectable = selectable;
     }
-    fn render(&mut self) -> Option<String> {
+    fn render(&mut self, _client_id: Option<ClientId>) -> Option<String> {
+        // we don't use client_id because terminal panes render the same for all users
         if self.should_render() {
             let mut vte_output = String::new();
             let mut character_styles = CharacterStyles::new();

--- a/zellij-server/src/tab.rs
+++ b/zellij-server/src/tab.rs
@@ -970,11 +970,8 @@ impl Tab {
             if !self.panes_to_hide.contains(&pane.pid()) {
                 let mut pane_contents_and_ui =
                     PaneContentsAndUi::new(pane, output, self.colors, &self.active_panes);
-                match kind {
-                    PaneId::Terminal(..) => {
-                        pane_contents_and_ui.render_pane_contents_for_all_clients();
-                    }
-                    _ => {}
+                if let PaneId::Terminal(..) = kind {
+                    pane_contents_and_ui.render_pane_contents_for_all_clients();
                 }
                 for client_id in self.connected_clients.iter() {
                     let client_mode = self
@@ -982,11 +979,8 @@ impl Tab {
                         .get(client_id)
                         .unwrap_or(&self.default_mode_info)
                         .mode;
-                    match kind {
-                        PaneId::Plugin(..) => {
-                            pane_contents_and_ui.render_pane_contents_for_client(*client_id);
-                        }
-                        _ => {}
+                    if let PaneId::Plugin(..) = kind {
+                        pane_contents_and_ui.render_pane_contents_for_client(*client_id);
                     }
                     if self.draw_pane_frames {
                         pane_contents_and_ui.render_pane_frame(

--- a/zellij-server/src/unit/tab_tests.rs
+++ b/zellij-server/src/unit/tab_tests.rs
@@ -106,6 +106,7 @@ fn create_new_tab(size: Size) -> Tab {
         LayoutTemplate::default().try_into().unwrap(),
         vec![1],
         index,
+        client_id,
     );
     tab
 }

--- a/zellij-server/src/wasm_vm.rs
+++ b/zellij-server/src/wasm_vm.rs
@@ -25,6 +25,7 @@ use crate::{
     pty::{ClientOrTabIndex, PtyInstruction},
     screen::ScreenInstruction,
     thread_bus::{Bus, ThreadSenders},
+    ClientId,
 };
 
 use zellij_utils::{
@@ -40,10 +41,12 @@ use zellij_utils::{
 
 #[derive(Clone, Debug)]
 pub(crate) enum PluginInstruction {
-    Load(Sender<u32>, RunPlugin, usize), // tx_pid, plugin metadata, tab_index
-    Update(Option<u32>, Event),          // Focused plugin / broadcast, event data
-    Render(Sender<String>, u32, usize, usize), // String buffer, plugin id, rows, cols
-    Unload(u32),
+    Load(Sender<u32>, RunPlugin, usize, ClientId), // tx_pid, plugin metadata, tab_index, client_ids
+    Update(Option<u32>, Option<ClientId>, Event), // Focused plugin / broadcast, client_id, event data
+    Render(Sender<String>, u32, ClientId, usize, usize), // String buffer, plugin id, client_id, rows, cols
+    Unload(u32),                                         // plugin_id
+    AddClient(ClientId),
+    RemoveClient(ClientId),
     Exit,
 }
 
@@ -53,8 +56,10 @@ impl From<&PluginInstruction> for PluginContext {
             PluginInstruction::Load(..) => PluginContext::Load,
             PluginInstruction::Update(..) => PluginContext::Update,
             PluginInstruction::Render(..) => PluginContext::Render,
-            PluginInstruction::Unload(_) => PluginContext::Unload,
+            PluginInstruction::Unload(..) => PluginContext::Unload,
             PluginInstruction::Exit => PluginContext::Exit,
+            PluginInstruction::AddClient(_) => PluginContext::AddClient,
+            PluginInstruction::RemoveClient(_) => PluginContext::RemoveClient,
         }
     }
 }
@@ -67,6 +72,7 @@ pub(crate) struct PluginEnv {
     pub wasi_env: WasiEnv,
     pub subscriptions: Arc<Mutex<HashSet<EventType>>>,
     pub tab_index: usize,
+    pub client_id: ClientId,
     plugin_own_data_dir: PathBuf,
 }
 
@@ -80,38 +86,25 @@ pub(crate) fn wasm_thread_main(
     info!("Wasm main thread starts");
 
     let mut plugin_id = 0;
-    let mut plugin_map = HashMap::new();
+    let mut headless_plugins = HashMap::new();
+    let mut plugin_map: HashMap<(u32, ClientId), (Instance, PluginEnv)> = HashMap::new(); // u32 => pid
+    let mut connected_clients: Vec<ClientId> = vec![];
     let plugin_dir = data_dir.join("plugins/");
     let plugin_global_data_dir = plugin_dir.join("data");
     fs::create_dir_all(plugin_global_data_dir.as_path()).unwrap();
-
-    for plugin in plugins.iter() {
-        if let PluginType::Headless = plugin.run {
-            let (instance, plugin_env) = start_plugin(
-                plugin_id,
-                plugin,
-                0,
-                &bus,
-                &store,
-                &data_dir,
-                &plugin_global_data_dir,
-            );
-            plugin_map.insert(plugin_id, (instance, plugin_env));
-            plugin_id += 1;
-        }
-    }
 
     loop {
         let (event, mut err_ctx) = bus.recv().expect("failed to receive event on channel");
         err_ctx.add_call(ContextType::Plugin((&event).into()));
         match event {
-            PluginInstruction::Load(pid_tx, run, tab_index) => {
+            PluginInstruction::Load(pid_tx, run, tab_index, client_id) => {
                 let plugin = plugins
                     .get(&run)
                     .unwrap_or_else(|| panic!("Plugin {:?} could not be resolved", run));
 
                 let (instance, plugin_env) = start_plugin(
                     plugin_id,
+                    client_id,
                     &plugin,
                     tab_index,
                     &bus,
@@ -120,28 +113,52 @@ pub(crate) fn wasm_thread_main(
                     &plugin_global_data_dir,
                 );
 
-                plugin_map.insert(plugin_id, (instance, plugin_env));
+                plugin_map.insert(
+                    (plugin_id, client_id),
+                    (instance.clone(), plugin_env.clone()),
+                );
+
+                // clone plugins for the rest of the client ids if they exist
+                for client_id in connected_clients.iter() {
+                    let mut new_plugin_env = plugin_env.clone();
+                    new_plugin_env.client_id = *client_id;
+                    let module = instance.module().clone();
+                    let wasi = new_plugin_env.wasi_env.import_object(&module).unwrap();
+                    let zellij = zellij_exports(&store, &new_plugin_env);
+                    let instance = Instance::new(&module, &zellij.chain_back(wasi)).unwrap();
+                    plugin_map.insert((plugin_id, *client_id), (instance, new_plugin_env));
+                }
                 pid_tx.send(plugin_id).unwrap();
                 plugin_id += 1;
             }
-            PluginInstruction::Update(pid, event) => {
-                for (&i, (instance, plugin_env)) in &plugin_map {
+            PluginInstruction::Update(pid, cid, event) => {
+                for (&(plugin_id, client_id), (instance, plugin_env)) in &plugin_map {
                     let subs = plugin_env.subscriptions.lock().unwrap();
                     // FIXME: This is very janky... Maybe I should write my own macro for Event -> EventType?
                     let event_type = EventType::from_str(&event.to_string()).unwrap();
-                    if (pid.is_none() || pid == Some(i)) && subs.contains(&event_type) {
-                        let update = instance.exports.get_function("update").unwrap();
-                        wasi_write_object(&plugin_env.wasi_env, &event);
-                        update.call(&[]).unwrap();
+                    if subs.contains(&event_type) {
+                        if pid.is_none() && cid.is_none() {
+                            let update = instance.exports.get_function("update").unwrap();
+                            wasi_write_object(&plugin_env.wasi_env, &event);
+                            update.call(&[]).unwrap();
+                        } else if pid.is_none() && cid == Some(client_id) {
+                            let update = instance.exports.get_function("update").unwrap();
+                            wasi_write_object(&plugin_env.wasi_env, &event);
+                            update.call(&[]).unwrap();
+                        } else if cid.is_none() && pid == Some(plugin_id) {
+                            let update = instance.exports.get_function("update").unwrap();
+                            wasi_write_object(&plugin_env.wasi_env, &event);
+                            update.call(&[]).unwrap();
+                        }
                     }
                 }
                 drop(bus.senders.send_to_screen(ScreenInstruction::Render));
             }
-            PluginInstruction::Render(buf_tx, pid, rows, cols) => {
+            PluginInstruction::Render(buf_tx, pid, cid, rows, cols) => {
                 if rows == 0 || cols == 0 {
                     buf_tx.send(String::new()).unwrap();
                 } else {
-                    let (instance, plugin_env) = plugin_map.get(&pid).unwrap();
+                    let (instance, plugin_env) = plugin_map.get(&(pid, cid)).unwrap();
                     let render = instance.exports.get_function("render").unwrap();
 
                     render
@@ -154,7 +171,54 @@ pub(crate) fn wasm_thread_main(
             PluginInstruction::Unload(pid) => {
                 info!("Bye from plugin {}", &pid);
                 // TODO: remove plugin's own data directory
-                drop(plugin_map.remove(&pid));
+                let ids_in_plugin_map: Vec<(u32, ClientId)> = plugin_map.keys().copied().collect();
+                for (plugin_id, client_id) in ids_in_plugin_map {
+                    if pid == plugin_id {
+                        drop(plugin_map.remove(&(plugin_id, client_id)));
+                    }
+                }
+            }
+            PluginInstruction::AddClient(client_id) => {
+                connected_clients.push(client_id);
+                let mut seen = HashSet::new();
+                let mut new_plugins = HashMap::new();
+                for (&(plugin_id, client_id), (instance, plugin_env)) in &plugin_map {
+                    if seen.contains(&plugin_id) {
+                        continue;
+                    } else {
+                        seen.insert(plugin_id);
+                        let mut new_plugin_env = plugin_env.clone();
+                        new_plugin_env.client_id = client_id;
+                        new_plugins.insert(plugin_id, (instance.module().clone(), new_plugin_env));
+                    }
+                }
+                for (plugin_id, (module, mut new_plugin_env)) in new_plugins.drain() {
+                    let wasi = new_plugin_env.wasi_env.import_object(&module).unwrap();
+                    let zellij = zellij_exports(&store, &new_plugin_env);
+                    let instance = Instance::new(&module, &zellij.chain_back(wasi)).unwrap();
+                    plugin_map.insert((plugin_id, client_id), (instance, new_plugin_env));
+                }
+
+                // load headless plugins
+                for plugin in plugins.iter() {
+                    if let PluginType::Headless = plugin.run {
+                        let (instance, plugin_env) = start_plugin(
+                            plugin_id,
+                            client_id,
+                            plugin,
+                            0,
+                            &bus,
+                            &store,
+                            &data_dir,
+                            &plugin_global_data_dir,
+                        );
+                        headless_plugins.insert(plugin_id, (instance, plugin_env));
+                        plugin_id += 1;
+                    }
+                }
+            }
+            PluginInstruction::RemoveClient(client_id) => {
+                connected_clients.retain(|c| c != &client_id);
             }
             PluginInstruction::Exit => break,
         }
@@ -165,6 +229,7 @@ pub(crate) fn wasm_thread_main(
 
 fn start_plugin(
     plugin_id: u32,
+    client_id: ClientId,
     plugin: &PluginConfig,
     tab_index: usize,
     bus: &Bus<PluginInstruction>,
@@ -224,6 +289,7 @@ fn start_plugin(
 
     let plugin_env = PluginEnv {
         plugin_id,
+        client_id,
         plugin,
         senders: bus.senders.clone(),
         wasi_env,
@@ -346,6 +412,7 @@ fn host_set_timeout(plugin_env: &PluginEnv, secs: f64) {
     // But that's a lot of code, and this is a few lines:
     let send_plugin_instructions = plugin_env.senders.to_plugin.clone();
     let update_target = Some(plugin_env.plugin_id);
+    let client_id = plugin_env.client_id;
     thread::spawn(move || {
         let start_time = Instant::now();
         thread::sleep(Duration::from_secs_f64(secs));
@@ -357,6 +424,7 @@ fn host_set_timeout(plugin_env: &PluginEnv, secs: f64) {
             .unwrap()
             .send(PluginInstruction::Update(
                 update_target,
+                Some(client_id),
                 Event::Timer(elapsed_time),
             ))
             .unwrap();

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -294,6 +294,8 @@ pub enum PluginContext {
     Render,
     Unload,
     Exit,
+    AddClient,
+    RemoveClient,
 }
 
 /// Stack call representations corresponding to the different types of [`ClientInstruction`]s.


### PR DESCRIPTION
This is another layer of preparation for supporting multiple users.

In this episode, we:
1. Change plugins so that one is created for each user
2. Change the infrastructure around them so that plugins are individually updated by user actions (rather than all relevant plugins be updated for each relevant user action)
3. Change the various input mode tracking around the app so that it's per client. This has the upshot that even not in mirrored sessions, the plugins are unique per client (which provides for a much nicer user experience).