### PR TITLE
add: `musl` target to `rust-toolchain`

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -8,4 +8,4 @@
 [toolchain]
 channel = "1.57.0"
 components = ["rustfmt", "clippy", "rust-analysis"]
-targets = ["wasm32-wasi"]
+targets = ["wasm32-wasi", "x86_64-unknown-linux-musl"]


### PR DESCRIPTION
Add `x86_64-unknown-linux-musl` target to `rust-toolchain`,
so that people are able to build the e2e tests.

Fixes #610