### PR TITLE
chore: bump `nix` version to 0.23.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,14 +1317,15 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.19.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
 dependencies = [
  "bitflags",
  "cc",
  "cfg-if 1.0.0",
  "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -21,7 +21,7 @@ directories-next = "2.0"
 interprocess = "1.1.1"
 lazy_static = "1.4.0"
 libc = "0.2"
-nix = "0.19.1"
+nix = "0.23.1"
 once_cell = "1.8.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"


### PR DESCRIPTION
This PR related to #1231 

The current version of `nix` potentially contains security issues.
(of course, we're not currently using the "problem" function directly)
Updating the `nix` version does not affect the system, so it is recommended to update it.