### PR TITLE
fix: release tagging

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -237,7 +237,7 @@ args = ["commit", "-aem", "chore(release): v${CARGO_MAKE_CRATE_VERSION}"]
 
 [tasks.tag-release]
 command = "git"
-args = ["tag", "v${CARGO_MAKE_CRATE_VERSION}"]
+args = ["tag", "--annotate", "--message", "Version ${CARGO_MAKE_CRATE_VERSION}", "v${CARGO_MAKE_CRATE_VERSION}"]
 
 [tasks.publish-zellij-tile]
 ignore_errors = true


### PR DESCRIPTION
Switch from "lightweight" tags to "annotated" tags for releases,
since "lightweight" tags are meant for private or temporary object
labels.

`man git tag`:

```
Tag objects (created with -a, -s, or -u) are called "annotated" tags; they contain a creation date, the
tagger name and e-mail, a tagging message, and an optional GnuPG signature. Whereas a "lightweight" tag is
simply a name for an object (usually a commit object).
Annotated tags are meant for release while lightweight tags are meant for private or temporary object
labels. For this reason, some git commands for naming objects (like git describe) will ignore lightweight
tags by default.
```