### PR TITLE
Fix empty ipc msg crash

### DIFF
--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -58,10 +58,13 @@ fn assert_socket(name: &str) -> bool {
         Ok(stream) => {
             let mut sender = IpcSenderWithContext::new(stream);
             sender.send(ClientToServerMsg::ConnStatus);
-
             let mut receiver: IpcReceiverWithContext<ServerToClientMsg> = sender.get_receiver();
-            let (instruction, _) = receiver.recv();
-            matches!(instruction, ServerToClientMsg::Connected)
+            match receiver.recv() {
+                Some((instruction, _)) => {
+                    matches!(instruction, ServerToClientMsg::Connected)
+                },
+                None => false
+            }
         }
         Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => {
             drop(fs::remove_file(path));

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -62,8 +62,8 @@ fn assert_socket(name: &str) -> bool {
             match receiver.recv() {
                 Some((instruction, _)) => {
                     matches!(instruction, ServerToClientMsg::Connected)
-                },
-                None => false
+                }
+                None => false,
             }
         }
         Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => {

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -280,9 +280,11 @@ pub fn start_client(
                         if should_break {
                             break;
                         }
-                    },
+                    }
                     None => {
-                        send_client_instructions.send(ClientInstruction::UnblockInputThread).unwrap();
+                        send_client_instructions
+                            .send(ClientInstruction::UnblockInputThread)
+                            .unwrap();
                         log::error!("Received empty message from server");
                     }
                 }

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -270,14 +270,21 @@ pub fn start_client(
             let os_input = os_input.clone();
             let mut should_break = false;
             move || loop {
-                let (instruction, err_ctx) = os_input.recv_from_server();
-                err_ctx.update_thread_ctx();
-                if let ServerToClientMsg::Exit(_) = instruction {
-                    should_break = true;
-                }
-                send_client_instructions.send(instruction.into()).unwrap();
-                if should_break {
-                    break;
+                match os_input.recv_from_server() {
+                    Some((instruction, err_ctx)) => {
+                        err_ctx.update_thread_ctx();
+                        if let ServerToClientMsg::Exit(_) = instruction {
+                            should_break = true;
+                        }
+                        send_client_instructions.send(instruction.into()).unwrap();
+                        if should_break {
+                            break;
+                        }
+                    },
+                    None => {
+                        send_client_instructions.send(ClientInstruction::UnblockInputThread).unwrap();
+                        log::error!("Received empty message from server");
+                    }
                 }
             }
         })

