### PR TITLE
allow osc52 copy destination configuration

### DIFF
--- a/default-plugins/status-bar/src/second_line.rs
+++ b/default-plugins/status-bar/src/second_line.rs
@@ -229,11 +229,18 @@ pub fn keybinds(help: &ModeInfo, tip_name: &str, max_width: usize) -> LinePart {
     best_effort_shortcut_list(help, tip_body.short, max_width)
 }
 
-pub fn text_copied_hint(palette: &Palette) -> LinePart {
-    let hint = " Text copied to clipboard";
+pub fn text_copied_hint(palette: &Palette, copy_destination: CopyDestination) -> LinePart {
     let green_color = match palette.green {
         PaletteColor::Rgb((r, g, b)) => RGB(r, g, b),
         PaletteColor::EightBit(color) => Fixed(color),
+    };
+    let hint = match copy_destination {
+        CopyDestination::Command => "Text piped to external command",
+        #[cfg(not(target_os = "macos"))]
+        CopyDestination::Primary => "Text copied to primary selection",
+        #[cfg(target_os = "macos")]
+        CopyDestination::Primary => "Text copied to clipboard",
+        CopyDestination::System => "Text copied to clipboard",
     };
     LinePart {
         part: Style::new().fg(green_color).bold().paint(hint).to_string(),

--- a/default-plugins/status-bar/src/second_line.rs
+++ b/default-plugins/status-bar/src/second_line.rs
@@ -238,7 +238,7 @@ pub fn text_copied_hint(palette: &Palette, copy_destination: CopyDestination) ->
         CopyDestination::Command => "Text piped to external command",
         #[cfg(not(target_os = "macos"))]
         CopyDestination::Primary => "Text copied to primary selection",
-        #[cfg(target_os = "macos")]
+        #[cfg(target_os = "macos")] // primary selection does not exist on macos
         CopyDestination::Primary => "Text copied to clipboard",
         CopyDestination::System => "Text copied to clipboard",
     };

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -6,6 +6,7 @@ use std::os::unix::io::RawFd;
 use std::rc::Rc;
 use std::str;
 
+use zellij_utils::input::options::Clipboard;
 use zellij_utils::pane_size::Size;
 use zellij_utils::{input::layout::Layout, position::Position, zellij_tile};
 
@@ -194,10 +195,12 @@ pub(crate) struct Screen {
     draw_pane_frames: bool,
     session_is_mirrored: bool,
     copy_command: Option<String>,
+    copy_clipboard: Clipboard,
 }
 
 impl Screen {
     /// Creates and returns a new [`Screen`].
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         bus: Bus<ScreenInstruction>,
         client_attributes: &ClientAttributes,
@@ -206,6 +209,7 @@ impl Screen {
         draw_pane_frames: bool,
         session_is_mirrored: bool,
         copy_command: Option<String>,
+        copy_clipboard: Clipboard,
     ) -> Self {
         Screen {
             bus,
@@ -222,6 +226,7 @@ impl Screen {
             draw_pane_frames,
             session_is_mirrored,
             copy_command,
+            copy_clipboard,
         }
     }
 
@@ -495,6 +500,7 @@ impl Screen {
             self.session_is_mirrored,
             client_id,
             self.copy_command.clone(),
+            self.copy_clipboard.clone(),
         );
         tab.apply_layout(layout, new_pids, tab_index, client_id);
         if self.session_is_mirrored {
@@ -700,6 +706,7 @@ pub(crate) fn screen_thread_main(
         draw_pane_frames,
         session_is_mirrored,
         config_options.copy_command,
+        config_options.copy_clipboard.unwrap_or_default(),
     );
     loop {
         let (event, mut err_ctx) = screen

--- a/zellij-server/src/tab/clipboard.rs
+++ b/zellij-server/src/tab/clipboard.rs
@@ -23,7 +23,10 @@ impl ClipboardProvider {
             }
             ClipboardProvider::Osc52(clipboard) => {
                 let dest = match clipboard {
+                    #[cfg(not(target_os = "macos"))]
                     Clipboard::Primary => 'p',
+                    #[cfg(target_os = "macos")] // primary selection does not exist on macos
+                    Clipboard::Primary => 'c',
                     Clipboard::System => 'c',
                 };
                 output.push_str_to_multiple_clients(

--- a/zellij-server/src/tab/clipboard.rs
+++ b/zellij-server/src/tab/clipboard.rs
@@ -1,0 +1,36 @@
+use zellij_utils::{anyhow::Result, input::options::Clipboard};
+
+use crate::ClientId;
+
+use super::{copy_command::CopyCommand, Output};
+
+pub(crate) enum ClipboardProvider {
+    Command(CopyCommand),
+    Osc52(Clipboard),
+}
+
+impl ClipboardProvider {
+    pub(crate) fn set_content(
+        &self,
+        content: &str,
+        output: &mut Output,
+        client_ids: impl Iterator<Item = ClientId>,
+    ) -> Result<()> {
+        match &self {
+            ClipboardProvider::Command(command) => {
+                command.set(content.to_string())?;
+            }
+            ClipboardProvider::Osc52(clipboard) => {
+                let dest = match clipboard {
+                    Clipboard::Primary => 'p',
+                    Clipboard::System => 'c',
+                };
+                output.push_str_to_multiple_clients(
+                    &format!("\u{1b}]52;{};{}\u{1b}\\", dest, base64::encode(content)),
+                    client_ids,
+                );
+            }
+        };
+        Ok(())
+    }
+}

--- a/zellij-server/src/tab/clipboard.rs
+++ b/zellij-server/src/tab/clipboard.rs
@@ -1,3 +1,4 @@
+use zellij_tile::prelude::CopyDestination;
 use zellij_utils::{anyhow::Result, input::options::Clipboard};
 
 use crate::ClientId;
@@ -32,5 +33,15 @@ impl ClipboardProvider {
             }
         };
         Ok(())
+    }
+
+    pub(crate) fn as_copy_destination(&self) -> CopyDestination {
+        match self {
+            ClipboardProvider::Command(_) => CopyDestination::Command,
+            ClipboardProvider::Osc52(clipboard) => match clipboard {
+                Clipboard::Primary => CopyDestination::Primary,
+                Clipboard::System => CopyDestination::System,
+            },
+        }
     }
 }

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1946,7 +1946,7 @@ impl Tab {
                 .send_to_plugin(PluginInstruction::Update(
                     None,
                     None,
-                    Event::CopyToClipboard,
+                    Event::CopyToClipboard(self.clipboard_provider.as_copy_destination()),
                 ))
                 .unwrap();
         }
@@ -1966,7 +1966,7 @@ impl Tab {
                     self.senders
                         .send_to_server(ServerInstruction::Render(Some(output)))
                         .unwrap();
-                    Event::CopyToClipboard
+                    Event::CopyToClipboard(self.clipboard_provider.as_copy_destination())
                 }
                 Err(err) => {
                     log::error!("could not write selection to clipboard: {}", err);

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -9,6 +9,7 @@ use crate::{
 use std::convert::TryInto;
 use std::path::PathBuf;
 use zellij_utils::input::layout::LayoutTemplate;
+use zellij_utils::input::options::Clipboard;
 use zellij_utils::ipc::IpcReceiverWithContext;
 use zellij_utils::pane_size::Size;
 
@@ -97,6 +98,7 @@ fn create_new_tab(size: Size) -> Tab {
     connected_clients.insert(client_id);
     let connected_clients = Rc::new(RefCell::new(connected_clients));
     let copy_command = None;
+    let copy_clipboard = Clipboard::default();
     let mut tab = Tab::new(
         index,
         position,
@@ -112,6 +114,7 @@ fn create_new_tab(size: Size) -> Tab {
         session_is_mirrored,
         client_id,
         copy_command,
+        copy_clipboard,
     );
     tab.apply_layout(
         LayoutTemplate::default().try_into().unwrap(),

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -10,6 +10,7 @@ use std::convert::TryInto;
 use std::path::PathBuf;
 use zellij_utils::input::command::TerminalAction;
 use zellij_utils::input::layout::LayoutTemplate;
+use zellij_utils::input::options::Clipboard;
 use zellij_utils::ipc::IpcReceiverWithContext;
 use zellij_utils::pane_size::Size;
 
@@ -92,6 +93,7 @@ fn create_new_screen(size: Size) -> Screen {
     let draw_pane_frames = false;
     let session_is_mirrored = true;
     let copy_command = None;
+    let copy_clipboard = Clipboard::default();
     Screen::new(
         bus,
         &client_attributes,
@@ -100,6 +102,7 @@ fn create_new_screen(size: Size) -> Screen {
         draw_pane_frames,
         session_is_mirrored,
         copy_command,
+        copy_clipboard,
     )
 }
 

--- a/zellij-tile/src/data.rs
+++ b/zellij-tile/src/data.rs
@@ -76,7 +76,7 @@ pub enum Event {
     Key(Key),
     Mouse(Mouse),
     Timer(f64),
-    CopyToClipboard,
+    CopyToClipboard(CopyDestination),
     SystemClipboardFailure,
     InputReceived,
     Visible(bool),
@@ -266,4 +266,11 @@ impl Default for PluginCapabilities {
     fn default() -> PluginCapabilities {
         PluginCapabilities { arrow_fonts: true }
     }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+pub enum CopyDestination {
+    Command,
+    Primary,
+    System,
 }

--- a/zellij-utils/assets/config/default.yaml
+++ b/zellij-utils/assets/config/default.yaml
@@ -477,3 +477,11 @@ plugins:
 #copy_command: "xclip -selection clipboard" # x11
 #copy_command: "wl-copy"                    # wayland
 #copy_command: "pbcopy"                     # osx
+
+# Choose the destination for copied text
+# Allows using the primary selection buffer (on x11/wayland) instead of the system clipboard.
+# Does not apply when using copy_command.
+# Options:
+#   - system (default)
+#   - primary
+# copy_clipboard: primary

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -87,6 +87,7 @@ pub struct Options {
 }
 
 #[derive(ArgEnum, Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
 pub enum Clipboard {
     System,
     Primary,

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -87,9 +87,10 @@ pub struct Options {
 }
 
 #[derive(ArgEnum, Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all = "lowercase")]
 pub enum Clipboard {
+    #[serde(alias = "system")]
     System,
+    #[serde(alias = "primary")]
     Primary,
 }
 

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -1,6 +1,6 @@
 //! Handles cli and configuration options
 use crate::cli::Command;
-use clap::{arg_enum, ArgEnum, Args};
+use clap::{ArgEnum, Args};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::str::FromStr;

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -1,6 +1,6 @@
 //! Handles cli and configuration options
 use crate::cli::Command;
-use clap::{ArgEnum, Args};
+use clap::{arg_enum, ArgEnum, Args};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -79,6 +79,23 @@ pub struct Options {
     #[clap(long)]
     #[serde(default)]
     pub copy_command: Option<String>,
+
+    /// OSC52 destination clipboard
+    #[clap(long, arg_enum, ignore_case = true, conflicts_with = "copy-command")]
+    #[serde(default)]
+    pub copy_clipboard: Option<Clipboard>,
+}
+
+#[derive(ArgEnum, Deserialize, Serialize, Debug, Clone, PartialEq)]
+pub enum Clipboard {
+    System,
+    Primary,
+}
+
+impl Default for Clipboard {
+    fn default() -> Self {
+        Self::System
+    }
 }
 
 impl Options {
@@ -105,6 +122,7 @@ impl Options {
         let on_force_close = other.on_force_close.or(self.on_force_close);
         let scroll_buffer_size = other.scroll_buffer_size.or(self.scroll_buffer_size);
         let copy_command = other.copy_command.or_else(|| self.copy_command.clone());
+        let copy_clipboard = other.copy_clipboard.or_else(|| self.copy_clipboard.clone());
 
         Options {
             simplified_ui,
@@ -118,6 +136,7 @@ impl Options {
             on_force_close,
             scroll_buffer_size,
             copy_command,
+            copy_clipboard,
         }
     }
 
@@ -148,6 +167,7 @@ impl Options {
         let on_force_close = other.on_force_close.or(self.on_force_close);
         let scroll_buffer_size = other.scroll_buffer_size.or(self.scroll_buffer_size);
         let copy_command = other.copy_command.or_else(|| self.copy_command.clone());
+        let copy_clipboard = other.copy_clipboard.or_else(|| self.copy_clipboard.clone());
 
         Options {
             simplified_ui,
@@ -161,6 +181,7 @@ impl Options {
             on_force_close,
             scroll_buffer_size,
             copy_command,
+            copy_clipboard,
         }
     }
 
@@ -210,6 +231,7 @@ impl From<CliOptions> for Options {
             on_force_close: opts.on_force_close,
             scroll_buffer_size: opts.scroll_buffer_size,
             copy_command: opts.copy_command,
+            copy_clipboard: opts.copy_clipboard,
         }
     }
 }

--- a/zellij-utils/src/lib.rs
+++ b/zellij-utils/src/lib.rs
@@ -11,6 +11,7 @@ pub mod position;
 pub mod setup;
 pub mod shared;
 
+pub use anyhow;
 pub use async_std;
 pub use clap;
 pub use interprocess;


### PR DESCRIPTION
allow setting primary selection or system clipboard

resolve #1018

Add the `copy-clipboard` option which can be set to:
- `system`
- `primary`

By default it is set to `system`, setting it to `primary` will write the copied text to the primary selection buffer on x11/wayland (it won't work on `macos`).