### PR TITLE
fix(input): handle discontiguous STDIN input

### DIFF
--- a/src/tests/e2e/cases.rs
+++ b/src/tests/e2e/cases.rs
@@ -1733,7 +1733,7 @@ pub fn focus_tab_with_layout() {
                 let mut step_is_complete = false;
                 if remote_terminal.status_bar_appears()
                     && remote_terminal.tip_appears()
-                    && remote_terminal.snapshot_contains("Tab #3")
+                    && remote_terminal.snapshot_contains("Tab #9")
                     && remote_terminal.cursor_position_is(63, 2)
                 {
                     step_is_complete = true;

--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -96,28 +96,11 @@ impl InputHandler {
                     }
                 }
                 Ok((
-                    InputInstruction::PastedText((
-                        send_bracketed_paste_start,
-                        raw_bytes,
-                        send_bracketed_paste_end,
-                    )),
+                    InputInstruction::PastedText(raw_bytes),
                     _error_context,
                 )) => {
                     if self.mode == InputMode::Normal || self.mode == InputMode::Locked {
-                        if send_bracketed_paste_start {
-                            let bracketed_paste_start = vec![27, 91, 50, 48, 48, 126]; // \u{1b}[200~
-                            let paste_start_action = Action::Write(bracketed_paste_start);
-                            self.dispatch_action(paste_start_action);
-                        }
-
-                        let pasted_text_action = Action::Write(raw_bytes);
-                        self.dispatch_action(pasted_text_action);
-
-                        if send_bracketed_paste_end {
-                            let bracketed_paste_end = vec![27, 91, 50, 48, 49, 126]; // \u{1b}[201~
-                            let paste_end_action = Action::Write(bracketed_paste_end);
-                            self.dispatch_action(paste_end_action);
-                        }
+                        self.dispatch_action(Action::Write(raw_bytes));
                     }
                 }
                 Ok((InputInstruction::SwitchToMode(input_mode), _error_context)) => {

--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -95,10 +95,7 @@ impl InputHandler {
                         }
                     }
                 }
-                Ok((
-                    InputInstruction::PastedText(raw_bytes),
-                    _error_context,
-                )) => {
+                Ok((InputInstruction::PastedText(raw_bytes), _error_context)) => {
                     if self.mode == InputMode::Normal || self.mode == InputMode::Locked {
                         self.dispatch_action(Action::Write(raw_bytes));
                     }

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -104,7 +104,7 @@ impl ClientInfo {
 pub(crate) enum InputInstruction {
     KeyEvent(termion::event::Event, Vec<u8>),
     SwitchToMode(InputMode),
-    PastedText((bool, Vec<u8>, bool)), // (send_brackted_paste_start, pasted_text, send_bracketed_paste_end)
+    PastedText(Vec<u8>),
 }
 
 pub fn start_client(

--- a/zellij-client/src/os_input_output.rs
+++ b/zellij-client/src/os_input_output.rs
@@ -82,6 +82,7 @@ pub trait ClientOsApi: Send + Sync {
     fn unset_raw_mode(&self, fd: RawFd);
     /// Returns the writer that allows writing to standard output.
     fn get_stdout_writer(&self) -> Box<dyn io::Write>;
+    fn get_stdin_reader(&self) -> Box<dyn io::Read>;
     /// Returns the raw contents of standard input.
     fn read_from_stdin(&self) -> Vec<u8>;
     /// Returns a [`Box`] pointer to this [`ClientOsApi`] struct.
@@ -128,6 +129,11 @@ impl ClientOsApi for ClientOsInputOutput {
         let stdout = ::std::io::stdout();
         Box::new(stdout)
     }
+    fn get_stdin_reader(&self) -> Box<dyn io::Read> {
+        let stdin = ::std::io::stdin();
+        Box::new(stdin)
+    }
+
     fn send_to_server(&self, msg: ClientToServerMsg) {
         self.send_instructions_to_server
             .lock()

--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -29,29 +29,6 @@ fn keys_to_adjust() -> HashMap<Vec<u8>, Vec<u8>> {
     keys_to_adjust
 }
 
-fn bracketed_paste_end_position(stdin_buffer: &[u8]) -> Option<usize> {
-    let bracketed_paste_end = vec![27, 91, 50, 48, 49, 126]; // \u{1b}[201~
-    let mut bp_position = 0;
-    let mut position = None;
-    for (i, byte) in stdin_buffer.iter().enumerate() {
-        if Some(byte) == bracketed_paste_end.get(bp_position) {
-            position = Some(i);
-            bp_position += 1;
-            if bp_position == bracketed_paste_end.len() {
-                break;
-            }
-        } else {
-            bp_position = 0;
-            position = None;
-        }
-    }
-    if bp_position == bracketed_paste_end.len() {
-        position
-    } else {
-        None
-    }
-}
-
 pub(crate) fn stdin_loop(
     os_input: Box<dyn ClientOsApi>,
     send_input_instructions: SenderWithContext<InputInstruction>,
@@ -129,5 +106,4 @@ pub(crate) fn stdin_loop(
             .send(InputInstruction::KeyEvent(key_event, raw_bytes))
             .unwrap();
     }
-    // }
 }

--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -62,6 +62,9 @@ pub(crate) fn stdin_loop(
     let adjusted_keys = keys_to_adjust();
     loop {
         let mut stdin_buffer = os_input.read_from_stdin();
+
+        log::info!("read from stdin: {stdin_buffer:?}");
+
         if pasting
             || (stdin_buffer.len() > bracketed_paste_start.len()
                 && stdin_buffer
@@ -120,6 +123,7 @@ pub(crate) fn stdin_loop(
         }
         for key_result in stdin_buffer.events_and_raw() {
             let (key_event, raw_bytes) = key_result.unwrap();
+            log::info!("event: {key_event:?}");
             let raw_bytes = adjusted_keys.get(&raw_bytes).cloned().unwrap_or(raw_bytes);
             if let termion::event::Event::Mouse(me) = key_event {
                 let mouse_event = zellij_utils::input::mouse::MouseEvent::from(me);

--- a/zellij-client/src/unit/input_handler_tests.rs
+++ b/zellij-client/src/unit/input_handler_tests.rs
@@ -106,6 +106,9 @@ impl ClientOsApi for FakeClientOsApi {
     fn get_stdout_writer(&self) -> Box<dyn io::Write> {
         unimplemented!()
     }
+    fn get_stdin_reader(&self) -> Box<dyn io::Read> {
+        unimplemented!()
+    }
     fn read_from_stdin(&self) -> Vec<u8> {
         unimplemented!()
     }


### PR DESCRIPTION
This fixes the behaviour of our STDIN reader so that it can handle STDIN input that might not come in contiguously. Thanks @tlinford for finding the issue and kicking this off.

This PR also fixes a flaky e2e test.

Fixes https://github.com/zellij-org/zellij/issues/1110 https://github.com/zellij-org/zellij/issues/816 https://github.com/zellij-org/zellij/issues/1107 and possibly others :)