### PR TITLE
add(feature): `unstable`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,4 @@ pkg-fmt = "tgz"
 
 [features]
 disable_automatic_asset_installation = [ "zellij-utils/disable_automatic_asset_installation" ]
+unstable = [ "zellij-client/unstable", "zellij-utils/unstable" ]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,14 +6,13 @@ use crate::sessions::{
     session_exists, ActiveSession, SessionNameMatch,
 };
 use dialoguer::Confirm;
-use miette::{IntoDiagnostic, Result};
+use miette::Result;
 use std::path::PathBuf;
 use std::process;
 use zellij_client::start_client as start_client_impl;
 use zellij_client::{os_input_output::get_client_os_input, ClientInfo};
 use zellij_server::os_input_output::get_server_os_input;
 use zellij_server::start_server as start_server_impl;
-use zellij_utils::input::actions::ActionsFromYaml;
 use zellij_utils::input::options::Options;
 use zellij_utils::nix;
 use zellij_utils::{
@@ -21,6 +20,11 @@ use zellij_utils::{
     envs,
     setup::{get_default_data_dir, Setup},
 };
+
+#[cfg(feature = "unstable")]
+use miette::IntoDiagnostic;
+#[cfg(feature = "unstable")]
+use zellij_utils::input::actions::ActionsFromYaml;
 
 pub(crate) use crate::sessions::list_sessions;
 
@@ -115,6 +119,7 @@ fn find_indexed_session(
 }
 
 /// Send a vec of `[Action]` to a currently running session.
+#[cfg(feature = "unstable")]
 pub(crate) fn send_action_to_session(opts: zellij_utils::cli::CliArgs) {
     match get_active_session() {
         ActiveSession::None => {
@@ -138,6 +143,7 @@ pub(crate) fn send_action_to_session(opts: zellij_utils::cli::CliArgs) {
     };
 }
 
+#[cfg(feature = "unstable")]
 fn attach_with_fake_client(opts: zellij_utils::cli::CliArgs, name: &str) {
     if let Some(zellij_utils::cli::Command::Sessions(zellij_utils::cli::Sessions::Action {
         action: Some(action),

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,11 +14,16 @@ fn main() {
     configure_logger();
     let opts = CliArgs::parse();
 
+    #[cfg(feature = "unstable")]
+    {
+        if let Some(Command::Sessions(Sessions::Action { .. })) = opts.command {
+            commands::send_action_to_session(opts);
+            std::process::exit(0);
+        }
+    }
+
     if let Some(Command::Sessions(Sessions::ListSessions)) = opts.command {
         commands::list_sessions();
-    }
-    if let Some(Command::Sessions(Sessions::Action { .. })) = opts.command {
-        commands::send_action_to_session(opts);
     } else if let Some(Command::Sessions(Sessions::KillAllSessions { yes })) = opts.command {
         commands::kill_all_sessions(yes);
     } else if let Some(Command::Sessions(Sessions::KillSession { ref target_session })) =

--- a/zellij-client/Cargo.toml
+++ b/zellij-client/Cargo.toml
@@ -18,4 +18,4 @@ log = "0.4.17"
 insta = "1.6.0"
 
 [features]
-
+unstable = [ ]

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -50,3 +50,4 @@ features = ["unstable"]
 
 [features]
 disable_automatic_asset_installation = []
+unstable = []

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -110,5 +110,6 @@ pub enum Sessions {
         yes: bool,
     },
     /// Send actions to a specific session
+    #[cfg(feature = "unstable")]
     Action { action: Option<String> },
 }


### PR DESCRIPTION
Add a feature `unstable`, which is intended to communicate the same
intent.

Gate: Send actions from cli with the `unstable` feature.