### PR TITLE
Add status bar tips

### DIFF
--- a/default-plugins/status-bar/src/main.rs
+++ b/default-plugins/status-bar/src/main.rs
@@ -125,9 +125,18 @@ fn color_elements(palette: Palette, different_color_alternates: bool) -> Colored
             unselected_suffix_separator: style!(palette.fg, background),
 
             unselected_alternate_prefix_separator: style!(background, alternate_background_color),
-            unselected_alternate_char_left_separator: style!(background, alternate_background_color).bold(),
-            unselected_alternate_char_shortcut: style!(palette.red, alternate_background_color).bold(),
-            unselected_alternate_char_right_separator: style!(background, alternate_background_color).bold(),
+            unselected_alternate_char_left_separator: style!(
+                background,
+                alternate_background_color
+            )
+            .bold(),
+            unselected_alternate_char_shortcut: style!(palette.red, alternate_background_color)
+                .bold(),
+            unselected_alternate_char_right_separator: style!(
+                background,
+                alternate_background_color
+            )
+            .bold(),
             unselected_alternate_styled_text: style!(background, alternate_background_color).bold(),
             unselected_alternate_suffix_separator: style!(alternate_background_color, background),
 
@@ -143,7 +152,12 @@ fn color_elements(palette: Palette, different_color_alternates: bool) -> Colored
             unselected_single_letter_suffix_separator: style!(palette.fg, background),
 
             unselected_alternate_single_letter_prefix_separator: style!(background, palette.fg),
-            unselected_alternate_single_letter_char_shortcut: style!(palette.red, alternate_background_color).bold().dimmed(),
+            unselected_alternate_single_letter_char_shortcut: style!(
+                palette.red,
+                alternate_background_color
+            )
+            .bold()
+            .dimmed(),
             unselected_alternate_single_letter_suffix_separator: style!(palette.fg, background),
 
             superkey_prefix: style!(foreground, background).bold(),
@@ -164,9 +178,18 @@ fn color_elements(palette: Palette, different_color_alternates: bool) -> Colored
             unselected_suffix_separator: style!(palette.fg, background),
 
             unselected_alternate_prefix_separator: style!(background, alternate_background_color),
-            unselected_alternate_char_left_separator: style!(background, alternate_background_color).bold(),
-            unselected_alternate_char_shortcut: style!(palette.red, alternate_background_color).bold(),
-            unselected_alternate_char_right_separator: style!(background, alternate_background_color).bold(),
+            unselected_alternate_char_left_separator: style!(
+                background,
+                alternate_background_color
+            )
+            .bold(),
+            unselected_alternate_char_shortcut: style!(palette.red, alternate_background_color)
+                .bold(),
+            unselected_alternate_char_right_separator: style!(
+                background,
+                alternate_background_color
+            )
+            .bold(),
             unselected_alternate_styled_text: style!(background, alternate_background_color).bold(),
             unselected_alternate_suffix_separator: style!(alternate_background_color, background),
 
@@ -182,7 +205,12 @@ fn color_elements(palette: Palette, different_color_alternates: bool) -> Colored
             unselected_single_letter_suffix_separator: style!(palette.fg, background),
 
             unselected_alternate_single_letter_prefix_separator: style!(background, palette.fg),
-            unselected_alternate_single_letter_char_shortcut: style!(palette.red, alternate_background_color).bold().dimmed(),
+            unselected_alternate_single_letter_char_shortcut: style!(
+                palette.red,
+                alternate_background_color
+            )
+            .bold()
+            .dimmed(),
             unselected_alternate_single_letter_suffix_separator: style!(palette.fg, background),
 
             superkey_prefix: style!(background, palette.fg).bold(),

--- a/default-plugins/status-bar/src/main.rs
+++ b/default-plugins/status-bar/src/main.rs
@@ -125,18 +125,9 @@ fn color_elements(palette: Palette, different_color_alternates: bool) -> Colored
             unselected_suffix_separator: style!(palette.fg, background),
 
             unselected_alternate_prefix_separator: style!(background, alternate_background_color),
-            unselected_alternate_char_left_separator: style!(
-                background,
-                alternate_background_color
-            )
-            .bold(),
-            unselected_alternate_char_shortcut: style!(palette.red, alternate_background_color)
-                .bold(),
-            unselected_alternate_char_right_separator: style!(
-                background,
-                alternate_background_color
-            )
-            .bold(),
+            unselected_alternate_char_left_separator: style!(background, alternate_background_color).bold(),
+            unselected_alternate_char_shortcut: style!(palette.red, alternate_background_color).bold(),
+            unselected_alternate_char_right_separator: style!(background, alternate_background_color).bold(),
             unselected_alternate_styled_text: style!(background, alternate_background_color).bold(),
             unselected_alternate_suffix_separator: style!(alternate_background_color, background),
 
@@ -151,19 +142,9 @@ fn color_elements(palette: Palette, different_color_alternates: bool) -> Colored
             unselected_single_letter_char_shortcut: style!(palette.red, palette.fg).bold().dimmed(),
             unselected_single_letter_suffix_separator: style!(palette.fg, background),
 
