### PR TITLE
fix: Allow terminal title passthrough even when not drawing pane frames.

### DIFF
--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -16,6 +16,7 @@ use zellij_utils::zellij_tile::prelude::{Event, InputMode, Mouse, PaletteColor};
 use zellij_utils::{
     channels::SenderWithContext,
     pane_size::{Dimension, PaneGeom},
+    shared::make_terminal_title,
 };
 
 pub(crate) struct PluginPane {
@@ -252,6 +253,16 @@ impl Pane for PluginPane {
         _text_color: PaletteColor,
     ) -> Option<String> {
         None
+    }
+    fn render_terminal_title(&mut self, input_mode: InputMode) -> String {
+        let pane_title = if self.pane_name.is_empty() && input_mode == InputMode::RenamePane {
+            "Enter name..."
+        } else if self.pane_name.is_empty() {
+            &self.pane_title
+        } else {
+            &self.pane_name
+        };
+        make_terminal_title(pane_title)
     }
     fn update_name(&mut self, name: &str) {
         match name {

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -17,6 +17,7 @@ use zellij_utils::pane_size::Offset;
 use zellij_utils::{
     pane_size::{Dimension, PaneGeom},
     position::Position,
+    shared::make_terminal_title,
     vte,
     zellij_tile::data::{InputMode, Palette, PaletteColor},
 };
@@ -302,6 +303,19 @@ impl Pane for TerminalPane {
             vte_output = Some(fake_cursor);
         }
         vte_output
+    }
+    fn render_terminal_title(&mut self, input_mode: InputMode) -> String {
+        let pane_title = if self.pane_name.is_empty() && input_mode == InputMode::RenamePane {
+            "Enter name..."
+        } else if self.pane_name.is_empty() {
+            self.grid
+                .title
+                .as_deref()
+                .unwrap_or(&self.pane_title)
+        } else {
+            &self.pane_name
+        };
+        make_terminal_title(pane_title)
     }
     fn update_name(&mut self, name: &str) {
         match name {

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -169,6 +169,7 @@ pub trait Pane {
         cursor_color: PaletteColor,
         text_color: PaletteColor,
     ) -> Option<String>;
+    fn render_terminal_title(&mut self, _input_mode: InputMode) -> String;
     fn update_name(&mut self, name: &str);
     fn pid(&self) -> PaneId;
     fn reduce_height(&mut self, percent: f64);
@@ -1225,6 +1226,7 @@ impl Tab {
                             self.session_is_mirrored,
                         );
                     }
+                    pane_contents_and_ui.render_terminal_title_if_needed(client_id, client_mode);
                     // this is done for panes that don't have their own cursor (eg. panes of
                     // another user)
                     pane_contents_and_ui.render_fake_cursor_if_needed(client_id);

--- a/zellij-server/src/ui/pane_boundaries_frame.rs
+++ b/zellij-server/src/ui/pane_boundaries_frame.rs
@@ -2,8 +2,8 @@ use crate::output::CharacterChunk;
 use crate::panes::{AnsiCode, CharacterStyles, TerminalCharacter, EMPTY_TERMINAL_CHARACTER};
 use crate::ui::boundaries::boundary_type;
 use crate::ClientId;
+use zellij_utils::pane_size::Viewport;
 use zellij_utils::zellij_tile::prelude::{client_id_to_colors, Palette, PaletteColor};
-use zellij_utils::{envs::get_session_name, pane_size::Viewport};
 
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -603,15 +603,6 @@ impl PaneFrame {
                 character_chunks.push(CharacterChunk::new(boundary_character_right, x, y));
             }
         }
-        let vte_output = if self.is_main_client {
-            Some(format!(
-                "\u{1b}]0;Zellij ({}) - {}\u{07}",
-                get_session_name().unwrap(),
-                self.title
-            ))
-        } else {
-            None
-        };
-        (character_chunks, vte_output)
+        (character_chunks, None)
     }
 }

--- a/zellij-server/src/ui/pane_contents_and_ui.rs
+++ b/zellij-server/src/ui/pane_contents_and_ui.rs
@@ -8,7 +8,6 @@ use std::collections::HashMap;
 use zellij_tile::data::{
     client_id_to_colors, single_client_color, InputMode, Palette, PaletteColor,
 };
-
 pub struct PaneContentsAndUi<'a> {
     pane: &'a mut Box<dyn Pane>,
     output: &'a mut Output,
@@ -110,6 +109,14 @@ impl<'a> PaneContentsAndUi<'a> {
                 }
             }
         }
+    }
+    pub fn render_terminal_title_if_needed(&mut self, client_id: ClientId, client_mode: InputMode) {
+        if !self.focused_clients.contains(&client_id) {
+            return;
+        }
+        let vte_output = self.pane.render_terminal_title(client_mode);
+        self.output
+            .add_post_vte_instruction_to_client(client_id, &vte_output);
     }
     pub fn render_pane_frame(
         &mut self,

--- a/zellij-utils/src/shared.rs
+++ b/zellij-utils/src/shared.rs
@@ -2,6 +2,7 @@
 
 use std::{iter, str::from_utf8};
 
+use crate::envs::get_session_name;
 use colorsys::Rgb;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
@@ -38,6 +39,14 @@ pub fn adjust_to_size(s: &str, rows: usize, columns: usize) -> String {
         .take(rows)
         .collect::<Vec<_>>()
         .join("\n\r")
+}
+
+pub fn make_terminal_title(pane_title: &str) -> String {
+    format!(
+        "\u{1b}]0;Zellij ({}) - {}\u{07}",
+        get_session_name().unwrap(),
+        pane_title,
+    )
 }
 
 // Colors


### PR DESCRIPTION
Currently the terminal title is set in the pane frame render function, which does not seem to run when displaying pane borders is disabled. 

This pull adds a `render_terminal_title` method to the `Pane` trait and a `render_terminal_title_if_needed` method to the `PaneContentsAndUi` struct. The latter can be called from `Tab::render` to ensure the title is always set when needed.

***Note***: First time looking at the Zellij codebase so I don't know if this is the correct approach. However, it does fix the issue for me with pane frames disabled (and terminal title setting still works with them enabled.)

Closes #1111
Other related issue: #883