### PR TITLE
Add `#[allow(dead_code)]` attribute to unused variables

### DIFF
--- a/zellij-server/src/ui/overlay/mod.rs
+++ b/zellij-server/src/ui/overlay/mod.rs
@@ -22,6 +22,7 @@ pub trait Overlayable {
     fn generate_overlay(&self, size: Size) -> String;
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug)]
 struct Padding {
     rows: usize,

--- a/zellij-server/src/wasm_vm.rs
+++ b/zellij-server/src/wasm_vm.rs
@@ -73,6 +73,7 @@ pub(crate) struct PluginEnv {
     pub subscriptions: Arc<Mutex<HashSet<EventType>>>,
     pub tab_index: usize,
     pub client_id: ClientId,
+    #[allow(dead_code)]
     plugin_own_data_dir: PathBuf,
 }
 


### PR DESCRIPTION
I would suggest deleting these variables unless you think they will be used.
If you would so, I would be pleased to remove them in this PR.