### PR TITLE
build(nix): fix buildInputs

### DIFF
--- a/nix/crate2nix.nix
+++ b/nix/crate2nix.nix
@@ -4,6 +4,8 @@
 , src
 , postInstall
 , desktopItems
+, nativeBuildInputs
+, buildInputs
 , meta
 }:
 
@@ -20,8 +22,10 @@ let
       buildRustCrateForPkgs = pkgs:
         pkgs.buildRustCrate.override {
           defaultCrateOverrides = pkgs.defaultCrateOverrides // {
-              inherit postInstall desktopItems meta;
             # Crate dependency overrides go here
+            zellij = attrs : {
+              inherit postInstall desktopItems meta buildInputs nativeBuildInputs;
+            };
           };
         };
     };

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -103,7 +103,8 @@ flake-utils.lib.eachSystem [
 
       # crate2nix - better incremental builds, but uses ifd
       packages.zellij = pkgs.callPackage ./crate2nix.nix {
-        inherit crate2nix name src desktopItems postInstall meta;
+          inherit crate2nix name src desktopItems postInstall meta
+          buildInputs nativeBuildInputs;
       };
 
       # native nixpkgs support - keep supported


### PR DESCRIPTION
Adds the inputs correctly to the `zelllij` package set.