### PR TITLE
Fix unused code warnings

### DIFF
--- a/zellij-server/src/ui/overlay/mod.rs
+++ b/zellij-server/src/ui/overlay/mod.rs
@@ -23,12 +23,6 @@ pub trait Overlayable {
 }
 
 #[derive(Clone, Debug)]
-struct Padding {
-    rows: usize,
-    cols: usize,
-}
-
-#[derive(Clone, Debug)]
 pub enum OverlayType {
     Prompt(prompt::Prompt),
 }

--- a/zellij-server/src/wasm_vm.rs
+++ b/zellij-server/src/wasm_vm.rs
@@ -73,6 +73,7 @@ pub(crate) struct PluginEnv {
     pub subscriptions: Arc<Mutex<HashSet<EventType>>>,
     pub tab_index: usize,
     pub client_id: ClientId,
+    #[allow(dead_code)]
     plugin_own_data_dir: PathBuf,
 }
 


### PR DESCRIPTION
This PR is doing what title suggests :bear:

I came across this while updating the Arch Linux package and thought they should be fixed :)

Log:

```
warning: field is never read: `rows`
  --> zellij-server/src/ui/overlay/mod.rs:27:5
   |
27 |     rows: usize,
   |     ^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: field is never read: `cols`
  --> zellij-server/src/ui/overlay/mod.rs:28:5
   |
28 |     cols: usize,
   |     ^^^^^^^^^^^

warning: field is never read: `plugin_own_data_dir`
  --> zellij-server/src/wasm_vm.rs:76:5
   |
76 |     plugin_own_data_dir: PathBuf,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: `zellij-server` (lib) generated 3 warnings
```

