### PR TITLE
Fix #1286 by sending SIGHUP when closing a pane

### DIFF
--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -300,7 +300,7 @@ impl ServerOsApi for ServerOsInputOutput {
         Box::new((*self).clone())
     }
     fn kill(&self, pid: Pid) -> Result<(), nix::Error> {
-        let _ = kill(pid, Some(Signal::SIGTERM));
+        let _ = kill(pid, Some(Signal::SIGHUP));
         Ok(())
     }
     fn force_kill(&self, pid: Pid) -> Result<(), nix::Error> {


### PR DESCRIPTION
SIGHUP correctly states the intention behind sending a signal when a
pane is closed: The controlling terminal is "hung up".
Also, SIGHUP is better suited than SIGTERM since bash ignores the
latter. This led to the zombie processes observed by some users.
Furthermore, SIGHUP has a special meaning in bash's job control, namely
re-sending the signal to all owned jobs before exiting.