-            unselected_alternate_single_letter_prefix_separator: style!(
-                palette.fg,
-                alternate_background_color
-            ),
-            unselected_alternate_single_letter_char_shortcut: style!(
-                palette.red,
-                alternate_background_color
-            )
-            .bold(),
-            unselected_alternate_single_letter_suffix_separator: style!(
-                palette.fg,
-                alternate_background_color
-            ),
+            unselected_alternate_single_letter_prefix_separator: style!(background, palette.fg),
+            unselected_alternate_single_letter_char_shortcut: style!(palette.red, alternate_background_color).bold().dimmed(),
+            unselected_alternate_single_letter_suffix_separator: style!(palette.fg, background),
 
             superkey_prefix: style!(foreground, background).bold(),
             superkey_suffix_separator: style!(background, background),
@@ -183,18 +164,9 @@ fn color_elements(palette: Palette, different_color_alternates: bool) -> Colored
             unselected_suffix_separator: style!(palette.fg, background),
 
             unselected_alternate_prefix_separator: style!(background, alternate_background_color),
-            unselected_alternate_char_left_separator: style!(
-                background,
-                alternate_background_color
-            )
-            .bold(),
-            unselected_alternate_char_shortcut: style!(palette.red, alternate_background_color)
-                .bold(),
-            unselected_alternate_char_right_separator: style!(
-                background,
-                alternate_background_color
-            )
-            .bold(),
+            unselected_alternate_char_left_separator: style!(background, alternate_background_color).bold(),
+            unselected_alternate_char_shortcut: style!(palette.red, alternate_background_color).bold(),
+            unselected_alternate_char_right_separator: style!(background, alternate_background_color).bold(),
             unselected_alternate_styled_text: style!(background, alternate_background_color).bold(),
             unselected_alternate_suffix_separator: style!(alternate_background_color, background),
 
@@ -209,19 +181,9 @@ fn color_elements(palette: Palette, different_color_alternates: bool) -> Colored
             unselected_single_letter_char_shortcut: style!(palette.red, palette.fg).bold(),
             unselected_single_letter_suffix_separator: style!(palette.fg, background),
 
-            unselected_alternate_single_letter_prefix_separator: style!(
-                palette.fg,
-                alternate_background_color
-            ),
-            unselected_alternate_single_letter_char_shortcut: style!(
-                palette.red,
-                alternate_background_color
-            )
-            .bold(),
-            unselected_alternate_single_letter_suffix_separator: style!(
-                palette.fg,
-                alternate_background_color
-            ),
+            unselected_alternate_single_letter_prefix_separator: style!(background, palette.fg),
+            unselected_alternate_single_letter_char_shortcut: style!(palette.red, alternate_background_color).bold().dimmed(),
+            unselected_alternate_single_letter_suffix_separator: style!(palette.fg, background),
 
             superkey_prefix: style!(background, palette.fg).bold(),
             superkey_suffix_separator: style!(palette.fg, background),

--- a/default-plugins/status-bar/src/tip/consts.rs
+++ b/default-plugins/status-bar/src/tip/consts.rs
@@ -1,2 +1,2 @@
 pub const DEFAULT_CACHE_FILE_PATH: &str = "/tmp/status-bar-tips.cache";
-pub const MAX_CACHE_HITS: usize = 10;
+pub const MAX_CACHE_HITS: usize = 20; // this should be 10, but right now there's a bug where the plugin load function is called twice, and sot he cache is hit twice

