### PR TITLE
fix(ui): restore get active at

### DIFF
--- a/zellij-server/src/panes/floating_panes.rs
+++ b/zellij-server/src/panes/floating_panes.rs
@@ -13,6 +13,7 @@ use crate::{
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::rc::Rc;
+use std::time::Instant;
 use zellij_tile::data::{ModeInfo, Palette};
 use zellij_utils::pane_size::{Offset, PaneGeom, Size, Viewport};
 
@@ -354,6 +355,11 @@ impl FloatingPanes {
         }
         return false;
     }
+    fn set_pane_active_at(&mut self, pane_id: PaneId) {
+        if let Some(pane) = self.panes.get_mut(&pane_id) {
+            pane.set_active_at(Instant::now());
+        }
+    }
     pub fn move_focus_left(
         &mut self,
         client_id: ClientId,
@@ -398,6 +404,7 @@ impl FloatingPanes {
                     for client_id in connected_clients {
                         self.focus_pane(p, client_id);
                     }
+                    self.set_pane_active_at(p);
 
                     self.set_force_render();
                     return true;
@@ -413,6 +420,7 @@ impl FloatingPanes {
                 for client_id in connected_clients {
                     self.focus_pane(updated_active_pane, client_id);
                 }
+                self.set_pane_active_at(updated_active_pane);
                 self.set_force_render();
             }
             None => {
@@ -468,6 +476,7 @@ impl FloatingPanes {
                         self.focus_pane(p, client_id);
                     }
 
+                    self.set_pane_active_at(p);
                     self.set_force_render();
                     return true;
                 }
@@ -482,6 +491,7 @@ impl FloatingPanes {
                 for client_id in connected_clients {
                     self.focus_pane(updated_active_pane, client_id);
                 }
+                self.set_pane_active_at(updated_active_pane);
                 self.set_force_render();
             }
             None => {
@@ -537,6 +547,7 @@ impl FloatingPanes {
                     }
 
                     self.set_force_render();
+                    self.set_pane_active_at(p);
                     return true;
                 }
                 None => Some(active_pane_id),
@@ -550,6 +561,7 @@ impl FloatingPanes {
                 for client_id in connected_clients {
                     self.focus_pane(updated_active_pane, client_id);
                 }
+                self.set_pane_active_at(updated_active_pane);
                 self.set_force_render();
             }
             None => {
@@ -603,6 +615,7 @@ impl FloatingPanes {
                     for client_id in connected_clients {
                         self.focus_pane(p, client_id);
                     }
+                    self.set_pane_active_at(p);
 
                     self.set_force_render();
                     return true;
@@ -618,6 +631,7 @@ impl FloatingPanes {
                 for client_id in connected_clients {
                     self.focus_pane(updated_active_pane, client_id);
                 }
+                self.set_pane_active_at(updated_active_pane);
                 self.set_force_render();
             }
             None => {
@@ -709,6 +723,7 @@ impl FloatingPanes {
         self.active_panes.insert(client_id, pane_id);
         self.z_indices.retain(|p_id| *p_id != pane_id);
         self.z_indices.push(pane_id);
+        self.set_pane_active_at(pane_id);
         self.set_force_render();
     }
     pub fn defocus_pane(&mut self, pane_id: PaneId, client_id: ClientId) {

--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -1,7 +1,6 @@
 use std::fmt::Write;
 use std::sync::mpsc::channel;
 use std::time::Instant;
-use std::unimplemented;
 
 use crate::output::CharacterChunk;
 use crate::panes::PaneId;
@@ -106,13 +105,14 @@ impl Pane for PluginPane {
         self.should_render = true;
     }
     fn handle_pty_bytes(&mut self, _event: VteBytes) {
-        unimplemented!()
+        // noop
     }
     fn cursor_coordinates(&self) -> Option<(usize, usize)> {
         None
     }
     fn adjust_input_to_terminal(&self, _input_bytes: Vec<u8>) -> Vec<u8> {
-        unimplemented!()
+        // noop
+        vec![]
     }
     fn position_and_size(&self) -> PaneGeom {
         self.geom

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1324,13 +1324,13 @@ impl Tab {
         all_terminals.next().is_some()
     }
     fn next_active_pane(&self, panes: &[PaneId]) -> Option<PaneId> {
-        let mut panes: Vec<_> = panes.iter().map(|p_id| self.panes.get(p_id).unwrap()).collect();
+        let mut panes: Vec<_> = panes
+            .iter()
+            .map(|p_id| self.panes.get(p_id).unwrap())
+            .collect();
         panes.sort_by(|a, b| b.active_at().cmp(&a.active_at()));
 
-        panes
-            .iter()
-            .find(|pane| pane.selectable())
-            .map(|p| p.pid())
+        panes.iter().find(|pane| pane.selectable()).map(|p| p.pid())
     }
     pub fn relayout_tab(&mut self, direction: Direction) {
         let mut pane_grid = TiledPaneGrid::new(

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1324,11 +1324,13 @@ impl Tab {
         all_terminals.next().is_some()
     }
     fn next_active_pane(&self, panes: &[PaneId]) -> Option<PaneId> {
+        let mut panes: Vec<_> = panes.iter().map(|p_id| self.panes.get(p_id).unwrap()).collect();
+        panes.sort_by(|a, b| b.active_at().cmp(&a.active_at()));
+
         panes
             .iter()
-            .rev()
-            .find(|pid| self.panes.get(pid).unwrap().selectable())
-            .copied()
+            .find(|pane| pane.selectable())
+            .map(|p| p.pid())
     }
     pub fn relayout_tab(&mut self, direction: Direction) {
         let mut pane_grid = TiledPaneGrid::new(
@@ -1511,6 +1513,11 @@ impl Tab {
             }
         }
     }
+    fn set_pane_active_at(&mut self, pane_id: PaneId) {
+        if let Some(pane) = self.panes.get_mut(&pane_id) {
+            pane.set_active_at(Instant::now());
+        }
+    }
 
     pub fn move_focus(&mut self, client_id: ClientId) {
         if !self.has_selectable_panes() {
@@ -1530,6 +1537,7 @@ impl Tab {
         for client_id in connected_clients {
             self.active_panes.insert(client_id, next_active_pane_id);
         }
+        self.set_pane_active_at(next_active_pane_id);
     }
     pub fn focus_next_pane(&mut self, client_id: ClientId) {
         if !self.has_selectable_panes() {
@@ -1549,6 +1557,7 @@ impl Tab {
         for client_id in connected_clients {
             self.active_panes.insert(client_id, next_active_pane_id);
         }
+        self.set_pane_active_at(next_active_pane_id);
     }
     pub fn focus_previous_pane(&mut self, client_id: ClientId) {
         if !self.has_selectable_panes() {
@@ -1568,6 +1577,7 @@ impl Tab {
         for client_id in connected_clients {
             self.active_panes.insert(client_id, next_active_pane_id);
         }
+        self.set_pane_active_at(next_active_pane_id);
     }
     // returns a boolean that indicates whether the focus moved
     pub fn move_focus_left(&mut self, client_id: ClientId) -> bool {
@@ -1619,6 +1629,7 @@ impl Tab {
                         } else {
                             self.active_panes.insert(client_id, p);
                         }
+                        self.set_pane_active_at(p);
 
                         return true;
                     }
@@ -1634,6 +1645,7 @@ impl Tab {
                     for client_id in connected_clients {
                         self.active_panes.insert(client_id, updated_active_pane);
                     }
+                    self.set_pane_active_at(updated_active_pane);
                 }
                 None => {
                     // TODO: can this happen?
@@ -1697,8 +1709,10 @@ impl Tab {
                         for client_id in connected_clients {
                             self.active_panes.insert(client_id, updated_active_pane);
                         }
+                        self.set_pane_active_at(updated_active_pane);
                     } else {
                         self.active_panes.insert(client_id, updated_active_pane);
+                        self.set_pane_active_at(updated_active_pane);
                     }
                 }
                 None => {
@@ -1761,8 +1775,10 @@ impl Tab {
                         for client_id in connected_clients {
                             self.active_panes.insert(client_id, updated_active_pane);
                         }
+                        self.set_pane_active_at(updated_active_pane);
                     } else {
                         self.active_panes.insert(client_id, updated_active_pane);
+                        self.set_pane_active_at(updated_active_pane);
                     }
                 }
                 None => {
@@ -1820,6 +1836,7 @@ impl Tab {
                         } else {
                             self.active_panes.insert(client_id, p);
                         }
+                        self.set_pane_active_at(p);
                         return true;
                     }
                     None => Some(active_pane_id),
@@ -1836,8 +1853,10 @@ impl Tab {
                         for client_id in connected_clients {
                             self.active_panes.insert(client_id, updated_active_pane);
                         }
+                        self.set_pane_active_at(updated_active_pane);
                     } else {
                         self.active_panes.insert(client_id, updated_active_pane);
+                        self.set_pane_active_at(updated_active_pane);
                     }
                 }
                 None => {
@@ -2468,6 +2487,7 @@ impl Tab {
                 for client_id in connected_clients {
                     self.floating_panes.focus_pane(clicked_pane, client_id);
                 }
+                self.set_pane_active_at(clicked_pane);
                 return;
             }
         }
@@ -2482,6 +2502,7 @@ impl Tab {
             } else {
                 self.active_panes.insert(client_id, clicked_pane);
             }
+            self.set_pane_active_at(clicked_pane);
             if self.floating_panes.panes_are_visible() {
                 self.floating_panes.toggle_show_panes(false);
                 self.set_force_render();


### PR DESCRIPTION
Panes used to refocus (eg. when a pane is closed) based on the most recently active pane. But this was accidentally removed in a previous change (by yours truly). This brings it back, as well as removing some potential crashes due to API misuse that we intend to change anyway.