### PR TITLE
Replace redundant `map` with `if let`

### DIFF
--- a/zellij-server/src/tab/active_terminal_scroll.rs
+++ b/zellij-server/src/tab/active_terminal_scroll.rs
@@ -1,0 +1,121 @@
+use crate::panes::PaneId;
+use crate::tab::{Pane, Tab};
+use crate::ClientId;
+
+#[derive(PartialEq)]
+enum Scroll {
+    Row(usize),
+    HalfPage,
+    FullPage,
+}
+
+#[derive(PartialEq)]
+enum Action {
+    Up(Scroll),
+    Down(Scroll),
+    Clear,
+}
+
+impl Action {
+    fn is_up(&self) -> bool {
+        match *self {
+            Action::Up(_) => true,
+            _ => false,
+        }
+    }
+
+    fn get_scroll_rows(&self) -> Option<usize> {
+        match *self {
+            Action::Up(Scroll::Row(count)) | Action::Down(Scroll::Row(count)) => Some(count),
+            _ => None,
+        }
+    }
+
+    fn contains_half_page(&self) -> bool {
+        match *self {
+            Action::Up(Scroll::HalfPage) | Action::Down(Scroll::HalfPage) => true,
+            _ => false,
+        }
+    }
+    fn contains_full_page(&self) -> bool {
+        match *self {
+            Action::Up(Scroll::FullPage) | Action::Down(Scroll::FullPage) => true,
+            _ => false,
+        }
+    }
+}
+
+pub(crate) struct ActiveTerminalScroll<'a> {
+    client_id: ClientId,
+    tab: Box<&'a mut Tab>,
+}
+
+impl<'a> ActiveTerminalScroll<'a> {
+    pub(crate) fn new(client_id: ClientId, tab: Box<&'a mut Tab>) -> Self {
+        Self { client_id, tab }
+    }
+
+    fn proceed_action_impl(action: &Action, active_pane: &mut Box<dyn Pane>, client_id: ClientId) {
+        let scroll_rows = if let Some(count) = action.get_scroll_rows() {
+            count
+        } else if action.contains_half_page() {
+            // prevent overflow when row == 0
+            (active_pane.rows().max(1) - 1) / 2
+        } else if action.contains_full_page() {
+            active_pane.get_content_rows()
+        } else {
+            0 // Action::Clear
+        };
+
+        match action {
+            Action::Up(_) => active_pane.scroll_up(scroll_rows, client_id),
+            Action::Down(_) => active_pane.scroll_down(scroll_rows, client_id),
+            Action::Clear => active_pane.clear_scroll(),
+        };
+    }
+
+    fn proceed_action(&mut self, action: Action) {
+        if self.tab.floating_panes.panes_are_visible() && self.tab.floating_panes.has_active_panes()
+        {
+            if let Some(active_pane) = self.tab.floating_panes.get_active_pane_mut(self.client_id) {
+                Self::proceed_action_impl(&action, active_pane, self.client_id);
+                if !action.is_up() && !active_pane.is_scrolled() {
+                    if let PaneId::Terminal(raw_fd) = active_pane.pid() {
+                        self.tab.process_pending_vte_events(raw_fd);
+                    }
+                }
+            }
+        } else if let Some(active_pane) = self
+            .tab
+            .active_panes
+            .get(&self.client_id)
+            .and_then(|active_pane_id| self.tab.panes.get_mut(active_pane_id))
+        {
+            Self::proceed_action_impl(&action, active_pane, self.client_id);
+            if !action.is_up() && !active_pane.is_scrolled() {
+                if let PaneId::Terminal(raw_fd) = active_pane.pid() {
+                    self.tab.process_pending_vte_events(raw_fd);
+                }
+            }
+        }
+    }
+
+    pub(crate) fn up(&mut self, count: usize) {
+        self.proceed_action(Action::Up(Scroll::Row(count)));
+    }
+    pub(crate) fn up_half_page(&mut self) {
+        self.proceed_action(Action::Up(Scroll::HalfPage));
+    }
+    pub(crate) fn down(&mut self, count: usize) {
+        self.proceed_action(Action::Down(Scroll::Row(count)));
+    }
+    pub(crate) fn down_page(&mut self) {
+        self.proceed_action(Action::Down(Scroll::FullPage));
+    }
+    pub(crate) fn down_half_page(&mut self) {
+        self.proceed_action(Action::Down(Scroll::HalfPage));
+    }
+    pub(crate) fn clear(&mut self) {
+        self.proceed_action(Action::Clear);
+    }
+}

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1,6 +1,7 @@
 //! `Tab`s holds multiple panes. It tracks their coordinates (x/y) and size,
 //! as well as how they should be resized
 
+mod active_terminal_scroll;
 mod clipboard;
 mod copy_command;
 pub mod floating_pane_grid;
@@ -28,6 +29,7 @@ use crate::{
     wasm_vm::PluginInstruction,
     ClientId, ServerInstruction,
 };
+use active_terminal_scroll::ActiveTerminalScroll;
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::os::unix::io::RawFd;
@@ -2197,50 +2199,13 @@ impl Tab {
         }
     }
 
