### PR TITLE
fix(terminal): properly trim lines with widechars on resize

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -651,7 +651,8 @@ impl Grid {
                     }
                 }
                 if let Some(trim_at) = trim_at {
-                    line.truncate(trim_at);
+                    let excess_width_until_trim_at = line.excess_width_until(trim_at);
+                    line.truncate(trim_at + excess_width_until_trim_at);
                 }
             }
 


### PR DESCRIPTION
This is a fix for https://github.com/zellij-org/zellij/issues/1206

This also happens when we simply resize the pane without even opening vim or a similar app. The latter happens because we call the resize/reflow method when moving away from an alternative screen (in case the scrollback was resized somewhere in between).

In such a case, we trim lines after the last whitespace to that we won't reflow needless whitespace (eg. have a wrapped line with only whitespace). This mechanism wasn't wide-char aware, and because of that this bug was created. I adjusted it and it now works.