### PR TITLE
Add 'ResizeExact' action to allow resizing panes in user-defined increments

### DIFF
--- a/docs/MANPAGE.md
+++ b/docs/MANPAGE.md
@@ -145,6 +145,8 @@ ACTIONS
   MODES section for possible values.
 * __Resize: <Direction\>__ - resizes focused pane in the specified direction
   (one of: Left, Right, Up, Down).
+* __ResizeExact: <Direction\> <Amount\> <Amount\>__ - resizes focused pane in
+  the specified direction the given amount (Fixed: <value\>, Percent: <value\>).
 * __FocusNextPane__ - switches focus to the next pane to the right or below if
   on  screen edge.
 * __FocusPreviousPane__ - switches focus to the next pane to the left or above

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -17,7 +17,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::rc::Rc;
 use std::time::Instant;
 use zellij_tile::data::ModeInfo;
-use zellij_utils::pane_size::{Offset, PaneGeom, Size, Viewport};
+use zellij_utils::pane_size::{Constraint, Offset, PaneGeom, Size, Viewport};
 
 macro_rules! resize_pty {
     ($pane:expr, $os_input:expr) => {
@@ -292,6 +292,7 @@ impl FloatingPanes {
     pub fn resize_active_pane_left(
         &mut self,
         client_id: ClientId,
+        constraint: Option<Constraint>,
         os_api: &mut Box<dyn ServerOsApi>,
     ) -> bool {
         // true => successfully resized
@@ -304,7 +305,7 @@ impl FloatingPanes {
                 display_area,
                 viewport,
             );
-            floating_pane_grid.resize_pane_left(active_floating_pane_id);
+            floating_pane_grid.resize_pane_left(active_floating_pane_id, constraint);
             for pane in self.panes.values_mut() {
                 resize_pty!(pane, os_api);
             }
@@ -316,6 +317,7 @@ impl FloatingPanes {
     pub fn resize_active_pane_right(
         &mut self,
         client_id: ClientId,
+        constraint: Option<Constraint>,
         os_api: &mut Box<dyn ServerOsApi>,
     ) -> bool {
         // true => successfully resized
@@ -328,7 +330,7 @@ impl FloatingPanes {
                 display_area,
                 viewport,
             );
-            floating_pane_grid.resize_pane_right(active_floating_pane_id);
+            floating_pane_grid.resize_pane_right(active_floating_pane_id, constraint);
             for pane in self.panes.values_mut() {
                 resize_pty!(pane, os_api);
             }
@@ -340,6 +342,7 @@ impl FloatingPanes {
     pub fn resize_active_pane_down(
         &mut self,
         client_id: ClientId,
+        constraint: Option<Constraint>,
         os_api: &mut Box<dyn ServerOsApi>,
     ) -> bool {
         // true => successfully resized
@@ -352,7 +355,7 @@ impl FloatingPanes {
                 display_area,
                 viewport,
             );
-            floating_pane_grid.resize_pane_down(active_floating_pane_id);
+            floating_pane_grid.resize_pane_down(active_floating_pane_id, constraint);
             for pane in self.panes.values_mut() {
                 resize_pty!(pane, os_api);
             }
@@ -364,6 +367,7 @@ impl FloatingPanes {
     pub fn resize_active_pane_up(
         &mut self,
         client_id: ClientId,
+        constraint: Option<Constraint>,
         os_api: &mut Box<dyn ServerOsApi>,
     ) -> bool {
         // true => successfully resized
@@ -376,7 +380,7 @@ impl FloatingPanes {
                 display_area,
                 viewport,
             );
-            floating_pane_grid.resize_pane_up(active_floating_pane_id);
+            floating_pane_grid.resize_pane_up(active_floating_pane_id, constraint);
             for pane in self.panes.values_mut() {
                 resize_pty!(pane, os_api);
             }
@@ -388,6 +392,8 @@ impl FloatingPanes {
     pub fn resize_active_pane_increase(
         &mut self,
         client_id: ClientId,
+        cx: Option<Constraint>,
+        cy: Option<Constraint>,
         os_api: &mut Box<dyn ServerOsApi>,
     ) -> bool {
         // true => successfully resized
@@ -400,7 +406,7 @@ impl FloatingPanes {
                 display_area,
                 viewport,
             );
-            floating_pane_grid.resize_increase(active_floating_pane_id);
+            floating_pane_grid.resize_increase(active_floating_pane_id, cx, cy);
             for pane in self.panes.values_mut() {
                 resize_pty!(pane, os_api);
             }
@@ -412,6 +418,8 @@ impl FloatingPanes {
     pub fn resize_active_pane_decrease(
         &mut self,
         client_id: ClientId,
+        cx: Option<Constraint>,
+        cy: Option<Constraint>,
         os_api: &mut Box<dyn ServerOsApi>,
     ) -> bool {
         // true => successfully resized
@@ -424,7 +432,7 @@ impl FloatingPanes {
                 display_area,
                 viewport,
             );
-            floating_pane_grid.resize_decrease(active_floating_pane_id);
+            floating_pane_grid.resize_decrease(active_floating_pane_id, cx, cy);
             for pane in self.panes.values_mut() {
                 resize_pty!(pane, os_api);
             }

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -18,7 +18,7 @@ use std::time::Instant;
 use zellij_tile::data::ModeInfo;
 use zellij_utils::{
     input::layout::Direction,
-    pane_size::{Offset, PaneGeom, Size, SizeInPixels, Viewport},
+    pane_size::{Constraint, Offset, PaneGeom, Size, SizeInPixels, Viewport},
 };
 
 macro_rules! resize_pty {
@@ -471,7 +471,7 @@ impl TiledPanes {
         }
         self.set_pane_frames(self.draw_pane_frames);
     }
-    pub fn resize_active_pane_left(&mut self, client_id: ClientId) {
+    pub fn resize_active_pane_left(&mut self, client_id: ClientId, constraint: Option<Constraint>) {
         if let Some(active_pane_id) = self.get_active_pane_id(client_id) {
             let mut pane_grid = TiledPaneGrid::new(
                 &mut self.panes,
@@ -479,13 +479,17 @@ impl TiledPanes {
                 *self.display_area.borrow(),
                 *self.viewport.borrow(),
             );
-            pane_grid.resize_pane_left(&active_pane_id);
+            pane_grid.resize_pane_left(&active_pane_id, constraint);
             for pane in self.panes.values_mut() {
                 resize_pty!(pane, self.os_api);
             }
         }
     }
-    pub fn resize_active_pane_right(&mut self, client_id: ClientId) {
+    pub fn resize_active_pane_right(
+        &mut self,
+        client_id: ClientId,
+        constraint: Option<Constraint>,
+    ) {
         if let Some(active_pane_id) = self.get_active_pane_id(client_id) {
             let mut pane_grid = TiledPaneGrid::new(
                 &mut self.panes,
@@ -493,13 +497,13 @@ impl TiledPanes {
                 *self.display_area.borrow(),
                 *self.viewport.borrow(),
             );
-            pane_grid.resize_pane_right(&active_pane_id);
+            pane_grid.resize_pane_right(&active_pane_id, constraint);
             for pane in self.panes.values_mut() {
                 resize_pty!(pane, self.os_api);
             }
         }
     }
-    pub fn resize_active_pane_up(&mut self, client_id: ClientId) {
+    pub fn resize_active_pane_up(&mut self, client_id: ClientId, constraint: Option<Constraint>) {
         if let Some(active_pane_id) = self.get_active_pane_id(client_id) {
             let mut pane_grid = TiledPaneGrid::new(
                 &mut self.panes,
@@ -507,13 +511,13 @@ impl TiledPanes {
                 *self.display_area.borrow(),
                 *self.viewport.borrow(),
             );
-            pane_grid.resize_pane_up(&active_pane_id);
+            pane_grid.resize_pane_up(&active_pane_id, constraint);
             for pane in self.panes.values_mut() {
                 resize_pty!(pane, self.os_api);
             }
         }
     }
-    pub fn resize_active_pane_down(&mut self, client_id: ClientId) {
+    pub fn resize_active_pane_down(&mut self, client_id: ClientId, constraint: Option<Constraint>) {
         if let Some(active_pane_id) = self.get_active_pane_id(client_id) {
             let mut pane_grid = TiledPaneGrid::new(
                 &mut self.panes,
@@ -521,13 +525,18 @@ impl TiledPanes {
                 *self.display_area.borrow(),
                 *self.viewport.borrow(),
             );
-            pane_grid.resize_pane_down(&active_pane_id);
+            pane_grid.resize_pane_down(&active_pane_id, constraint);
             for pane in self.panes.values_mut() {
                 resize_pty!(pane, self.os_api);
             }
         }
     }
-    pub fn resize_active_pane_increase(&mut self, client_id: ClientId) {
+    pub fn resize_active_pane_increase(
+        &mut self,
+        client_id: ClientId,
+        cx: Option<Constraint>,
+        cy: Option<Constraint>,
+    ) {
         if let Some(active_pane_id) = self.get_active_pane_id(client_id) {
             let mut pane_grid = TiledPaneGrid::new(
                 &mut self.panes,
@@ -535,13 +544,18 @@ impl TiledPanes {
                 *self.display_area.borrow(),
                 *self.viewport.borrow(),
             );
-            pane_grid.resize_increase(&active_pane_id);
+            pane_grid.resize_increase(&active_pane_id, cx, cy);
             for pane in self.panes.values_mut() {
                 resize_pty!(pane, self.os_api);
             }
         }
     }
-    pub fn resize_active_pane_decrease(&mut self, client_id: ClientId) {
+    pub fn resize_active_pane_decrease(
+        &mut self,
+        client_id: ClientId,
+        cx: Option<Constraint>,
+        cy: Option<Constraint>,
+    ) {
         if let Some(active_pane_id) = self.get_active_pane_id(client_id) {
             let mut pane_grid = TiledPaneGrid::new(
                 &mut self.panes,
@@ -549,7 +563,7 @@ impl TiledPanes {
                 *self.display_area.borrow(),
                 *self.viewport.borrow(),
             );
-            pane_grid.resize_decrease(&active_pane_id);
+            pane_grid.resize_decrease(&active_pane_id, cx, cy);
             for pane in self.panes.values_mut() {
                 resize_pty!(pane, self.os_api);
             }

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -92,12 +92,27 @@ fn route_action(
         },
         Action::Resize(direction) => {
             let screen_instr = match direction {
-                ResizeDirection::Left => ScreenInstruction::ResizeLeft(client_id),
-                ResizeDirection::Right => ScreenInstruction::ResizeRight(client_id),
-                ResizeDirection::Up => ScreenInstruction::ResizeUp(client_id),
-                ResizeDirection::Down => ScreenInstruction::ResizeDown(client_id),
-                ResizeDirection::Increase => ScreenInstruction::ResizeIncrease(client_id),
-                ResizeDirection::Decrease => ScreenInstruction::ResizeDecrease(client_id),
+                ResizeDirection::Left => ScreenInstruction::ResizeLeft(client_id, None),
+                ResizeDirection::Right => ScreenInstruction::ResizeRight(client_id, None),
+                ResizeDirection::Up => ScreenInstruction::ResizeUp(client_id, None),
+                ResizeDirection::Down => ScreenInstruction::ResizeDown(client_id, None),
+                ResizeDirection::Increase => {
+                    ScreenInstruction::ResizeIncrease(client_id, None, None)
+                },
+                ResizeDirection::Decrease => {
+                    ScreenInstruction::ResizeDecrease(client_id, None, None)
+                },
+            };
+            session.senders.send_to_screen(screen_instr).unwrap();
+        },
+        Action::ResizeExact(direction, cx, cy) => {
+            let screen_instr = match direction {
+                ResizeDirection::Left => ScreenInstruction::ResizeLeft(client_id, cx),
+                ResizeDirection::Right => ScreenInstruction::ResizeRight(client_id, cx),
+                ResizeDirection::Up => ScreenInstruction::ResizeUp(client_id, cx),
+                ResizeDirection::Down => ScreenInstruction::ResizeDown(client_id, cx),
+                ResizeDirection::Increase => ScreenInstruction::ResizeIncrease(client_id, cx, cy),
+                ResizeDirection::Decrease => ScreenInstruction::ResizeDecrease(client_id, cx, cy),
             };
             session.senders.send_to_screen(screen_instr).unwrap();
         },

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -9,7 +9,7 @@ use std::str;
 use zellij_tile::data::{Palette, PaletteColor};
 use zellij_tile::prelude::Style;
 use zellij_utils::input::options::Clipboard;
-use zellij_utils::pane_size::{Size, SizeInPixels};
+use zellij_utils::pane_size::{Constraint, Size, SizeInPixels};
 use zellij_utils::{
     input::command::TerminalAction, input::layout::Layout, position::Position, zellij_tile,
 };
@@ -46,12 +46,12 @@ pub enum ScreenInstruction {
     HorizontalSplit(PaneId, ClientId),
     VerticalSplit(PaneId, ClientId),
     WriteCharacter(Vec<u8>, ClientId),
-    ResizeLeft(ClientId),
-    ResizeRight(ClientId),
-    ResizeDown(ClientId),
-    ResizeUp(ClientId),
-    ResizeIncrease(ClientId),
-    ResizeDecrease(ClientId),
+    ResizeLeft(ClientId, Option<Constraint>),
+    ResizeRight(ClientId, Option<Constraint>),
+    ResizeDown(ClientId, Option<Constraint>),
+    ResizeUp(ClientId, Option<Constraint>),
+    ResizeIncrease(ClientId, Option<Constraint>, Option<Constraint>),
+    ResizeDecrease(ClientId, Option<Constraint>, Option<Constraint>),
     SwitchFocus(ClientId),
     FocusNextPane(ClientId),
     FocusPreviousPane(ClientId),
@@ -973,33 +973,34 @@ pub(crate) fn screen_thread_main(
                     }
                 });
             },
-            ScreenInstruction::ResizeLeft(client_id) => {
+            ScreenInstruction::ResizeLeft(client_id, constraint) => {
                 active_tab!(screen, client_id, |tab: &mut Tab| tab
-                    .resize_left(client_id));
+                    .resize_left(client_id, constraint));
                 screen.render();
             },
-            ScreenInstruction::ResizeRight(client_id) => {
+            ScreenInstruction::ResizeRight(client_id, constraint) => {
                 active_tab!(screen, client_id, |tab: &mut Tab| tab
-                    .resize_right(client_id));
+                    .resize_right(client_id, constraint));
                 screen.render();
             },
-            ScreenInstruction::ResizeDown(client_id) => {
+            ScreenInstruction::ResizeDown(client_id, constraint) => {
                 active_tab!(screen, client_id, |tab: &mut Tab| tab
-                    .resize_down(client_id));
+                    .resize_down(client_id, constraint));
                 screen.render();
             },
-            ScreenInstruction::ResizeUp(client_id) => {
-                active_tab!(screen, client_id, |tab: &mut Tab| tab.resize_up(client_id));
+            ScreenInstruction::ResizeUp(client_id, constraint) => {
+                active_tab!(screen, client_id, |tab: &mut Tab| tab
+                    .resize_up(client_id, constraint));
                 screen.render();
             },
-            ScreenInstruction::ResizeIncrease(client_id) => {
+            ScreenInstruction::ResizeIncrease(client_id, cx, cy) => {
                 active_tab!(screen, client_id, |tab: &mut Tab| tab
-                    .resize_increase(client_id));
+                    .resize_increase(client_id, cx, cy));
                 screen.render();
             },
-            ScreenInstruction::ResizeDecrease(client_id) => {
+            ScreenInstruction::ResizeDecrease(client_id, cx, cy) => {
                 active_tab!(screen, client_id, |tab: &mut Tab| tab
-                    .resize_decrease(client_id));
+                    .resize_decrease(client_id, cx, cy));
                 screen.render();
             },
             ScreenInstruction::SwitchFocus(client_id) => {

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -8,6 +8,7 @@ use copy_command::CopyCommand;
 use std::env::temp_dir;
 use uuid::Uuid;
 use zellij_tile::prelude::Style;
+use zellij_utils::pane_size::Constraint;
 use zellij_utils::position::{Column, Line};
 use zellij_utils::{position::Position, serde, zellij_tile};
 
@@ -1153,76 +1154,104 @@ impl Tab {
         self.tiled_panes.resize(new_screen_size);
         self.should_clear_display_before_rendering = true;
     }
-    pub fn resize_left(&mut self, client_id: ClientId) {
+    pub fn resize_left(&mut self, client_id: ClientId, constraint: Option<Constraint>) {
         if self.floating_panes.panes_are_visible() {
-            let successfully_resized = self
-                .floating_panes
-                .resize_active_pane_left(client_id, &mut self.os_api);
+            let successfully_resized = self.floating_panes.resize_active_pane_left(
+                client_id,
+                constraint,
+                &mut self.os_api,
+            );
             if successfully_resized {
                 self.set_force_render(); // we force render here to make sure the panes under the floating pane render and don't leave "garbage" in case of a decrease
             }
         } else {
-            self.tiled_panes.resize_active_pane_left(client_id);
+            self.tiled_panes
+                .resize_active_pane_left(client_id, constraint);
         }
     }
-    pub fn resize_right(&mut self, client_id: ClientId) {
+    pub fn resize_right(&mut self, client_id: ClientId, constraint: Option<Constraint>) {
         if self.floating_panes.panes_are_visible() {
-            let successfully_resized = self
-                .floating_panes
-                .resize_active_pane_right(client_id, &mut self.os_api);
+            let successfully_resized = self.floating_panes.resize_active_pane_right(
+                client_id,
+                constraint,
+                &mut self.os_api,
+            );
             if successfully_resized {
                 self.set_force_render(); // we force render here to make sure the panes under the floating pane render and don't leave "garbage" in case of a decrease
             }
         } else {
-            self.tiled_panes.resize_active_pane_right(client_id);
+            self.tiled_panes
+                .resize_active_pane_right(client_id, constraint);
         }
     }
-    pub fn resize_down(&mut self, client_id: ClientId) {
+    pub fn resize_down(&mut self, client_id: ClientId, constraint: Option<Constraint>) {
         if self.floating_panes.panes_are_visible() {
-            let successfully_resized = self
-                .floating_panes
-                .resize_active_pane_down(client_id, &mut self.os_api);
+            let successfully_resized = self.floating_panes.resize_active_pane_down(
+                client_id,
+                constraint,
+                &mut self.os_api,
+            );
             if successfully_resized {
                 self.set_force_render(); // we force render here to make sure the panes under the floating pane render and don't leave "garbage" in case of a decrease
             }
         } else {
-            self.tiled_panes.resize_active_pane_down(client_id);
+            self.tiled_panes
+                .resize_active_pane_down(client_id, constraint);
         }
     }
-    pub fn resize_up(&mut self, client_id: ClientId) {
+    pub fn resize_up(&mut self, client_id: ClientId, constraint: Option<Constraint>) {
         if self.floating_panes.panes_are_visible() {
-            let successfully_resized = self
-                .floating_panes
-                .resize_active_pane_up(client_id, &mut self.os_api);
+            let successfully_resized =
+                self.floating_panes
+                    .resize_active_pane_up(client_id, constraint, &mut self.os_api);
             if successfully_resized {
                 self.set_force_render(); // we force render here to make sure the panes under the floating pane render and don't leave "garbage" in case of a decrease
             }
         } else {
-            self.tiled_panes.resize_active_pane_up(client_id);
+            self.tiled_panes
+                .resize_active_pane_up(client_id, constraint);
         }
     }
-    pub fn resize_increase(&mut self, client_id: ClientId) {
+    pub fn resize_increase(
+        &mut self,
+        client_id: ClientId,
+        cx: Option<Constraint>,
+        cy: Option<Constraint>,
+    ) {
         if self.floating_panes.panes_are_visible() {
-            let successfully_resized = self
-                .floating_panes
-                .resize_active_pane_increase(client_id, &mut self.os_api);
+            let successfully_resized = self.floating_panes.resize_active_pane_increase(
+                client_id,
+                cx,
+                cy,
+                &mut self.os_api,
+            );
             if successfully_resized {
                 self.set_force_render(); // we force render here to make sure the panes under the floating pane render and don't leave "garbage" in case of a decrease
             }
         } else {
-            self.tiled_panes.resize_active_pane_increase(client_id);
+            self.tiled_panes
+                .resize_active_pane_increase(client_id, cx, cy);
         }
     }
-    pub fn resize_decrease(&mut self, client_id: ClientId) {
+    pub fn resize_decrease(
+        &mut self,
+        client_id: ClientId,
+        cx: Option<Constraint>,
+        cy: Option<Constraint>,
+    ) {
         if self.floating_panes.panes_are_visible() {
-            let successfully_resized = self
-                .floating_panes
-                .resize_active_pane_decrease(client_id, &mut self.os_api);
+            let successfully_resized = self.floating_panes.resize_active_pane_decrease(
+                client_id,
+                cx,
+                cy,
+                &mut self.os_api,
+            );
             if successfully_resized {
                 self.set_force_render(); // we force render here to make sure the panes under the floating pane render and don't leave "garbage" in case of a decrease
             }
         } else {
-            self.tiled_panes.resize_active_pane_decrease(client_id);
+            self.tiled_panes
+                .resize_active_pane_decrease(client_id, cx, cy);
         }
     }
     fn set_pane_active_at(&mut self, pane_id: PaneId) {

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -387,7 +387,7 @@ fn increase_floating_pane_size() {
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
     );
-    tab.resize_increase(client_id);
+    tab.resize_increase(client_id, None, None);
     tab.render(&mut output, None);
     let snapshot = take_snapshot(
         output.serialize().get(&client_id).unwrap(),
@@ -414,7 +414,7 @@ fn decrease_floating_pane_size() {
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
     );
-    tab.resize_decrease(client_id);
+    tab.resize_decrease(client_id, None, None);
     tab.render(&mut output, None);
     let snapshot = take_snapshot(
         output.serialize().get(&client_id).unwrap(),
@@ -441,7 +441,7 @@ fn resize_floating_pane_left() {
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
     );
-    tab.resize_left(client_id);
+    tab.resize_left(client_id, None);
     tab.render(&mut output, None);
     let snapshot = take_snapshot(
         output.serialize().get(&client_id).unwrap(),
@@ -468,7 +468,7 @@ fn resize_floating_pane_right() {
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
     );
-    tab.resize_right(client_id);
+    tab.resize_right(client_id, None);
     tab.render(&mut output, None);
     let snapshot = take_snapshot(
         output.serialize().get(&client_id).unwrap(),
@@ -495,7 +495,7 @@ fn resize_floating_pane_up() {
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
     );
-    tab.resize_up(client_id);
+    tab.resize_up(client_id, None);
     tab.render(&mut output, None);
     let snapshot = take_snapshot(
         output.serialize().get(&client_id).unwrap(),
@@ -522,7 +522,7 @@ fn resize_floating_pane_down() {
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
     );
-    tab.resize_down(client_id);
+    tab.resize_down(client_id, None);
     tab.render(&mut output, None);
     let snapshot = take_snapshot(
         output.serialize().get(&client_id).unwrap(),

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -1462,7 +1462,7 @@ pub fn close_pane_with_multiple_panes_above_it_away_from_screen_edges() {
     tab.horizontal_split(new_pane_id_5, 1);
     tab.move_focus_left(1);
     tab.move_focus_up(1);
-    tab.resize_down(1);
+    tab.resize_down(1, None);
     tab.vertical_split(new_pane_id_6, 1);
     tab.move_focus_down(1);
     tab.close_focused_pane(1);
@@ -1761,7 +1761,7 @@ pub fn close_pane_with_multiple_panes_below_it_away_from_screen_edges() {
     tab.move_focus_right(1);
     tab.horizontal_split(new_pane_id_5, 1);
     tab.move_focus_left(1);
-    tab.resize_up(1);
+    tab.resize_up(1, None);
     tab.vertical_split(new_pane_id_6, 1);
     tab.move_focus_up(1);
     tab.close_focused_pane(1);
@@ -2063,9 +2063,9 @@ pub fn close_pane_with_multiple_panes_to_the_left_away_from_screen_edges() {
     tab.vertical_split(new_pane_id_5, 1);
     tab.move_focus_up(1);
     tab.move_focus_left(1);
-    tab.resize_right(1);
-    tab.resize_up(1);
-    tab.resize_up(1);
+    tab.resize_right(1, None);
+    tab.resize_up(1, None);
+    tab.resize_up(1, None);
     tab.horizontal_split(new_pane_id_6, 1);
     tab.move_focus_right(1);
     tab.close_focused_pane(1);
@@ -2366,9 +2366,9 @@ pub fn close_pane_with_multiple_panes_to_the_right_away_from_screen_edges() {
     tab.move_focus_down(1);
     tab.vertical_split(new_pane_id_5, 1);
     tab.move_focus_up(1);
-    tab.resize_left(1);
-    tab.resize_up(1);
-    tab.resize_up(1);
+    tab.resize_left(1, None);
+    tab.resize_up(1, None);
+    tab.resize_up(1, None);
     tab.horizontal_split(new_pane_id_6, 1);
     tab.move_focus_left(1);
     tab.close_focused_pane(1);
@@ -3086,7 +3086,7 @@ pub fn resize_down_with_pane_above() {
     let mut tab = create_new_tab(size);
     let new_pane_id = PaneId::Terminal(2);
     tab.horizontal_split(new_pane_id, 1);
-    tab.resize_down(1);
+    tab.resize_down(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -3193,7 +3193,7 @@ pub fn resize_down_with_pane_below() {
     let new_pane_id = PaneId::Terminal(2);
     tab.horizontal_split(new_pane_id, 1);
     tab.move_focus_up(1);
-    tab.resize_down(1);
+    tab.resize_down(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -3307,7 +3307,7 @@ pub fn resize_down_with_panes_above_and_below() {
     tab.horizontal_split(new_pane_id_1, 1);
     tab.horizontal_split(new_pane_id_2, 1);
     tab.move_focus_up(1);
-    tab.resize_down(1);
+    tab.resize_down(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -3461,7 +3461,7 @@ pub fn resize_down_with_multiple_panes_above() {
     tab.move_focus_up(1);
     tab.vertical_split(new_pane_id_2, 1);
     tab.move_focus_down(1);
-    tab.resize_down(1);
+    tab.resize_down(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -3617,7 +3617,7 @@ pub fn resize_down_with_panes_above_aligned_left_with_current_pane() {
     tab.move_focus_up(1);
     tab.vertical_split(pane_above, 1);
     tab.move_focus_down(1);
-    tab.resize_down(1);
+    tab.resize_down(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -3816,7 +3816,7 @@ pub fn resize_down_with_panes_below_aligned_left_with_current_pane() {
     tab.vertical_split(pane_below, 1);
     tab.move_focus_up(1);
     tab.vertical_split(focused_pane, 1);
-    tab.resize_down(1);
+    tab.resize_down(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -4017,7 +4017,7 @@ pub fn resize_down_with_panes_above_aligned_right_with_current_pane() {
     tab.vertical_split(pane_above_and_right, 1);
     tab.move_focus_down(1);
     tab.move_focus_left(1);
-    tab.resize_down(1);
+    tab.resize_down(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -4217,7 +4217,7 @@ pub fn resize_down_with_panes_below_aligned_right_with_current_pane() {
     tab.move_focus_up(1);
     tab.vertical_split(pane_to_the_right, 1);
     tab.move_focus_left(1);
-    tab.resize_down(1);
+    tab.resize_down(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -4416,7 +4416,7 @@ pub fn resize_down_with_panes_above_aligned_left_and_right_with_current_pane() {
     tab.vertical_split(PaneId::Terminal(6), 1);
     tab.move_focus_left(1);
     tab.move_focus_down(1);
-    tab.resize_down(1);
+    tab.resize_down(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -4700,7 +4700,7 @@ pub fn resize_down_with_panes_below_aligned_left_and_right_with_current_pane() {
     tab.vertical_split(PaneId::Terminal(5), 1);
     tab.vertical_split(PaneId::Terminal(6), 1);
     tab.move_focus_left(1);
-    tab.resize_down(1);
+    tab.resize_down(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -4988,7 +4988,7 @@ pub fn resize_down_with_panes_above_aligned_left_and_right_with_panes_to_the_lef
     tab.vertical_split(PaneId::Terminal(7), 1);
     tab.vertical_split(PaneId::Terminal(8), 1);
     tab.move_focus_left(1);
-    tab.resize_down(1);
+    tab.resize_down(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -5364,7 +5364,7 @@ pub fn resize_down_with_panes_below_aligned_left_and_right_with_to_the_left_and_
     tab.move_focus_left(1);
     tab.move_focus_up(1);
     tab.move_focus_left(1);
-    tab.resize_down(1);
+    tab.resize_down(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -5727,7 +5727,7 @@ pub fn cannot_resize_down_when_pane_below_is_at_minimum_height() {
     let mut tab = create_new_tab(size);
     tab.horizontal_split(PaneId::Terminal(2), 1);
     tab.move_focus_up(1);
-    tab.resize_down(1);
+    tab.resize_down(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -5768,7 +5768,7 @@ pub fn resize_left_with_pane_to_the_left() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), 1);
-    tab.resize_left(1);
+    tab.resize_left(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -5872,7 +5872,7 @@ pub fn resize_left_with_pane_to_the_right() {
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), 1);
     tab.move_focus_left(1);
-    tab.resize_left(1);
+    tab.resize_left(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -5978,7 +5978,7 @@ pub fn resize_left_with_panes_to_the_left_and_right() {
     tab.vertical_split(PaneId::Terminal(2), 1);
     tab.vertical_split(PaneId::Terminal(3), 1);
     tab.move_focus_left(1);
-    tab.resize_left(1);
+    tab.resize_left(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -6127,7 +6127,7 @@ pub fn resize_left_with_multiple_panes_to_the_left() {
     tab.move_focus_left(1);
     tab.horizontal_split(PaneId::Terminal(3), 1);
     tab.move_focus_right(1);
-    tab.resize_left(1);
+    tab.resize_left(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -6278,7 +6278,7 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_with_current_pane() {
     tab.move_focus_up(1);
     tab.vertical_split(PaneId::Terminal(4), 1);
     tab.move_focus_down(1);
-    tab.resize_left(1);
+    tab.resize_left(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -6473,7 +6473,7 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_with_current_pane() {
     tab.vertical_split(PaneId::Terminal(4), 1);
     tab.move_focus_down(1);
     tab.move_focus_left(1);
-    tab.resize_left(1);
+    tab.resize_left(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -6666,7 +6666,7 @@ pub fn resize_left_with_panes_to_the_left_aligned_bottom_with_current_pane() {
     tab.vertical_split(PaneId::Terminal(3), 1);
     tab.move_focus_up(1);
     tab.vertical_split(PaneId::Terminal(4), 1);
-    tab.resize_left(1);
+    tab.resize_left(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -6860,7 +6860,7 @@ pub fn resize_left_with_panes_to_the_right_aligned_bottom_with_current_pane() {
     tab.move_focus_up(1);
     tab.vertical_split(PaneId::Terminal(4), 1);
     tab.move_focus_left(1);
-    tab.resize_left(1);
+    tab.resize_left(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -7059,7 +7059,7 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_and_bottom_with_current_pa
     tab.move_focus_up(1);
     tab.vertical_split(PaneId::Terminal(6), 1);
     tab.move_focus_down(1);
-    tab.resize_left(1);
+    tab.resize_left(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -7345,7 +7345,7 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_and_bottom_with_current_p
     tab.vertical_split(PaneId::Terminal(6), 1);
     tab.move_focus_down(1);
     tab.move_focus_left(1);
-    tab.resize_left(1);
+    tab.resize_left(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -7629,12 +7629,12 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_and_bottom_with_panes_abov
     tab.move_focus_up(1);
     tab.vertical_split(PaneId::Terminal(5), 1);
     tab.move_focus_down(1);
-    tab.resize_down(1);
+    tab.resize_down(1, None);
     tab.vertical_split(PaneId::Terminal(6), 1);
     tab.horizontal_split(PaneId::Terminal(7), 1);
     tab.horizontal_split(PaneId::Terminal(8), 1);
     tab.move_focus_up(1);
-    tab.resize_left(1);
+    tab.resize_left(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -8004,13 +8004,13 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_and_bottom_with_panes_abo
     tab.move_focus_up(1);
     tab.vertical_split(PaneId::Terminal(5), 1);
     tab.move_focus_down(1);
-    tab.resize_down(1);
+    tab.resize_down(1, None);
     tab.vertical_split(PaneId::Terminal(6), 1);
     tab.move_focus_left(1);
     tab.horizontal_split(PaneId::Terminal(7), 1);
     tab.horizontal_split(PaneId::Terminal(8), 1);
     tab.move_focus_up(1);
-    tab.resize_left(1);
+    tab.resize_left(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -8369,7 +8369,7 @@ pub fn cannot_resize_left_when_pane_to_the_left_is_at_minimum_width() {
     let size = Size { cols: 10, rows: 20 };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), 1);
-    tab.resize_left(1);
+    tab.resize_left(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -8410,7 +8410,7 @@ pub fn resize_right_with_pane_to_the_left() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), 1);
-    tab.resize_right(1);
+    tab.resize_right(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -8515,7 +8515,7 @@ pub fn resize_right_with_pane_to_the_right() {
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), 1);
     tab.move_focus_left(1);
-    tab.resize_right(1);
+    tab.resize_right(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -8621,7 +8621,7 @@ pub fn resize_right_with_panes_to_the_left_and_right() {
     tab.vertical_split(PaneId::Terminal(2), 1);
     tab.vertical_split(PaneId::Terminal(3), 1);
     tab.move_focus_left(1);
-    tab.resize_right(1);
+    tab.resize_right(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -8771,7 +8771,7 @@ pub fn resize_right_with_multiple_panes_to_the_left() {
     tab.move_focus_left(1);
     tab.horizontal_split(PaneId::Terminal(3), 1);
     tab.move_focus_right(1);
-    tab.resize_right(1);
+    tab.resize_right(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -8922,7 +8922,7 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_with_current_pane() {
     tab.horizontal_split(PaneId::Terminal(3), 1);
     tab.move_focus_right(1);
     tab.horizontal_split(PaneId::Terminal(4), 1);
-    tab.resize_right(1);
+    tab.resize_right(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -9116,7 +9116,7 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_with_current_pane() {
     tab.move_focus_right(1);
     tab.horizontal_split(PaneId::Terminal(4), 1);
     tab.move_focus_left(1);
-    tab.resize_right(1);
+    tab.resize_right(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -9311,7 +9311,7 @@ pub fn resize_right_with_panes_to_the_left_aligned_bottom_with_current_pane() {
     tab.move_focus_right(1);
     tab.horizontal_split(PaneId::Terminal(4), 1);
     tab.move_focus_up(1);
-    tab.resize_right(1);
+    tab.resize_right(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -9507,7 +9507,7 @@ pub fn resize_right_with_panes_to_the_right_aligned_bottom_with_current_pane() {
     tab.horizontal_split(PaneId::Terminal(4), 1);
     tab.move_focus_up(1);
     tab.move_focus_left(1);
-    tab.resize_right(1);
+    tab.resize_right(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -9706,7 +9706,7 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_and_bottom_with_current_p
     tab.move_focus_up(1);
     tab.vertical_split(PaneId::Terminal(6), 1);
     tab.move_focus_down(1);
-    tab.resize_right(1);
+    tab.resize_right(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -9991,7 +9991,7 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_and_bottom_with_current_
     tab.vertical_split(PaneId::Terminal(6), 1);
     tab.move_focus_down(1);
     tab.move_focus_left(1);
-    tab.resize_right(1);
+    tab.resize_right(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -10274,12 +10274,12 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_and_bottom_with_panes_abo
     tab.move_focus_up(1);
     tab.vertical_split(PaneId::Terminal(5), 1);
     tab.move_focus_down(1);
-    tab.resize_up(1);
+    tab.resize_up(1, None);
     tab.vertical_split(PaneId::Terminal(6), 1);
     tab.horizontal_split(PaneId::Terminal(7), 1);
     tab.horizontal_split(PaneId::Terminal(8), 1);
     tab.move_focus_up(1);
-    tab.resize_right(1);
+    tab.resize_right(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -10648,13 +10648,13 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_and_bottom_with_panes_ab
     tab.move_focus_up(1);
     tab.vertical_split(PaneId::Terminal(5), 1);
     tab.move_focus_down(1);
-    tab.resize_up(1);
+    tab.resize_up(1, None);
     tab.vertical_split(PaneId::Terminal(6), 1);
     tab.move_focus_left(1);
     tab.horizontal_split(PaneId::Terminal(7), 1);
     tab.horizontal_split(PaneId::Terminal(8), 1);
     tab.move_focus_up(1);
-    tab.resize_right(1);
+    tab.resize_right(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -11012,7 +11012,7 @@ pub fn cannot_resize_right_when_pane_to_the_left_is_at_minimum_width() {
     let size = Size { cols: 10, rows: 20 };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), 1);
-    tab.resize_right(1);
+    tab.resize_right(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -11054,7 +11054,7 @@ pub fn resize_up_with_pane_above() {
     };
     let mut tab = create_new_tab(size);
     tab.horizontal_split(PaneId::Terminal(2), 1);
-    tab.resize_up(1);
+    tab.resize_up(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -11160,7 +11160,7 @@ pub fn resize_up_with_pane_below() {
     let mut tab = create_new_tab(size);
     tab.horizontal_split(PaneId::Terminal(2), 1);
     tab.move_focus_up(1);
-    tab.resize_up(1);
+    tab.resize_up(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -11270,7 +11270,7 @@ pub fn resize_up_with_panes_above_and_below() {
     tab.horizontal_split(PaneId::Terminal(2), 1);
     tab.horizontal_split(PaneId::Terminal(3), 1);
     tab.move_focus_up(1);
-    tab.resize_up(1);
+    tab.resize_up(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -11420,7 +11420,7 @@ pub fn resize_up_with_multiple_panes_above() {
     tab.move_focus_up(1);
     tab.vertical_split(PaneId::Terminal(3), 1);
     tab.move_focus_down(1);
-    tab.resize_up(1);
+    tab.resize_up(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -11570,7 +11570,7 @@ pub fn resize_up_with_panes_above_aligned_left_with_current_pane() {
     tab.vertical_split(PaneId::Terminal(3), 1);
     tab.move_focus_down(1);
     tab.vertical_split(PaneId::Terminal(4), 1);
-    tab.resize_up(1);
+    tab.resize_up(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -11766,7 +11766,7 @@ pub fn resize_up_with_panes_below_aligned_left_with_current_pane() {
     tab.move_focus_down(1);
     tab.vertical_split(PaneId::Terminal(4), 1);
     tab.move_focus_up(1);
-    tab.resize_up(1);
+    tab.resize_up(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -11962,7 +11962,7 @@ pub fn resize_up_with_panes_above_aligned_right_with_current_pane() {
     tab.move_focus_down(1);
     tab.vertical_split(PaneId::Terminal(4), 1);
     tab.move_focus_left(1);
-    tab.resize_up(1);
+    tab.resize_up(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -12159,7 +12159,7 @@ pub fn resize_up_with_panes_below_aligned_right_with_current_pane() {
     tab.vertical_split(PaneId::Terminal(4), 1);
     tab.move_focus_left(1);
     tab.move_focus_up(1);
-    tab.resize_up(1);
+    tab.resize_up(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -12356,7 +12356,7 @@ pub fn resize_up_with_panes_above_aligned_left_and_right_with_current_pane() {
     tab.vertical_split(PaneId::Terminal(5), 1);
     tab.vertical_split(PaneId::Terminal(6), 1);
     tab.move_focus_left(1);
-    tab.resize_up(1);
+    tab.resize_up(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -12640,7 +12640,7 @@ pub fn resize_up_with_panes_below_aligned_left_and_right_with_current_pane() {
     tab.vertical_split(PaneId::Terminal(6), 1);
     tab.move_focus_left(1);
     tab.move_focus_up(1);
-    tab.resize_up(1);
+    tab.resize_up(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -12927,7 +12927,7 @@ pub fn resize_up_with_panes_above_aligned_left_and_right_with_panes_to_the_left_
     tab.vertical_split(PaneId::Terminal(7), 1);
     tab.vertical_split(PaneId::Terminal(8), 1);
     tab.move_focus_left(1);
-    tab.resize_up(1);
+    tab.resize_up(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -13301,7 +13301,7 @@ pub fn resize_up_with_panes_below_aligned_left_and_right_with_to_the_left_and_ri
     tab.vertical_split(PaneId::Terminal(7), 1);
     tab.vertical_split(PaneId::Terminal(8), 1);
     tab.move_focus_left(1);
-    tab.resize_up(1);
+    tab.resize_up(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -13663,7 +13663,7 @@ pub fn cannot_resize_up_when_pane_above_is_at_minimum_height() {
     };
     let mut tab = create_new_tab(size);
     tab.horizontal_split(PaneId::Terminal(2), 1);
-    tab.resize_down(1);
+    tab.resize_down(1, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -13696,7 +13696,7 @@ pub fn nondirectional_resize_increase_with_1_pane() {
         rows: 10,
     };
     let mut tab = create_new_tab(size);
-    tab.resize_increase(1);
+    tab.resize_increase(1, None, None);
 
     assert_eq!(
         tab.get_active_pane(1).unwrap().position_and_size().y,
@@ -13720,7 +13720,7 @@ pub fn nondirectional_resize_increase_with_1_pane_to_left() {
     let mut tab = create_new_tab(size);
     let new_pane_id_1 = PaneId::Terminal(2);
     tab.vertical_split(new_pane_id_1, 1);
-    tab.resize_increase(1);
+    tab.resize_increase(1, None, None);
 
     // should behave like `resize_left_with_pane_to_the_left`
     assert_eq!(
@@ -13756,7 +13756,7 @@ pub fn nondirectional_resize_increase_with_2_panes_to_left() {
     tab.move_focus_left(1);
     tab.horizontal_split(PaneId::Terminal(3), 1);
     tab.move_focus_right(1);
-    tab.resize_increase(1);
+    tab.resize_increase(1, None, None);
 
     // should behave like `resize_left_with_multiple_panes_to_the_left`
     assert_eq!(
@@ -13813,7 +13813,7 @@ pub fn nondirectional_resize_increase_with_1_pane_to_right_1_pane_above() {
     tab.vertical_split(PaneId::Terminal(2), 1);
     tab.move_focus_left(1);
     tab.horizontal_split(PaneId::Terminal(3), 1);
-    tab.resize_increase(1);
+    tab.resize_increase(1, None, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -13869,7 +13869,7 @@ pub fn nondirectional_resize_increase_with_1_pane_to_right_1_pane_to_left() {
     tab.vertical_split(PaneId::Terminal(2), 1);
     tab.vertical_split(PaneId::Terminal(3), 1);
     tab.move_focus_left(1);
-    tab.resize_increase(1);
+    tab.resize_increase(1, None, None);
 
     assert_eq!(
         tab.tiled_panes
@@ -13925,7 +13925,7 @@ pub fn nondirectional_resize_increase_with_pane_above_aligned_right_with_current
     tab.vertical_split(PaneId::Terminal(2), 1);
     tab.vertical_split(PaneId::Terminal(3), 1);
     tab.move_focus_left(1);
-    tab.resize_increase(1);
+    tab.resize_increase(1, None, None);
 
     assert_eq!(
         tab.tiled_panes

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -3,6 +3,7 @@
 use super::command::RunCommandAction;
 use super::layout::TabLayout;
 use crate::input::options::OnForceClose;
+use crate::pane_size::Constraint;
 use serde::{Deserialize, Serialize};
 use zellij_tile::data::InputMode;
 
@@ -44,6 +45,11 @@ pub enum Action {
     SwitchToMode(InputMode),
     /// Resize focus pane in specified direction.
     Resize(ResizeDirection),
+    ResizeExact(
+        ResizeDirection,
+        #[serde(default)] Option<Constraint>,
+        #[serde(default)] Option<Constraint>,
+    ),
     /// Switch focus to next pane in specified direction.
     FocusNextPane,
     FocusPreviousPane,


### PR DESCRIPTION
This was initially intended to just complete #647, but instead of simply adding resize increments of 1 I decided to implement user-defined fixed or percentage based resize increments through a new "ResizeExact" action.

This ended up being a pretty big MR, so I'm sure there are some additional changes I should make before it's merged in. I'd appreciate any feedback, thanks!