### PR TITLE
Initial solution to issue #195

### DIFF
--- a/default-plugins/strider/src/main.rs
+++ b/default-plugins/strider/src/main.rs
@@ -87,7 +87,13 @@ impl ZellijPlugin for State {
     }
 
     fn render(&mut self, rows: usize, cols: usize) {
-        for i in 0..rows {
+        let display_current_dir = FsEntry::DisplayDir(self.current_dir.clone())
+            .as_line(cols)
+            .normal()
+            .on_yellow()
+            .black();
+        println!("{}", display_current_dir);
+        for i in 0..rows - 1 {
             if self.selected() < self.scroll() {
                 *self.scroll_mut() = self.selected();
             }
@@ -99,9 +105,9 @@ impl ZellijPlugin for State {
             if let Some(entry) = self.files.get(i) {
                 let mut path = entry.as_line(cols).normal();
 
-                if let FsEntry::Dir(..) = entry {
+                if let FsEntry::OpenableDir(..) = entry {
                     path = path.dimmed().bold();
-                }
+                };
 
                 if i == self.selected() {
                     println!("{}", path.reversed());

--- a/default-plugins/strider/src/state.rs
+++ b/default-plugins/strider/src/state.rs
@@ -14,55 +14,87 @@ pub struct State {
     pub files: Vec<FsEntry>,
     pub cursor_hist: HashMap<PathBuf, (usize, usize)>,
     pub hide_hidden_files: bool,
-    pub ev_history: VecDeque<(Event, Instant)>, // stores last event, can be expanded in future
+    pub ev_history: VecDeque<(Event, Instant)>, // - stores last event, can be expanded in future
+    pub current_dir: PathBuf,                   // - stores current relative path with
+                                                //   respect to the dir in which zellij
+                                                //   was opened in
 }
 
 impl State {
+    /// Same as `self.selected()` but returns a mutable reference.
     pub fn selected_mut(&mut self) -> &mut usize {
         &mut self.cursor_hist.entry(self.path.clone()).or_default().0
     }
+    /// Returns the index of the selected item in a directory given as `self.path`.
+    ///
+    /// The corresponding FsEntry for this item can be found in `self.files` at this index.
+    ///
+    /// The selected item is highlighted to show that actions (like going into a dir, opening a
+    /// file) are going to effect it
     pub fn selected(&self) -> usize {
-        self.cursor_hist.get(&self.path).unwrap_or(&(0, 0)).0
+        const DEFAULT_SELECTION: usize = 0;
+        self.cursor_hist
+            .get(&self.path)
+            .map(|&(lastest_selection_state, _)| lastest_selection_state)
+            .unwrap_or(DEFAULT_SELECTION)
     }
     pub fn scroll_mut(&mut self) -> &mut usize {
         &mut self.cursor_hist.entry(self.path.clone()).or_default().1
     }
     pub fn scroll(&self) -> usize {
-        self.cursor_hist.get(&self.path).unwrap_or(&(0, 0)).1
+        const DEFAULT_SCROLL: usize = 0;
+        self.cursor_hist
+            .get(&self.path)
+            .map(|&(_, latest_scroll_state)| latest_scroll_state)
+            .unwrap_or(DEFAULT_SCROLL)
     }
     pub fn toggle_hidden_files(&mut self) {
         self.hide_hidden_files = !self.hide_hidden_files;
     }
     pub fn traverse_dir_or_open_file(&mut self) {
         match self.files[self.selected()].clone() {
-            FsEntry::Dir(p, _) => {
+            FsEntry::OpenableDir(p, _) => {
                 self.path = p;
                 refresh_directory(self);
             }
             FsEntry::File(p, _) => open_file(p.strip_prefix(ROOT).unwrap()),
+            FsEntry::DisplayDir(_) => {}
         }
     }
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum FsEntry {
-    Dir(PathBuf, usize),
+    OpenableDir(PathBuf, usize),
     File(PathBuf, u64),
+    DisplayDir(PathBuf),
 }
 
 impl FsEntry {
     pub fn name(&self) -> String {
         let path = match self {
-            FsEntry::Dir(p, _) => p,
+            FsEntry::OpenableDir(p, _) => p,
             FsEntry::File(p, _) => p,
+            FsEntry::DisplayDir(p) => p,
         };
-        path.file_name().unwrap().to_string_lossy().into_owned()
+        match self {
+            FsEntry::File(..) | FsEntry::OpenableDir(..) => {
+                // only use the filename
+                path.file_name().unwrap().to_string_lossy().into_owned()
+            }
+            FsEntry::DisplayDir(..) => {
+                // use full path, but we need to remove the host part
+                let path = path.to_string_lossy().into_owned().replace("/host", "");
+                ".".to_string() + &path
+            }
+        }
     }
 
     pub fn as_line(&self, width: usize) -> String {
         let info = match self {
-            FsEntry::Dir(_, s) => s.to_string(),
+            FsEntry::OpenableDir(_, s) => s.to_string(),
             FsEntry::File(_, s) => pb::convert(*s as f64),
+            FsEntry::DisplayDir(_) => "".to_string(),
         };
         let space = width.saturating_sub(info.len());
         let name = self.name();
@@ -80,13 +112,17 @@ impl FsEntry {
 }
 
 pub(crate) fn refresh_directory(state: &mut State) {
+    // update the current dir
+    state.current_dir = state.current_dir.join(&state.path);
+
+    // get contents of dir with path `state.path`
     state.files = read_dir(Path::new(ROOT).join(&state.path))
         .unwrap()
         .filter_map(|res| {
             res.and_then(|d| {
                 if d.metadata()?.is_dir() {
                     let children = read_dir(d.path())?.count();
-                    Ok(FsEntry::Dir(d.path(), children))
+                    Ok(FsEntry::OpenableDir(d.path(), children))
                 } else {
                     let size = d.metadata()?.len();
                     Ok(FsEntry::File(d.path(), size))
@@ -96,6 +132,6 @@ pub(crate) fn refresh_directory(state: &mut State) {
             .filter(|d| !d.is_hidden_file() || !state.hide_hidden_files)
         })
         .collect();
-
+    // sort contents of dir with path `state.path`
     state.files.sort_unstable();
 }


### PR DESCRIPTION
This is my first try to solve issue #195 

I kind of built it on top of @a-kenji s idea.

The current path is displayed as a relative path starting from the origin of where zellij was originally started.

![PR1](https://user-images.githubusercontent.com/26892280/151260526-c29a25b5-991e-49b0-9ea1-039609059c23.png)

I've made sure that the path is always displayed at the top of the plugin pane, even when scrolling.
![PR2](https://user-images.githubusercontent.com/26892280/151260540-e7270d9b-4362-449c-866c-c92b216a7fbe.png)

Here is an example of how a deeper path looks.
![PR3](https://user-images.githubusercontent.com/26892280/151260544-ecbdc6ab-0eac-43e6-8200-81405be0c7b6.png)

I don't really know about the colors here. Some feedback on that would be nice.
Also, in my first attempt I wanted to display the absolute path. But I had no idea how to get the "pwd" info inside of the plugin.
Is there any way to do this.

Also what is the "/host" prefix in the path supposed to achieve?

The proposed idea from @imsnif to display the path in the pane title is also kind of hard, since the title is part of the pane and I don't know how to communicate information out from the plugin to make it available in the pane.



While writing I noticed that I should think about the case again, where the path doesn't fit in the pane.
