### PR TITLE
utils/input: Make key order consistent

### DIFF
--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__scrolling_inside_a_pane.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__scrolling_inside_a_pane.snap
@@ -26,4 +26,4 @@ expression: last_snapshot
 │                                                          ││line19 00000000000000000000000000000000000000000000000000█│
 └──────────────────────────────────────────────────────────┘└──────────────────────────────────────────────────────────┘
  Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SCROLL  <o> SESSION  <q> QUIT           
- <↓↑> Scroll / <PgUp/PgDn> Scroll / <u/d> Scroll / <e> Edit / <ENTER> Select pane                                       
+ <↓↑> Scroll / <PgDn/PgUp> Scroll / <d/u> Scroll / <e> Edit / <ENTER> Select pane                                       

--- a/zellij-utils/src/input/mod.rs
+++ b/zellij-utils/src/input/mod.rs
@@ -53,8 +53,8 @@ pub fn get_mode_info(mode: InputMode, style: Style, capabilities: PluginCapabili
         ],
         InputMode::Scroll => vec![
             ("↓↑".to_string(), "Scroll".to_string()),
-            ("PgUp/PgDn".to_string(), "Scroll Page".to_string()),
-            ("u/d".to_string(), "Scroll Half Page".to_string()),
+            ("PgDn/PgUp".to_string(), "Scroll Page".to_string()),
+            ("d/u".to_string(), "Scroll Half Page".to_string()),
             (
                 "e".to_string(),
                 "Edit Scrollback in Default Editor".to_string(),


### PR DESCRIPTION
The order of the "arrow" keys is always left/down/up/right, make the
keybindings for the Scroll mode align with this ordering.

I know it's a nitpick, but I have a talent for spotting such things and subsequently becoming annoyed by them...