### PR TITLE
add: `.git-blame-ignore-revs` file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# This file contains a list of commits that are not likely what you
+# are looking for in a blame, such as mass reformatting or renaming.
+# You can set this file as a default ignore file for blame by running
+# the following command.
+#
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs


### PR DESCRIPTION
Add `.git-blame-ignore-revs` file. That way we can accept `fmt` and
`clippy` PR's, that change quite a bit of our codebase without
negatively impacting the functionality of `git blame`.

Anyone wishing to use this file can set:
```
$ git config blame.ignoreRevsFile .git-blame-ignore-revs
```