### PR TITLE
add(nix): lorri integration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,5 @@
-use_flake
+if command -v lorri >/dev/null 2>&1; then
+  eval "$(lorri direnv)"
+else
+  use flake
+fi


### PR DESCRIPTION
Check, if direnv supports lorri, if not run
`use_flake` directly from direnv.