### PR TITLE
fix: add usage comment to fish shell auto-start snippet (#1574)

### DIFF
--- a/zellij-utils/assets/shell/auto-start.fish
+++ b/zellij-utils/assets/shell/auto-start.fish
@@ -1,3 +1,11 @@
+# The following snippet is meant to be used like this in your fish config:
+#
+# if status is-interactive
+#     # Configure auto-attach/exit to your likings (default is off).
+#     # set ZELLIJ_AUTO_ATTACH true
+#     # set ZELLIJ_AUTO_EXIT true
+#     eval (zellij setup --generate-auto-start fish | string collect)
+# end
 if not set -q ZELLIJ
     if test "$ZELLIJ_AUTO_ATTACH" = "true"
         zellij attach -c


### PR DESCRIPTION
This PR adds a usage comment before the auto-start snipped for the fish shell which is emitted by `zellij setup --generate-auto-start fish` as discussed in #1574.