### PR TITLE
fix(crash): ensure ZELLIJ_TMP_DIR exists when starting plugins

### DIFF
--- a/zellij-server/src/wasm_vm.rs
+++ b/zellij-server/src/wasm_vm.rs
@@ -264,6 +264,15 @@ fn start_plugin(
         )
     });
 
+    // ensure tmp dir exists, in case it somehow was deleted (e.g systemd-tmpfiles)
+    fs::create_dir_all(ZELLIJ_TMP_DIR.as_path()).unwrap_or_else(|e| {
+        log::error!(
+            "Could not create ZELLIJ_TMP_DIR at {:?} \n Error: {:?}",
+            &ZELLIJ_TMP_DIR.as_path(),
+            e
+        )
+    });
+
     let mut wasi_env = WasiState::new("Zellij")
         .env("CLICOLOR_FORCE", "1")
         .map_dir("/host", ".")


### PR DESCRIPTION
fixes #1217

Simply try and create the `ZELLIJ_TMP_DIR` in `start_plugin` before mapping it in wasi, instead of messing around with sticky bits as discusses in the issue, to keep things simpler.