### PR TITLE
fix(action): send `WriteChars` once per action

### DIFF
--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -235,7 +235,7 @@ impl InputHandler {
                 },
                 // Actions, that are indepenedent from the specific client
                 // should be specified here.
-                Action::NewTab(_) | Action::Run(_) | Action::NewPane(_) => {
+                Action::NewTab(_) | Action::Run(_) | Action::NewPane(_) | Action::WriteChars(_) => {
                     let client_id = clients.first().unwrap();
                     log::error!("Sending action to client: {}", client_id);
                     self.dispatch_action(action, Some(*client_id));


### PR DESCRIPTION
`WriteChars` is not an idempotent action, that's why it should only
be sent to it's destination client.