### PR TITLE
fix: invalid assignment of `client_id` 

### DIFF
--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -61,10 +61,7 @@ fn assert_socket(name: &str) -> bool {
 
             let mut receiver: IpcReceiverWithContext<ServerToClientMsg> = sender.get_receiver();
             let (instruction, _) = receiver.recv();
-            match instruction {
-                ServerToClientMsg::Pong => true,
-                _ => false,
-            }
+            matches!(instruction, ServerToClientMsg::Pong)
         }
         Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => {
             drop(fs::remove_file(path));

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -6,7 +6,7 @@ use zellij_utils::{
     consts::ZELLIJ_SOCK_DIR,
     envs,
     interprocess::local_socket::LocalSocketStream,
-    ipc::{ClientToServerMsg, IpcSenderWithContext},
+    ipc::{ClientToServerMsg, IpcReceiverWithContext, IpcSenderWithContext, ServerToClientMsg},
 };
 
 pub(crate) fn get_sessions() -> Result<Vec<String>, io::ErrorKind> {
@@ -56,14 +56,21 @@ fn assert_socket(name: &str) -> bool {
     let path = &*ZELLIJ_SOCK_DIR.join(name);
     match LocalSocketStream::connect(path) {
         Ok(stream) => {
-            IpcSenderWithContext::new(stream).send(ClientToServerMsg::ClientExited);
-            true
+            let mut sender = IpcSenderWithContext::new(stream);
+            sender.send(ClientToServerMsg::Ping);
+
+            let mut receiver: IpcReceiverWithContext<ServerToClientMsg> = sender.get_receiver();
+            let (instruction, _) = receiver.recv();
+            match instruction {
+                ServerToClientMsg::Pong => true,
+                _ => false,
+            }
         }
         Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => {
             drop(fs::remove_file(path));
             false
         }
-        Err(_) => true,
+        Err(_) => false,
     }
 }
 

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -57,11 +57,11 @@ fn assert_socket(name: &str) -> bool {
     match LocalSocketStream::connect(path) {
         Ok(stream) => {
             let mut sender = IpcSenderWithContext::new(stream);
-            sender.send(ClientToServerMsg::Ping);
+            sender.send(ClientToServerMsg::ConnStatus);
 
             let mut receiver: IpcReceiverWithContext<ServerToClientMsg> = sender.get_receiver();
             let (instruction, _) = receiver.recv();
-            matches!(instruction, ServerToClientMsg::Pong)
+            matches!(instruction, ServerToClientMsg::Connected)
         }
         Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => {
             drop(fs::remove_file(path));

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -35,6 +35,7 @@ pub(crate) enum ClientInstruction {
     UnblockInputThread,
     Exit(ExitReason),
     SwitchToMode(InputMode),
+    Pong,
 }
 
 impl From<ServerToClientMsg> for ClientInstruction {
@@ -46,6 +47,7 @@ impl From<ServerToClientMsg> for ClientInstruction {
             ServerToClientMsg::SwitchToMode(input_mode) => {
                 ClientInstruction::SwitchToMode(input_mode)
             }
+            ServerToClientMsg::Pong => ClientInstruction::Pong,
         }
     }
 }
@@ -58,6 +60,7 @@ impl From<&ClientInstruction> for ClientContext {
             ClientInstruction::Render(_) => ClientContext::Render,
             ClientInstruction::UnblockInputThread => ClientContext::UnblockInputThread,
             ClientInstruction::SwitchToMode(_) => ClientContext::SwitchToMode,
+            ClientInstruction::Pong => ClientContext::Pong,
         }
     }
 }
@@ -323,6 +326,7 @@ pub fn start_client(
                     .send(InputInstruction::SwitchToMode(input_mode))
                     .unwrap();
             }
+            _ => {}
         }
     }
 

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -35,7 +35,7 @@ pub(crate) enum ClientInstruction {
     UnblockInputThread,
     Exit(ExitReason),
     SwitchToMode(InputMode),
-    Pong,
+    Connected,
 }
 
 impl From<ServerToClientMsg> for ClientInstruction {
@@ -47,7 +47,7 @@ impl From<ServerToClientMsg> for ClientInstruction {
             ServerToClientMsg::SwitchToMode(input_mode) => {
                 ClientInstruction::SwitchToMode(input_mode)
             }
-            ServerToClientMsg::Pong => ClientInstruction::Pong,
+            ServerToClientMsg::Connected => ClientInstruction::Connected,
         }
     }
 }
@@ -60,7 +60,7 @@ impl From<&ClientInstruction> for ClientContext {
             ClientInstruction::Render(_) => ClientContext::Render,
             ClientInstruction::UnblockInputThread => ClientContext::UnblockInputThread,
             ClientInstruction::SwitchToMode(_) => ClientContext::SwitchToMode,
-            ClientInstruction::Pong => ClientContext::Pong,
+            ClientInstruction::Connected => ClientContext::Connected,
         }
     }
 }

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -71,7 +71,7 @@ pub enum ServerInstruction {
     KillSession,
     DetachSession(ClientId),
     AttachClient(ClientAttributes, Options, ClientId),
-    Ping(ClientId),
+    ConnStatus(ClientId),
 }
 
 impl From<&ServerInstruction> for ServerContext {
@@ -86,7 +86,7 @@ impl From<&ServerInstruction> for ServerContext {
             ServerInstruction::KillSession => ServerContext::KillSession,
             ServerInstruction::DetachSession(..) => ServerContext::DetachSession,
             ServerInstruction::AttachClient(..) => ServerContext::AttachClient,
-            ServerInstruction::Ping(..) => ServerContext::Ping,
+            ServerInstruction::ConnStatus(..) => ServerContext::ConnStatus,
         }
     }
 }
