### PR TITLE
feat(theme): allow hex colors for themes

### DIFF
--- a/zellij-utils/src/input/theme.rs
+++ b/zellij-utils/src/input/theme.rs
@@ -77,7 +77,7 @@ impl<'de> Visitor<'de> for HexColorVisitor {
     where
         E: Error,
     {
-	println!("{}", s);
+        println!("{}", s);
         if s.starts_with("#") {
             return self.visit_str(&s[1..]);
         }

--- a/zellij-utils/src/input/theme.rs
+++ b/zellij-utils/src/input/theme.rs
@@ -77,6 +77,11 @@ impl<'de> Visitor<'de> for HexColorVisitor {
     where
         E: Error,
     {
+	println!("{}", s);
+        if s.starts_with("#") {
+            return self.visit_str(&s[1..]);
+        }
+
         if s.len() == 3 {
             Ok(HexColor(
                 u8::from_str_radix(&s[0..1], 16).map_err(E::custom)? * 0x11,
@@ -90,7 +95,9 @@ impl<'de> Visitor<'de> for HexColorVisitor {
                 u8::from_str_radix(&s[4..6], 16).map_err(E::custom)?,
             ))
         } else {
-            Err(Error::custom("Hex color must be of form #RGB or #RRGGBB"))
+            Err(Error::custom(
+                "Hex color must be of form \"#RGB\" or \"#RRGGBB\"",
+            ))
         }
     }
 }

--- a/zellij-utils/src/input/theme.rs
+++ b/zellij-utils/src/input/theme.rs
@@ -77,8 +77,8 @@ impl<'de> Visitor<'de> for HexColorVisitor {
     where
         E: Error,
     {
-        if s.starts_with("#") {
-            return self.visit_str(&s[1..]);
+        if let Some(stripped) = s.strip_prefix('#') {
+            return self.visit_str(stripped);
         }
 
         if s.len() == 3 {

--- a/zellij-utils/src/input/theme.rs
+++ b/zellij-utils/src/input/theme.rs
@@ -77,7 +77,6 @@ impl<'de> Visitor<'de> for HexColorVisitor {
     where
         E: Error,
     {
-        println!("{}", s);
         if s.starts_with("#") {
             return self.visit_str(&s[1..]);
         }


### PR DESCRIPTION
This is a redo of a previous PR which I had made on a different account. It does the hex conversion in a much nicer way, and uses a custom Deserialize impl.

This adds support for hex colors in the form
```yaml
fg: ff4500
bg: 3f7
```
because hashtags are recognized as comments.

Should solve #880 