### PR TITLE
fix(editor): handle editor/visual/configured editor with arguments

### DIFF
--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -165,7 +165,11 @@ fn handle_terminal(
 // this is a utility method to separate the arguments from a pathbuf before we turn it into a
 // Command. eg. "/usr/bin/vim -e" ==> "/usr/bin/vim" + "-e" (the latter will be pushed to args)
 fn separate_command_arguments(command: &mut PathBuf, args: &mut Vec<String>) {
-    if let Some(file_name) = command.file_name().and_then(|f_n| f_n.to_str()).map(|f_n| f_n.to_string()) {
+    if let Some(file_name) = command
+        .file_name()
+        .and_then(|f_n| f_n.to_str())
+        .map(|f_n| f_n.to_string())
+    {
         let mut file_name_parts = file_name.split_ascii_whitespace();
         if let Some(first_part) = file_name_parts.next() {
             command.set_file_name(first_part);


### PR DESCRIPTION
This is a fix to handle the case where the `EDITOR` and `VISUAL` environment variables or `scrollback_editor` config value contain arguments. Eg. `/usr/bin/vim -e`. Previously we either ignored them or silently failed - now we stick them on to the command (after optionally placing the +<line_number> argument).