### PR TITLE
add(ci/makefile): run clippy on all features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,4 +76,4 @@ jobs:
       uses: actions-rs/clippy-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        args: --all-features
+        args: --all-features --all-targets

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -92,7 +92,7 @@ args = [
 
 # Simple clippy tweak
 [tasks.clippy]
-args = ["clippy", "--all-targets", "--", "@@split(CARGO_MAKE_TASK_ARGS,;)"]
+args = ["clippy", "--all-targets","--all-features","--", "@@split(CARGO_MAKE_TASK_ARGS,;)"]
 
 # Release building and installing Zellij
 [tasks.install]


### PR DESCRIPTION
Run clippy on all exposed features, to minimize the possiblility
of breakage.