### PR TITLE
fix(cli): `list-sessions` stderr on fail

### DIFF
--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -133,8 +133,8 @@ pub(crate) fn list_sessions() {
             0
         }
         Ok(_) => {
-            println!("No active zellij sessions found.");
-            0
+            eprintln!("No active zellij sessions found.");
+            1
         }
         Err(e) => {
             eprintln!("Error occurred: {:?}", e);


### PR DESCRIPTION
Change `list-sessions` to report an error `1` on the shell
and put the output to stderr,
this can be valuable for scriping and should be consistent with expectations