### PR TITLE
add tmux ctrl+b d shortcut for detach

### DIFF
--- a/zellij-utils/assets/config/default.yaml
+++ b/zellij-utils/assets/config/default.yaml
@@ -504,6 +504,8 @@ keybinds:
           key: [ Alt: '+']
         - action: [Resize: Decrease,]
           key: [ Alt: '-']
+        - action: [Detach,]
+          key: [Char: 'd',]
 plugins:
     - path: tab-bar
       tag: tab-bar


### PR DESCRIPTION
The default keybinding for tmux detach is `ctrl+b` `d` adding this to the default might be nice for `tmux` users.