### PR TITLE
add(assets): `bottom-tab-bar` layout

### DIFF
--- a/zellij-utils/assets/layouts/bottom-tab-bar.yaml
+++ b/zellij-utils/assets/layouts/bottom-tab-bar.yaml
@@ -1,0 +1,13 @@
+---
+template:
+  direction: Horizontal
+  parts:
+    - direction: Vertical
+      body: true
+    - direction: Vertical
+      borderless: true
+      split_size:
+        Fixed: 1
+      run:
+        plugin:
+          location: "zellij:tab-bar"


### PR DESCRIPTION
Add layout, that loads the `tab-bar` plugin as the bottom pane,
by default.

It can be run by specifying:
```
zellij -l bottom-tab-bar
```