### PR TITLE
fix(tab): do not crash when only floating panes are left

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -429,7 +429,7 @@ impl Screen {
         let size = self.size;
         let overlay = self.overlay.clone();
         for (tab_index, tab) in &mut self.tabs {
-            if tab.has_selectable_panes() {
+            if tab.has_selectable_tiled_panes() {
                 let vte_overlay = overlay.generate_overlay(size);
                 tab.render(&mut output, Some(vte_overlay));
             } else {

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1035,6 +1035,10 @@ impl Tab {
             .filter(|(_, p)| p.selectable());
         selectable_tiled_panes.count() > 0 || selectable_floating_panes.count() > 0
     }
+    pub fn has_selectable_tiled_panes(&self) -> bool {
+        let selectable_tiled_panes = self.tiled_panes.get_panes().filter(|(_, p)| p.selectable());
+        selectable_tiled_panes.count() > 0
+    }
     pub fn resize_whole_tab(&mut self, new_screen_size: Size) {
         self.floating_panes.resize(new_screen_size);
         self.tiled_panes.resize(new_screen_size);


### PR DESCRIPTION
Fixes #1241 

Tabs will now close if there are no tiled panes left.