### PR TITLE
fix(compatibility): handle deleting chars in lines with widechars

### DIFF
--- a/src/tests/fixtures/wide-chars-delete-middle
+++ b/src/tests/fixtures/wide-chars-delete-middle
@@ -1,0 +1,1 @@
+[?2004h[aram@green zellij]$ [K[aram@green zellij]$ [7m🏠[27m🏠 abc5~[K[Kdabceabcfabc abc[1@x[1P

--- a/src/tests/fixtures/wide-chars-delete-middle-after-multi
+++ b/src/tests/fixtures/wide-chars-delete-middle-after-multi
@@ -1,0 +1,1 @@
+[?2004h[aram@green zellij]$ [K[aram@green zellij]$ [7m🏠[27m🏠[7m🏠[27m🏠[7m🏠[27m🏠a🏠[1P🏠

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -2253,7 +2253,8 @@ impl Row {
         match self.columns.len().cmp(&insert_position) {
             Ordering::Equal => self.columns.push_back(terminal_character),
             Ordering::Less => {
-                self.columns.resize(insert_position, EMPTY_TERMINAL_CHARACTER);
+                self.columns
+                    .resize(insert_position, EMPTY_TERMINAL_CHARACTER);
                 self.columns.push_back(terminal_character);
             }
             Ordering::Greater => {

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -2249,13 +2249,11 @@ impl Row {
         }
     }
     pub fn insert_character_at(&mut self, terminal_character: TerminalCharacter, x: usize) {
-        let width_offset = self.excess_width_until(x);
-        let insert_position = x.saturating_sub(width_offset);
+        let insert_position = self.absolute_character_index(x);
         match self.columns.len().cmp(&insert_position) {
             Ordering::Equal => self.columns.push_back(terminal_character),
             Ordering::Less => {
-                self.columns
-                    .resize(insert_position, EMPTY_TERMINAL_CHARACTER);
+                self.columns.resize(insert_position, EMPTY_TERMINAL_CHARACTER);
                 self.columns.push_back(terminal_character);
             }
             Ordering::Greater => {
@@ -2368,8 +2366,9 @@ impl Row {
         self.columns.is_empty()
     }
     pub fn delete_and_return_character(&mut self, x: usize) -> Option<TerminalCharacter> {
-        if x < self.columns.len() {
-            Some(self.columns.remove(x).unwrap()) // TODO: just return the remove part?
+        let erase_position = self.absolute_character_index(x);
+        if erase_position < self.columns.len() {
+            Some(self.columns.remove(erase_position).unwrap()) // TODO: just return the remove part?
         } else {
             None
         }

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -433,6 +433,30 @@ fn insert_character_in_line_with_wide_character() {
 }
 
 #[test]
+fn delete_char_in_middle_of_line_with_widechar() {
+    let mut vte_parser = vte::Parser::new();
+    let mut grid = Grid::new(21, 104, Palette::default());
+    let fixture_name = "wide-chars-delete-middle";
+    let content = read_fixture(fixture_name);
+    for byte in content {
+        vte_parser.advance(&mut grid, byte);
+    }
+    assert_snapshot!(format!("{:?}", grid));
+}
+
+#[test]
+fn delete_char_in_middle_of_line_with_multiple_widechars() {
+    let mut vte_parser = vte::Parser::new();
+    let mut grid = Grid::new(21, 104, Palette::default());
+    let fixture_name = "wide-chars-delete-middle-after-multi";
+    let content = read_fixture(fixture_name);
+    for byte in content {
+        vte_parser.advance(&mut grid, byte);
+    }
+    assert_snapshot!(format!("{:?}", grid));
+}
+
+#[test]
 fn fish_wide_characters_override_clock() {
     let mut vte_parser = vte::Parser::new();
     let mut grid = Grid::new(21, 104, Palette::default());

--- a/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__delete_char_in_middle_of_line_with_multiple_widechars.snap
+++ b/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__delete_char_in_middle_of_line_with_multiple_widechars.snap
@@ -1,0 +1,7 @@
+---
+source: zellij-server/src/panes/./unit/grid_tests.rs
+expression: "format!(\"{:?}\", grid)"
+
+---
+00 (C): [aram@green zellij]$ 🏠🏠🏠                                                                            
+

--- a/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__delete_char_in_middle_of_line_with_widechar.snap
+++ b/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__delete_char_in_middle_of_line_with_widechar.snap
@@ -1,0 +1,7 @@
+---
+source: zellij-server/src/panes/./unit/grid_tests.rs
+expression: "format!(\"{:?}\", grid)"
+
+---
+00 (C): [aram@green zellij]$ 🏠 def abc                                                                        
+


### PR DESCRIPTION
This is another fix for https://github.com/zellij-org/zellij/issues/943

In this case we make sure when deleting a character in the middle of the line with a widechar uses the proper absolute index.
