### PR TITLE
fix(editor): handle editor in fullscreen

### DIFF
--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -103,7 +103,7 @@ impl Pane for PluginPane {
         self.geom = position_and_size;
         self.should_render = true;
     }
-    fn get_geom_override(&mut self, pane_geom: PaneGeom) {
+    fn set_geom_override(&mut self, pane_geom: PaneGeom) {
         self.geom_override = Some(pane_geom);
         self.should_render = true;
     }

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -95,7 +95,7 @@ impl Pane for TerminalPane {
         self.geom = position_and_size;
         self.reflow_lines();
     }
-    fn get_geom_override(&mut self, pane_geom: PaneGeom) {
+    fn set_geom_override(&mut self, pane_geom: PaneGeom) {
         self.geom_override = Some(pane_geom);
         self.reflow_lines();
     }

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -142,8 +142,13 @@ impl TiledPanes {
         }
         let removed_pane = self.panes.remove(&pane_id).map(|removed_pane| {
             let with_pane_id = with_pane.pid();
-            let removed_pane_geom = removed_pane.current_geom();
+            let removed_pane_geom = removed_pane.position_and_size();
+            let removed_pane_geom_override = removed_pane.geom_override();
             with_pane.set_geom(removed_pane_geom);
+            match removed_pane_geom_override {
+                Some(geom_override) => with_pane.set_geom_override(geom_override),
+                None => with_pane.reset_size_and_position_override(),
+            };
             self.panes.insert(with_pane_id, with_pane);
             removed_pane
         });
@@ -780,7 +785,7 @@ impl TiledPanes {
         let next_geom_override = new_position.geom_override();
         new_position.set_geom(prev_geom);
         if let Some(geom) = prev_geom_override {
-            new_position.get_geom_override(geom);
+            new_position.set_geom_override(geom);
         }
         resize_pty!(new_position, self.os_api);
         new_position.set_should_render(true);
@@ -788,7 +793,7 @@ impl TiledPanes {
         let current_position = self.panes.get_mut(&active_pane_id).unwrap();
         current_position.set_geom(next_geom);
         if let Some(geom) = next_geom_override {
-            current_position.get_geom_override(geom);
+            current_position.set_geom_override(geom);
         }
         resize_pty!(current_position, self.os_api);
         current_position.set_should_render(true);
@@ -813,7 +818,7 @@ impl TiledPanes {
                 let next_geom_override = new_position.geom_override();
                 new_position.set_geom(prev_geom);
                 if let Some(geom) = prev_geom_override {
-                    new_position.get_geom_override(geom);
+                    new_position.set_geom_override(geom);
                 }
                 resize_pty!(new_position, self.os_api);
                 new_position.set_should_render(true);
@@ -821,7 +826,7 @@ impl TiledPanes {
                 let current_position = self.panes.get_mut(active_pane_id).unwrap();
                 current_position.set_geom(next_geom);
                 if let Some(geom) = next_geom_override {
-                    current_position.get_geom_override(geom);
+                    current_position.set_geom_override(geom);
                 }
                 resize_pty!(current_position, self.os_api);
                 current_position.set_should_render(true);
@@ -848,7 +853,7 @@ impl TiledPanes {
                 let next_geom_override = new_position.geom_override();
                 new_position.set_geom(prev_geom);
                 if let Some(geom) = prev_geom_override {
-                    new_position.get_geom_override(geom);
+                    new_position.set_geom_override(geom);
                 }
                 resize_pty!(new_position, self.os_api);
                 new_position.set_should_render(true);
@@ -856,7 +861,7 @@ impl TiledPanes {
                 let current_position = self.panes.get_mut(active_pane_id).unwrap();
                 current_position.set_geom(next_geom);
                 if let Some(geom) = next_geom_override {
-                    current_position.get_geom_override(geom);
+                    current_position.set_geom_override(geom);
                 }
                 resize_pty!(current_position, self.os_api);
                 current_position.set_should_render(true);
@@ -883,7 +888,7 @@ impl TiledPanes {
                 let next_geom_override = new_position.geom_override();
                 new_position.set_geom(prev_geom);
                 if let Some(geom) = prev_geom_override {
-                    new_position.get_geom_override(geom);
+                    new_position.set_geom_override(geom);
                 }
                 resize_pty!(new_position, self.os_api);
                 new_position.set_should_render(true);
@@ -891,7 +896,7 @@ impl TiledPanes {
                 let current_position = self.panes.get_mut(active_pane_id).unwrap();
                 current_position.set_geom(next_geom);
                 if let Some(geom) = next_geom_override {
-                    current_position.get_geom_override(geom);
+                    current_position.set_geom_override(geom);
                 }
                 resize_pty!(current_position, self.os_api);
                 current_position.set_should_render(true);
@@ -918,7 +923,7 @@ impl TiledPanes {
                 let next_geom_override = new_position.geom_override();
                 new_position.set_geom(prev_geom);
                 if let Some(geom) = prev_geom_override {
-                    new_position.get_geom_override(geom);
+                    new_position.set_geom_override(geom);
                 }
                 resize_pty!(new_position, self.os_api);
                 new_position.set_should_render(true);
@@ -926,7 +931,7 @@ impl TiledPanes {
                 let current_position = self.panes.get_mut(active_pane_id).unwrap();
                 current_position.set_geom(next_geom);
                 if let Some(geom) = next_geom_override {
-                    current_position.get_geom_override(geom);
+                    current_position.set_geom_override(geom);
                 }
                 resize_pty!(current_position, self.os_api);
                 current_position.set_should_render(true);
@@ -1059,7 +1064,7 @@ impl TiledPanes {
                         .collect();
                     for pid in viewport_pane_ids {
                         let viewport_pane = self.get_pane_mut(pid).unwrap();
-                        viewport_pane.get_geom_override(viewport_pane.position_and_size());
+                        viewport_pane.set_geom_override(viewport_pane.position_and_size());
                     }
                     let viewport = { *self.viewport.borrow() };
                     let active_terminal = self.get_pane_mut(active_pane_id).unwrap();
@@ -1068,7 +1073,7 @@ impl TiledPanes {
                         y: viewport.y,
                         ..Default::default()
                     };
-                    active_terminal.get_geom_override(full_screen_geom);
+                    active_terminal.set_geom_override(full_screen_geom);
                 }
                 let connected_client_list: Vec<ClientId> =
                     { self.connected_clients.borrow().iter().copied().collect() };

--- a/zellij-server/src/panes/tiled_panes/pane_resizer.rs
+++ b/zellij-server/src/panes/tiled_panes/pane_resizer.rs
@@ -139,7 +139,7 @@ impl<'a> PaneResizer<'a> {
                 },
             };
             if pane.geom_override().is_some() {
-                pane.get_geom_override(new_geom);
+                pane.set_geom_override(new_geom);
             } else {
                 pane.set_geom(new_geom);
             }

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -121,7 +121,7 @@ pub trait Pane {
     fn get_content_rows(&self) -> usize;
     fn reset_size_and_position_override(&mut self);
     fn set_geom(&mut self, position_and_size: PaneGeom);
-    fn get_geom_override(&mut self, pane_geom: PaneGeom);
+    fn set_geom_override(&mut self, pane_geom: PaneGeom);
     fn handle_pty_bytes(&mut self, bytes: VteBytes);
     fn cursor_coordinates(&self) -> Option<(usize, usize)>;
     fn adjust_input_to_terminal(&self, input_bytes: Vec<u8>) -> Vec<u8>;
@@ -1517,7 +1517,6 @@ impl Tab {
         let mut file = temp_dir();
         file.push(format!("{}.dump", Uuid::new_v4()));
         self.dump_active_terminal_screen(Some(String::from(file.to_string_lossy())), client_id);
-        // let line_number = self.get_active_pane(client_id).map(|a_t| a_t.get_line_number());
         let line_number = self
             .get_active_pane(client_id)
             .and_then(|a_t| a_t.get_line_number());


### PR DESCRIPTION
This fixes a bug where if you opened the in place editor (ctrl+s+e), switched to fullscreen (ctrl+p+f) and closed the editor, the app would be in a bad state and you'd likely have to restart. This also fixes the other way around (switching to fullscreen, opening the inplace editor, switching off fullscreen and closing the pane).