### PR TITLE
fix(readme): cargo install instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,9 @@ all contributors are expected to adhere to.
 
 ## Building
 To build Zellij, we're using cargo-make – you can install it by running `cargo
-install --force cargo-make`.
+install --locked --force cargo-make`.
 
-To edit our manpage, the mandown crate (`cargo install
+To edit our manpage, the mandown crate (`cargo install --locked
 mandown`) is used and the work is done on a markdown file in docs/MANPAGE.md.
 
 Here are some of the commands currently supported by the build system:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Zellij was initially called "Mosaic".
 You can install with `cargo`:
 
 ```
-cargo install zellij
+cargo install --locked zellij
 ```
 
 Or if want to a prebuilt binary, you can download it from our [Releases](https://github.com/zellij-org/zellij/releases), or use [`cargo-binstall`](https://github.com/ryankurte/cargo-binstall).
@@ -78,7 +78,7 @@ To get started, you can:
 ## How do I start a development environment?
 
 * Clone the project
-* Install cargo-make with `cargo install --force cargo-make`
+* Install cargo-make with `cargo install --locked --force cargo-make`
 * In the project folder, for debug builds run: `cargo make run`
 * To run all tests: `cargo make test`
 


### PR DESCRIPTION
The default `cargo install` behaviour ignores, in contrast to the `run`,
or `build` behaviour the `Cargo.lock` file. This can lead to
builds breaking after the package is released in a non breaking state.

ref: https://github.com/rust-lang/cargo/issues/7169

We now recommend users to install through `cargo install --locked`.