-    fn operate_active_terminal_scroll<ClosureT>(
-        &mut self,
-        client_id: ClientId,
-        action: ClosureT,
-        process_pending_vte_events: bool,
-    ) where
-        ClosureT: Fn(&mut Box<dyn Pane>),
-    {
-        if self.floating_panes.panes_are_visible() && self.floating_panes.has_active_panes() {
-            if let Some(active_pane) = self.floating_panes.get_active_pane_mut(client_id) {
-                action(active_pane);
-                if process_pending_vte_events && !active_pane.is_scrolled() {
-                    if let PaneId::Terminal(raw_fd) = active_pane.pid() {
-                        self.process_pending_vte_events(raw_fd);
-                    }
-                }
-            }
-        } else if let Some(active_pane) = self
-            .active_panes
-            .get(&client_id)
-            .and_then(|active_pane_id| self.panes.get_mut(active_pane_id))
-        {
-            action(active_pane);
-            if process_pending_vte_events && !active_pane.is_scrolled() {
-                if let PaneId::Terminal(raw_fd) = active_pane.pid() {
-                    self.process_pending_vte_events(raw_fd);
-                }
-            }
-        }
-    }
-
     pub fn scroll_active_terminal_up(&mut self, client_id: ClientId) {
-        self.operate_active_terminal_scroll(
-            client_id,
-            |active_pane| active_pane.scroll_up(1, client_id),
-            false,
-        );
+        let boxed_tab = Box::new(self);
+        ActiveTerminalScroll::new(client_id, boxed_tab).up(1);
     }
     pub fn scroll_active_terminal_down(&mut self, client_id: ClientId) {
-        self.operate_active_terminal_scroll(
-            client_id,
-            |active_pane| active_pane.scroll_down(1, client_id),
-            true,
-        );
+        let boxed_tab = Box::new(self);
+        ActiveTerminalScroll::new(client_id, boxed_tab).down(1);
     }
     pub fn scroll_active_terminal_up_page(&mut self, client_id: ClientId) {
         if self.floating_panes.panes_are_visible() && self.floating_panes.has_active_panes() {
@@ -2260,50 +2225,25 @@ impl Tab {
         }
     }
     pub fn scroll_active_terminal_down_page(&mut self, client_id: ClientId) {
-        self.operate_active_terminal_scroll(
-            client_id,
-            |active_pane| {
-                let scroll_rows = active_pane.get_content_rows();
-                active_pane.scroll_down(scroll_rows, client_id);
-            },
-            true,
-        );
+        let boxed_tab = Box::new(self);
+        ActiveTerminalScroll::new(client_id, boxed_tab).down_page();
     }
     pub fn scroll_active_terminal_up_half_page(&mut self, client_id: ClientId) {
-        self.operate_active_terminal_scroll(
-            client_id,
-            |active_pane| {
-                // prevent overflow when row == 0
-                let scroll_rows = (active_pane.rows().max(1) - 1) / 2;
-                active_pane.scroll_up(scroll_rows, client_id);
-            },
-            false,
-        );
+        let boxed_tab = Box::new(self);
+        ActiveTerminalScroll::new(client_id, boxed_tab).up_half_page();
     }
     pub fn scroll_active_terminal_down_half_page(&mut self, client_id: ClientId) {
-        self.operate_active_terminal_scroll(
-            client_id,
-            |active_pane| {
-                let scroll_rows = (active_pane.rows().max(1) - 1) / 2;
-                active_pane.scroll_down(scroll_rows, client_id);
-            },
-            true,
-        );
+        let boxed_tab = Box::new(self);
+        ActiveTerminalScroll::new(client_id, boxed_tab).down_half_page();
     }
     pub fn scroll_active_terminal_to_bottom(&mut self, client_id: ClientId) {
-        self.operate_active_terminal_scroll(
-            client_id,
-            |active_pane| active_pane.clear_scroll(),
-            true,
-        );
+        let boxed_tab = Box::new(self);
+        ActiveTerminalScroll::new(client_id, boxed_tab).clear();
     }
     pub fn clear_active_terminal_scroll(&mut self, client_id: ClientId) {
         // TODO: is this a thing?
-        self.operate_active_terminal_scroll(
-            client_id,
-            |active_pane| active_pane.clear_scroll(),
-            true,
-        );
+        let boxed_tab = Box::new(self);
+        ActiveTerminalScroll::new(client_id, boxed_tab).clear();
     }
     pub fn scroll_terminal_up(&mut self, point: &Position, lines: usize, client_id: ClientId) {
         if let Some(pane) = self.get_pane_at(point, false) {


### PR DESCRIPTION
I mainly replaced the redundant `map` with `if let` to make them much simpler and easy to understand, which was also pointed out by clippy.
Additionally, I unified duplicate codes in the `operate_active_terminal_scroll` function.
Through the unification, I found the following possible problems:
1. `scroll_active_terminal_to_bottom` & `clear_active_terminal_scroll` are perfectly the same
2. `scroll_active_terminal_up_page` are the only function that uses different action between floating_pane and active_pane

These might be problems, so I hope you can check them out :)