### PR TITLE
chore: bump internal autocfg dependency to 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"


### PR DESCRIPTION
`autocfg` 1.0.1 can cause problems when running cross compilation with the `--locked` configuration, for example in the Void Linux builds: https://github.com/void-linux/void-packages/issues/34889