### PR TITLE
fix: minor system improvements

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -25,7 +25,7 @@ pub(crate) use crate::sessions::list_sessions;
 pub(crate) fn kill_all_sessions(yes: bool) {
     match get_sessions() {
         Ok(sessions) if sessions.is_empty() => {
-            println!("No active zellij sessions found.");
+            eprintln!("No active zellij sessions found.");
             process::exit(1);
         }
         Ok(sessions) => {
@@ -119,7 +119,7 @@ fn attach_with_session_index(config_options: Options, index: usize, create: bool
             if create {
                 create_new_client()
             } else {
-                println!("No active zellij sessions found.");
+                eprintln!("No active zellij sessions found.");
                 process::exit(1);
             }
         }
@@ -151,7 +151,7 @@ fn attach_with_session_name(
         None => match get_active_session() {
             ActiveSession::None if create => create_new_client(),
             ActiveSession::None => {
-                println!("No active zellij sessions found.");
+                eprintln!("No active zellij sessions found.");
                 process::exit(1);
             }
             ActiveSession::One(session_name) => ClientInfo::Attach(session_name, config_options),

--- a/src/install.rs
+++ b/src/install.rs
@@ -36,7 +36,7 @@ pub(crate) fn populate_data_dir(data_dir: &Path) {
         // We already have the path and the parent through `data_dir`
         if let Some(parent_path) = path.parent() {
             fs::create_dir_all(parent_path).unwrap_or_else(|e| log::error!("{:?}", e));
-            set_permissions(parent_path).unwrap_or_else(|e| log::error!("{:?}", e));
+            set_permissions(parent_path, 0o700).unwrap_or_else(|e| log::error!("{:?}", e));
             if out_of_date || !path.exists() {
                 fs::write(path, bytes)
                     .unwrap_or_else(|e| log::error!("Failed to install default assets! {:?}", e));

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -230,7 +230,7 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
             move || {
                 drop(std::fs::remove_file(&socket_path));
                 let listener = LocalSocketListener::bind(&*socket_path).unwrap();
-                set_permissions(&socket_path).unwrap();
+                set_permissions(&socket_path, 0o700).unwrap();
                 for stream in listener.incoming() {
                     match stream {
                         Ok(stream) => {

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -46,7 +46,7 @@ lazy_static! {
     pub static ref ZELLIJ_IPC_PIPE: PathBuf = {
         let mut sock_dir = ZELLIJ_SOCK_DIR.clone();
         fs::create_dir_all(&sock_dir).unwrap();
-        set_permissions(&sock_dir).unwrap();
+        set_permissions(&sock_dir, 0o700).unwrap();
         sock_dir.push(envs::get_session_name().unwrap());
         sock_dir
     };

--- a/zellij-utils/src/logging.rs
+++ b/zellij-utils/src/logging.rs
@@ -70,7 +70,7 @@ pub fn atomic_create_file(file_name: &Path) -> io::Result<()> {
         .append(true)
         .create(true)
         .open(file_name)?;
-    set_permissions(file_name)
+    set_permissions(file_name, 0o600)
 }
 
 pub fn atomic_create_dir(dir_name: &Path) -> io::Result<()> {
@@ -84,7 +84,7 @@ pub fn atomic_create_dir(dir_name: &Path) -> io::Result<()> {
         Ok(())
     };
     if result.is_ok() {
-        set_permissions(dir_name)?;
+        set_permissions(dir_name, 0o700)?;
     }
     result
 }
@@ -98,6 +98,6 @@ pub fn debug_to_file(message: &[u8], pid: RawFd) -> io::Result<()> {
         .append(true)
         .create(true)
         .open(&path)?;
-    set_permissions(&path)?;
+    set_permissions(&path, 0o600)?;
     file.write_all(message)
 }

--- a/zellij-utils/src/shared.rs
+++ b/zellij-utils/src/shared.rs
@@ -11,11 +11,9 @@ use strip_ansi_escapes::strip;
 use unicode_width::UnicodeWidthStr;
 use zellij_tile::data::{Palette, PaletteColor, PaletteSource, ThemeHue};
 
-const UNIX_PERMISSIONS: u32 = 0o700;
-
-pub fn set_permissions(path: &Path) -> io::Result<()> {
+pub fn set_permissions(path: &Path, mode: u32) -> io::Result<()> {
     let mut permissions = fs::metadata(path)?.permissions();
-    permissions.set_mode(UNIX_PERMISSIONS);
+    permissions.set_mode(mode);
     fs::set_permissions(path, permissions)
 }
 


### PR DESCRIPTION
This PR is a suggestion from the [discord channel.](https://discord.com/channels/771367133715628073/777801519097184257/964380029297496094)

#### Summary

> - /tmp/zellij-1000/zellij-log/zellij.log this file seems to have 700 permission on linux systems. I don't understand why the executable permission is required here. It can just have 600.
> - I think that the No active zellij sessions found. message on running zellij attach command should go to stderr instead of stdout. Same with the zellij list-sessions command. It makes scripting easier e.g. zellij list-sessions | grep -qF "$session_name" . Ideally, there should be no output to stdout when no session is running.