### PR TITLE
chore: upgrade wasmer, wasmer-wasi

### DIFF
--- a/zellij-server/Cargo.toml
+++ b/zellij-server/Cargo.toml
@@ -18,8 +18,8 @@ daemonize = "0.4.1"
 serde_json = "1.0"
 unicode-width = "0.1.8"
 url = "2.2.2"
-wasmer = "1.0.0"
-wasmer-wasi = "1.0.0"
+wasmer = "2.1.0"
+wasmer-wasi = { version = "2.1.0", features = ["enable-serde"] }
 cassowary = "0.3.0"
 zellij-utils = { path = "../zellij-utils/", version = "0.22.1" }
 zellij-tile = { path = "../zellij-tile/", version = "0.22.1" }
@@ -29,8 +29,9 @@ chrono = "0.4.19"
 close_fds = "0.3.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-darwin-libproc = "0.2.0"
+darwin-libproc-sys = "0.2.0"
+libc = "0.2.112"
+memchr = "2.4.1"
 
 [dev-dependencies]
 insta = "1.6.0"
-

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -338,7 +338,7 @@ impl ServerOsApi for ServerOsInputOutput {
     }
     #[cfg(target_os = "macos")]
     fn get_cwd(&self, pid: Pid) -> Option<PathBuf> {
-        darwin_libproc::pid_cwd(pid.as_raw()).ok()
+        zellij_darwin_libproc::pid_cwd(pid.as_raw()).ok()
     }
     #[cfg(target_os = "linux")]
     fn get_cwd(&self, pid: Pid) -> Option<PathBuf> {
@@ -347,6 +347,41 @@ impl ServerOsApi for ServerOsInputOutput {
     #[cfg(all(not(target_os = "linux"), not(target_os = "macos")))]
     fn get_cwd(&self, _pid: Pid) -> Option<PathBuf> {
         None
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod zellij_darwin_libproc {
+    use std::ffi::OsStr;
+    use std::io;
+    use std::mem;
+    use std::os::unix::ffi::OsStrExt;
+    use std::path::PathBuf;
+    use std::slice;
+
+    // Fetch current working directory for process with `pid` provided.
+    fn pid_cwd(pid: libc::pid_t) -> io::Result<PathBuf> {
+        let vnode_path = vnode_path_info(pid)?;
+        let raw_path = unsafe {
+            slice::from_raw_parts(
+                vnode_path.pvi_cdir.vip_path.as_ptr() as *const u8,
+                vnode_path.pvi_cdir.vip_path.len(),
+            )
+        };
+        let first_null = memchr::memchr(0x00, &raw_path).unwrap_or(0);
+
+        let os_str = OsStr::from_bytes(&raw_path[..first_null]);
+
+        Ok(PathBuf::from(os_str.to_os_string()))
+    }
+
+    // Returns filled `proc_vnodepathinfo` struct for pid given.
+    fn vnode_path_info(pid: libc::pid_t) -> io::Result<darwin_libproc_sys::proc_vnodepathinfo> {
+        pid_info(
+            pid,
+            darwin_libproc_sys::PROC_PIDVNODEPATHINFO as libc::c_int,
+            0,
+        )
     }
 }
 


### PR DESCRIPTION
I resolved a dependency conflict with `darwin-libproc` (because of its requirement of memchr = "~2.3") by depending on `darwin-libproc-sys` directly and adding the 2 necessary functions from darwin-libproc to zellij.
A pull request was opened 6 months ago for this issue with `darwin-libproc` but no response was made since then. 
I ran `cargo test --all --all-features` and everything passed. 
I haven't figured out yet how to run the tests in the docker container.