### PR TITLE
fix(ci): remove cachix environment

### DIFF
--- a/.github/workflows/nix-develop.yml
+++ b/.github/workflows/nix-develop.yml
@@ -22,7 +22,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
     name: "nix check"
-    environment: cachix
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
@@ -41,7 +40,6 @@ jobs:
   develop:
     runs-on: ubuntu-latest
     name: "nix develop"
-    environment: cachix
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -12,7 +12,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: "nix build"
-    environment: cachix
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@v3
@@ -30,7 +29,6 @@ jobs:
   build-msrv:
     runs-on: ubuntu-latest
     name: "build msrv"
-    environment: cachix
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Remove the cachix environment.

While environments are a good idea in theory,
github does make working with them tedious, as they do spam status
updates between useful discussions.