--- a/zellij-client/src/os_input_output.rs
+++ b/zellij-client/src/os_input_output.rs
@@ -93,7 +93,7 @@ pub trait ClientOsApi: Send + Sync {
     fn send_to_server(&self, msg: ClientToServerMsg);
     /// Receives a message on client-side IPC channel
     // This should be called from the client-side router thread only.
-    fn recv_from_server(&self) -> (ServerToClientMsg, ErrorContext);
+    fn recv_from_server(&self) -> Option<(ServerToClientMsg, ErrorContext)>;
     fn handle_signals(&self, sigwinch_cb: Box<dyn Fn()>, quit_cb: Box<dyn Fn()>);
     /// Establish a connection with the server socket.
     fn connect_to_server(&self, path: &Path);
@@ -144,7 +144,7 @@ impl ClientOsApi for ClientOsInputOutput {
             .unwrap()
             .send(msg);
     }
-    fn recv_from_server(&self) -> (ServerToClientMsg, ErrorContext) {
+    fn recv_from_server(&self) -> Option<(ServerToClientMsg, ErrorContext)> {
         self.receive_instructions_from_server
             .lock()
             .unwrap()

--- a/zellij-client/src/unit/input_handler_tests.rs
+++ b/zellij-client/src/unit/input_handler_tests.rs
@@ -151,7 +151,7 @@ impl ClientOsApi for FakeClientOsApi {
             command_is_executing.unblock_input_thread();
         }
     }
-    fn recv_from_server(&self) -> (ServerToClientMsg, ErrorContext) {
+    fn recv_from_server(&self) -> Option<(ServerToClientMsg, ErrorContext)> {
         unimplemented!()
     }
     fn handle_signals(&self, _sigwinch_cb: Box<dyn Fn()>, _quit_cb: Box<dyn Fn()>) {

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -397,81 +397,87 @@ pub(crate) fn route_thread_main(
     client_id: ClientId,
 ) {
     loop {
-        let (instruction, err_ctx) = receiver.recv();
-        err_ctx.update_thread_ctx();
-        let rlocked_sessions = session_data.read().unwrap();
+        match receiver.recv() {
+            Some((instruction, err_ctx)) => {
+                err_ctx.update_thread_ctx();
+                let rlocked_sessions = session_data.read().unwrap();
 
-        match instruction {
-            ClientToServerMsg::Action(action) => {
-                if let Some(rlocked_sessions) = rlocked_sessions.as_ref() {
-                    if let Action::SwitchToMode(input_mode) = action {
-                        os_input
-                            .send_to_client(client_id, ServerToClientMsg::SwitchToMode(input_mode));
+                match instruction {
+                    ClientToServerMsg::Action(action) => {
+                        if let Some(rlocked_sessions) = rlocked_sessions.as_ref() {
+                            if let Action::SwitchToMode(input_mode) = action {
+                                os_input
+                                    .send_to_client(client_id, ServerToClientMsg::SwitchToMode(input_mode));
+                            }
+                            if route_action(action, rlocked_sessions, &*os_input, &to_server, client_id) {
+                                break;
+                            }
+                        }
                     }
-                    if route_action(action, rlocked_sessions, &*os_input, &to_server, client_id) {
+                    ClientToServerMsg::TerminalResize(new_size) => {
+                        session_state
+                            .write()
+                            .unwrap()
+                            .set_client_size(client_id, new_size);
+                        let min_size = session_state
+                            .read()
+                            .unwrap()
+                            .min_client_terminal_size()
+                            .unwrap();
+                        rlocked_sessions
+                            .as_ref()
+                            .unwrap()
+                            .senders
+                            .send_to_screen(ScreenInstruction::TerminalResize(min_size))
+                            .unwrap();
+                    }
+                    ClientToServerMsg::TerminalPixelDimensions(pixel_dimensions) => {
+                        rlocked_sessions
+                            .as_ref()
+                            .unwrap()
+                            .senders
+                            .send_to_screen(ScreenInstruction::TerminalPixelDimensions(pixel_dimensions))
+                            .unwrap();
+                    }
+                    ClientToServerMsg::NewClient(
+                        client_attributes,
+                        cli_args,
+                        opts,
+                        layout,
+                        plugin_config,
+                    ) => {
+                        let new_client_instruction = ServerInstruction::NewClient(
+                            client_attributes,
+                            cli_args,
+                            opts,
+                            layout,
+                            client_id,
+                            plugin_config,
+                        );
+                        to_server.send(new_client_instruction).unwrap();
+                    }
+                    ClientToServerMsg::AttachClient(client_attributes, opts) => {
+                        let attach_client_instruction =
+                            ServerInstruction::AttachClient(client_attributes, opts, client_id);
+                        to_server.send(attach_client_instruction).unwrap();
+                    }
+                    ClientToServerMsg::ClientExited => {
+                        // we don't unwrap this because we don't really care if there's an error here (eg.
+                        // if the main server thread exited before this router thread did)
+                        let _ = to_server.send(ServerInstruction::RemoveClient(client_id));
+                        break;
+                    }
+                    ClientToServerMsg::KillSession => {
+                        to_server.send(ServerInstruction::KillSession).unwrap();
+                    }
+                    ClientToServerMsg::ConnStatus => {
+                        let _ = to_server.send(ServerInstruction::ConnStatus(client_id));
                         break;
                     }
                 }
-            }
-            ClientToServerMsg::TerminalResize(new_size) => {
-                session_state
-                    .write()
-                    .unwrap()
-                    .set_client_size(client_id, new_size);
-                let min_size = session_state
-                    .read()
-                    .unwrap()
-                    .min_client_terminal_size()
-                    .unwrap();
-                rlocked_sessions
-                    .as_ref()
-                    .unwrap()
-                    .senders
-                    .send_to_screen(ScreenInstruction::TerminalResize(min_size))
-                    .unwrap();
-            }
-            ClientToServerMsg::TerminalPixelDimensions(pixel_dimensions) => {
-                rlocked_sessions
-                    .as_ref()
-                    .unwrap()
-                    .senders
-                    .send_to_screen(ScreenInstruction::TerminalPixelDimensions(pixel_dimensions))
-                    .unwrap();
-            }
-            ClientToServerMsg::NewClient(
-                client_attributes,
-                cli_args,
-                opts,
-                layout,
-                plugin_config,
-            ) => {
-                let new_client_instruction = ServerInstruction::NewClient(
-                    client_attributes,
-                    cli_args,
-                    opts,
-                    layout,
-                    client_id,
-                    plugin_config,
-                );
-                to_server.send(new_client_instruction).unwrap();
-            }
-            ClientToServerMsg::AttachClient(client_attributes, opts) => {
-                let attach_client_instruction =
-                    ServerInstruction::AttachClient(client_attributes, opts, client_id);
-                to_server.send(attach_client_instruction).unwrap();
-            }
-            ClientToServerMsg::ClientExited => {
-                // we don't unwrap this because we don't really care if there's an error here (eg.
-                // if the main server thread exited before this router thread did)
-                let _ = to_server.send(ServerInstruction::RemoveClient(client_id));
-                break;
-            }
-            ClientToServerMsg::KillSession => {
-                to_server.send(ServerInstruction::KillSession).unwrap();
-            }
-            ClientToServerMsg::ConnStatus => {
-                let _ = to_server.send(ServerInstruction::ConnStatus(client_id));
-                break;
+            },
+            None => {
+                log::error!("Received empty message from client");
             }
         }
     }

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -406,10 +406,18 @@ pub(crate) fn route_thread_main(
                     ClientToServerMsg::Action(action) => {
                         if let Some(rlocked_sessions) = rlocked_sessions.as_ref() {
                             if let Action::SwitchToMode(input_mode) = action {
-                                os_input
-                                    .send_to_client(client_id, ServerToClientMsg::SwitchToMode(input_mode));
+                                os_input.send_to_client(
+                                    client_id,
+                                    ServerToClientMsg::SwitchToMode(input_mode),
+                                );
                             }
-                            if route_action(action, rlocked_sessions, &*os_input, &to_server, client_id) {
+                            if route_action(
+                                action,
+                                rlocked_sessions,
+                                &*os_input,
+                                &to_server,
+                                client_id,
+                            ) {
                                 break;
                             }
                         }
@@ -436,7 +444,9 @@ pub(crate) fn route_thread_main(
                             .as_ref()
                             .unwrap()
                             .senders
-                            .send_to_screen(ScreenInstruction::TerminalPixelDimensions(pixel_dimensions))
+                            .send_to_screen(ScreenInstruction::TerminalPixelDimensions(
+                                pixel_dimensions,
+                            ))
                             .unwrap();
                     }
                     ClientToServerMsg::NewClient(
@@ -475,7 +485,7 @@ pub(crate) fn route_thread_main(
                         break;
                     }
                 }
-            },
+            }
             None => {
                 log::error!("Received empty message from client");
             }

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -184,8 +184,11 @@ where
     }
 
     /// Receives an event, along with the current [`ErrorContext`], on this [`IpcReceiverWithContext`]'s socket.
-    pub fn recv(&mut self) -> (T, ErrorContext) {
-        bincode::deserialize_from(&mut self.receiver).unwrap()
+    pub fn recv(&mut self) -> Option<(T, ErrorContext)> {
+        match bincode::deserialize_from(&mut self.receiver) {
+            Ok(msg) => Some(msg),
+            Err(_) => None,
+        }
     }
 
     /// Returns an [`IpcSenderWithContext`] with the same socket as this receiver.


### PR DESCRIPTION
This fixes some edge cases in which the ipc message buffer (between client and server) was corrupted and Zellij would crash as a result. Now, instead of crashing we will log the error and attempt to re-read the channel.

This might be masking other problems (maybe the channel buffer is too small? and there are times when it is filled up?) but in any case these errors should be almost invisible to the user (one render missed or one keypress missed when the load is heavy, etc.)

If this is indeed masking other problems, it'll be much easier to find them and fix them individually now that we log these.