### PR TITLE
Ensure Title doesn't overrun

### DIFF
--- a/zellij-server/src/ui/pane_boundaries_frame.rs
+++ b/zellij-server/src/ui/pane_boundaries_frame.rs
@@ -605,7 +605,7 @@ impl PaneFrame {
         }
         let vte_output = if self.is_main_client {
             Some(format!(
-                "\u{1b}]0;Zellij ({}) - {}",
+                "\u{1b}]0;Zellij ({}) - {}\u{07}",
                 get_session_name().unwrap(),
                 self.title
             ))


### PR DESCRIPTION
The set title escape code needs to be terminated with a bell character. See https://tldp.org/HOWTO/Xterm-Title-3.html
Before this change I was seeing the following
<img width="1440" alt="Screen Shot 2022-02-22 at 4 50 56 PM" src="https://user-images.githubusercontent.com/78201/155244725-db0d0276-4312-47d2-8b23-b0d4722fd6fa.png">
 