### PR TITLE
Simplify the conversion from `bool` to `i32`

### DIFF
--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -18,7 +18,7 @@ pub fn unsubscribe(event_types: &[EventType]) {
 // Plugin Settings
 
 pub fn set_selectable(selectable: bool) {
-    unsafe { host_set_selectable(if selectable { 1 } else { 0 }) };
+    unsafe { host_set_selectable(selectable as i32) };
 }
 
 // Query Functions


### PR DESCRIPTION
`true` and `false` can respectively be `1` and `0` using the type cast expression simply.