### PR TITLE
add(comp): dynamic completions for fish

### DIFF
--- a/zellij-utils/assets/completions/README.md
+++ b/zellij-utils/assets/completions/README.md
@@ -1,0 +1,2 @@
+Extra completion files that get appended to the
+clap output, in order to support dynamic commands.

--- a/zellij-utils/assets/completions/comp.fish
+++ b/zellij-utils/assets/completions/comp.fish
@@ -1,0 +1,8 @@
+function __fish_complete_sessions
+    zellij list-sessions 2>/dev/null
+end
+complete -c zellij -n "__fish_seen_subcommand_from attach" -f -a "(__fish_complete_sessions)" -d "Session"
+complete -c zellij -n "__fish_seen_subcommand_from a" -f -a "(__fish_complete_sessions)" -d "Session"
+complete -c zellij -n "__fish_seen_subcommand_from kill-session" -f -a "(__fish_complete_sessions)" -d "Session"
+complete -c zellij -n "__fish_seen_subcommand_from a" -f -a "(__fish_complete_sessions)" -d "Session"
+complete -c zellij -n "__fish_seen_subcommand_from setup --generate-completion" -f -a "bash elvish fish zsh powershell" -d "Shell"

--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -109,6 +109,12 @@ pub const NO_STATUS_LAYOUT: &[u8] = include_bytes!(concat!(
     "assets/layouts/disable-status-bar.yaml"
 ));
 
+pub const FISH_EXTRA_COMPLETION: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/",
+    "assets/completions/comp.fish"
+));
+
 pub fn dump_default_config() -> std::io::Result<()> {
     dump_asset(DEFAULT_CONFIG)
 }
@@ -387,6 +393,17 @@ impl Setup {
         };
         let mut out = std::io::stdout();
         clap_complete::generate(shell, &mut CliArgs::into_app(), "zellij", &mut out);
+        // add shell dependent extra completion
+        match shell {
+            Shell::Bash => {}
+            Shell::Elvish => {}
+            Shell::Fish => {
+                let _ = out.write_all(&FISH_EXTRA_COMPLETION);
+            }
+            Shell::PowerShell => {}
+            Shell::Zsh => {}
+            _ => {}
+        };
     }
 }
 


### PR DESCRIPTION
And infrastructure to make it possible
to add more dynamic completions for
different shells in the future.

eg:

```
zellij attach [completes-active-sessions]
zellij kill-session [completes-active-sessions]
```

fixes: #1030