### PR TITLE
fix(layout): allow lowercase keys and values

### DIFF
--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -37,7 +37,9 @@ use url::Url;
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Copy)]
 #[serde(crate = "self::serde")]
 pub enum Direction {
+    #[serde(alias = "horizontal")]
     Horizontal,
+    #[serde(alias = "vertical")]
     Vertical,
 }
 
@@ -55,7 +57,9 @@ impl Not for Direction {
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq)]
 #[serde(crate = "self::serde")]
 pub enum SplitSize {
+    #[serde(alias = "percent")]
     Percent(f64), // 1 to 100
+    #[serde(alias = "fixed")]
     Fixed(usize), // An absolute number of columns or rows
 }
 


### PR DESCRIPTION
A layout needed to be specified as follows:
```
---
template:
  direction: Horizontal
  parts:
    - direction: Vertical
      body: true
    - direction: Vertical
      borderless: true
      split_size:
        Fixed: 1
```
now the same layout can be specified as:
```
---
template:
  direction: horizontal
  parts:
    - direction: vertical
      body: true
    - direction: vertical
      borderless: true
      split_size:
        fixed: 1
```