### PR TITLE
chore(docs): add more matrix links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thanks for considering contributing to Zellij!
 
 **First**: if you're unsure of anything, feel free to ask on our [Discord
-server](https://discord.gg/MHV3n76PDq). We're a friendly and welcoming bunch!
+server](https://discord.gg/MHV3n76PDq), or on [Matrix](https://matrix.to/#/#zellij_general:matrix.org). We're a friendly and welcoming bunch!
 
 # Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Please report any code of conduct violations to [aram@poor.dev](mailto:aram@poor
 
 To get started, you can:
 1. Take a look at the "Issues" in this repository - especially those marked "Good first issue". Those with the "Help Wanted" tag probably don't have anyone else working on them.
-2. Drop by our [chat](https://discord.gg/CrUAFH3) and ask what you can work on, or how to get started.
+2. Drop by our [discord](https://discord.gg/CrUAFH3), or [matrix](https://matrix.to/#/#zellij_general:matrix.org) chat and ask what you can work on, or how to get started.
 3. Open an issue with your idea(s) for the project or tell us about them in our chat.
 
 ## How do I start a development environment?


### PR DESCRIPTION
There references to discord, but not to matrix at the exact same spot.

fixes #1580