### PR TITLE
build(nix): apply overrrides correctly

### DIFF
--- a/nix/crate2nix.nix
+++ b/nix/crate2nix.nix
@@ -3,6 +3,7 @@
 , name
 , src
 , postInstall
+, nativeBuildInputs
 , desktopItems
 , meta
 }:
@@ -20,8 +21,11 @@ let
       buildRustCrateForPkgs = pkgs:
         pkgs.buildRustCrate.override {
           defaultCrateOverrides = pkgs.defaultCrateOverrides // {
-              inherit postInstall desktopItems meta;
             # Crate dependency overrides go here
+            zellij = attrs: {
+              inherit postInstall desktopItems meta name nativeBuildInputs;
+
+            };
           };
         };
     };

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -103,7 +103,8 @@ flake-utils.lib.eachSystem [
 
       # crate2nix - better incremental builds, but uses ifd
       packages.zellij = pkgs.callPackage ./crate2nix.nix {
-        inherit crate2nix name src desktopItems postInstall meta;
+          inherit crate2nix name src desktopItems postInstall
+          meta nativeBuildInputs;
       };
 
       # native nixpkgs support - keep supported


### PR DESCRIPTION
Overrides in the global scope dont apply all
attributes for the package in `crate2nix`.