### PR TITLE
chore: upgrade wasmer, wasmer-wasi

### DIFF
--- a/zellij-server/Cargo.toml
+++ b/zellij-server/Cargo.toml
@@ -18,8 +18,8 @@ daemonize = "0.4.1"
 serde_json = "1.0"
 unicode-width = "0.1.8"
 url = "2.2.2"
-wasmer = "1.0.0"
-wasmer-wasi = "1.0.0"
+wasmer = "2.1.0"
+wasmer-wasi = { version = "2.1.0", features = ["enable-serde"] }
 cassowary = "0.3.0"
 zellij-utils = { path = "../zellij-utils/", version = "0.22.1" }
 zellij-tile = { path = "../zellij-tile/", version = "0.22.1" }
@@ -29,8 +29,9 @@ chrono = "0.4.19"
 close_fds = "0.3.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-darwin-libproc = "0.2.0"
+darwin-libproc-sys = "0.2.0"
+libc = "0.2.112"
+memchr = "2.4.1"
 
 [dev-dependencies]
 insta = "1.6.0"
-


### PR DESCRIPTION
I resolved a dependency conflict with darwin-libproc (because of its requirement of memchr = "~2.3") by depending on darwin-libproc-sys directly and adding the 2 necessary functions from darwin-libproc to zellij.
A pull request was opened 6 months ago for this issue with darwin-libproc but no response was made since then.

I use linux and I couldn't get `darwin-libproc-sys` to typecheck because it only gets compiled on macos. 
I hope I didn't miss anyhting, and it compiles without problem on macos.