### PR TITLE
feat: change dependency for `process_cwd`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
 name = "cranelift-bforest"
 version = "0.68.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,26 +616,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "darwin-libproc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc629b7cf42586fee31dae31f9ab73fa5ff5f0170016aa61be5fcbc12a90c516"
-dependencies = [
- "darwin-libproc-sys",
- "libc",
- "memchr",
-]
-
-[[package]]
-name = "darwin-libproc-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef0aa083b94c54aa4cfd9bbfd37856714c139d1dc511af80270558c7ba3b4816"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1157,9 +1143,9 @@ checksum = "4d234d89ecf5621c935b69a4c7266c9a634a95e465081682be47358617ce825b"
 
 [[package]]
 name = "libc"
-version = "0.2.106"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libloading"
@@ -2148,6 +2134,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f1bfab07306a27332451a662ca9c8156e3a9986f82660ba9c8e744fe8455d43"
+dependencies = [
+ "cfg-if 1.0.0",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
+]
+
+[[package]]
 name = "tab-bar"
 version = "0.1.0"
 dependencies = [
@@ -2871,11 +2872,11 @@ dependencies = [
  "chrono",
  "close_fds",
  "daemonize",
- "darwin-libproc",
  "highway",
  "insta",
  "log",
  "serde_json",
+ "sysinfo",
  "typetag",
  "unicode-width",
  "url",

--- a/zellij-server/Cargo.toml
+++ b/zellij-server/Cargo.toml
@@ -27,9 +27,7 @@ log = "0.4.14"
 typetag = "0.1.7"
 chrono = "0.4.19"
 close_fds = "0.3.2"
-
-[target.'cfg(target_os = "macos")'.dependencies]
-darwin-libproc = "0.2.0"
+sysinfo = "0.22.5"
 
 [dev-dependencies]
 insta = "1.6.0"


### PR DESCRIPTION
This issue related the `darwin-libproc` dependency.

The darwin-libproc library has not been updated for a long time, including dependency issues.
(reference: https://github.com/heim-rs/darwin-libproc/pull/3 and current problem is similar to this: https://github.com/zellij-org/zellij/pull/953#issuecomment-997219613)

So this PR simplifies the `get_cwd` function while using the new library [sysinfo](https://docs.rs/sysinfo/latest/sysinfo/).

This library solves dependency problems and supports various OSes.