### PR TITLE
feature(mouse): forward mouse events

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -306,6 +306,7 @@ pub struct Grid {
     pub link_handler: Rc<RefCell<LinkHandler>>,
     pub ring_bell: bool,
     scrollback_buffer_lines: usize,
+    pub mouse_mode: bool,
 }
 
 impl Debug for Grid {
@@ -363,6 +364,7 @@ impl Grid {
             link_handler,
             ring_bell: false,
             scrollback_buffer_lines: 0,
+            mouse_mode: false,
         }
     }
     pub fn render_full_viewport(&mut self) {
@@ -1769,6 +1771,9 @@ impl Perform for Grid {
                     Some(7) => {
                         self.disable_linewrap = true;
                     }
+                    Some(1006) => {
+                        self.mouse_mode = false;
+                    }
                     _ => {}
                 };
             } else if let Some(4) = params_iter.next().map(|param| param[0]) {
@@ -1821,6 +1826,9 @@ impl Perform for Grid {
                     }
                     Some(7) => {
                         self.disable_linewrap = false;
+                    }
+                    Some(1006) => {
+                        self.mouse_mode = true;
                     }
                     _ => {}
                 };

--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -401,4 +401,7 @@ impl Pane for PluginPane {
             ))
             .unwrap();
     }
+    fn mouse_mode(&self) -> bool {
+        false
+    }
 }

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -459,6 +459,10 @@ impl Pane for TerminalPane {
     fn borderless(&self) -> bool {
         self.borderless
     }
+
+    fn mouse_mode(&self) -> bool {
+        self.grid.mouse_mode
+    }
 }
 
 impl TerminalPane {

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -289,6 +289,7 @@ pub trait Pane {
     fn set_borderless(&mut self, borderless: bool);
     fn borderless(&self) -> bool;
     fn handle_right_click(&mut self, _to: &Position, _client_id: ClientId) {}
+    fn mouse_mode(&self) -> bool;
 }
 
 impl Tab {

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -977,6 +977,14 @@ impl Tab {
         self.write_to_pane_id(input_bytes, pane_id);
     }
     pub fn write_to_terminal_at(&mut self, input_bytes: Vec<u8>, position: &Position) {
+        if self.floating_panes.panes_are_visible() {
+            let pane_id = self.floating_panes.get_pane_id_at(position, false);
+            if let Some(pane_id) = pane_id {
+                self.write_to_pane_id(input_bytes, pane_id);
+                return;
+            }
+        }
+
         let pane_id = self.get_pane_id_at(position, false);
         if let Some(pane_id) = pane_id {
             self.write_to_pane_id(input_bytes, pane_id);
@@ -2302,7 +2310,6 @@ impl Tab {
                     relative_position.column.0 + 1,
                     relative_position.line.0 + 1
                 );
-                log::info!("scroll up event: {mouse_event}");
                 self.write_to_terminal_at(mouse_event.into_bytes(), point);
             } else {
                 pane.scroll_up(lines, client_id);


### PR DESCRIPTION
Initial support for forwarding mouse events for applications that request it.

For now support only `SGR` format.

Since the events we get from `termion` do not have mouse button information for `hold` and `release` events, forward them with hardcoded left button.

Thanks @dantepippi for the work in #624, I redid a new branch here since solving the conflicts looked a bit problematic.

Resolves #579 