### PR TITLE
Replace `sort_by` with `sort_by_key`

### DIFF
--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -30,6 +30,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
+use std::cmp::Reverse;
 use std::os::unix::io::RawFd;
 use std::rc::Rc;
 use std::sync::mpsc::channel;
@@ -1328,7 +1329,7 @@ impl Tab {
             .iter()
             .map(|p_id| self.panes.get(p_id).unwrap())
             .collect();
-        panes.sort_by(|a, b| b.active_at().cmp(&a.active_at()));
+        panes.sort_by_key(|b| Reverse(b.active_at()));
 
         panes.iter().find(|pane| pane.selectable()).map(|p| p.pid())
     }


### PR DESCRIPTION
This PR fixes a warning pointed out by `clippy`:

```
warning: use Vec::sort_by_key here instead
    --> zellij-server/src/tab/mod.rs:1331:9
     |
1331 |         panes.sort_by(|a, b| b.active_at().cmp(&a.active_at()));
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `panes.sort_by_key(|b| Reverse(b.active_at()))`
     |
     = note: `#[warn(clippy::unnecessary_sort_by)]` on by default
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_sort_by
```