### PR TITLE
Initial KDL support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.15.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
- "gimli 0.24.0",
+ "gimli 0.26.1",
 ]
 
 [[package]]
@@ -218,16 +218,16 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.59"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4717cfcbfaa661a0fd48f8453951837ae7e8f81e481fbb136e3202d72805a744"
+checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
 dependencies = [
  "addr2line",
  "cc",
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object 0.24.0",
+ "object 0.27.1",
  "rustc-demangle",
 ]
 
@@ -326,6 +326,12 @@ dependencies = [
  "time",
  "winapi",
 ]
+
+[[package]]
+name = "chumsky"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d02796e4586c6c41aeb68eae9bfb4558a522c35f1430c14b40136c3706e09e4"
 
 [[package]]
 name = "clap"
@@ -963,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.24.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "gloo-timers"
@@ -1121,6 +1127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,6 +1145,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "knuffel"
+version = "1.0.1-alpha.0"
+source = "git+https://github.com/tailhook/knuffel#f8fd3e8475b4c1a7f61300ea442dbe37c93a9deb"
+dependencies = [
+ "base64",
+ "chumsky",
+ "knuffel-derive",
+ "miette",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "knuffel-derive"
+version = "1.0.1-alpha.0"
+source = "git+https://github.com/tailhook/knuffel#f8fd3e8475b4c1a7f61300ea442dbe37c93a9deb"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1303,6 +1340,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "miette"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd2adcfcced5d625bf90a958a82ae5b93231f57f3df1383fee28c9b5096d35ed"
+dependencies = [
+ "atty",
+ "backtrace",
+ "miette-derive",
+ "once_cell",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "thiserror",
+]
+
+[[package]]
+name = "miette-derive"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c01a8b61312d367ce87956bb686731f87e4c6dd5dbc550e8f06e3c24fb1f67f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,9 +1494,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.24.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5b3dd1c072ee7963717671d1ca129f1048fda25edea6b752bfc71ac8854170"
+checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "once_cell"
@@ -1467,6 +1537,12 @@ checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20448fd678ec04e6ea15bbe0476874af65e98a01515d667aa49f1434dc44ebf4"
 
 [[package]]
 name = "parking"
@@ -2020,6 +2096,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
+name = "smawk"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
 name = "socket2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,6 +2202,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "015336207b7660be204f5012fcdb84b3ff35442b26cea77ebe6103929a56e54b"
 dependencies = [
  "lev_distance",
+]
+
+[[package]]
+name = "supports-color"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872ced36b91d47bae8a214a683fe54e7078875b399dfa251df346c9b547d1f9"
+dependencies = [
+ "atty",
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590b34f7c5f01ecc9d78dba4b3f445f31df750a67621cf31626f3b7441ce6406"
+dependencies = [
+ "atty",
+]
+
+[[package]]
+name = "supports-unicode"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8b945e45b417b125a8ec51f1b7df2f8df7920367700d1f98aedd21e5735f8b2"
+dependencies = [
+ "atty",
 ]
 
 [[package]]
@@ -2228,6 +2338,11 @@ name = "textwrap"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -2363,6 +2478,15 @@ name = "unicode-bidi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a52dcaab0c48d931f7cc8ef826fa51690a08e1ea55117ef26f89864f532383f"
+dependencies = [
+ "regex",
+]
 
 [[package]]
 name = "unicode-normalization"
@@ -2848,6 +2972,7 @@ dependencies = [
  "dialoguer",
  "insta",
  "log",
+ "miette",
  "names",
  "rand 0.8.4",
  "ssh2",
@@ -2899,7 +3024,9 @@ dependencies = [
 name = "zellij-tile"
 version = "0.25.0"
 dependencies = [
+ "anyhow",
  "clap",
+ "knuffel",
  "serde",
  "serde_json",
  "strum",
@@ -2928,6 +3055,7 @@ dependencies = [
  "crossbeam",
  "directories-next",
  "interprocess",
+ "knuffel",
  "lazy_static",
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ zellij-utils = { path = "zellij-utils/", version = "0.25.0" }
 log = "0.4.14"
 dialoguer = "0.9.0"
 suggestion = "0.1.0"
+miette = { version = "3.3.0", features = ["fancy"] }
 
 [dev-dependencies]
 insta = { version = "1.6.0", features = ["backtrace"] }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -18,6 +18,7 @@ use zellij_utils::{
     cli::{CliArgs, Command, SessionCommand, Sessions},
     envs,
     setup::{get_default_data_dir, Setup},
+    input::config::ConfigError,
 };
 
 pub(crate) use crate::sessions::list_sessions;
@@ -168,8 +169,12 @@ fn attach_with_session_name(
 pub(crate) fn start_client(opts: CliArgs) {
     let (config, layout, config_options) = match Setup::from_options(&opts) {
         Ok(results) => results,
+        Err(ConfigError::Kdl(e)) => {
+            eprintln!("{:?}", miette::Report::new(e));
+            process::exit(1);
+        }
         Err(e) => {
-            eprintln!("{}", e);
+            eprintln!("{:#}", e);
             process::exit(1);
         }
     };

--- a/zellij-tile/Cargo.toml
+++ b/zellij-tile/Cargo.toml
@@ -12,3 +12,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 strum = "0.20.0"
 strum_macros = "0.20.0"
+anyhow = "1.0"
+knuffel = "1.1"

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -37,6 +37,7 @@ zellij-tile = { path = "../zellij-tile/", version = "0.25.0" }
 log = "0.4.14"
 log4rs = "1.0.0"
 unicode-width = "0.1.8"
+knuffel = "1.1"
 
 [dependencies.async-std]
 version = "1.3.0"

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -10,6 +10,7 @@ use crate::position::Position;
 
 /// The four directions (left, right, up, down).
 #[derive(Eq, Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(knuffel::DecodeScalar)]
 pub enum Direction {
     Left,
     Right,
@@ -18,6 +19,7 @@ pub enum Direction {
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(knuffel::DecodeScalar)]
 pub enum ResizeDirection {
     Left,
     Right,
@@ -33,34 +35,37 @@ pub enum ResizeDirection {
 // as well `../../assets/config/default.yaml`
 /// Actions that can be bound to keys.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(knuffel::Decode)]
 pub enum Action {
     /// Quit Zellij.
     Quit,
     /// Write to the terminal.
-    Write(Vec<u8>),
+    Write(#[knuffel(argument, bytes)] Vec<u8>),
     /// Write Characters to the terminal.
-    WriteChars(String),
+    WriteChars(#[knuffel(argument)] String),
     /// Switch to the specified input mode.
-    SwitchToMode(InputMode),
+    SwitchToMode(#[knuffel(argument)] InputMode),
     /// Resize focus pane in specified direction.
-    Resize(ResizeDirection),
+    Resize(#[knuffel(argument)] ResizeDirection),
     /// Switch focus to next pane in specified direction.
     FocusNextPane,
     FocusPreviousPane,
     /// Move the focus pane in specified direction.
     SwitchFocus,
-    MoveFocus(Direction),
+    MoveFocus(#[knuffel(argument)] Direction),
     /// Tries to move the focus pane in specified direction.
     /// If there is no pane in the direction, move to previous/next Tab.
-    MoveFocusOrTab(Direction),
-    MovePane(Option<Direction>),
+    MoveFocusOrTab(#[knuffel(argument)] Direction),
+    MovePane(#[knuffel(argument)] Option<Direction>),
     /// Scroll up in focus pane.
     ScrollUp,
     /// Scroll up at point
+    #[knuffel(skip)]
     ScrollUpAt(Position),
     /// Scroll down in focus pane.
     ScrollDown,
     /// Scroll down at point
+    #[knuffel(skip)]
     ScrollDownAt(Position),
     /// Scroll down to bottom in focus pane.
     ScrollToBottom,
@@ -80,10 +85,10 @@ pub enum Action {
     ToggleActiveSyncTab,
     /// Open a new pane in the specified direction (relative to focus).
     /// If no direction is specified, will try to use the biggest available space.
-    NewPane(Option<Direction>),
+    NewPane(#[knuffel(argument)] Option<Direction>),
     /// Close the focus pane.
     CloseFocus,
-    PaneNameInput(Vec<u8>),
+    PaneNameInput(#[knuffel(argument, bytes)] Vec<u8>),
     /// Create a new tab, optionally with a specified tab layout.
     NewTab(Option<TabLayout>),
     /// Do nothing.
@@ -94,16 +99,20 @@ pub enum Action {
     GoToPreviousTab,
     /// Close the current tab.
     CloseTab,
-    GoToTab(u32),
+    GoToTab(#[knuffel(argument)] u32),
     ToggleTab,
-    TabNameInput(Vec<u8>),
+    TabNameInput(#[knuffel(argument, bytes)] Vec<u8>),
     /// Run speficied command in new pane.
     Run(RunCommandAction),
     /// Detach session and exit
     Detach,
+    #[knuffel(skip)]
     LeftClick(Position),
+    #[knuffel(skip)]
     RightClick(Position),
+    #[knuffel(skip)]
     MouseRelease(Position),
+    #[knuffel(skip)]
     MouseHold(Position),
     Copy,
     /// Confirm a prompt

--- a/zellij-utils/src/input/command.rs
+++ b/zellij-utils/src/input/command.rs
@@ -10,25 +10,34 @@ pub enum TerminalAction {
 }
 
 #[derive(Clone, Debug, Deserialize, Default, Serialize, PartialEq, Eq)]
+#[derive(knuffel::Decode)]
 pub struct RunCommand {
     #[serde(alias = "cmd")]
+    #[knuffel(argument)]
     pub command: PathBuf,
     #[serde(default)]
+    #[knuffel(arguments)]
     pub args: Vec<String>,
     #[serde(default)]
+    #[knuffel(property)]
     pub cwd: Option<PathBuf>,
 }
 
 /// Intermediate representation
 #[derive(Clone, Debug, Deserialize, Default, Serialize, PartialEq, Eq)]
+#[derive(knuffel::Decode)]
 pub struct RunCommandAction {
     #[serde(rename = "cmd")]
+    #[knuffel(argument)]
     pub command: PathBuf,
     #[serde(default)]
+    #[knuffel(arguments)]
     pub args: Vec<String>,
     #[serde(default)]
+    #[knuffel(property)]
     pub cwd: Option<PathBuf>,
     #[serde(default)]
+    #[knuffel(property)]
     pub direction: Option<Direction>,
 }
 

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 use zellij_tile::data::InputMode;
 
 #[derive(Copy, Clone, Debug, PartialEq, Deserialize, Serialize, ArgEnum)]
+#[derive(knuffel::DecodeScalar)]
 pub enum OnForceClose {
     #[serde(alias = "quit")]
     Quit,
@@ -33,6 +34,7 @@ impl FromStr for OnForceClose {
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Deserialize, Serialize, Args)]
+#[derive(knuffel::Decode)]
 /// Options that can be set either through the config file,
 /// or cli flags - cli flags should take precedence over the config file
 /// TODO: In order to correctly parse boolean flags, this is currently split
@@ -42,51 +44,64 @@ pub struct Options {
     /// that is compatible with more fonts (true or false)
     #[clap(long)]
     #[serde(default)]
+    #[knuffel(child, unwrap(argument))]
     pub simplified_ui: Option<bool>,
     /// Set the default theme
     #[clap(long)]
+    #[knuffel(child, unwrap(argument))]
     pub theme: Option<String>,
     /// Set the default mode
     #[clap(long, arg_enum, hide_possible_values = true)]
+    #[knuffel(child, unwrap(argument))]
     pub default_mode: Option<InputMode>,
     /// Set the default shell
     #[clap(long, parse(from_os_str))]
+    #[knuffel(child, unwrap(argument))]
     pub default_shell: Option<PathBuf>,
     /// Set the layout_dir, defaults to
     /// subdirectory of config dir
     #[clap(long, parse(from_os_str))]
+    #[knuffel(child, unwrap(argument))]
     pub layout_dir: Option<PathBuf>,
     #[clap(long)]
     #[serde(default)]
     /// Set the handling of mouse events (true or false)
     /// Can be temporarily bypassed by the [SHIFT] key
+    #[knuffel(child, unwrap(argument))]
     pub mouse_mode: Option<bool>,
     #[clap(long)]
     #[serde(default)]
+    #[knuffel(child, unwrap(argument))]
     /// Set display of the pane frames (true or false)
     pub pane_frames: Option<bool>,
     #[clap(long)]
     #[serde(default)]
+    #[knuffel(child, unwrap(argument))]
     /// Mirror session when multiple users are connected (true or false)
     pub mirror_session: Option<bool>,
     /// Set behaviour on force close (quit or detach)
     #[clap(long, arg_enum, hide_possible_values = true)]
+    #[knuffel(child, unwrap(argument))]
     pub on_force_close: Option<OnForceClose>,
     #[clap(long)]
+    #[knuffel(child, unwrap(argument))]
     pub scroll_buffer_size: Option<usize>,
 
     /// Switch to using a user supplied command for clipboard instead of OSC52
     #[clap(long)]
     #[serde(default)]
+    #[knuffel(child, unwrap(argument))]
     pub copy_command: Option<String>,
 
     /// OSC52 destination clipboard
     #[clap(long, arg_enum, ignore_case = true, conflicts_with = "copy-command")]
     #[serde(default)]
+    #[knuffel(child, unwrap(argument))]
     pub copy_clipboard: Option<Clipboard>,
 }
 
 #[derive(ArgEnum, Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(knuffel::DecodeScalar)]
 pub enum Clipboard {
     #[serde(alias = "system")]
     System,

--- a/zellij-utils/src/input/plugins.rs
+++ b/zellij-utils/src/input/plugins.rs
@@ -78,6 +78,14 @@ impl Default for PluginsConfig {
     }
 }
 
+impl FromIterator<PluginConfigFromYaml> for PluginsConfigFromYaml {
+    fn from_iter<T>(iter: T) -> Self
+        where T: IntoIterator<Item=PluginConfigFromYaml>
+    {
+        PluginsConfigFromYaml(iter.into_iter().collect())
+    }
+}
+
 impl TryFrom<PluginsConfigFromYaml> for PluginsConfig {
     type Error = PluginsConfigError;
 
@@ -173,19 +181,25 @@ impl Default for PluginType {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[derive(knuffel::Decode)]
 pub struct PluginConfigFromYaml {
+    #[knuffel(child, unwrap(argument))]
     pub path: PathBuf,
+    #[knuffel(argument, str)]
     pub tag: PluginTag,
     #[serde(default)]
+    #[knuffel(child, unwrap(argument))]
     pub run: PluginTypeFromYaml,
+    //#[serde(default)] // TODO(tailhook) unused, should turn into KDL?
+    //pub config: serde_yaml::Value,
     #[serde(default)]
-    pub config: serde_yaml::Value,
-    #[serde(default)]
+    #[knuffel(child, unwrap(argument, default))]
     pub _allow_exec_host_cmd: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
+#[derive(knuffel::DecodeScalar)]
 pub enum PluginTypeFromYaml {
     Headless,
     Pane,


### PR DESCRIPTION
Here is my approach to #771.

I'm not sure it parses exactly the same format that is shown in #1036, but should be generally close to that. One of my goals was to make the PR small, so most Rust structures are similar to Yamlish ones, but KDL is more powerful, so config should be quite nice nevertheless.

I've not tested all the settings, but simple configs look like work. This is obviously just a draft, but it shows how easy the integration might be.

Here is a non-comprehensive list of questions and things that could be changed:
1. Keybindings can be grouped by mode, in the current implementation thay have `key ... mode="normal" {...}`. This layout makes multi-modal bindings easier.
2. Themes and plugins are scattered as `theme "xx"`, `plugin "xx"` items in the single section. They might be in the `themes` and `plugins` sections. But with KDL I prefer more flat.
3. All names are in `kebab-case` for simplicity (including node names, properties and enum values). But we may tweak a style for some of them if it's needed. But I feel that single style should be less confusing (although not like in #1036)
4. Duplicate theme and duplicate plugins check is not handled in the current implementation
5. Serializing config back is not implemented (I think it worked with Yaml, right?)
6. We should figure out plugin config. My approach would be to serialize KDL nodes with `minicbor` (is already implemented in the `knuffel`) and then plugin can deserialise nodes and use their own derive macro to validate and process the config.

<details>
<summary>Example config</summary>

```kdl
keybinds {
    unbind-all mode="normal"
    key "F1" {
        go-to-tab 1
    }
    key "F2" {
        go-to-tab 2
    }
    key "F3" {
        go-to-tab 3
    }
    key "F4" {
        go-to-tab 4
    }
    key "F5" mode="normal" {
        new-tab
    }
    key "Alt+h" mode="normal" {
        move-focus "left"
    }
    key "Alt+l" mode="normal" {
        move-focus "right"
    }
    key "Alt+j" mode="normal" {
        move-focus "down"
    }
    key "Alt+k" mode="normal" {
        move-focus "up"
    }
    key "n" mode="pane" {
        switch-to-mode "normal"
    }
    key "N" mode="pane" {
        new-pane
    }
}
```

</details>
