### PR TITLE
refactor(tab): simplify mouse hold and release

### DIFF
--- a/default-plugins/strider/src/main.rs
+++ b/default-plugins/strider/src/main.rs
@@ -58,14 +58,12 @@ impl ZellijPlugin for State {
                 Mouse::ScrollUp(_) => {
                     *self.selected_mut() = self.selected().saturating_sub(1);
                 }
-                Mouse::Release(Some((line, _))) => {
+                Mouse::Release(line, _) => {
                     if line < 0 {
                         return;
                     }
                     let mut should_select = true;
-                    if let Some((Event::Mouse(Mouse::Release(Some((prev_line, _)))), t)) =
-                        prev_event
-                    {
+                    if let Some((Event::Mouse(Mouse::Release(prev_line, _)), t)) = prev_event {
                         if prev_line == line
                             && Instant::now().saturating_duration_since(t).as_millis() < 400
                         {

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1391,7 +1391,11 @@ impl Grid {
         // for now trim after building the selection to handle whitespace in wrapped lines
         let selection: Vec<_> = selection.iter().map(|l| l.trim_end()).collect();
 
-        Some(selection.join("\n"))
+        if selection.is_empty() {
+            None
+        } else {
+            Some(selection.join("\n"))
+        }
     }
 
     fn update_selected_lines(&mut self, old_selection: &Selection, new_selection: &Selection) {

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1303,9 +1303,9 @@ impl Grid {
         self.mark_for_rerender();
     }
 
-    pub fn end_selection(&mut self, end: Option<&Position>) {
+    pub fn end_selection(&mut self, end: &Position) {
         let old_selection = self.selection;
-        self.selection.end(end);
+        self.selection.end(*end);
         self.update_selected_lines(&old_selection, &self.selection.clone());
         self.mark_for_rerender();
     }

--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -360,14 +360,12 @@ impl Pane for PluginPane {
             ))
             .unwrap();
     }
-    fn end_selection(&mut self, end: Option<&Position>, client_id: ClientId) {
+    fn end_selection(&mut self, end: &Position, client_id: ClientId) {
         self.send_plugin_instructions
             .send(PluginInstruction::Update(
                 Some(self.pid),
                 Some(client_id),
-                Event::Mouse(Mouse::Release(
-                    end.map(|Position { line, column }| (line.0, column.0)),
-                )),
+                Event::Mouse(Mouse::Release(end.line(), end.column())),
             ))
             .unwrap();
     }

--- a/zellij-server/src/panes/selection.rs
+++ b/zellij-server/src/panes/selection.rs
@@ -32,11 +32,9 @@ impl Selection {
         self.end = to
     }
 
-    pub fn end(&mut self, to: Option<&Position>) {
+    pub fn end(&mut self, end: Position) {
         self.active = false;
-        if let Some(to) = to {
-            self.end = *to
-        }
+        self.end = end;
     }
 
     pub fn contains(&self, row: usize, col: usize) -> bool {

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -431,7 +431,7 @@ impl Pane for TerminalPane {
         self.set_should_render(true);
     }
 
-    fn end_selection(&mut self, end: Option<&Position>, _client_id: ClientId) {
+    fn end_selection(&mut self, end: &Position, _client_id: ClientId) {
         self.grid.end_selection(end);
         self.set_should_render(true);
     }

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -851,7 +851,7 @@ fn copy_selected_text_from_viewport() {
 
     grid.start_selection(&Position::new(23, 6));
     // check for widechar, 📦 occupies columns 34, 35, and gets selected even if only the first column is selected
-    grid.end_selection(Some(&Position::new(25, 35)));
+    grid.end_selection(&Position::new(25, 35));
     let text = grid.get_selected_text();
     assert_eq!(
         text.unwrap(),
@@ -875,7 +875,7 @@ fn copy_wrapped_selected_text_from_viewport() {
     }
 
     grid.start_selection(&Position::new(5, 0));
-    grid.end_selection(Some(&Position::new(8, 42)));
+    grid.end_selection(&Position::new(8, 42));
     let text = grid.get_selected_text();
     assert_eq!(
         text.unwrap(),
@@ -900,7 +900,7 @@ fn copy_selected_text_from_lines_above() {
 
     grid.start_selection(&Position::new(-2, 10));
     // check for widechar, 📦 occupies columns 34, 35, and gets selected even if only the first column is selected
-    grid.end_selection(Some(&Position::new(2, 8)));
+    grid.end_selection(&Position::new(2, 8));
     let text = grid.get_selected_text();
     assert_eq!(
         text.unwrap(),
@@ -927,7 +927,7 @@ fn copy_selected_text_from_lines_below() {
 
     grid.start_selection(&Position::new(63, 6));
     // check for widechar, 📦 occupies columns 34, 35, and gets selected even if only the first column is selected
-    grid.end_selection(Some(&Position::new(65, 35)));
+    grid.end_selection(&Position::new(65, 35));
     let text = grid.get_selected_text();
     assert_eq!(
         text.unwrap(),

--- a/zellij-server/src/panes/unit/selection_tests.rs
+++ b/zellij-server/src/panes/unit/selection_tests.rs
@@ -22,24 +22,13 @@ fn selection_to() {
 }
 
 #[test]
-fn selection_end_with_position() {
+fn selection_end() {
     let mut selection = Selection::default();
     selection.start(Position::new(10, 10));
-    selection.end(Some(&Position::new(20, 30)));
+    selection.end(Position::new(20, 30));
 
     assert!(!selection.active);
     assert_eq!(selection.end, Position::new(20, 30));
-}
-
-#[test]
-fn selection_end_without_position() {
-    let mut selection = Selection::default();
-    selection.start(Position::new(10, 10));
-    selection.to(Position::new(15, 100));
-    selection.end(None);
-
-    assert!(!selection.active);
-    assert_eq!(selection.end, Position::new(15, 100));
 }
 
 #[test]

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -2336,17 +2336,16 @@ impl Tab {
     pub fn handle_left_click(&mut self, position: &Position, client_id: ClientId) {
         self.focus_pane_at(position, client_id);
 
-        let show_floating_panes = self.floating_panes.panes_are_visible();
-        if show_floating_panes {
-            let search_selectable = false;
-            if self
+        let search_selectable = false;
+        if self.floating_panes.panes_are_visible()
+            && self
                 .floating_panes
                 .move_pane_with_mouse(*position, search_selectable)
-            {
-                self.set_force_render();
-                return;
-            }
+        {
+            self.set_force_render();
+            return;
         }
+
         if let Some(pane) = self.get_pane_at(position, false) {
             let relative_position = pane.relative_position(position);
             pane.start_selection(&relative_position, client_id);
@@ -2419,9 +2418,10 @@ impl Tab {
                 let relative_position = active_pane.relative_position(position_on_screen);
                 active_pane.update_selection(&relative_position, client_id);
             }
-        } else if self
-            .floating_panes
-            .move_pane_with_mouse(*position_on_screen, search_selectable)
+        } else if self.floating_panes.panes_are_visible()
+            && self
+                .floating_panes
+                .move_pane_with_mouse(*position_on_screen, search_selectable)
         {
             self.set_force_render();
         }

--- a/zellij-tile/src/data.rs
+++ b/zellij-tile/src/data.rs
@@ -58,12 +58,12 @@ pub enum Key {
 // left click) and the `ScrollUp` and `ScrollDown` events could probably be
 // merged into a single `Scroll(isize)` event.
 pub enum Mouse {
-    ScrollUp(usize),                 // number of lines
-    ScrollDown(usize),               // number of lines
-    LeftClick(isize, usize),         // line and column
-    RightClick(isize, usize),        // line and column
-    Hold(isize, usize),              // line and column
-    Release(Option<(isize, usize)>), // line and column
+    ScrollUp(usize),          // number of lines
+    ScrollDown(usize),        // number of lines
+    LeftClick(isize, usize),  // line and column
+    RightClick(isize, usize), // line and column
+    Hold(isize, usize),       // line and column
+    Release(isize, usize),    // line and column
 }
 
 #[derive(Debug, Clone, PartialEq, EnumDiscriminants, ToString, Serialize, Deserialize)]


### PR DESCRIPTION
Simplify some code around mouse handling:
* remove unnecessary `Option` for position when ending selection, and return `None` when `Grid` has empty selection
* simplify `Tab` mouse release and hold handlers
* when a selection is initiated in a floating pane, and the mouse leaves the floating pane the selection stays active, instead of starting to move the pane
