### PR TITLE
fix(mouse): prevent unhandled mouse events escape to terminal

### DIFF
--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -70,7 +70,9 @@ impl InputHandler {
             if self.should_exit {
                 break;
             }
-            match self.receive_input_instructions.recv() {
+            let input_instruction = self.receive_input_instructions.recv();
+            log::info!("received input instruction: {:?}", input_instruction);
+            match input_instruction {
                 Ok((InputInstruction::KeyEvent(event, raw_bytes), _error_context)) => {
                     match event {
                         termion::event::Event::Key(key) => {

--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -70,9 +70,7 @@ impl InputHandler {
             if self.should_exit {
                 break;
             }
-            let input_instruction = self.receive_input_instructions.recv();
-            log::info!("received input instruction: {:?}", input_instruction);
-            match input_instruction {
+            match self.receive_input_instructions.recv() {
                 Ok((InputInstruction::KeyEvent(event, raw_bytes), _error_context)) => {
                     match event {
                         termion::event::Event::Key(key) => {

--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -62,7 +62,6 @@ pub(crate) fn stdin_loop(
     let adjusted_keys = keys_to_adjust();
     loop {
         let mut stdin_buffer = os_input.read_from_stdin();
-        log::info!("read from stdin: {:?}", stdin_buffer);
         if pasting
             || (stdin_buffer.len() > bracketed_paste_start.len()
                 && stdin_buffer
@@ -160,7 +159,6 @@ pub(crate) fn stdin_loop(
                 if raw_bytes.len() > csi_mouse_sgr_start.len()
                     && raw_bytes[0..csi_mouse_sgr_start.len()] == csi_mouse_sgr_start
                 {
-                    log::info!("discarding unhandled csi sgr sequence: {:?}", raw_bytes);
                     continue;
                 }
             }

--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -58,6 +58,7 @@ pub(crate) fn stdin_loop(
 ) {
     let mut pasting = false;
     let bracketed_paste_start = vec![27, 91, 50, 48, 48, 126]; // \u{1b}[200~
+    let csi_mouse_sgr_start = vec![27, 91, 60];
     let adjusted_keys = keys_to_adjust();
     loop {
         let mut stdin_buffer = os_input.read_from_stdin();
@@ -150,6 +151,20 @@ pub(crate) fn stdin_loop(
                     continue;
                 }
             }
+
+            // FIXME: termion does not properly parse some csi sgr mouse sequences
+            // like ctrl + click.
+            // As a workaround, to avoid writing these sequences to tty stdin,
+            // we discard them.
+            if let termion::event::Event::Unsupported(_) = key_event {
+                if raw_bytes.len() > csi_mouse_sgr_start.len()
+                    && raw_bytes[0..csi_mouse_sgr_start.len()] == csi_mouse_sgr_start
+                {
+                    log::info!("discarding unhandled csi sgr sequence: {:?}", raw_bytes);
+                    continue;
+                }
+            }
+
             send_input_instructions
                 .send(InputInstruction::KeyEvent(key_event, raw_bytes))
                 .unwrap();

--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -61,6 +61,7 @@ pub(crate) fn stdin_loop(
     let adjusted_keys = keys_to_adjust();
     loop {
         let mut stdin_buffer = os_input.read_from_stdin();
+        log::info!("read from stdin: {:?}", stdin_buffer);
         if pasting
             || (stdin_buffer.len() > bracketed_paste_start.len()
                 && stdin_buffer

--- a/zellij-server/src/tab.rs
+++ b/zellij-server/src/tab.rs
@@ -3377,8 +3377,8 @@ impl Tab {
 
         if let Some(selected_text) = selected_text {
             self.write_selection_to_clipboard(&selected_text);
-            self.selecting_with_mouse = false;
         }
+        self.selecting_with_mouse = false;
     }
     pub fn handle_mouse_hold(&mut self, position_on_screen: &Position, client_id: ClientId) {
         if let Some(active_pane_id) = self.get_active_pane_id(client_id) {


### PR DESCRIPTION
resolve #932 (workaround)

Avoid writing csi sgr mouse sequences that don't get parsed by termion to terminal.
Improve mouse copy by limiting copying only to release events that happen after a selection has been initiated.