### PR TITLE
fix: tab selection by left click in compact-bar

### DIFF
--- a/default-plugins/compact-bar/src/main.rs
+++ b/default-plugins/compact-bar/src/main.rs
@@ -115,11 +115,11 @@ impl ZellijPlugin for State {
             if self.should_render
                 && self.mouse_click_pos > len_cnt
                 && self.mouse_click_pos <= len_cnt + bar_part.len
-                && idx > 2
+                && idx > 3
             {
-                // First three elements of tab_line are "Zellij", session name and empty thing, hence the idx > 2 condition.
-                // Tabs are indexed starting from 1, therefore we need subtract 2 below.
-                switch_tab_to(TryInto::<u32>::try_into(idx).unwrap() - 2);
+                // First three elements of tab_line are "Zellij", session name and mode, hence the idx > 3 condition.
+                // Tabs are indexed starting from 1, therefore we need subtract 3 below.
+                switch_tab_to(TryInto::<u32>::try_into(idx).unwrap() - 3);
             }
             len_cnt += bar_part.len;
         }


### PR DESCRIPTION
Fixes #1477

One thing I wasn't able to figure out:
It works when running "cargo make run -l compact"
but not when running "cargo make install ./test && ./test -l compact".

The latter seems to re-build the old version of the plugin and replace the wasm file in the "plugins" directory?
I don't know enough about WebAssembly / cargo make / the build process to be able to figure this one out.

Any pointers on how to fix this?
Or maybe someone more qualified can take over from here.