@@ -527,8 +527,8 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                 }
                 break;
             }
-            ServerInstruction::Ping(client_id) => {
-                os_input.send_to_client(client_id, ServerToClientMsg::Pong);
+            ServerInstruction::ConnStatus(client_id) => {
+                os_input.send_to_client(client_id, ServerToClientMsg::Connected);
                 remove_client!(client_id, os_input, session_state);
             }
         }

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -71,6 +71,7 @@ pub enum ServerInstruction {
     KillSession,
     DetachSession(ClientId),
     AttachClient(ClientAttributes, Options, ClientId),
+    Ping(ClientId),
 }
 
 impl From<&ServerInstruction> for ServerContext {
@@ -85,6 +86,7 @@ impl From<&ServerInstruction> for ServerContext {
             ServerInstruction::KillSession => ServerContext::KillSession,
             ServerInstruction::DetachSession(..) => ServerContext::DetachSession,
             ServerInstruction::AttachClient(..) => ServerContext::AttachClient,
+            ServerInstruction::Ping(..) => ServerContext::Ping,
         }
     }
 }
@@ -524,6 +526,10 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                     remove_client!(client_id, os_input, session_state);
                 }
                 break;
+            }
+            ServerInstruction::Ping(client_id) => {
+                os_input.send_to_client(client_id, ServerToClientMsg::Pong);
+                remove_client!(client_id, os_input, session_state);
             }
         }
     }

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -446,8 +446,8 @@ pub(crate) fn route_thread_main(
             ClientToServerMsg::KillSession => {
                 to_server.send(ServerInstruction::KillSession).unwrap();
             }
-            ClientToServerMsg::Ping => {
-                let _ = to_server.send(ServerInstruction::Ping(client_id));
+            ClientToServerMsg::ConnStatus => {
+                let _ = to_server.send(ServerInstruction::ConnStatus(client_id));
                 break;
             }
         }

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -446,6 +446,10 @@ pub(crate) fn route_thread_main(
             ClientToServerMsg::KillSession => {
                 to_server.send(ServerInstruction::KillSession).unwrap();
             }
+            ClientToServerMsg::Ping => {
+                let _ = to_server.send(ServerInstruction::Ping(client_id));
+                break;
+            }
         }
     }
 }

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -309,6 +309,7 @@ pub enum ClientContext {
     Render,
     ServerError,
     SwitchToMode,
+    Pong,
 }
 
 /// Stack call representations corresponding to the different types of [`ServerInstruction`]s.
@@ -323,4 +324,5 @@ pub enum ServerContext {
     KillSession,
     DetachSession,
     AttachClient,
+    Ping,
 }

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -309,7 +309,7 @@ pub enum ClientContext {
     Render,
     ServerError,
     SwitchToMode,
-    Pong,
+    Connected,
 }
 
 /// Stack call representations corresponding to the different types of [`ServerInstruction`]s.
@@ -324,5 +324,5 @@ pub enum ServerContext {
     KillSession,
     DetachSession,
     AttachClient,
-    Ping,
+    ConnStatus,
 }

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -69,7 +69,7 @@ pub enum ClientToServerMsg {
     Action(Action),
     ClientExited,
     KillSession,
-    Ping,
+    ConnStatus,
 }
 
 // Types of messages sent from the server to the client
@@ -83,7 +83,7 @@ pub enum ServerToClientMsg {
     UnblockInputThread,
     Exit(ExitReason),
     SwitchToMode(InputMode),
-    Pong,
+    Connected,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -69,6 +69,7 @@ pub enum ClientToServerMsg {
     Action(Action),
     ClientExited,
     KillSession,
+    Ping,
 }
 
 // Types of messages sent from the server to the client
@@ -82,6 +83,7 @@ pub enum ServerToClientMsg {
     UnblockInputThread,
     Exit(ExitReason),
     SwitchToMode(InputMode),
+    Pong,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
![화면 캡처 2022-02-10 163335](https://user-images.githubusercontent.com/32578710/153359603-c17ae37f-0e8f-4fa2-8192-3e695d70f16d.png)

This PR is related the invalid assignment of `client_id`.
As the above log, the problem occurs when `attaching` to a session.

The cause of the problem is the `assert_socket` function, which checks whether the socket is connected before attaching.
Ideally, this should work like this:
![mermaid-diagram-20220210165805](https://user-images.githubusercontent.com/32578710/153362656-160d25c9-90a3-4d58-90b2-95730235d350.png)

But, currently like this:
![mermaid-diagram-20220210170028](https://user-images.githubusercontent.com/32578710/153363067-16719a98-15fe-4be5-bcaa-f5b56668cd7e.png)

To solve this problem, `assert_socket` has to wait for a message from the server.