### PR TITLE
fix(compatibility): don't crash on invalid state when padding line

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1066,6 +1066,9 @@ impl Grid {
     }
 
     fn pad_current_line_until(&mut self, position: usize) {
+        if self.viewport.get(self.cursor.y).is_none() {
+            self.pad_lines_until(self.cursor.y, EMPTY_TERMINAL_CHARACTER);
+        }
         let current_row = self.viewport.get_mut(self.cursor.y).unwrap();
         for _ in current_row.width()..position {
             current_row.push(EMPTY_TERMINAL_CHARACTER);


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/1284