### PR TITLE
add(ci): install `cargo-make` through `nix`

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,7 @@ jobs:
   test:
     name: Build generic binary and run tests on it
     runs-on: ubuntu-latest
+    environment: cachix
 
     services:
       ssh:
@@ -30,6 +31,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v16
+    - uses: cachix/cachix-action@v10
+      with:
+        name: zellij
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - name: Add WASM target
       run: rustup target add wasm32-wasi
     - name: Install musl-tools
@@ -40,7 +45,6 @@ jobs:
       run: nix profile install nixpkgs#cargo-make
       #run: cargo install --debug cargo-make
     - name: Build asset
-      #run: nix develop .#e2eShell --command cargo make build-e2e
       run: cargo make build-e2e
       # we copy this manually into the target folder instead of mounting it because
       # github actions creates the service first, and if it has a mount that is part
@@ -54,5 +58,4 @@ jobs:
       with:
         args: docker restart ssh
     - name: Test
-      #run: nix develop .#e2eShell --command cargo make e2e-test
       run: cargo make e2e-test

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,6 +29,7 @@ jobs:
         options: -v ${{ github.workspace }}/target:/usr/src/zellij --name ssh
     steps:
     - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v16
     - name: Add WASM target
       run: rustup target add wasm32-wasi
     - name: Install musl-tools
@@ -36,8 +37,10 @@ jobs:
     - name: Add musl target
       run: rustup target add x86_64-unknown-linux-musl
     - name: Install cargo-make
-      run: cargo install --debug cargo-make
+      run: nix profile install nixpkgs#cargo-make
+      #run: cargo install --debug cargo-make
     - name: Build asset
+      #run: nix develop .#e2eShell --command cargo make build-e2e
       run: cargo make build-e2e
       # we copy this manually into the target folder instead of mounting it because
       # github actions creates the service first, and if it has a mount that is part
@@ -51,4 +54,5 @@ jobs:
       with:
         args: docker restart ssh
     - name: Test
+      #run: nix develop .#e2eShell --command cargo make e2e-test
       run: cargo make e2e-test

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -158,6 +158,12 @@ in rec {
       name = "fmt-shell";
       nativeBuildInputs = fmtInputs;
     };
+    e2eShell = pkgs.mkShell {
+      name = "e2e-shell";
+      nativeBuildInputs = [
+        pkgs.cargo-make
+      ];
+    };
   };
 
   devShell = devShells.zellij;


### PR DESCRIPTION
Should speed the e2e tests up by about 2 minutes.