### PR TITLE
fix(compatibility): handle inserting characters after wide character

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2879,7 +2879,7 @@ dependencies = [
 
 [[package]]
 name = "zellij"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "dialoguer",
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "zellij-client"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "insta",
  "log",
@@ -2909,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "zellij-server"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "ansi_term 0.12.1",
  "async-trait",
@@ -2935,7 +2935,7 @@ dependencies = [
 
 [[package]]
 name = "zellij-tile"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2945,14 +2945,14 @@ dependencies = [
 
 [[package]]
 name = "zellij-tile-utils"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "ansi_term 0.12.1",
 ]
 
 [[package]]
 name = "zellij-utils"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-std",

--- a/src/tests/fixtures/wide_characters_middle_line_insert
+++ b/src/tests/fixtures/wide_characters_middle_line_insert
@@ -1,0 +1,1 @@
+[?2004h[aram@green zellij]$ [K[aram@green zellij]$ [7m🏠[27m🏠 abcdabceabcfabc abc[1@x

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -2254,7 +2254,8 @@ impl Row {
         match self.columns.len().cmp(&insert_position) {
             Ordering::Equal => self.columns.push_back(terminal_character),
             Ordering::Less => {
-                self.columns.resize(insert_position, EMPTY_TERMINAL_CHARACTER);
+                self.columns
+                    .resize(insert_position, EMPTY_TERMINAL_CHARACTER);
                 self.columns.push_back(terminal_character);
             }
             Ordering::Greater => {

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -2249,14 +2249,16 @@ impl Row {
         }
     }
     pub fn insert_character_at(&mut self, terminal_character: TerminalCharacter, x: usize) {
-        match self.columns.len().cmp(&x) {
+        let width_offset = self.excess_width_until(x);
+        let insert_position = x.saturating_sub(width_offset);
+        match self.columns.len().cmp(&insert_position) {
             Ordering::Equal => self.columns.push_back(terminal_character),
             Ordering::Less => {
-                self.columns.resize(x, EMPTY_TERMINAL_CHARACTER);
+                self.columns.resize(insert_position, EMPTY_TERMINAL_CHARACTER);
                 self.columns.push_back(terminal_character);
             }
             Ordering::Greater => {
-                self.columns.insert(x, terminal_character);
+                self.columns.insert(insert_position, terminal_character);
             }
         }
     }

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -421,6 +421,18 @@ fn wide_characters_line_wrap() {
 }
 
 #[test]
+fn insert_character_in_line_with_wide_character() {
+    let mut vte_parser = vte::Parser::new();
+    let mut grid = Grid::new(21, 104, Palette::default());
+    let fixture_name = "wide_characters_middle_line_insert";
+    let content = read_fixture(fixture_name);
+    for byte in content {
+        vte_parser.advance(&mut grid, byte);
+    }
+    assert_snapshot!(format!("{:?}", grid));
+}
+
+#[test]
 fn fish_wide_characters_override_clock() {
     let mut vte_parser = vte::Parser::new();
     let mut grid = Grid::new(21, 104, Palette::default());

--- a/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__insert_character_in_line_with_wide_character.snap
+++ b/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__insert_character_in_line_with_wide_character.snap
@@ -1,0 +1,7 @@
+---
+source: zellij-server/src/panes/./unit/grid_tests.rs
+expression: "format!(\"{:?}\", grid)"
+
+---
+00 (C): [aram@green zellij]$ 🏠 xdef abc                                                                        
+


### PR DESCRIPTION
This is a fix for https://github.com/zellij-org/zellij/issues/943

The issue was that specifically when inserting a character in the middle of the line, we did not account for wide characters in the line before it and inserted at the absolute position rather at the relative position (removing the excess width caused by wide characters).