### PR TITLE
chore(deps): update `crossbeam`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,9 +174,9 @@ checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
 
 [[package]]
 name = "async-trait"
-version = "0.1.54"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159c7edec63db93c5eb1e5e6928f6dec9aea1174cf983a8e5fc4caa179792814"
+checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -16,7 +16,7 @@ clap = { version = "3.0", features = ["derive", "env"] }
 clap_complete = "3.0"
 colored = "2.0.0"
 colorsys = "0.6.5"
-crossbeam = "0.8.0"
+crossbeam = "0.8.1"
 directories-next = "2.0"
 interprocess = "1.1.1"
 lazy_static = "1.4.0"


### PR DESCRIPTION
There is a possible race condition in `0.8.0`.