### PR TITLE
fix(scroll): reset scroll properly when typing

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -854,13 +854,13 @@ impl Grid {
         self.output_buffer.update_all_lines();
     }
     pub fn reset_viewport(&mut self) {
-        let row_count_below = self.lines_below.len();
-        for _ in 0..row_count_below {
+        let max_lines_to_scroll = *SCROLL_BUFFER_SIZE.get().unwrap() * 2; // while not very elegant, this can prevent minor bugs from becoming showstoppers by sticking the whole app display in an endless loop
+        let mut lines_scrolled = 0;
+        while self.is_scrolled && lines_scrolled < max_lines_to_scroll {
             self.scroll_down_one_line();
+            lines_scrolled += 1;
         }
-        if row_count_below > 0 {
-            self.output_buffer.update_all_lines();
-        }
+        self.output_buffer.update_all_lines();
     }
     pub fn rotate_scroll_region_up(&mut self, count: usize) {
         if let Some((scroll_region_top, scroll_region_bottom)) = self


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/1546

This mostly happened in some edge cases (eg. scrolling up, resizing the terminal and then typing something). This happened because of some mistake in the line reflow calculation in this case.