### PR TITLE
Exit client-loop on empty message receive

### DIFF
--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -16,7 +16,7 @@ use zellij_utils::{
         command::TerminalAction,
         get_mode_info,
     },
-    ipc::{ClientToServerMsg, IpcReceiverWithContext, ServerToClientMsg},
+    ipc::{ClientToServerMsg, ExitReason, IpcReceiverWithContext, ServerToClientMsg},
 };
 
 use crate::ClientId;
@@ -514,6 +514,13 @@ pub(crate) fn route_thread_main(
             }
             None => {
                 log::error!("Received empty message from client");
+                os_input.send_to_client(
+                    client_id,
+                    ServerToClientMsg::Exit(ExitReason::Error(
+                        "Received empty message".to_string(),
+                    )),
+                );
+                break;
             }
         }
     }


### PR DESCRIPTION
This closes #1419.

By extension it should fix #1410 as well bu I think it would be a good idea to implement a limit for the log file so this doesn't happen again 