### PR TITLE
Improve terminal performance

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -5,6 +5,7 @@ pub mod tab;
 
 mod logging_pipe;
 mod pty;
+mod terminal_bytes;
 mod pty_writer;
 mod route;
 mod screen;

--- a/zellij-server/src/terminal_bytes.rs
+++ b/zellij-server/src/terminal_bytes.rs
@@ -1,0 +1,155 @@
+use crate::{
+    os_input_output::{AsyncReader, ServerOsApi},
+    screen::ScreenInstruction,
+    thread_bus::ThreadSenders,
+};
+use async_std::{
+    future::timeout as async_timeout,
+    task,
+};
+use std::{
+    os::unix::io::RawFd,
+    time::{Duration, Instant},
+};
+use zellij_utils::{
+    async_std,
+    errors::{get_current_ctx, ContextType},
+    logging::debug_to_file,
+};
+
+enum ReadResult {
+    Ok(usize),
+    Timeout,
+    Err(std::io::Error),
+}
+
+impl From<std::io::Result<usize>> for ReadResult {
+    fn from(e: std::io::Result<usize>) -> ReadResult {
+        match e {
+            Err(e) => ReadResult::Err(e),
+            Ok(n) => ReadResult::Ok(n),
+        }
+    }
+}
+
+pub(crate) struct TerminalBytes {
+    pid: RawFd,
+    senders: ThreadSenders,
+    async_reader: Box<dyn AsyncReader>,
+    debug: bool,
+    render_deadline: Option<Instant>,
+    backed_up: bool,
+    minimum_render_send_time: Option<Duration>,
+    buffering_pause: Duration,
+    last_render: Instant
+}
+
+impl TerminalBytes {
+    pub fn new(pid: RawFd, senders: ThreadSenders, os_input: Box<dyn ServerOsApi>, debug: bool) -> Self {
+        TerminalBytes {
+            pid,
+            senders,
+            debug,
+            async_reader: os_input.async_file_reader(pid),
+            render_deadline: None,
+            backed_up: false,
+            minimum_render_send_time: None,
+            buffering_pause: Duration::from_millis(30),
+            last_render: Instant::now(),
+        }
+    }
+    pub async fn listen(&mut self) {
+        // This function reads bytes from the pty and then sends them as
+        // ScreenInstruction::PtyBytes to screen to be parsed there
+        // We also send a separate instruction to Screen to render as ScreenInstruction::Render
+        //
+        // We endeavour to send a Render instruction to screen immediately after having send bytes
+        // to parse - this is so that the rendering is quick and smooth. However, this can cause
+        // latency if the screen is backed up. For this reason, if we detect a peak in the time it
+        // takes to send the render instruction, we assume the screen thread is backed up and so
+        // only send a render instruction sparingly, giving screen time to process bytes and render
+        // while still allowing the user to see an indication that things are happening (the
+        // sparing render instructions)
+        let mut err_ctx = get_current_ctx();
+        err_ctx.add_call(ContextType::AsyncTask);
+        let mut buf = [0u8; 65536];
+        loop {
+            match self.deadline_read(&mut buf).await {
+            // match deadline_read(async_reader.as_mut(), self.render_deadline, &mut buf).await {
+                ReadResult::Ok(0) | ReadResult::Err(_) => break, // EOF or error
+                ReadResult::Timeout => {
+                    let time_to_send_render = self.async_send_to_screen(ScreenInstruction::Render).await;
+                    self.update_render_send_time(time_to_send_render);
+                    // next read does not need a deadline as we just rendered everything
+                    self.render_deadline = None;
+                    self.last_render = Instant::now();
+                },
+                ReadResult::Ok(n_bytes) => {
+                    let bytes = &buf[..n_bytes];
+                    if self.debug {
+                        let _ = debug_to_file(bytes, self.pid);
+                    }
+                    self.async_send_to_screen(ScreenInstruction::PtyBytes(self.pid, bytes.to_vec())).await;
+                    if !self.backed_up {
+                        // we're not backed up, let's send an immediate render instruction
+                        let time_to_send_render = self.async_send_to_screen(ScreenInstruction::Render).await;
+                        self.update_render_send_time(time_to_send_render);
+                    }
+                    // if we already have a render_deadline we keep it, otherwise we set it
+                    // to buffering_pause since the last time we rendered.
+                    self.render_deadline.get_or_insert(self.last_render + self.buffering_pause);
+                },
+            }
+        }
+        self.async_send_to_screen(ScreenInstruction::Render).await;
+    }
+    async fn async_send_to_screen(&self, screen_instruction: ScreenInstruction) -> Duration { // returns the time it blocked the thread for
+        let sent_at = Instant::now();
+        let senders = self.senders.clone();
+        task::spawn_blocking(move || senders.send_to_screen(screen_instruction))
+            .await
+            .unwrap();
+        sent_at.elapsed()
+    }
+    fn update_render_send_time(&mut self, time_to_send_render: Duration) {
+        match self.minimum_render_send_time.as_mut() {
+            Some(minimum_render_time) => {
+                if time_to_send_render < *minimum_render_time {
+                    *minimum_render_time = time_to_send_render;
+                }
+                if time_to_send_render > *minimum_render_time * 10 {
+                    // sending the render instruction took an especially long time, we can safely
+                    // assume the screen thread is backed up and we should only send render
+                    // instructions sparingly
+                    self.backed_up = true;
+                } else if time_to_send_render < *minimum_render_time * 5 {
+                    // the screen thread is not backed up, we atomically unset the backed_up
+                    // indication
+                    self.backed_up = false;
+                }
+            },
+            None => {
+                self.minimum_render_send_time = Some(time_to_send_render);
+            }
+        }
+    }
+    async fn deadline_read(
+        &mut self,
+        buf: &mut [u8],
+    ) -> ReadResult {
+        if let Some(deadline) = self.render_deadline {
+            let timeout = deadline.checked_duration_since(Instant::now());
+            if let Some(timeout) = timeout {
+                match async_timeout(timeout, self.async_reader.read(buf)).await {
+                    Ok(res) => res.into(),
+                    _ => ReadResult::Timeout,
+                }
+            } else {
+                // deadline has already elapsed
+                ReadResult::Timeout
+            }
+        } else {
+            self.async_reader.read(buf).await.into()
+        }
+    }
+}


