### PR TITLE
add(nix): `overlays` for `zellij` to flake outputs

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -185,3 +185,13 @@ in rec {
 
   devShell = devShells.zellij;
 })
+// rec {
+  overlays = {
+    default = final: prev: rec {
+      zellij = self.packages.${prev.system}.zellij;
+    };
+    nightly = final: prev: rec {
+      zellij-nightly = self.packages.${prev.system}.zellij;
+    };
+  };
+}


### PR DESCRIPTION
Add `overlays` to the flake outputs.

- the `default` `overlay` supplies the package with the `zellij` name
- the `nightly` `overlay` supplies the package with the `zellij-nightly` name