### PR TITLE
fix(ci): change checksum tool in macos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,13 +85,16 @@ jobs:
 
       - name: Create checksum
         id: make-checksum
-        if: runner.os != 'macos'
         working-directory: ./target/${{ matrix.target }}/release
         run: |
           name="zellij-${{ matrix.target }}.sha256sum"
-          sha256sum "zellij" > "${name}"
+          if [[ "$RUNNER_OS" != "macOS" ]]; then
+            sha256sum "zellij" > "${name}"
+          else
+            shasum -a 256 "zellij" > "${name}"
+          fi
           echo "::set-output name=name::${name}"
-        
+
       - name: Tar release
         id: make-artifact
         working-directory: ./target/${{ matrix.target }}/release
@@ -112,7 +115,6 @@ jobs:
 
       - name: Upload checksum
         uses: actions/upload-release-asset@v1.0.2
-        if: runner.os != 'macos'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
* macOS does not natively support sha256sum.