### PR TITLE
fix(config): warn on mode without actions

### DIFF
--- a/zellij-utils/src/input/keybinds.rs
+++ b/zellij-utils/src/input/keybinds.rs
@@ -198,7 +198,14 @@ impl Keybinds {
             keybinds
                 .0
                 .get(mode)
-                .unwrap_or_else(|| unreachable!("Unrecognized mode: {:?}", mode))
+                .unwrap_or({
+                    log::warn!(
+                        "The following mode has no action associated with it: {:?}",
+                        mode
+                    );
+                    // create a dummy mode to recover from
+                    &ModeKeybinds::new()
+                })
                 .0
                 .get(key)
                 .cloned()


### PR DESCRIPTION
Log with a warning, if the user finds himself in a mode,
that has no action associated with it.

fix #949