### PR TITLE
fix: theme not loading without config

### DIFF
--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -270,7 +270,10 @@ mod not_wasm {
                         if let Some(extension) = entry.path().extension() {
                             if extension == "yaml" || extension == "yml" {
                                 if let Ok(themes) = ThemesFromYaml::from_path(&entry.path()) {
-                                    config.themes = config.themes.map(|t| t.merge(themes.into()));
+                                    match config.themes {
+                                        Some(t) => config.themes = Some(t.merge(themes.into())),
+                                        None => config.themes = Some(themes.into()),
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Fixed the theme not being loaded from `themes` folder if there is no `config.yaml` file or `themes:` does not exist in the file.