### PR TITLE
fix(readme): switch badges and gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,15 @@
 </h1>
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/zellij-org/zellij/main/assets/demo.gif" alt="demo">
-</p>
-
-<p align="center">
   <a href="https://discord.gg/CrUAFH3"><img alt="Discord Chat" src="https://img.shields.io/discord/771367133715628073?color=%235865F2%20&label=chat%3A%20discord&style=flat-square"></a>
   <a href="https://matrix.to/#/#zellij_general:matrix.org"><img alt="Matrix Chat" src="https://img.shields.io/matrix/zellij_general:matrix.org?color=%230FBD8C&label=chat%3A%20matrix&style=flat-square&logo=matrix"></a>
   <a href="https://zellij.dev/documentation/"><img alt="Zellij documentation" src="https://img.shields.io/badge/zellij-documentation-fc0060?style=flat-square"></a>
 </p>
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/zellij-org/zellij/main/assets/demo.gif" alt="demo">
+</p>
+
 
 # What is this?
 


### PR DESCRIPTION
Switch the badges and the large gif on the landing page,
makes it easier to see the badges and get in contact with
the project, as well as find the documentation.