### PR TITLE
fix selection rendering of unstyled characters

### DIFF
--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -685,7 +685,7 @@ impl Cursor {
             x,
             y,
             is_hidden: false,
-            pending_styles: CharacterStyles::new(),
+            pending_styles: RESET_STYLES,
             charsets: Default::default(),
             shape: CursorShape::Initial,
         }


### PR DESCRIPTION
With a basic bash session the character style diffing was not emitting a reset when rendering the first character after the selection. By starting the cursor off with `RESET_STYLES`, the problem goes away, and have noticed no problems otherwise.

fixes #1208

cc @imsnif 