### PR TITLE
Add option to default config for copy_command (PR #996)

### DIFF
--- a/zellij-utils/assets/config/default.yaml
+++ b/zellij-utils/assets/config/default.yaml
@@ -468,3 +468,12 @@ plugins:
 # Valid values: positive integers
 # Default value: 10000
 #scroll_buffer_size: 10000
+
+# Provide a command to execute when copying text. The text will be piped to
+# the stdin of the program to perform the copy. This can be used with
+# terminal emulators which do not support the OSC 52 ANSI control sequence
+# that will be used by default if this option is not set.
+# Examples:
+#copy_command: "xclip -selection clipboard" # x11
+#copy_command: "wl-copy"                    # wayland
+#copy_command: "pbcopy"                     # osx


### PR DESCRIPTION
Document the new --copy-command / copy_command option (#996) in the default config with examples.