### PR TITLE
Log every panic to the logfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix: avoid sending mouse click events on pane frames to applications (https://github.com/zellij-org/zellij/pull/1584)
 * feat: search through terminal scrollback (https://github.com/zellij-org/zellij/pull/1521)
 * feat: support themes directory (https://github.com/zellij-org/zellij/pull/1577)
+* feat: Improve logging by writing all panics into the logfile (https://github.com/zellij-org/zellij/pull/1602)
 
 ## [0.30.0] - 2022-06-07
 * fix: right and middle clicks creating selection (https://github.com/zellij-org/zellij/pull/1372)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix: avoid sending mouse click events on pane frames to applications (https://github.com/zellij-org/zellij/pull/1584)
 * feat: search through terminal scrollback (https://github.com/zellij-org/zellij/pull/1521)
 * feat: support themes directory (https://github.com/zellij-org/zellij/pull/1577)
-* feat: Improve logging by writing all panics into the logfile (https://github.com/zellij-org/zellij/pull/1602)
+* feat: Improve logging by writing server panics into the logfile (https://github.com/zellij-org/zellij/pull/1602)
 
 ## [0.30.0] - 2022-06-07
 * fix: right and middle clicks creating selection (https://github.com/zellij-org/zellij/pull/1372)

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -7,7 +7,6 @@ mod sessions;
 mod stdin_ansi_parser;
 mod stdin_handler;
 
-use log::error;
 use log::info;
 use std::env::current_exe;
 use std::io::{self, Write};
@@ -210,7 +209,6 @@ pub fn start_client(
         let send_client_instructions = send_client_instructions.clone();
         let os_input = os_input.clone();
         Box::new(move |info| {
-            error!("Panic occurred in client:\n{:?}", info);
             if let Ok(()) = os_input.unset_raw_mode(0) {
                 handle_panic(info, &send_client_instructions);
             }

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -3,6 +3,7 @@
 
 use crate::channels::{SenderWithContext, ASYNCOPENCALLS, OPENCALLS};
 use colored::*;
+use log::error;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Error, Formatter};
 use std::panic::PanicInfo;
@@ -70,13 +71,15 @@ where
 
     let mut report: Report = Panic(format!("\u{1b}[0;31m{}\u{1b}[0;0m", msg)).into();
 
+    let mut location_string = String::new();
     if let Some(location) = info.location() {
-        report = report.wrap_err(format!(
+        location_string = format!(
             "At {}:{}:{}",
             location.file(),
             location.line(),
             location.column()
-        ));
+        );
+        report = report.wrap_err(location_string.clone());
     }
 
     if !err_ctx.is_empty() {
@@ -87,6 +90,17 @@ where
         "Thread '\u{1b}[0;31m{}\u{1b}[0;0m' panicked.",
         thread
     ));
+
+    error!(
+        "{}",
+        format!(
+            "Panic occured:
+             thread: {}
+             location: {}
+             message: {}",
+            thread, location_string, msg
+        )
+    );
 
     if thread == "main" {
         // here we only show the first line because the backtrace is not readable otherwise


### PR DESCRIPTION
As an extension to logging only panics in the client (https://github.com/zellij-org/zellij/pull/1433#issuecomment-1135170659), this change should log every panic, no matter if it happens in client or server.

I believe I had some sessions disappearing mysteriously without being attached, so I never saw panic traces. This should be the first step to investigate.

Example log entry:
```
ERROR  |zellij_utils::errors     | 2022-07-25 15:57:30.802 [main      ] [zellij-utils/src/errors.rs:94]: Panic occured:
thread: main
location: At /home/<redacted>/zellij/zellij-utils/src/ipc.rs:158:68
message: called `Result::unwrap()` on an `Err` value: Io(Os { code: 32, kind: BrokenPipe, message: "Broken pipe" })
```