--- a/default-plugins/status-bar/src/tip/data/compact_layout.rs
+++ b/default-plugins/status-bar/src/tip/data/compact_layout.rs
@@ -1,0 +1,78 @@
+use ansi_term::{
+    unstyled_len, ANSIString, ANSIStrings,
+    Color::{Fixed, RGB},
+    Style,
+};
+
+use crate::LinePart;
+use zellij_tile::prelude::*;
+use zellij_tile_utils::palette_match;
+
+macro_rules! strings {
+    ($ANSIStrings:expr) => {{
+        let strings: &[ANSIString<'static>] = $ANSIStrings;
+
+        let ansi_strings = ANSIStrings(strings);
+
+        LinePart {
+            part: format!("{}", ansi_strings),
+            len: unstyled_len(&ansi_strings),
+        }
+    }};
+}
+
+pub fn compact_layout_full(palette: Palette) -> LinePart {
+    // Tip: UI taking up too much space? Start Zellij with
+    // zellij -l compact or remove pane frames with Ctrl + <p> + <z>
+    let green_color = palette_match!(palette.green);
+    let orange_color = palette_match!(palette.orange);
+
+    strings!(&[
+        Style::new().paint(" Tip: "),
+        Style::new().paint("UI taking up too much space? Start Zellij with "),
+        Style::new().fg(green_color).bold().paint("zellij -l compact"),
+        Style::new().paint(" or remove pane frames with "),
+        Style::new().fg(orange_color).bold().paint("Ctrl"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<p>"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<z>"),
+    ])
+}
+
+pub fn compact_layout_medium(palette: Palette) -> LinePart {
+    // Tip: To save screen space, start Zellij with
+    // zellij -l compact or remove pane frames with Ctrl + <p> + <z>
+    let green_color = palette_match!(palette.green);
+    let orange_color = palette_match!(palette.orange);
+
+    strings!(&[
+        Style::new().paint(" Tip: "),
+        Style::new().paint("To save screen space, start Zellij with "),
+        Style::new().fg(green_color).bold().paint("zellij -l compact"),
+        Style::new().paint(" or remove frames with "),
+        Style::new().fg(orange_color).bold().paint("Ctrl"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<p>"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<z>"),
+    ])
+}
+
+pub fn compact_layout_short(palette: Palette) -> LinePart {
+    // Save screen space, start Zellij with
+    // zellij -l compact or remove pane frames with Ctrl + <p> + <z>
+    let green_color = palette_match!(palette.green);
+    let orange_color = palette_match!(palette.orange);
+
+    strings!(&[
+        Style::new().paint(" Save screen space, start with: "),
+        Style::new().fg(green_color).bold().paint("zellij -l compact"),
+        Style::new().paint(" or remove frames with "),
+        Style::new().fg(orange_color).bold().paint("Ctrl"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<p>"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<z>"),
+    ])
+}

--- a/default-plugins/status-bar/src/tip/data/compact_layout.rs
+++ b/default-plugins/status-bar/src/tip/data/compact_layout.rs
@@ -30,7 +30,10 @@ pub fn compact_layout_full(palette: Palette) -> LinePart {
     strings!(&[
         Style::new().paint(" Tip: "),
         Style::new().paint("UI taking up too much space? Start Zellij with "),
-        Style::new().fg(green_color).bold().paint("zellij -l compact"),
+        Style::new()
+            .fg(green_color)
+            .bold()
+            .paint("zellij -l compact"),
         Style::new().paint(" or remove pane frames with "),
         Style::new().fg(orange_color).bold().paint("Ctrl"),
         Style::new().paint(" + "),
@@ -49,7 +52,10 @@ pub fn compact_layout_medium(palette: Palette) -> LinePart {
     strings!(&[
         Style::new().paint(" Tip: "),
         Style::new().paint("To save screen space, start Zellij with "),
-        Style::new().fg(green_color).bold().paint("zellij -l compact"),
+        Style::new()
+            .fg(green_color)
+            .bold()
+            .paint("zellij -l compact"),
         Style::new().paint(" or remove frames with "),
         Style::new().fg(orange_color).bold().paint("Ctrl"),
         Style::new().paint(" + "),
@@ -67,7 +73,10 @@ pub fn compact_layout_short(palette: Palette) -> LinePart {
 
     strings!(&[
         Style::new().paint(" Save screen space, start with: "),
-        Style::new().fg(green_color).bold().paint("zellij -l compact"),
+        Style::new()
+            .fg(green_color)
+            .bold()
+            .paint("zellij -l compact"),
         Style::new().paint(" or remove frames with "),
         Style::new().fg(orange_color).bold().paint("Ctrl"),
         Style::new().paint(" + "),

--- a/default-plugins/status-bar/src/tip/data/edit_scrollbuffer.rs
+++ b/default-plugins/status-bar/src/tip/data/edit_scrollbuffer.rs
@@ -1,0 +1,78 @@
+use ansi_term::{
+    unstyled_len, ANSIString, ANSIStrings,
+    Color::{Fixed, RGB},
+    Style,
+};
+
+use crate::LinePart;
+use zellij_tile::prelude::*;
+use zellij_tile_utils::palette_match;
+
+macro_rules! strings {
+    ($ANSIStrings:expr) => {{
+        let strings: &[ANSIString<'static>] = $ANSIStrings;
+
+        let ansi_strings = ANSIStrings(strings);
+
+        LinePart {
+            part: format!("{}", ansi_strings),
+            len: unstyled_len(&ansi_strings),
+        }
+    }};
+}
+
+pub fn edit_scrollbuffer_full(palette: Palette) -> LinePart {
+    // Tip: Search through the scrollbuffer using your default $EDITOR with
+    // Ctrl + <s> + <e>
+    let green_color = palette_match!(palette.green);
+    let orange_color = palette_match!(palette.orange);
+
+    strings!(&[
+        Style::new().paint(" Tip: "),
+        Style::new().paint("Search through the scrollbuffer using your default "),
+        Style::new().fg(green_color).bold().paint("$EDITOR"),
+        Style::new().paint(" with "),
+        Style::new().fg(orange_color).bold().paint("Ctrl"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<s>"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<e>"),
+    ])
+}
+
+pub fn edit_scrollbuffer_medium(palette: Palette) -> LinePart {
+    // Tip: Search the scrollbuffer using your $EDITOR with
+    // Ctrl + <s> + <e>
+    let green_color = palette_match!(palette.green);
+    let orange_color = palette_match!(palette.orange);
+
+    strings!(&[
+        Style::new().paint(" Tip: "),
+        Style::new().paint("Search the scrollbuffer using your "),
+        Style::new().fg(green_color).bold().paint("$EDITOR"),
+        Style::new().paint(" with "),
+        Style::new().fg(orange_color).bold().paint("Ctrl"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<s>"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<e>"),
+    ])
+}
+
+pub fn edit_scrollbuffer_short(palette: Palette) -> LinePart {
+    // Search using $EDITOR with
+    // Ctrl + <s> + <e>
+    let green_color = palette_match!(palette.green);
+    let orange_color = palette_match!(palette.orange);
+
+    strings!(&[
+        Style::new().paint(" Search using "),
+        Style::new().fg(green_color).bold().paint("$EDITOR"),
+        Style::new().paint(" with "),
+        Style::new().fg(orange_color).bold().paint("Ctrl"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<s>"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<e>"),
+    ])
+}

--- a/default-plugins/status-bar/src/tip/data/floating_panes_mouse.rs
+++ b/default-plugins/status-bar/src/tip/data/floating_panes_mouse.rs
@@ -1,0 +1,69 @@
+use ansi_term::{
+    unstyled_len, ANSIString, ANSIStrings,
+    Color::{Fixed, RGB},
+    Style,
+};
+
+use crate::LinePart;
+use zellij_tile::prelude::*;
+use zellij_tile_utils::palette_match;
+
+macro_rules! strings {
+    ($ANSIStrings:expr) => {{
+        let strings: &[ANSIString<'static>] = $ANSIStrings;
+
+        let ansi_strings = ANSIStrings(strings);
+
+        LinePart {
+            part: format!("{}", ansi_strings),
+            len: unstyled_len(&ansi_strings),
+        }
+    }};
+}
+
+pub fn floating_panes_mouse_full(palette: Palette) -> LinePart {
+    // Tip: Toggle floating panes with Ctrl + <p> + <w> and move them with keyboard or mouse
+    let green_color = palette_match!(palette.green);
+    let orange_color = palette_match!(palette.orange);
+
+    strings!(&[
+        Style::new().paint(" Tip: "),
+        Style::new().paint("Toggle floating panes with "),
+        Style::new().fg(orange_color).bold().paint("Ctrl"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<p>"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<w>"),
+        Style::new().paint(" and move them with keyboard or mouse"),
+    ])
+}
+
+pub fn floating_panes_mouse_medium(palette: Palette) -> LinePart {
+    // Tip: Toggle floating panes with Ctrl + <p> + <w>
+    let green_color = palette_match!(palette.green);
+    let orange_color = palette_match!(palette.orange);
+    strings!(&[
+        Style::new().paint(" Tip: "),
+        Style::new().paint("Toggle floating panes with "),
+        Style::new().fg(orange_color).bold().paint("Ctrl"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<p>"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<w>"),
+    ])
+}
+
+pub fn floating_panes_mouse_short(palette: Palette) -> LinePart {
+    // Ctrl + <p> + <w> => floating panes
+    let green_color = palette_match!(palette.green);
+    let orange_color = palette_match!(palette.orange);
+
+    strings!(&[
+        Style::new().fg(orange_color).bold().paint(" Ctrl"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<p>"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<w>"),
+        Style::new().paint(" => floating panes"),
+    ])
+}

--- a/default-plugins/status-bar/src/tip/data/mod.rs
+++ b/default-plugins/status-bar/src/tip/data/mod.rs
@@ -2,17 +2,17 @@ use std::collections::HashMap;
 
 use lazy_static::lazy_static;
 
-use crate::{tip::TipBody};
+use crate::tip::TipBody;
 
-mod quicknav;
-mod floating_panes_mouse;
-mod send_mouse_click_to_terminal;
-mod move_focus_hjkl_tab_switch;
-mod zellij_setup_check;
-mod use_mouse;
-mod sync_tab;
-mod edit_scrollbuffer;
 mod compact_layout;
+mod edit_scrollbuffer;
+mod floating_panes_mouse;
+mod move_focus_hjkl_tab_switch;
+mod quicknav;
+mod send_mouse_click_to_terminal;
+mod sync_tab;
+mod use_mouse;
+mod zellij_setup_check;
 
 lazy_static! {
     pub static ref TIPS: HashMap<&'static str, TipBody> = HashMap::from([
@@ -90,4 +90,3 @@ lazy_static! {
         ),
     ]);
 }
-

--- a/default-plugins/status-bar/src/tip/data/mod.rs
+++ b/default-plugins/status-bar/src/tip/data/mod.rs
@@ -1,0 +1,93 @@
+use std::collections::HashMap;
+
+use lazy_static::lazy_static;
+
+use crate::{tip::TipBody};
+
+mod quicknav;
+mod floating_panes_mouse;
+mod send_mouse_click_to_terminal;
+mod move_focus_hjkl_tab_switch;
+mod zellij_setup_check;
+mod use_mouse;
+mod sync_tab;
+mod edit_scrollbuffer;
+mod compact_layout;
+
+lazy_static! {
+    pub static ref TIPS: HashMap<&'static str, TipBody> = HashMap::from([
+        (
+            "quicknav",
+            TipBody {
+                short: quicknav::quicknav_short,
+                medium: quicknav::quicknav_medium,
+                full: quicknav::quicknav_full,
+            }
+        ),
+        (
+            "floating_panes_mouse",
+            TipBody {
+                short: floating_panes_mouse::floating_panes_mouse_short,
+                medium: floating_panes_mouse::floating_panes_mouse_medium,
+                full: floating_panes_mouse::floating_panes_mouse_full,
+            }
+        ),
+        (
+            "send_mouse_clicks_to_terminal",
+            TipBody {
+                short: send_mouse_click_to_terminal::mouse_click_to_terminal_short,
+                medium: send_mouse_click_to_terminal::mouse_click_to_terminal_medium,
+                full: send_mouse_click_to_terminal::mouse_click_to_terminal_full,
+            }
+        ),
+        (
+            "move_focus_hjkl_tab_switch",
+            TipBody {
+                short: move_focus_hjkl_tab_switch::move_focus_hjkl_tab_switch_short,
+                medium: move_focus_hjkl_tab_switch::move_focus_hjkl_tab_switch_medium,
+                full: move_focus_hjkl_tab_switch::move_focus_hjkl_tab_switch_full,
+            }
+        ),
+        (
+            "zellij_setup_check",
+            TipBody {
+                short: zellij_setup_check::zellij_setup_check_short,
+                medium: zellij_setup_check::zellij_setup_check_medium,
+                full: zellij_setup_check::zellij_setup_check_full,
+            }
+        ),
+        (
+            "use_mouse",
+            TipBody {
+                short: use_mouse::use_mouse_short,
+                medium: use_mouse::use_mouse_medium,
+                full: use_mouse::use_mouse_full,
+            }
+        ),
+        (
+            "sync_tab",
+            TipBody {
+                short: sync_tab::sync_tab_short,
+                medium: sync_tab::sync_tab_medium,
+                full: sync_tab::sync_tab_full,
+            }
+        ),
+        (
+            "edit_scrollbuffer",
+            TipBody {
+                short: edit_scrollbuffer::edit_scrollbuffer_short,
+                medium: edit_scrollbuffer::edit_scrollbuffer_medium,
+                full: edit_scrollbuffer::edit_scrollbuffer_full,
+            }
+        ),
+        (
+            "compact_layout",
+            TipBody {
+                short: compact_layout::compact_layout_short,
+                medium: compact_layout::compact_layout_medium,
+                full: compact_layout::compact_layout_full,
+            }
+        ),
+    ]);
+}
+

--- a/default-plugins/status-bar/src/tip/data/move_focus_hjkl_tab_switch.rs
+++ b/default-plugins/status-bar/src/tip/data/move_focus_hjkl_tab_switch.rs
@@ -1,0 +1,64 @@
+use ansi_term::{
+    unstyled_len, ANSIString, ANSIStrings,
+    Color::{Fixed, RGB},
+    Style,
+};
+
+use crate::LinePart;
+use zellij_tile::prelude::*;
+use zellij_tile_utils::palette_match;
+
+macro_rules! strings {
+    ($ANSIStrings:expr) => {{
+        let strings: &[ANSIString<'static>] = $ANSIStrings;
+
+        let ansi_strings = ANSIStrings(strings);
+
+        LinePart {
+            part: format!("{}", ansi_strings),
+            len: unstyled_len(&ansi_strings),
+        }
+    }};
+}
+
+pub fn move_focus_hjkl_tab_switch_full(palette: Palette) -> LinePart {
+    // Tip: When changing focus with Alt + <←↓↑→> moving off screen left/right focuses the next tab.
+    let green_color = palette_match!(palette.green);
+    let orange_color = palette_match!(palette.orange);
+
+    strings!(&[
+        Style::new().paint(" Tip: "),
+        Style::new().paint("When changing focus with "),
+        Style::new().fg(orange_color).bold().paint("Alt"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<←↓↑→>"),
+        Style::new().paint(" moving off screen left/right focuses the next tab."),
+    ])
+}
+
+pub fn move_focus_hjkl_tab_switch_medium(palette: Palette) -> LinePart {
+    // Tip: Changing focus with Alt + <←↓↑→> off screen focuses the next tab.
+    let green_color = palette_match!(palette.green);
+    let orange_color = palette_match!(palette.orange);
+    strings!(&[
+        Style::new().paint(" Tip: "),
+        Style::new().paint("Changing focus with "),
+        Style::new().fg(orange_color).bold().paint("Alt"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<←↓↑→>"),
+        Style::new().paint(" off screen focuses the next tab."),
+    ])
+}
+
+pub fn move_focus_hjkl_tab_switch_short(palette: Palette) -> LinePart {
+    // Alt + <←↓↑→> off screen edge focuses next tab.
+    let green_color = palette_match!(palette.green);
+    let orange_color = palette_match!(palette.orange);
+
+    strings!(&[
+        Style::new().fg(orange_color).bold().paint(" Alt"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<←↓↑→>"),
+        Style::new().paint(" off screen edge focuses next tab."),
+    ])
+}

--- a/default-plugins/status-bar/src/tip/data/quicknav.rs
+++ b/default-plugins/status-bar/src/tip/data/quicknav.rs
@@ -1,13 +1,10 @@
-use std::collections::HashMap;
-
 use ansi_term::{
     unstyled_len, ANSIString, ANSIStrings,
     Color::{Fixed, RGB},
     Style,
 };
-use lazy_static::lazy_static;
 
-use crate::{tip::TipBody, LinePart};
+use crate::LinePart;
 use zellij_tile::prelude::*;
 use zellij_tile_utils::palette_match;
 
@@ -24,18 +21,7 @@ macro_rules! strings {
     }};
 }
 
-lazy_static! {
-    pub static ref TIPS: HashMap<&'static str, TipBody> = HashMap::from([(
-        "quicknav",
-        TipBody {
-            short: quicknav_short,
-            medium: quicknav_medium,
-            full: quicknav_full,
-        }
-    )]);
-}
-
-fn quicknav_full(palette: Palette) -> LinePart {
+pub fn quicknav_full(palette: Palette) -> LinePart {
     let green_color = palette_match!(palette.green);
     let orange_color = palette_match!(palette.orange);
 
@@ -58,7 +44,7 @@ fn quicknav_full(palette: Palette) -> LinePart {
     ])
 }
 
-fn quicknav_medium(palette: Palette) -> LinePart {
+pub fn quicknav_medium(palette: Palette) -> LinePart {
     let green_color = palette_match!(palette.green);
     let orange_color = palette_match!(palette.orange);
 
@@ -81,7 +67,7 @@ fn quicknav_medium(palette: Palette) -> LinePart {
     ])
 }
 
-fn quicknav_short(palette: Palette) -> LinePart {
+pub fn quicknav_short(palette: Palette) -> LinePart {
     let green_color = palette_match!(palette.green);
     let orange_color = palette_match!(palette.orange);
 

--- a/default-plugins/status-bar/src/tip/data/send_mouse_click_to_terminal.rs
+++ b/default-plugins/status-bar/src/tip/data/send_mouse_click_to_terminal.rs
@@ -1,0 +1,63 @@
+use ansi_term::{
+    unstyled_len, ANSIString, ANSIStrings,
+    Color::{Fixed, RGB},
+    Style,
+};
+
+use crate::LinePart;
+use zellij_tile::prelude::*;
+use zellij_tile_utils::palette_match;
+
+macro_rules! strings {
+    ($ANSIStrings:expr) => {{
+        let strings: &[ANSIString<'static>] = $ANSIStrings;
+
+        let ansi_strings = ANSIStrings(strings);
+
+        LinePart {
+            part: format!("{}", ansi_strings),
+            len: unstyled_len(&ansi_strings),
+        }
+    }};
+}
+
+pub fn mouse_click_to_terminal_full(palette: Palette) -> LinePart {
+    // Tip: SHIFT + <mouse-click> bypasses Zellij and sends the mouse click directly to the terminal
+    let green_color = palette_match!(palette.green);
+    let orange_color = palette_match!(palette.orange);
+
+    strings!(&[
+        Style::new().paint(" Tip: "),
+        Style::new().fg(orange_color).bold().paint("SHIFT"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<mouse-click>"),
+        Style::new().paint(" bypasses Zellij and sends the mouse click directly to the terminal."),
+    ])
+}
+
+pub fn mouse_click_to_terminal_medium(palette: Palette) -> LinePart {
+    // Tip: SHIFT + <mouse-click> sends the click directly to the terminal
+    let green_color = palette_match!(palette.green);
+    let orange_color = palette_match!(palette.orange);
+    strings!(&[
+        Style::new().paint(" Tip: "),
+        Style::new().fg(orange_color).bold().paint("SHIFT"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<mouse-click>"),
+        Style::new().paint(" sends the click directly to the terminal."),
+    ])
+}
+
+pub fn mouse_click_to_terminal_short(palette: Palette) -> LinePart {
+    // Tip: SHIFT + <mouse-click>  => sends click to terminal.
+    let green_color = palette_match!(palette.green);
+    let orange_color = palette_match!(palette.orange);
+
+    strings!(&[
+        Style::new().paint(" Tip: "),
+        Style::new().fg(orange_color).bold().paint("SHIFT"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<mouse-click>"),
+        Style::new().paint(" => sends click to terminal."),
+    ])
+}

--- a/default-plugins/status-bar/src/tip/data/sync_tab.rs
+++ b/default-plugins/status-bar/src/tip/data/sync_tab.rs
@@ -1,0 +1,69 @@
+use ansi_term::{
+    unstyled_len, ANSIString, ANSIStrings,
+    Color::{Fixed, RGB},
+    Style,
+};
+
+use crate::LinePart;
+use zellij_tile::prelude::*;
+use zellij_tile_utils::palette_match;
+
+macro_rules! strings {
+    ($ANSIStrings:expr) => {{
+        let strings: &[ANSIString<'static>] = $ANSIStrings;
+
+        let ansi_strings = ANSIStrings(strings);
+
+        LinePart {
+            part: format!("{}", ansi_strings),
+            len: unstyled_len(&ansi_strings),
+        }
+    }};
+}
+
+pub fn sync_tab_full(palette: Palette) -> LinePart {
+    // Tip: Sync a tab and write keyboard input to all panes with Ctrl + <t> + <s>
+    let green_color = palette_match!(palette.green);
+    let orange_color = palette_match!(palette.orange);
+
+    strings!(&[
+        Style::new().paint(" Tip: "),
+        Style::new().paint("Sync a tab and write keyboard input to all its panes with "),
+        Style::new().fg(orange_color).bold().paint("Ctrl"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<t>"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<s>"),
+    ])
+}
+
+pub fn sync_tab_medium(palette: Palette) -> LinePart {
+    // Tip: Sync input to panes in a tab with Ctrl + <t> + <s>
+    let green_color = palette_match!(palette.green);
+    let orange_color = palette_match!(palette.orange);
+
+    strings!(&[
+        Style::new().paint(" Tip: "),
+        Style::new().paint("Sync input to panes in a tab with "),
+        Style::new().fg(orange_color).bold().paint("Ctrl"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<t>"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<s>"),
+    ])
+}
+
+pub fn sync_tab_short(palette: Palette) -> LinePart {
+    // Sync input in a tab with Ctrl + <t> + <s>
+    let green_color = palette_match!(palette.green);
+    let orange_color = palette_match!(palette.orange);
+
+    strings!(&[
+        Style::new().paint(" Sync input in a tab with "),
+        Style::new().fg(orange_color).bold().paint("Ctrl"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<t>"),
+        Style::new().paint(" + "),
+        Style::new().fg(green_color).bold().paint("<s>"),
+    ])
+}

--- a/default-plugins/status-bar/src/tip/data/use_mouse.rs
+++ b/default-plugins/status-bar/src/tip/data/use_mouse.rs
@@ -1,0 +1,56 @@
+use ansi_term::{
+    unstyled_len, ANSIString, ANSIStrings,
+    Color::{Fixed, RGB},
+    Style,
+};
+
+use crate::LinePart;
+use zellij_tile::prelude::*;
+use zellij_tile_utils::palette_match;
+
+macro_rules! strings {
+    ($ANSIStrings:expr) => {{
+        let strings: &[ANSIString<'static>] = $ANSIStrings;
+
+        let ansi_strings = ANSIStrings(strings);
+
+        LinePart {
+            part: format!("{}", ansi_strings),
+            len: unstyled_len(&ansi_strings),
+        }
+    }};
+}
+
+pub fn use_mouse_full(palette: Palette) -> LinePart {
+    // Tip: Use the mouse to switch pane focus, scroll through the pane
+    // scrollbuffer, switch or scroll through tabs
+    let green_color = palette_match!(palette.green);
+
+    strings!(&[
+        Style::new().paint(" Tip: "),
+        Style::new().fg(green_color).bold().paint("Use the mouse"),
+        Style::new().paint(" to switch pane focus, scroll through the pane scrollbuffer, switch or scroll through the tabs."),
+    ])
+}
+
+pub fn use_mouse_medium(palette: Palette) -> LinePart {
+    // Tip: Use the mouse to switch panes/tabs or scroll through the pane
+    // scrollbuffer
+    let green_color = palette_match!(palette.green);
+
+    strings!(&[
+        Style::new().paint(" Tip: "),
+        Style::new().fg(green_color).bold().paint("Use the mouse"),
+        Style::new().paint(" to switch pane/tabs or scroll through the pane scrollbuffer."),
+    ])
+}
+
+pub fn use_mouse_short(palette: Palette) -> LinePart {
+    // Tip: Use the mouse to switch panes/tabs or scroll
+    let green_color = palette_match!(palette.green);
+
+    strings!(&[
+        Style::new().fg(green_color).bold().paint(" Use the mouse"),
+        Style::new().paint(" to switch pane/tabs or scroll."),
+    ])
+}

--- a/default-plugins/status-bar/src/tip/data/zellij_setup_check.rs
+++ b/default-plugins/status-bar/src/tip/data/zellij_setup_check.rs
@@ -1,0 +1,56 @@
+use ansi_term::{
+    unstyled_len, ANSIString, ANSIStrings,
+    Color::{Fixed, RGB},
+    Style,
+};
+
+use crate::LinePart;
+use zellij_tile::prelude::*;
+use zellij_tile_utils::palette_match;
+
+macro_rules! strings {
+    ($ANSIStrings:expr) => {{
+        let strings: &[ANSIString<'static>] = $ANSIStrings;
+
+        let ansi_strings = ANSIStrings(strings);
+
+        LinePart {
+            part: format!("{}", ansi_strings),
+            len: unstyled_len(&ansi_strings),
+        }
+    }};
+}
+
+pub fn zellij_setup_check_full(palette: Palette) -> LinePart {
+    // Tip: Having issues with Zellij? Try running "zellij setup --check"
+    let orange_color = palette_match!(palette.orange);
+
+    strings!(&[
+        Style::new().paint(" Tip: "),
+        Style::new().paint("Having issues with Zellij? Try running "),
+        Style::new().fg(orange_color).bold().paint("zellij setup --check"),
+    ])
+}
+
+pub fn zellij_setup_check_medium(palette: Palette) -> LinePart {
+    // Tip: Run "zellij setup --check" to find issues
+    let orange_color = palette_match!(palette.orange);
+
+    strings!(&[
+        Style::new().paint(" Tip: "),
+        Style::new().paint("Run "),
+        Style::new().fg(orange_color).bold().paint("zellij setup --check"),
+        Style::new().paint(" to find issues"),
+    ])
+}
+
+pub fn zellij_setup_check_short(palette: Palette) -> LinePart {
+    // Run "zellij setup --check" to find issues
+    let orange_color = palette_match!(palette.orange);
+
+    strings!(&[
+        Style::new().paint(" Run "),
+        Style::new().fg(orange_color).bold().paint("zellij setup --check"),
+        Style::new().paint(" to find issues"),
+    ])
+}

--- a/default-plugins/status-bar/src/tip/data/zellij_setup_check.rs
+++ b/default-plugins/status-bar/src/tip/data/zellij_setup_check.rs
@@ -28,7 +28,10 @@ pub fn zellij_setup_check_full(palette: Palette) -> LinePart {
     strings!(&[
         Style::new().paint(" Tip: "),
         Style::new().paint("Having issues with Zellij? Try running "),
-        Style::new().fg(orange_color).bold().paint("zellij setup --check"),
+        Style::new()
+            .fg(orange_color)
+            .bold()
+            .paint("zellij setup --check"),
     ])
 }
 
@@ -39,7 +42,10 @@ pub fn zellij_setup_check_medium(palette: Palette) -> LinePart {
     strings!(&[
         Style::new().paint(" Tip: "),
         Style::new().paint("Run "),
-        Style::new().fg(orange_color).bold().paint("zellij setup --check"),
+        Style::new()
+            .fg(orange_color)
+            .bold()
+            .paint("zellij setup --check"),
         Style::new().paint(" to find issues"),
     ])
 }
@@ -50,7 +56,10 @@ pub fn zellij_setup_check_short(palette: Palette) -> LinePart {
 
     strings!(&[
         Style::new().paint(" Run "),
-        Style::new().fg(orange_color).bold().paint("zellij setup --check"),
+        Style::new()
+            .fg(orange_color)
+            .bold()
+            .paint("zellij setup --check"),
         Style::new().paint(" to find issues"),
     ])
 }

--- a/default-plugins/status-bar/src/tip/utils.rs
+++ b/default-plugins/status-bar/src/tip/utils.rs
@@ -21,6 +21,14 @@ macro_rules! get_name_and_caching {
     }};
 }
 
+macro_rules! populate_cache {
+    ($cache:expr) => {{
+        for tip_name in TIPS.keys() {
+            $cache.caching(tip_name.clone()).unwrap();
+        }
+    }};
+}
+
 pub fn get_random_tip_name() -> String {
     TIPS.keys()
         .choose(&mut rand::thread_rng())
@@ -38,13 +46,19 @@ pub fn get_cached_tip_name() -> String {
     }
 
     if local_cache.is_empty() {
-        get_name_and_caching!(local_cache);
+        populate_cache!(local_cache);
+    }
+
+    let quicknav_show_count = local_cache.get_cached_data().get("quicknav").unwrap_or(&0);
+    eprintln!("quicknav_show_count: {:?}", quicknav_show_count);
+    if quicknav_show_count <= &MAX_CACHE_HITS {
+        let _ = local_cache.caching("quicknav");
+        return String::from("quicknav");
     }
 
     let usable_tips = local_cache
         .get_cached_data()
         .iter()
-        .filter(|(_, &v)| v < MAX_CACHE_HITS)
         .map(|(k, _)| k.to_string())
         .collect::<Vec<String>>();
 

--- a/src/tests/e2e/remote_runner.rs
+++ b/src/tests/e2e/remote_runner.rs
@@ -57,6 +57,8 @@ fn setup_remote_environment(channel: &mut ssh2::Channel, win_size: Size) {
 }
 
 fn stop_zellij(channel: &mut ssh2::Channel) {
+    // here we remove the status-bar-tips cache to make sure only the quicknav tip is loaded
+    channel.write_all(b"find /tmp | grep status-bar-tips | xargs rm\n").unwrap();
     channel.write_all(b"killall -KILL zellij\n").unwrap();
 }
 

--- a/src/tests/e2e/remote_runner.rs
+++ b/src/tests/e2e/remote_runner.rs
@@ -58,7 +58,9 @@ fn setup_remote_environment(channel: &mut ssh2::Channel, win_size: Size) {
 
 fn stop_zellij(channel: &mut ssh2::Channel) {
     // here we remove the status-bar-tips cache to make sure only the quicknav tip is loaded
-    channel.write_all(b"find /tmp | grep status-bar-tips | xargs rm\n").unwrap();
+    channel
+        .write_all(b"find /tmp | grep status-bar-tips | xargs rm\n")
+        .unwrap();
     channel.write_all(b"killall -KILL zellij\n").unwrap();
 }
 


### PR DESCRIPTION
This adds more tips to the status bar to help users discover more features of Zellij.
The first quicknav tip will be shown at least for the first 10 times Zellij is started, and afterwards a random tip will be chosen.

I used suggestions from here: https://github.com/zellij-org/zellij/issues/938 as well as others. We can of course add more tips in the future.