### PR TITLE
fix(compatibility): revert change in csi erase in display handling

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1697,14 +1697,16 @@ impl Perform for Grid {
             };
         } else if c == 'J' {
             // clear all (0 => below, 1 => above, 2 => all, 3 => saved)
+            let mut char_to_replace = EMPTY_TERMINAL_CHARACTER;
+            char_to_replace.styles = self.cursor.pending_styles;
 
             if let Some(clear_type) = params_iter.next().map(|param| param[0]) {
                 if clear_type == 0 {
-                    self.clear_all_after_cursor(EMPTY_TERMINAL_CHARACTER);
+                    self.clear_all_after_cursor(char_to_replace);
                 } else if clear_type == 1 {
-                    self.clear_all_before_cursor(EMPTY_TERMINAL_CHARACTER);
+                    self.clear_all_before_cursor(char_to_replace);
                 } else if clear_type == 2 {
-                    self.fill_viewport(EMPTY_TERMINAL_CHARACTER);
+                    self.fill_viewport(char_to_replace);
                 } else if clear_type == 3 {
                     self.clear_lines_above();
                 }


### PR DESCRIPTION
Revert "fix(compatibilty): do not use current cursor style in csi erase display (#1142)"

This reverts commit efd2fa412f0f4494795d44a10826597b257dd525.

Fixes #1282, while #1097 should be properly handled now by the changes in #1250.