### PR TITLE
Use the `clippy-check` action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,7 +72,8 @@ jobs:
           ~/.cargo/git
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Install cargo-make
-      run: test -x "${HOME}/.cargo/bin/cargo-make" || cargo install --debug cargo-make
     - name: Check Lints
-      run: cargo make clippy
+      uses: actions-rs/clippy-check@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        args: --all-features


### PR DESCRIPTION
This PR is created because of [this discussion](https://github.com/zellij-org/zellij/pull/1090#issuecomment-1051007086).
I could confirm that the clippy command I use is the same as the `cargo make clippy` command:
https://github.com/zellij-org/zellij/runs/5334524327?check_suite_focus=true#step:5:44