### PR TITLE
fix(deps): Rename `suggestion` crate to `suggest`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2359,10 +2359,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "suggestion"
-version = "0.3.3"
+name = "suggest"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de6a8caa0781c40b2dfaafd9a5f39e7688d1c7b72173346469dc68e7ff04e927"
+checksum = "2558d0d6327d908558f161bc862d365c0d33aa796bdc81c13c0f954868576659"
 dependencies = [
  "clap",
  "lev_distance",
@@ -3215,7 +3215,7 @@ dependencies = [
  "names",
  "rand 0.8.5",
  "ssh2",
- "suggestion",
+ "suggest",
  "zellij-client",
  "zellij-server",
  "zellij-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ zellij-server = { path = "zellij-server/", version = "0.30.0" }
 zellij-utils = { path = "zellij-utils/", version = "0.30.0" }
 log = "0.4.16"
 dialoguer = "0.9.0"
-suggestion = "0.3"
+suggest = "0.4"
 
 [dev-dependencies]
 insta = { version = "1.6.0", features = ["backtrace"] }

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -1,7 +1,7 @@
 use std::os::unix::fs::FileTypeExt;
 use std::time::SystemTime;
 use std::{fs, io, process};
-use suggestion::Suggest;
+use suggest::Suggest;
 use zellij_utils::{
     consts::ZELLIJ_SOCK_DIR,
     envs,


### PR DESCRIPTION
I changed the name of the `suggestion` crate to `suggest` to be shortened.