### PR TITLE
fix(router): retry messages when server is not ready

### DIFF
--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -445,6 +445,25 @@ fn route_action(
     should_break
 }
 
+macro_rules! send_to_screen_or_retry_queue {
+    ($rlocked_sessions:expr, $message:expr, $instruction: expr, $retry_queue:expr) => {{
+        match $rlocked_sessions.as_ref() {
+            Some(session_metadata) => {
+                session_metadata
+                    .senders
+                    .send_to_screen($message)
+                    .unwrap();
+            },
+            None => {
+                log::warn!("Server not ready, trying to place instruction in retry queue...");
+                if let Some(retry_queue) = $retry_queue.as_mut() {
+                    retry_queue.push($instruction);
+                }
+            }
+        }
+    }}
+}
+
 pub(crate) fn route_thread_main(
     session_data: Arc<RwLock<Option<SessionMetaData>>>,
     session_state: Arc<RwLock<SessionState>>,
@@ -453,132 +472,146 @@ pub(crate) fn route_thread_main(
     mut receiver: IpcReceiverWithContext<ClientToServerMsg>,
     client_id: ClientId,
 ) {
-    loop {
+    let mut retry_queue = vec![];
+    'route_loop: loop {
         match receiver.recv() {
             Some((instruction, err_ctx)) => {
                 err_ctx.update_thread_ctx();
                 let rlocked_sessions = session_data.read().unwrap();
-
-                match instruction {
-                    ClientToServerMsg::Action(action, maybe_client_id) => {
-                        let client_id = maybe_client_id.unwrap_or(client_id);
-                        if let Some(rlocked_sessions) = rlocked_sessions.as_ref() {
-                            if let Action::SwitchToMode(input_mode) = action {
-                                os_input.send_to_client(
+                let handle_instruction = |instruction: ClientToServerMsg, mut retry_queue: Option<&mut Vec<ClientToServerMsg>>| -> bool {
+                    let mut should_break = false;
+                    match instruction {
+                        ClientToServerMsg::Action(action, maybe_client_id) => {
+                            let client_id = maybe_client_id.unwrap_or(client_id);
+                            if let Some(rlocked_sessions) = rlocked_sessions.as_ref() {
+                                if let Action::SwitchToMode(input_mode) = action {
+                                    os_input.send_to_client(
+                                        client_id,
+                                        ServerToClientMsg::SwitchToMode(input_mode),
+                                    );
+                                }
+                                if route_action(
+                                    action,
+                                    rlocked_sessions,
+                                    &*os_input,
+                                    &to_server,
                                     client_id,
-                                    ServerToClientMsg::SwitchToMode(input_mode),
-                                );
+                                ) {
+                                    should_break = true;
+                                }
                             }
-                            if route_action(
-                                action,
+                        },
+                        ClientToServerMsg::TerminalResize(new_size) => {
+                            session_state
+                                .write()
+                                .unwrap()
+                                .set_client_size(client_id, new_size);
+                            let min_size = session_state
+                                .read()
+                                .unwrap()
+                                .min_client_terminal_size()
+                                .unwrap();
+                            rlocked_sessions
+                                .as_ref()
+                                .unwrap()
+                                .senders
+                                .send_to_screen(ScreenInstruction::TerminalResize(min_size))
+                                .unwrap();
+                        },
+                        ClientToServerMsg::TerminalPixelDimensions(pixel_dimensions) => {
+                            // this is experimental, please be cautious implementing this elsewhere
+                            send_to_screen_or_retry_queue!(
                                 rlocked_sessions,
-                                &*os_input,
-                                &to_server,
-                                client_id,
-                            ) {
-                                break;
-                            }
-                        }
-                    },
-                    ClientToServerMsg::TerminalResize(new_size) => {
-                        session_state
-                            .write()
-                            .unwrap()
-                            .set_client_size(client_id, new_size);
-                        let min_size = session_state
-                            .read()
-                            .unwrap()
-                            .min_client_terminal_size()
-                            .unwrap();
-                        rlocked_sessions
-                            .as_ref()
-                            .unwrap()
-                            .senders
-                            .send_to_screen(ScreenInstruction::TerminalResize(min_size))
-                            .unwrap();
-                    },
-                    ClientToServerMsg::TerminalPixelDimensions(pixel_dimensions) => {
-                        rlocked_sessions
-                            .as_ref()
-                            .unwrap()
-                            .senders
-                            .send_to_screen(ScreenInstruction::TerminalPixelDimensions(
-                                pixel_dimensions,
-                            ))
-                            .unwrap();
-                    },
-                    ClientToServerMsg::BackgroundColor(background_color_instruction) => {
-                        rlocked_sessions
-                            .as_ref()
-                            .unwrap()
-                            .senders
-                            .send_to_screen(ScreenInstruction::TerminalBackgroundColor(
-                                background_color_instruction,
-                            ))
-                            .unwrap();
-                    },
-                    ClientToServerMsg::ForegroundColor(foreground_color_instruction) => {
-                        rlocked_sessions
-                            .as_ref()
-                            .unwrap()
-                            .senders
-                            .send_to_screen(ScreenInstruction::TerminalForegroundColor(
-                                foreground_color_instruction,
-                            ))
-                            .unwrap();
-                    },
-                    ClientToServerMsg::ColorRegisters(color_registers) => {
-                        rlocked_sessions
-                            .as_ref()
-                            .unwrap()
-                            .senders
-                            .send_to_screen(ScreenInstruction::TerminalColorRegisters(
-                                color_registers,
-                            ))
-                            .unwrap();
-                    },
-                    ClientToServerMsg::NewClient(
-                        client_attributes,
-                        cli_args,
-                        opts,
-                        layout,
-                        plugin_config,
-                    ) => {
-                        let new_client_instruction = ServerInstruction::NewClient(
+                                ScreenInstruction::TerminalPixelDimensions(pixel_dimensions),
+                                instruction,
+                                retry_queue
+                            );
+                        },
+                        ClientToServerMsg::BackgroundColor(background_color_instruction) => {
+                            rlocked_sessions
+                                .as_ref()
+                                .unwrap()
+                                .senders
+                                .send_to_screen(ScreenInstruction::TerminalBackgroundColor(
+                                    background_color_instruction,
+                                ))
+                                .unwrap();
+                        },
+                        ClientToServerMsg::ForegroundColor(foreground_color_instruction) => {
+                            rlocked_sessions
+                                .as_ref()
+                                .unwrap()
+                                .senders
+                                .send_to_screen(ScreenInstruction::TerminalForegroundColor(
+                                    foreground_color_instruction,
+                                ))
+                                .unwrap();
+                        },
+                        ClientToServerMsg::ColorRegisters(color_registers) => {
+                            rlocked_sessions
+                                .as_ref()
+                                .unwrap()
+                                .senders
+                                .send_to_screen(ScreenInstruction::TerminalColorRegisters(
+                                    color_registers,
+                                ))
+                                .unwrap();
+                        },
+                        ClientToServerMsg::NewClient(
                             client_attributes,
                             cli_args,
                             opts,
                             layout,
-                            client_id,
                             plugin_config,
-                        );
-                        to_server.send(new_client_instruction).unwrap();
-                    },
-                    ClientToServerMsg::AttachClient(client_attributes, opts) => {
-                        let attach_client_instruction =
-                            ServerInstruction::AttachClient(client_attributes, opts, client_id);
-                        to_server.send(attach_client_instruction).unwrap();
-                    },
-                    ClientToServerMsg::ClientExited => {
-                        // we don't unwrap this because we don't really care if there's an error here (eg.
-                        // if the main server thread exited before this router thread did)
-                        let _ = to_server.send(ServerInstruction::RemoveClient(client_id));
-                        break;
-                    },
-                    ClientToServerMsg::KillSession => {
-                        to_server.send(ServerInstruction::KillSession).unwrap();
-                    },
-                    ClientToServerMsg::ConnStatus => {
-                        let _ = to_server.send(ServerInstruction::ConnStatus(client_id));
-                        break;
-                    },
-                    ClientToServerMsg::DetachSession(client_id) => {
-                        let _ = to_server.send(ServerInstruction::DetachSession(client_id));
-                        break;
-                    },
-                    ClientToServerMsg::ListClients => {
-                        let _ = to_server.send(ServerInstruction::ActiveClients(client_id));
-                    },
+                        ) => {
+                            let new_client_instruction = ServerInstruction::NewClient(
+                                client_attributes,
+                                cli_args,
+                                opts,
+                                layout,
+                                client_id,
+                                plugin_config,
+                            );
+                            to_server.send(new_client_instruction).unwrap();
+                        },
+                        ClientToServerMsg::AttachClient(client_attributes, opts) => {
+                            let attach_client_instruction =
+                                ServerInstruction::AttachClient(client_attributes, opts, client_id);
+                            to_server.send(attach_client_instruction).unwrap();
+                        },
+                        ClientToServerMsg::ClientExited => {
+                            // we don't unwrap this because we don't really care if there's an error here (eg.
+                            // if the main server thread exited before this router thread did)
+                            let _ = to_server.send(ServerInstruction::RemoveClient(client_id));
+                            return true;
+                        },
+                        ClientToServerMsg::KillSession => {
+                            to_server.send(ServerInstruction::KillSession).unwrap();
+                        },
+                        ClientToServerMsg::ConnStatus => {
+                            let _ = to_server.send(ServerInstruction::ConnStatus(client_id));
+                            should_break = true;
+                        },
+                        ClientToServerMsg::DetachSession(client_id) => {
+                            let _ = to_server.send(ServerInstruction::DetachSession(client_id));
+                            should_break = true;
+                        },
+                        ClientToServerMsg::ListClients => {
+                            let _ = to_server.send(ServerInstruction::ActiveClients(client_id));
+                        },
+                    }
+                    should_break
+                };
+                for instruction_to_retry in retry_queue.drain(..) {
+                    log::warn!("Server ready, retrying sending instruction.");
+                    let should_break = handle_instruction(instruction_to_retry, None);
+                    if should_break {
+                        break 'route_loop;
+                    }
+                }
+                let should_break = handle_instruction(instruction, Some(&mut retry_queue));
+                if should_break {
+                    break 'route_loop;
                 }
             },
             None => {

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -449,19 +449,16 @@ macro_rules! send_to_screen_or_retry_queue {
     ($rlocked_sessions:expr, $message:expr, $instruction: expr, $retry_queue:expr) => {{
         match $rlocked_sessions.as_ref() {
             Some(session_metadata) => {
-                session_metadata
-                    .senders
-                    .send_to_screen($message)
-                    .unwrap();
+                session_metadata.senders.send_to_screen($message).unwrap();
             },
             None => {
                 log::warn!("Server not ready, trying to place instruction in retry queue...");
                 if let Some(retry_queue) = $retry_queue.as_mut() {
                     retry_queue.push($instruction);
                 }
-            }
+            },
         }
-    }}
+    }};
 }
 
 pub(crate) fn route_thread_main(
@@ -478,7 +475,9 @@ pub(crate) fn route_thread_main(
             Some((instruction, err_ctx)) => {
                 err_ctx.update_thread_ctx();
                 let rlocked_sessions = session_data.read().unwrap();
-                let handle_instruction = |instruction: ClientToServerMsg, mut retry_queue: Option<&mut Vec<ClientToServerMsg>>| -> bool {
+                let handle_instruction = |instruction: ClientToServerMsg,
+                                          mut retry_queue: Option<&mut Vec<ClientToServerMsg>>|
+                 -> bool {
                     let mut should_break = false;
                     match instruction {
                         ClientToServerMsg::Action(action, maybe_client_id) => {


### PR DESCRIPTION
This fixes a crash introduced in the latest release where Zellij would sometimes crash on startup with this error:

```
Error occurred in server:

  × Thread 'server_router' panicked.
  ├─▶ Originating Thread(s)
  │     1. stdin_handler_thread: AcceptInput
  │   
  ├─▶ At zellij-server/src/route.rs:503:30
  ╰─▶ called `Option::unwrap()` on a `None` value
  help: If you are seeing this message, it means that something went wrong.
        Please report this error to the github issue.
        (https://github.com/zellij-org/zellij/issues)
        
        Also, if you want to see the backtrace, you can set the `RUST_BACKTRACE` environment variable to `1`.

```

This was a race condition that happened when the Zellij client sent a message to the server before it was ready. This was exposed in the latest release because we broke down the queries we make to the terminal emulator (for stuff like pixel-to-cell dimensions and the terminal color palette) into several different messages. This caused them to be sent faster and hit the issue.

This fix involves adding a retry queue for these kinds of messages, placing instructions there when the server is not ready, and retrying them again along with the next messages when they come.

Right now I only implemented this for this one particular message that was causing the issue as an experiment. Care should be taken before duplicating this logic to other instructions.