### PR TITLE
fix(ci): add new rust toolchain location to action

### DIFF
--- a/.github/workflows/update-rust-toolchain.yml
+++ b/.github/workflows/update-rust-toolchain.yml
@@ -17,6 +17,7 @@ jobs:
         uses: a-kenji/update-rust-toolchain@v1
         with:
           minor-version-delta: 2
+          toolchain-path: './rust-toolchain.toml'
           token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
           pr-labels: |
             dependencies


### PR DESCRIPTION
The action still had a reference to the old toolchain location.