### PR TITLE
add: musl package to nix

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -17,6 +17,10 @@ flake-utils.lib.eachSystem [
   overlays = [(import rust-overlay)];
 
   pkgs = import nixpkgs {inherit system overlays;};
+  pkgsMusl = import nixpkgs {
+    inherit system overlays;
+    crossSystem = {config = "x86_64-unknown-linux-musl";};
+  };
 
   crate2nixPkgs = import nixpkgs {
     inherit system;
@@ -142,6 +146,19 @@ in rec {
       meta
       ;
   };
+  # musl cross-compilation - static binary
+  packages.zellij-musl = (pkgsMusl.makeRustPlatform {inherit rustc cargo;}).buildRustPackage {
+    inherit
+      src
+      name
+      cargoLock
+      postInstall
+      buildInputs
+      nativeBuildInputs
+      desktopItems
+      meta
+      ;
+  };
 
   defaultPackage = packages.zellij;
 
@@ -158,10 +175,11 @@ in rec {
       name = "fmt-shell";
       nativeBuildInputs = fmtInputs;
     };
-    e2eShell = pkgs.mkShell {
+    e2eShell = pkgs.pkgsMusl.mkShell {
       name = "e2e-shell";
       nativeBuildInputs = [
         pkgs.cargo-make
+        pkgs.pkgsMusl.cargo
       ];
     };
   };

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -8,4 +8,4 @@
 [toolchain]
 channel = "1.57.0"
 components = ["rustfmt", "clippy", "rust-analysis"]
-targets = ["wasm32-wasi"]
+targets = ["wasm32-wasi", "x86_64-unknown-linux-musl"]


### PR DESCRIPTION
Build a musl package from the repo, by invoking:
```
nix build "github:zellij-org/zellij#zellij-musl"
```
makes it possible to build bundled applications, that don't need patches
to run:
```
nix bundle --bundler github:NixOS/bundlers#toDEB "github:zellij-org/zellij#zellij-musl"
```
This will build a `.deb` file, that can be installed with `apt`.