### PR TITLE
Merge --layout and --layout-path

### DIFF
--- a/src/tests/e2e/remote_runner.rs
+++ b/src/tests/e2e/remote_runner.rs
@@ -127,7 +127,7 @@ fn start_zellij_with_layout(channel: &mut ssh2::Channel, layout_path: &str) {
     channel
         .write_all(
             format!(
-                "{} --layout-path {} --session {} --data-dir {}\n",
+                "{} --layout {} --session {} --data-dir {}\n",
                 ZELLIJ_EXECUTABLE_LOCATION, layout_path, SESSION_NAME, ZELLIJ_DATA_DIR
             )
             .as_bytes(),

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -26,13 +26,10 @@ pub struct CliArgs {
     #[clap(long, short, overrides_with = "session")]
     pub session: Option<String>,
 
-    /// Name of a layout file in the layout directory
+    /// If it's a bare name it's interpreted as the name of a layout file in the layout dir,
+    /// Otherwise it's interpreted as a path to a layout yaml file
     #[clap(short, long, parse(from_os_str), overrides_with = "layout")]
     pub layout: Option<PathBuf>,
-
-    /// Path to a layout yaml file
-    #[clap(long, parse(from_os_str), overrides_with = "layout_path")]
-    pub layout_path: Option<PathBuf>,
 
     /// Change where zellij looks for the configuration file
     #[clap(short, long, overrides_with = "config", env = ZELLIJ_CONFIG_FILE_ENV, parse(from_os_str))]

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -26,8 +26,7 @@ pub struct CliArgs {
     #[clap(long, short, overrides_with = "session")]
     pub session: Option<String>,
 
-    /// If it's a bare name it's interpreted as the name of a layout file in the layout dir,
-    /// Otherwise it's interpreted as a path to a layout yaml file
+    /// Name of a predefined layout or path to a layout file
     #[clap(short, long, parse(from_os_str), overrides_with = "layout")]
     pub layout: Option<PathBuf>,
 

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -239,12 +239,21 @@ impl LayoutFromYamlIntermediate {
 
     pub fn from_path_or_default(
         layout: Option<&PathBuf>,
-        layout_path: Option<&PathBuf>,
         layout_dir: Option<PathBuf>,
     ) -> Option<LayoutFromYamlIntermediateResult> {
         layout
-            .map(|p| LayoutFromYamlIntermediate::from_dir(p, layout_dir.as_ref()))
-            .or_else(|| layout_path.map(|p| LayoutFromYamlIntermediate::from_path(p)))
+            .map(|layout| {
+                // The way we determine where to look for the layout is similar to
+                // how a path would look for an executable.
+                // See the gh issue for more: https://github.com/zellij-org/zellij/issues/1412#issuecomment-1131559720
+                if layout.extension().is_some() || layout.components().count() > 1 {
+                    // We look localy!
+                    LayoutFromYamlIntermediate::from_path(layout)
+                } else {
+                    // We look in the default dir
+                    LayoutFromYamlIntermediate::from_dir(layout, layout_dir.as_ref())
+                }
+            })
             .or_else(|| {
                 Some(LayoutFromYamlIntermediate::from_dir(
                     &std::path::PathBuf::from("default"),

--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -223,11 +223,8 @@ impl Setup {
             .layout_dir
             .clone()
             .or_else(|| get_layout_dir(opts.config_dir.clone().or_else(find_default_config_dir)));
-        let layout_result = LayoutFromYamlIntermediate::from_path_or_default(
-            opts.layout.as_ref(),
-            opts.layout_path.as_ref(),
-            layout_dir,
-        );
+        let layout_result =
+            LayoutFromYamlIntermediate::from_path_or_default(opts.layout.as_ref(), layout_dir);
         let layout = match layout_result {
             None => None,
             Some(Ok(layout)) => Some(layout),


### PR DESCRIPTION
closes #1412 

A layout is considered local if:
`layout.extension().is_some() || layout.components().count() > 1`

This check produces the following results:
"foo": Abs
"foo.yml": Local
"./foo": Local
"foo/bar": Local
"foo/bar.yml": Local
 
TODO:
- [x] Fix tests