### PR TITLE
add: set `env` var's from config and layout

### DIFF
--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -133,6 +133,7 @@ pub fn start_client(
         .write(clear_client_terminal_attributes.as_bytes())
         .unwrap();
     envs::set_zellij("0".to_string());
+    config.env.set_vars();
 
     let palette = config.themes.clone().map_or_else(
         || os_input.load_palette(),

--- a/zellij-utils/src/envs.rs
+++ b/zellij-utils/src/envs.rs
@@ -1,6 +1,10 @@
 /// Uniformly operates ZELLIJ* environment variables
 use anyhow::Result;
-use std::env::{set_var, var};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    env::{set_var, var},
+};
 
 pub const ZELLIJ_ENV_KEY: &str = "ZELLIJ";
 pub fn get_zellij() -> Result<String> {
@@ -23,4 +27,27 @@ pub fn set_session_name(v: String) {
 pub const SOCKET_DIR_ENV_KEY: &str = "ZELLIJ_SOCKET_DIR";
 pub fn get_socket_dir() -> Result<String> {
     Ok(var(SOCKET_DIR_ENV_KEY)?)
+}
+
+/// Manage ENVIRONMENT VARIABLES from the configuration and the layout files
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EnvironmentVariablesFromYaml {
+    env: HashMap<String, String>,
+}
+
+impl EnvironmentVariablesFromYaml {
+    /// Merges two structs, keys from `other` supercede keys from `self`
+    pub fn merge(&self, other: Self) -> Self {
+        let mut env = self.clone();
+        env.env.extend(other.env);
+        env
+    }
+
+    /// Set all the ENVIRONMENT VARIABLES, that are configured
+    /// in the configuration and layout files
+    pub fn set_vars(&self) {
+        for (k, v) in &self.env {
+            set_var(k, v);
+        }
+    }
 }

--- a/zellij-utils/src/input/config.rs
+++ b/zellij-utils/src/input/config.rs
@@ -13,6 +13,7 @@ use super::options::Options;
 use super::plugins::{PluginsConfig, PluginsConfigError, PluginsConfigFromYaml};
 use super::theme::ThemesFromYaml;
 use crate::cli::{CliArgs, Command};
+use crate::envs::EnvironmentVariablesFromYaml;
 use crate::setup;
 
 const DEFAULT_CONFIG_FILE_NAME: &str = "config.yaml";
@@ -26,6 +27,8 @@ pub struct ConfigFromYaml {
     pub options: Option<Options>,
     pub keybinds: Option<KeybindsFromYaml>,
     pub themes: Option<ThemesFromYaml>,
+    #[serde(flatten)]
+    pub env: Option<EnvironmentVariablesFromYaml>,
     #[serde(default)]
     pub plugins: PluginsConfigFromYaml,
 }
@@ -37,6 +40,7 @@ pub struct Config {
     pub options: Options,
     pub themes: Option<ThemesFromYaml>,
     pub plugins: PluginsConfig,
+    pub env: EnvironmentVariablesFromYaml,
 }
 
 #[derive(Error, Debug)]
@@ -66,6 +70,7 @@ impl Default for Config {
         let keybinds = Keybinds::default();
         let options = Options::default();
         let themes = None;
+        let env = EnvironmentVariablesFromYaml::default();
         let plugins = PluginsConfig::default();
 
         Config {
@@ -73,6 +78,7 @@ impl Default for Config {
             options,
             themes,
             plugins,
+            env,
         }
     }
 }
@@ -160,6 +166,7 @@ impl Config {
             keybinds: self.keybinds.clone(),
             options: self.options.merge(other.options),
             themes: self.themes.clone(), // TODO
+            env: self.env.merge(other.env),
             plugins: self.plugins.merge(other.plugins),
         }
     }
@@ -172,12 +179,14 @@ impl TryFrom<ConfigFromYaml> for Config {
         let keybinds = Keybinds::get_default_keybinds_with_config(config_from_yaml.keybinds);
         let options = Options::from_yaml(config_from_yaml.options);
         let themes = config_from_yaml.themes;
+        let env = config_from_yaml.env.unwrap_or_default();
         let plugins = PluginsConfig::get_plugins_with_default(config_from_yaml.plugins.try_into()?);
         Ok(Self {
             keybinds,
             options,
             plugins,
             themes,
+            env,
         })
     }
 }


### PR DESCRIPTION
Add ability to set `ENVIRONMENT VARIABLES` from the
config and the layout files.

example:

```
env:
  ZELLIJ_CONFIG:
    DEFAULT
```

or

```
env:
  ZELLIJ_LAYOUT_NAME:
    BUILD_SESSION
```

If two keys conflict (configuration and layout), then the key
from the layout is used.

fixes: #1059