### PR TITLE
feat: fullscreen focus swapping

### DIFF
--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -1082,6 +1082,19 @@ impl TiledPanes {
             }
         }
     }
+
+    pub fn switch_next_pane_fullscreen(&mut self, client_id: ClientId) {
+        self.unset_fullscreen();
+        self.focus_next_pane(client_id);
+        self.toggle_active_pane_fullscreen(client_id);
+    }
+
+    pub fn switch_prev_pane_fullscreen(&mut self, client_id: ClientId) {
+        self.unset_fullscreen();
+        self.focus_previous_pane(client_id);
+        self.toggle_active_pane_fullscreen(client_id);
+    }
+
     pub fn panes_to_hide_count(&self) -> usize {
         self.panes_to_hide.len()
     }

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -990,6 +990,18 @@ impl Tab {
     pub fn are_floating_panes_visible(&self) -> bool {
         self.floating_panes.panes_are_visible()
     }
+    pub fn switch_next_pane_fullscreen(&mut self, client_id: ClientId) {
+        if !self.is_fullscreen_active() {
+            return;
+        }
+        self.tiled_panes.switch_next_pane_fullscreen(client_id);
+    }
+    pub fn switch_prev_pane_fullscreen(&mut self, client_id: ClientId) {
+        if !self.is_fullscreen_active() {
+            return;
+        }
+        self.tiled_panes.switch_next_pane_fullscreen(client_id);
+    }
     pub fn set_force_render(&mut self) {
         self.tiled_panes.set_force_render();
         self.floating_panes.set_force_render();
@@ -1222,6 +1234,7 @@ impl Tab {
             return;
         }
         if self.tiled_panes.fullscreen_is_active() {
+            self.switch_next_pane_fullscreen(client_id);
             return;
         }
         self.tiled_panes.focus_next_pane(client_id);
@@ -1231,6 +1244,7 @@ impl Tab {
             return;
         }
         if self.tiled_panes.fullscreen_is_active() {
+            self.switch_prev_pane_fullscreen(client_id);
             return;
         }
         self.tiled_panes.focus_previous_pane(client_id);
@@ -1247,7 +1261,8 @@ impl Tab {
                 return false;
             }
             if self.tiled_panes.fullscreen_is_active() {
-                return false;
+                self.switch_next_pane_fullscreen(client_id);
+                return true;
             }
             self.tiled_panes.move_focus_left(client_id)
         }
@@ -1296,7 +1311,8 @@ impl Tab {
                 return false;
             }
             if self.tiled_panes.fullscreen_is_active() {
-                return false;
+                self.switch_next_pane_fullscreen(client_id);
+                return true;
             }
             self.tiled_panes.move_focus_right(client_id)
         }

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -670,45 +670,64 @@ pub fn toggle_focused_pane_fullscreen() {
 }
 
 #[test]
-pub fn move_focus_is_disabled_in_fullscreen() {
+fn switch_to_next_pane_fullscreen() {
     let size = Size {
         cols: 121,
         rows: 20,
     };
-    let mut tab = create_new_tab(size);
-    for i in 2..5 {
-        let new_pane_id = PaneId::Terminal(i);
-        tab.new_pane(new_pane_id, Some(1));
-    }
-    tab.toggle_active_pane_fullscreen(1);
-    tab.move_focus_left(1);
+
+    let mut active_tab = create_new_tab(size);
+
+    active_tab.new_pane(PaneId::Terminal(1), Some(1));
+    active_tab.new_pane(PaneId::Terminal(2), Some(1));
+    active_tab.new_pane(PaneId::Terminal(3), Some(1));
+    active_tab.new_pane(PaneId::Terminal(4), Some(1));
+    active_tab.toggle_active_pane_fullscreen(1);
+
+    // order is now 1 ->2 -> 3 -> 4 due to how new panes are inserted
+
+    active_tab.switch_next_pane_fullscreen(1);
+    active_tab.switch_next_pane_fullscreen(1);
+    active_tab.switch_next_pane_fullscreen(1);
+    active_tab.switch_next_pane_fullscreen(1);
+
+    // position should now be back in terminal 4.
+
     assert_eq!(
-        tab.tiled_panes.panes.get(&PaneId::Terminal(4)).unwrap().x(),
-        0,
-        "Pane x is on screen edge"
+        active_tab.get_active_pane_id(1).unwrap(),
+        PaneId::Terminal(4),
+        "Active pane did not switch in fullscreen mode"
     );
+}
+
+#[test]
+fn switch_to_prev_pane_fullscreen() {
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let mut active_tab = create_new_tab(size);
+
+    //testing four consecutive switches in fullscreen mode
+
+    active_tab.new_pane(PaneId::Terminal(1), Some(1));
+    active_tab.new_pane(PaneId::Terminal(2), Some(1));
+    active_tab.new_pane(PaneId::Terminal(3), Some(1));
+    active_tab.new_pane(PaneId::Terminal(4), Some(1));
+    active_tab.toggle_active_pane_fullscreen(1);
+    // order is now 1 2 3 4
+
+    active_tab.switch_prev_pane_fullscreen(1);
+    active_tab.switch_prev_pane_fullscreen(1);
+    active_tab.switch_prev_pane_fullscreen(1);
+    active_tab.switch_prev_pane_fullscreen(1);
+
+    // the position should now be in Terminal 4.
+
     assert_eq!(
-        tab.tiled_panes.panes.get(&PaneId::Terminal(4)).unwrap().y(),
-        0,
-        "Pane y is on screen edge"
-    );
-    assert_eq!(
-        tab.tiled_panes
-            .panes
-            .get(&PaneId::Terminal(4))
-            .unwrap()
-            .cols(),
-        121,
-        "Pane cols match fullscreen cols"
-    );
-    assert_eq!(
-        tab.tiled_panes
-            .panes
-            .get(&PaneId::Terminal(4))
-            .unwrap()
-            .rows(),
-        20,
-        "Pane rows match fullscreen rows"
+        active_tab.get_active_pane_id(1).unwrap(),
+        PaneId::Terminal(4),
+        "Active pane did not switch in fullscreen mode"
     );
 }
 


### PR DESCRIPTION
Adds support for swapping between panes in fullscreen mode. This can be accomplished by either using the next pane command in pane mode or navigating focus left and right in normal mode.
Closes #1466