### PR TITLE
fix(ci): run clippy with `-D warnings`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,4 +75,4 @@ jobs:
     - name: Install cargo-make
       run: test -x "${HOME}/.cargo/bin/cargo-make" || cargo install --debug cargo-make
     - name: Check Lints
-      run: cargo make clippy
+      run: cargo make clippy -D warnings


### PR DESCRIPTION
I hope I resolved all `clippy` lint warnings in my previous unmerged PRs.
So then it should be the next step to enforce failing CI by default when any warning is found to keep the quality of Zellij.