### PR TITLE
fix(tab): floating panes embed/fullscreen and frame color

### DIFF
--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -314,12 +314,12 @@ impl TiledPanes {
     pub fn has_panes(&self) -> bool {
         !self.panes.is_empty()
     }
-    pub fn render(&mut self, output: &mut Output) {
+    pub fn render(&mut self, output: &mut Output, floating_panes_are_visible: bool) {
         let connected_clients: Vec<ClientId> =
             { self.connected_clients.borrow().iter().copied().collect() };
         let multiple_users_exist_in_session = { self.connected_clients_in_app.borrow().len() > 1 };
         let mut client_id_to_boundaries: HashMap<ClientId, Boundaries> = HashMap::new();
-        let active_panes = if self.session_is_mirrored {
+        let active_panes = if self.session_is_mirrored || floating_panes_are_visible {
             HashMap::new()
         } else {
             self.active_panes

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -946,7 +946,8 @@ impl Tab {
         );
 
         self.hide_cursor_and_clear_display_as_needed(output);
-        self.tiled_panes.render(output, self.floating_panes.panes_are_visible());
+        self.tiled_panes
+            .render(output, self.floating_panes.panes_are_visible());
         if self.floating_panes.panes_are_visible() && self.floating_panes.has_active_panes() {
             self.floating_panes.render(output);
         }

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -554,6 +554,9 @@ impl Tab {
         self.connected_clients.borrow().is_empty()
     }
     pub fn toggle_pane_embed_or_floating(&mut self, client_id: ClientId) {
+        if self.tiled_panes.fullscreen_is_active() {
+            self.tiled_panes.unset_fullscreen();
+        }
         if self.floating_panes.panes_are_visible() {
             if let Some(focused_floating_pane_id) = self.floating_panes.active_pane_id(client_id) {
                 if self.tiled_panes.has_room_for_new_pane() {
@@ -943,7 +946,7 @@ impl Tab {
         );
 
         self.hide_cursor_and_clear_display_as_needed(output);
-        self.tiled_panes.render(output);
+        self.tiled_panes.render(output, self.floating_panes.panes_are_visible());
         if self.floating_panes.panes_are_visible() && self.floating_panes.has_active_panes() {
             self.floating_panes.render(output);
         }


### PR DESCRIPTION
This fixes two issues:

1. (regression only in main) when a floating pane is focused the active tiled pane is no-longer colored as active
2. when embedding a floated pane when a tiled pane is in fullscreen, it now behaves properly