### PR TITLE
performance(pty): update last render time on non-backed-up render

### DIFF
--- a/zellij-server/src/terminal_bytes.rs
+++ b/zellij-server/src/terminal_bytes.rs
@@ -145,7 +145,9 @@ impl TerminalBytes {
         }
     }
     async fn deadline_read(&mut self, buf: &mut [u8]) -> ReadResult {
-        if let Some(deadline) = self.render_deadline {
+        if !self.backed_up {
+            self.async_reader.read(buf).await.into()
+        } else if let Some(deadline) = self.render_deadline {
             let timeout = deadline.checked_duration_since(Instant::now());
             if let Some(timeout) = timeout {
                 match async_timeout(timeout, self.async_reader.read(buf)).await {

--- a/zellij-server/src/terminal_bytes.rs
+++ b/zellij-server/src/terminal_bytes.rs
@@ -102,6 +102,7 @@ impl TerminalBytes {
                         let time_to_send_render =
                             self.async_send_to_screen(ScreenInstruction::Render).await;
                         self.update_render_send_time(time_to_send_render);
+                        self.last_render = Instant::now();
                     }
                     // if we already have a render_deadline we keep it, otherwise we set it
                     // to buffering_pause since the last time we rendered.


### PR DESCRIPTION
This includes two minor fixes following that changes in https://github.com/zellij-org/zellij/pull/1585

1. We now make sure that when the screen thread is not backed up (i.e. there's room in its buffer to receive immediate render instructions rather than buffering them), we update the render deadline so that timed-out renders will be sent properly.
2. That being said, we also ignore the render deadline if the screen is not backed up to prevent extraneous renders