### PR TITLE
fix(docs): replace the list with a table that is more readable rather than strikethrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,13 @@ Zellij should be ready for everyday use, but it's still classified as a beta. Th
 
 ## Roadmap
 This section contains an ever-changing list of the major features that are either currently being worked on, or planned for the near future.
-  * <strike>**Share sessions with others** - See the focused window and cursor of other users, work on a problem or a code base together in real time.</strike> - *implemented in `0.23.0`*
-  * **A web client/server** - Connect to Zellij through the browser instead of opening a terminal window. Either on a local or remote machine.
-  * **Support for multiple terminal windows across screens** - Transfer panes across different windows and screens by having them all belong to the same session.
-  * **Smart layouts** - expand the current layout system so that it rearranges and hides panes intelligently when new ones are added or the window size is changed.
+
+| Feature | Description | Status |
+| :-----: | ----------- | :----: |
+| **Share sessions with others** | See the focused window and cursor of other users, work on a problem or a code base together in real time. | :white_check_mark:<br>*(implemented in `0.23.0`)* |
+| **A web client/server** | Connect to Zellij through the browser instead of opening a terminal window. Either on a local or remote machine. |  |
+| **Support for multiple terminal windows across screens** | Transfer panes across different windows and screens by having them all belong to the same session. |  |
+| **Smart layouts** | Expand the current layout system so that it rearranges and hides panes intelligently when new ones are added or the window size is changed. |  |
 
 ## License
 


### PR DESCRIPTION
Since strike-through texts are difficult to read, I made them easier to read by putting them in a table.