### PR TITLE
Fix tab fullscreen switch

### DIFF
--- a/zellij-server/src/tab.rs
+++ b/zellij-server/src/tab.rs
@@ -129,7 +129,7 @@ pub(crate) struct Tab {
     pub name: String,
     panes: BTreeMap<PaneId, Box<dyn Pane>>,
     pub panes_to_hide: HashSet<PaneId>,
-    active_panes: HashMap<ClientId, PaneId>,
+    pub active_panes: HashMap<ClientId, PaneId>,
     max_panes: Option<usize>,
     viewport: Viewport, // includes all non-UI panes
     display_area: Size, // includes all panes (including eg. the status bar and tab bar in the default layout)
@@ -507,6 +507,7 @@ impl Tab {
                     return;
                 }
                 pane_ids.sort(); // TODO: make this predictable
+                pane_ids.retain(|p| !self.panes_to_hide.contains(p));
                 let first_pane_id = pane_ids.get(0).unwrap();
                 self.connected_clients.insert(client_id);
                 self.active_panes.insert(client_id, *first_pane_id);
@@ -530,11 +531,6 @@ impl Tab {
             self.add_client(client_id);
         }
         for (client_id, client_mode_info) in client_mode_infos {
-            log::info!(
-                "add_multiple_clients: client_id: {:?}, mode: {:?}",
-                client_id,
-                client_mode_info.mode
-            );
             self.mode_info.insert(client_id, client_mode_info);
         }
     }

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -438,3 +438,33 @@ pub fn toggle_to_previous_tab_delete() {
         "Tab history is invalid"
     );
 }
+
+#[test]
+fn switch_to_tab_with_fullscreen() {
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let mut screen = create_new_screen(size);
+
+    new_tab(&mut screen, 1);
+    {
+        let active_tab = screen.get_active_tab_mut(1).unwrap();
+        active_tab.new_pane(PaneId::Terminal(2), Some(1));
+        active_tab.toggle_active_pane_fullscreen(1);
+    }
+    new_tab(&mut screen, 2);
+
+    screen.switch_tab_prev(1);
+
+    assert_eq!(
+        screen.get_active_tab(1).unwrap().position,
+        0,
+        "Active tab switched to previous"
+    );
+    assert_eq!(
+        screen.get_active_tab(1).unwrap().active_panes.get(&1).unwrap(),
+        &PaneId::Terminal(2),
+        "Active pane is still the fullscreen pane"
+    );
+}

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -463,7 +463,12 @@ fn switch_to_tab_with_fullscreen() {
         "Active tab switched to previous"
     );
     assert_eq!(
-        screen.get_active_tab(1).unwrap().active_panes.get(&1).unwrap(),
+        screen
+            .get_active_tab(1)
+            .unwrap()
+            .active_panes
+            .get(&1)
+            .unwrap(),
         &PaneId::Terminal(2),
         "Active pane is still the fullscreen pane"
     );


### PR DESCRIPTION
This is a fix for https://github.com/zellij-org/zellij/issues/940

This was a regression - when switching tabs, we didn't check to see if there's a fullscreen pane we should switch to. I also added a test for this.