### PR TITLE
feat: Shows subcommand aliases in help text

### DIFF
--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -74,11 +74,11 @@ pub enum SessionCommand {
 #[derive(Debug, Subcommand, Clone, Serialize, Deserialize)]
 pub enum Sessions {
     /// List active sessions
-    #[clap(alias = "ls")]
+    #[clap(visible_alias = "ls")]
     ListSessions,
 
     /// Attach to a session
-    #[clap(alias = "a")]
+    #[clap(visible_alias = "a")]
     Attach {
         /// Name of the session to attach to.
         session_name: Option<String>,
@@ -97,14 +97,14 @@ pub enum Sessions {
     },
 
     /// Kill the specific session
-    #[clap(alias = "k")]
+    #[clap(visible_alias = "k")]
     KillSession {
         /// Name of target session
         target_session: Option<String>,
     },
 
     /// Kill all sessions
-    #[clap(alias = "ka")]
+    #[clap(visible_alias = "ka")]
     KillAllSessions {
         /// Automatic yes to prompts
         #[clap(short, long)]


### PR DESCRIPTION
Resolves #918 by utilizing clap's built-in ["visible alias" feature](https://docs.rs/clap/3.0.14/clap/struct.App.html#method.visible_alias). It won't display the aliases exactly as requested in the issue, but I don't believe there's any easy method to format it that way.

Before:
```
SUBCOMMANDS:
    attach               Attach to a session
    help                 Print this message or the help of the given subcommand(s)
    kill-all-sessions    Kill all sessions
    kill-session         Kill the specific session
    list-sessions        List active sessions
    options              Change the behaviour of zellij
    setup                Setup zellij and check its configuration
```
After:
```
SUBCOMMANDS:
    attach               Attach to a session [aliases: a]
    help                 Print this message or the help of the given subcommand(s)
    kill-all-sessions    Kill all sessions [aliases: ka]
    kill-session         Kill the specific session [aliases: k]
    list-sessions        List active sessions [aliases: ls]
    options              Change the behaviour of zellij
    setup                Setup zellij and check its configuration
```