### PR TITLE
fix: add checking for missing extensions

### DIFF
--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -262,7 +262,7 @@ impl LayoutFromYamlIntermediate {
         match layout_dir {
             Some(dir) => {
                 let layout_path = &dir.join(layout);
-                if layout_path.exists() {
+                if layout_path.with_extension("yaml").exists() {
                     Self::from_path(layout_path)
                 } else {
                     LayoutFromYamlIntermediate::from_default_assets(layout)


### PR DESCRIPTION
Fixes #1431 

Under the circumstance of checking the existence of a `layout` file, the default assets are always loaded due to missing extensions.