### PR TITLE
Fix crash in intermediate no-tabs state

### DIFF
--- a/default-plugins/tab-bar/src/main.rs
+++ b/default-plugins/tab-bar/src/main.rs
@@ -42,9 +42,13 @@ impl ZellijPlugin for State {
         match event {
             Event::ModeUpdate(mode_info) => self.mode_info = mode_info,
             Event::TabUpdate(tabs) => {
-                // tabs are indexed starting from 1 so we need to add 1
-                self.active_tab_idx = tabs.iter().position(|t| t.active).unwrap() + 1;
-                self.tabs = tabs;
+                if let Some(active_tab_index) = tabs.iter().position(|t| t.active) {
+                    // tabs are indexed starting from 1 so we need to add 1
+                    self.active_tab_idx = active_tab_index + 1;
+                    self.tabs = tabs;
+                } else {
+                    eprintln!("Could not find active tab.");
+                }
             }
             Event::Mouse(me) => match me {
                 Mouse::LeftClick(_, col) => {
@@ -59,7 +63,9 @@ impl ZellijPlugin for State {
                 }
                 _ => {}
             },
-            _ => unimplemented!(), // FIXME: This should be unreachable, but this could be cleaner
+            _ => {
+                eprintln!("Got unrecognized event: {:?}", event);
+            }
         }
     }
 

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -256,7 +256,10 @@ impl Screen {
         client_ids_and_mode_infos: Vec<(ClientId, ModeInfo)>,
     ) {
         if self.tabs.is_empty() {
-            log::error!("No tabs left, cannot move clients: {:?} from closed tab", client_ids_and_mode_infos);
+            log::error!(
+                "No tabs left, cannot move clients: {:?} from closed tab",
+                client_ids_and_mode_infos
+            );
             return;
         }
         let first_tab_index = *self.tabs.keys().next().unwrap();

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -255,27 +255,26 @@ impl Screen {
         &mut self,
         client_ids_and_mode_infos: Vec<(ClientId, ModeInfo)>,
     ) {
-        // this will panic if there are no more tabs (ie. if self.tabs.is_empty() == true)
+        if self.tabs.is_empty() {
+            log::error!("No tabs left, cannot move clients: {:?} from closed tab", client_ids_and_mode_infos);
+            return;
+        }
+        let first_tab_index = *self.tabs.keys().next().unwrap();
         for (client_id, client_mode_info) in client_ids_and_mode_infos {
             let client_tab_history = self.tab_history.entry(client_id).or_insert_with(Vec::new);
-            match client_tab_history.pop() {
-                Some(client_previous_tab) => {
+            if let Some(client_previous_tab) = client_tab_history.pop() {
+                if let Some(client_active_tab) = self.tabs.get_mut(&client_previous_tab) {
                     self.active_tab_indices
                         .insert(client_id, client_previous_tab);
-                    self.tabs
-                        .get_mut(&client_previous_tab)
-                        .unwrap()
-                        .add_client(client_id, Some(client_mode_info));
-                }
-                None => {
-                    let next_tab_index = *self.tabs.keys().next().unwrap();
-                    self.active_tab_indices.insert(client_id, next_tab_index);
-                    self.tabs
-                        .get_mut(&next_tab_index)
-                        .unwrap()
-                        .add_client(client_id, Some(client_mode_info));
+                    client_active_tab.add_client(client_id, Some(client_mode_info));
+                    continue;
                 }
             }
+            self.active_tab_indices.insert(client_id, first_tab_index);
+            self.tabs
+                .get_mut(&first_tab_index)
+                .unwrap()
+                .add_client(client_id, Some(client_mode_info));
         }
     }
     fn move_clients_between_tabs(


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/929

There are various cases in which we try to move clients between tabs and there are no tabs to move them to (eg. when closing the last tab under certain race conditions). This makes the move function resilient, recovering when possible (eg. moving clients to another tab) and logging the error when not (no tabs left).

This also adds a fix to the tab bar to handle situations in which there is no focused tab for the client in question (also related to these edge cases). What it does is not update its own state - which while not desirable, doesn't really matter because this is a corrupt state and only happens because an additional render happened before we managed to close everything.