### PR TITLE
fix(tests): ensure e2e tests use updated plugins

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,7 @@ jobs:
       ssh:
         image: ghcr.io/linuxserver/openssh-server
         env:
-          PUID: 1000
+          PUID: 1001
           PGID: 1000
           TZ: Europe/Vienna
           PASSWORD_ACCESS: true

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -9,13 +9,13 @@ ZELLIJ_ASSETS_DIR = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/zellij-utils/asse
 # Add clippy to the default flow
 [tasks.dev-test-flow]
 dependencies = [
-  "format-flow",
-  "format-toml-conditioned-flow",
-  "pre-build",
-  "build",
-  "post-build",
-  "test-flow",
-  "clippy",
+    "format-flow",
+    "format-toml-conditioned-flow",
+    "pre-build",
+    "build",
+    "post-build",
+    "test-flow",
+    "clippy",
 ]
 
 # Patching the default flows to skip testing of wasm32-wasi targets
@@ -63,9 +63,32 @@ end
 writefile ${data_dir}/VERSION ${CARGO_MAKE_CRATE_VERSION}
 '''
 
+[tasks.build-e2e-data-dir]
+dependencies = ["build-plugins-release"]
+script_runner = "@duckscript"
+script = '''
+target_dir = set ${CARGO_TARGET_DIR}
+data_dir = set ${target_dir}/e2e-data
+rm -r ${data_dir}
+plugins = glob_array ${target_dir}/wasm32-wasi/release/*.wasm
+mkdir ${data_dir}
+mkdir ${data_dir}/plugins
+for plugin in ${plugins}
+    plugin_name = basename ${plugin}
+    cp ${plugin} ${data_dir}/plugins/${plugin_name}
+end
+writefile ${data_dir}/VERSION ${CARGO_MAKE_CRATE_VERSION}
+'''
+
 [tasks.launch]
 command = "cargo"
-args = ["run", "--", "--data-dir", "${CARGO_TARGET_DIR}/dev-data/", "@@split(CARGO_MAKE_TASK_ARGS,;)"]
+args = [
+    "run",
+    "--",
+    "--data-dir",
+    "${CARGO_TARGET_DIR}/dev-data/",
+    "@@split(CARGO_MAKE_TASK_ARGS,;)",
+]
 
 # Simple clippy tweak
 [tasks.clippy]
@@ -85,11 +108,19 @@ end
 '''
 
 [tasks.build-plugins-release]
-env = { "CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS" = ["default-plugins/status-bar", "default-plugins/strider", "default-plugins/tab-bar"] }
+env = { "CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS" = [
+    "default-plugins/status-bar",
+    "default-plugins/strider",
+    "default-plugins/tab-bar",
+] }
 run_task = { name = "build-release", fork = true }
 
 [tasks.build-plugins]
-env = { "CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS" = ["default-plugins/status-bar", "default-plugins/strider", "default-plugins/tab-bar"] }
+env = { "CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS" = [
+    "default-plugins/status-bar",
+    "default-plugins/strider",
+    "default-plugins/tab-bar",
+] }
 run_task = { name = "build", fork = true }
 
 [tasks.wasm-opt-plugins]
@@ -135,23 +166,48 @@ cp ${ZELLIJ_ASSETS_DIR}/config/default.yaml ${ZELLIJ_EXAMPLE_DIR}/default.yaml
 # CI Releasing Zellij
 [tasks.ci-build-release]
 workspace = false
-dependencies = ["setup-cross-compilation", "build-plugins-release", "wasm-opt-plugins", "manpage"]
+dependencies = [
+    "setup-cross-compilation",
+    "build-plugins-release",
+    "wasm-opt-plugins",
+    "manpage",
+]
 command = "cross"
-args = ["build", "--verbose", "--release", "--target", "${CARGO_MAKE_TASK_ARGS}"]
+args = [
+    "build",
+    "--verbose",
+    "--release",
+    "--target",
+    "${CARGO_MAKE_TASK_ARGS}",
+]
 
 # Build e2e asset
 [tasks.build-e2e]
 workspace = false
-dependencies = ["build-plugins", "build-dev-data-dir"]
+dependencies = ["build-plugins-release", "build-e2e-data-dir"]
 command = "cargo"
-args = ["build", "--verbose", "--release", "--target", "x86_64-unknown-linux-musl"]
+args = [
+    "build",
+    "--verbose",
+    "--release",
+    "--target",
+    "x86_64-unknown-linux-musl",
+]
 
 # Run e2e tests - we mark the e2e tests as "ignored" so they will not be run with the normal ones
 [tasks.e2e-test]
 workspace = false
 dependencies = ["build-e2e"]
 command = "cargo"
-args = ["test", "--", "--ignored", "--nocapture", "--test-threads", "1", "@@split(CARGO_MAKE_TASK_ARGS,;)"]
+args = [
+    "test",
+    "--",
+    "--ignored",
+    "--nocapture",
+    "--test-threads",
+    "1",
+    "@@split(CARGO_MAKE_TASK_ARGS,;)",
+]
 
 [tasks.setup-cross-compilation]
 command = "cargo"
@@ -161,7 +217,12 @@ args = ["install", "cross"]
 [tasks.publish]
 clear = true
 workspace = false
-dependencies = [ "update-default-config", "build-plugins-release", "wasm-opt-plugins", "release-commit"]
+dependencies = [
+    "update-default-config",
+    "build-plugins-release",
+    "wasm-opt-plugins",
+    "release-commit",
+]
 run_task = "publish-zellij"
 
 [tasks.release-commit]
@@ -207,6 +268,10 @@ cwd = "zellij-tile-utils"
 script = "cargo publish && sleep 15"
 
 [tasks.publish-zellij]
-dependencies = ["publish-zellij-client", "publish-zellij-server", "publish-zellij-utils",]
+dependencies = [
+    "publish-zellij-client",
+    "publish-zellij-server",
+    "publish-zellij-utils",
+]
 command = "cargo"
 args = ["publish"]

--- a/src/install.rs
+++ b/src/install.rs
@@ -28,10 +28,10 @@ pub(crate) fn populate_data_dir(data_dir: &Path) {
 
     for (path, bytes) in assets {
         let path = data_dir.join(path);
-        let parent_path = path.parent().unwrap();
-        fs::create_dir_all(parent_path).unwrap();
-        set_permissions(parent_path).unwrap();
         if out_of_date || !path.exists() {
+            let parent_path = path.parent().unwrap();
+            fs::create_dir_all(parent_path).unwrap();
+            set_permissions(parent_path).unwrap();
             fs::write(path, bytes).expect("Failed to install default assets!");
         }
     }

--- a/src/install.rs
+++ b/src/install.rs
@@ -28,10 +28,10 @@ pub(crate) fn populate_data_dir(data_dir: &Path) {
 
     for (path, bytes) in assets {
         let path = data_dir.join(path);
+        let parent_path = path.parent().unwrap();
+        fs::create_dir_all(parent_path).unwrap();
+        set_permissions(parent_path).unwrap();
         if out_of_date || !path.exists() {
-            let parent_path = path.parent().unwrap();
-            fs::create_dir_all(parent_path).unwrap();
-            set_permissions(parent_path).unwrap();
             fs::write(path, bytes).expect("Failed to install default assets!");
         }
     }

--- a/src/tests/e2e/remote_runner.rs
+++ b/src/tests/e2e/remote_runner.rs
@@ -88,8 +88,8 @@ fn start_zellij_in_session(channel: &mut ssh2::Channel, session_name: &str, mirr
     channel
         .write_all(
             format!(
-                "{} --session {} options --mirror-session {}\n",
-                ZELLIJ_EXECUTABLE_LOCATION, session_name, mirrored
+                "{} --session {} --data-dir {} options --mirror-session {}\n",
+                ZELLIJ_EXECUTABLE_LOCATION, session_name, ZELLIJ_DATA_DIR, mirrored
             )
             .as_bytes(),
         )
@@ -109,8 +109,8 @@ fn start_zellij_without_frames(channel: &mut ssh2::Channel) {
     channel
         .write_all(
             format!(
-                "{} --session {} options --no-pane-frames\n",
-                ZELLIJ_EXECUTABLE_LOCATION, SESSION_NAME
+                "{} --session {} --data-dir {} options --no-pane-frames\n",
+                ZELLIJ_EXECUTABLE_LOCATION, SESSION_NAME, ZELLIJ_DATA_DIR
             )
             .as_bytes(),
         )
@@ -123,8 +123,8 @@ fn start_zellij_with_layout(channel: &mut ssh2::Channel, layout_path: &str) {
     channel
         .write_all(
             format!(
-                "{} --layout-path {} --session {}\n",
-                ZELLIJ_EXECUTABLE_LOCATION, layout_path, SESSION_NAME
+                "{} --layout-path {} --session {} --data-dir {}\n",
+                ZELLIJ_EXECUTABLE_LOCATION, layout_path, SESSION_NAME, ZELLIJ_DATA_DIR
             )
             .as_bytes(),
         )

--- a/src/tests/e2e/remote_runner.rs
+++ b/src/tests/e2e/remote_runner.rs
@@ -14,6 +14,7 @@ use std::path::Path;
 
 const ZELLIJ_EXECUTABLE_LOCATION: &str = "/usr/src/zellij/x86_64-unknown-linux-musl/release/zellij";
 const ZELLIJ_LAYOUT_PATH: &str = "/usr/src/zellij/fixtures/layouts";
+const ZELLIJ_DATA_DIR: &str = "/usr/src/zellij/e2e-data";
 const CONNECTION_STRING: &str = "127.0.0.1:2222";
 const CONNECTION_USERNAME: &str = "test";
 const CONNECTION_PASSWORD: &str = "test";
@@ -59,8 +60,8 @@ fn start_zellij(channel: &mut ssh2::Channel) {
     channel
         .write_all(
             format!(
-                "{} --session {}\n",
-                ZELLIJ_EXECUTABLE_LOCATION, SESSION_NAME
+                "{} --session {} --data-dir {}\n",
+                ZELLIJ_EXECUTABLE_LOCATION, SESSION_NAME, ZELLIJ_DATA_DIR
             )
             .as_bytes(),
         )
@@ -73,8 +74,8 @@ fn start_zellij_mirrored_session(channel: &mut ssh2::Channel) {
     channel
         .write_all(
             format!(
-                "{} --session {} options --mirror-session true\n",
-                ZELLIJ_EXECUTABLE_LOCATION, SESSION_NAME
+                "{} --session {} --data-dir {} options --mirror-session true\n",
+                ZELLIJ_EXECUTABLE_LOCATION, SESSION_NAME, ZELLIJ_DATA_DIR
             )
             .as_bytes(),
         )


### PR DESCRIPTION
Spent some time debugging some strange test failures in #1045 with @RobWalt, and we realized that currently
the e2e tests are using the pre-built plugins from the assets folder. Also they are installed into a directory inside the container
that persists between runs when testing locally, so even updating the plugins in `assets` was not giving reliable results.
 
Solve this issue by:
- launching zellij with `--data-dir` flag in e2e tests, to avoid using prebuilt
  plugins from assets dir, and instead use the ones from the docker
  mount.
- making the tests use plugins built in release mode to avoid some test
  failures due to timing issues.

Other changes are auto-formatting of Makefile.toml.