### PR TITLE
Fix installation with MacPorts

### DIFF
--- a/docs/THIRD_PARTY_INSTALL.md
+++ b/docs/THIRD_PARTY_INSTALL.md
@@ -42,7 +42,7 @@ brew install zellij
 Or install with [MacPorts](https://ports.macports.org/port/zellij/details/):
 
 ```
-port install zellij
+sudo port install zellij
 ```
 
 ### Void Linux


### PR DESCRIPTION
MacPorts installed in a general way requires `sudo`.
Ref: https://superuser.com/a/1413502