### PR TITLE
fix: update switch to tab bug in multiple users

### DIFF
--- a/zellij-server/src/wasm_vm.rs
+++ b/zellij-server/src/wasm_vm.rs
@@ -398,7 +398,10 @@ fn host_open_file(plugin_env: &PluginEnv) {
 fn host_switch_tab_to(plugin_env: &PluginEnv, tab_idx: u32) {
     plugin_env
         .senders
-        .send_to_screen(ScreenInstruction::GoToTab(tab_idx, None)) // this is a hack, we should be able to return the client id here
+        .send_to_screen(ScreenInstruction::GoToTab(
+            tab_idx,
+            Some(plugin_env.client_id),
+        )) // this is a hack, we should be able to return the client id here
         .unwrap();
 }
 

--- a/zellij-server/src/wasm_vm.rs
+++ b/zellij-server/src/wasm_vm.rs
@@ -401,7 +401,7 @@ fn host_switch_tab_to(plugin_env: &PluginEnv, tab_idx: u32) {
         .send_to_screen(ScreenInstruction::GoToTab(
             tab_idx,
             Some(plugin_env.client_id),
-        )) // this is a hack, we should be able to return the client id here
+        ))
         .unwrap();
 }
 


### PR DESCRIPTION
Attach users cannot change tabs by clicking the mouse.
Because `tab-bar` plugin call the `host_switch_tab_to` function which it does not return `client_id`.

Since each client passes the `client_id` in the `PluginEnv` structure, I added it.