### PR DESCRIPTION
This started as an attempt to fix https://github.com/zellij-org/zellij/issues/873. I'm happy to say that not only was that issue fixed, but the overall performance, responsiveness and feel of the terminal was drastically improved as well.

## Background
When we read bytes from the pty, we send two types of instructions to the screen thread: `PtyBytes` containing the bytes themselves to be parsed and `Render` to control when the screen needs to serialize its state and send it to the user's terminal. 

If we send one render instruction per every `PtyBytes` instruction, the experience would be very smooth but we would end up backing up the message bug between pty and screen. Causing it to be unresponsive (eg. ctrl-c would take a long time coming through) and ultimately slower (too many render instructions would be sent to the user's terminal - taking a very long time to work).

Instead, what we do is send one if we have bytes on the wire and more than 30ms have passed since the last render.

## What was the issue?
In #873, neovim first sends an instruction to the terminal to render the single keystroke (this is arguably neovim's bug), because it assumes the character will be instantly overridden by the next ANSI instructions sent immediately afterwards. However, we often receive these bytes chunked and end up (because of the above logic) sending a render instruction in between them as we wait to buffer the rest of the bytes into the 30ms rendering deadline.

## What does this fix change?
With this fix, we start measuring how long it took us to send a render instruction to the screen thread (sending these instructions is a blocking operation that is only released once the screen thread received this message into its bounded queue). We log the minimal amount of time it takes us to to render, and then if we suddenly detect that sending render instructions takes more than 10 times that amount, we assume the screen thread is backed up.

When the screen thread is backed up, we perform the exact same logic we did up until now. "Buffering" render instructions and only sending them once every 30ms (or when we're done reading). However, when the screen thread is not backed up (which should be most of the time), we send a render instruction immediately after we send the bytes. Creating a very smooth experience, preventing the cursor from jumping around for these fractions of a second and preventing the single character from displaying in neovim.

It's likely that quite some other issues will be fixed by this as well.