### PR TITLE
fix(compatibility): properly clear pane before switching to alternate screen

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1802,6 +1802,7 @@ impl Perform for Grid {
                             Some((current_lines_above, current_viewport, current_cursor));
                         self.clear_viewport_before_rendering = true;
                         self.scrollback_buffer_lines = self.recalculate_scrollback_buffer_count();
+                        self.output_buffer.update_all_lines(); // make sure the screen gets cleared in the next render
                     }
                     Some(1) => {
                         self.cursor_key_mode = true;


### PR DESCRIPTION
This fixes cases in which when switching to alternate screen (eg. when opening vim), we sometimes wouldn't properly clear the render artifacts from the previous render eg. when the alternate screen didn't have enough content.