### PR TITLE
fix: add exception for cwd does not exist

### DIFF
--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -113,7 +113,9 @@ fn handle_openpty(
     let mut child = unsafe {
         let command = &mut Command::new(cmd.command);
         if let Some(current_dir) = cmd.cwd {
-            command.current_dir(current_dir);
+            if current_dir.exists() {
+                command.current_dir(current_dir);
+            }
         }
         command
             .args(&cmd.args)


### PR DESCRIPTION
This issue resolve #993 

Fix an error that occurs when calling the `current_dir` function with a non-existent `PathBuf`.