### PR TITLE
fix(tab-bar): fix tab bar click when tabs are collapsed, fix tab bar length calculation

### DIFF
--- a/default-plugins/tab-bar/src/line.rs
+++ b/default-plugins/tab-bar/src/line.rs
@@ -26,8 +26,24 @@ fn populate_tabs_in_tab_line(
     loop {
         let left_count = tabs_before_active.len();
         let right_count = tabs_after_active.len();
-        let collapsed_left = left_more_message(left_count, palette, tab_separator(capabilities));
-        let collapsed_right = right_more_message(right_count, palette, tab_separator(capabilities));
+
+        // left_more_tab_index is first tab to the left of the leftmost visible tab
+        let left_more_tab_index = left_count.saturating_sub(1);
+        let collapsed_left = left_more_message(
+            left_count,
+            palette,
+            tab_separator(capabilities),
+            left_more_tab_index,
+        );
+
+        // right_more_tab_index is the first tab to the right of the rightmost visible tab
+        let right_more_tab_index = left_count + tabs_to_render.len();
+        let collapsed_right = right_more_message(
+            right_count,
+            palette,
+            tab_separator(capabilities),
+            right_more_tab_index,
+        );
 
         let total_size = collapsed_left.len + middle_size + collapsed_right.len;
 
@@ -90,7 +106,12 @@ fn populate_tabs_in_tab_line(
     }
 }
 
-fn left_more_message(tab_count_to_the_left: usize, palette: Palette, separator: &str) -> LinePart {
+fn left_more_message(
+    tab_count_to_the_left: usize,
+    palette: Palette,
+    separator: &str,
+    tab_index: usize,
+) -> LinePart {
     if tab_count_to_the_left == 0 {
         return LinePart::default();
     }
@@ -114,6 +135,7 @@ fn left_more_message(tab_count_to_the_left: usize, palette: Palette, separator: 
     LinePart {
         part: more_styled_text,
         len: more_text_len,
+        tab_index: Some(tab_index),
     }
 }
 
@@ -121,6 +143,7 @@ fn right_more_message(
     tab_count_to_the_right: usize,
     palette: Palette,
     separator: &str,
+    tab_index: usize,
 ) -> LinePart {
     if tab_count_to_the_right == 0 {
         return LinePart::default();
@@ -144,6 +167,7 @@ fn right_more_message(
     LinePart {
         part: more_styled_text,
         len: more_text_len,
+        tab_index: Some(tab_index),
     }
 }
 
@@ -163,6 +187,7 @@ fn tab_line_prefix(session_name: Option<&str>, palette: Palette, cols: usize) ->
     let mut parts = vec![LinePart {
         part: prefix_styled_text.to_string(),
         len: prefix_text_len,
+        tab_index: None,
     }];
     if let Some(name) = session_name {
         let name_part = format!("({}) ", name);
@@ -176,6 +201,7 @@ fn tab_line_prefix(session_name: Option<&str>, palette: Palette, cols: usize) ->
             parts.push(LinePart {
                 part: name_part_styled_text.to_string(),
                 len: name_part_len,
+                tab_index: None,
             })
         }
     }

--- a/default-plugins/tab-bar/src/main.rs
+++ b/default-plugins/tab-bar/src/main.rs
@@ -13,6 +13,7 @@ use crate::tab::tab_style;
 pub struct LinePart {
     part: String,
     len: usize,
+    tab_index: Option<usize>,
 }
 
 #[derive(Default)]
@@ -94,6 +95,7 @@ impl ZellijPlugin for State {
                 self.mode_info.style.colors,
                 self.mode_info.capabilities,
                 t.other_focused_clients.as_slice(),
+                t.position,
             );
             is_alternate_tab = !is_alternate_tab;
             all_tabs.push(tab);
@@ -108,17 +110,17 @@ impl ZellijPlugin for State {
         );
         let mut s = String::new();
         let mut len_cnt = 0;
-        for (idx, bar_part) in tab_line.iter().enumerate() {
+        for bar_part in tab_line {
             s = format!("{}{}", s, &bar_part.part);
 
             if self.should_render
-                && self.mouse_click_pos > len_cnt
-                && self.mouse_click_pos <= len_cnt + bar_part.len
-                && idx > 2
+                && self.mouse_click_pos >= len_cnt
+                && self.mouse_click_pos < len_cnt + bar_part.len
+                && bar_part.tab_index.is_some()
             {
-                // First three elements of tab_line are "Zellij", session name and empty thing, hence the idx > 2 condition.
-                // Tabs are indexed starting from 1, therefore we need subtract 2 below.
-                switch_tab_to(TryInto::<u32>::try_into(idx).unwrap() - 2);
+                // Tabs are indexed starting from 1, therefore we need add 1 to tab_index.
+                let tab_index: u32 = bar_part.tab_index.unwrap().try_into().unwrap();
+                switch_tab_to(tab_index + 1);
             }
             len_cnt += bar_part.len;
         }

--- a/default-plugins/tab-bar/src/main.rs
+++ b/default-plugins/tab-bar/src/main.rs
@@ -89,13 +89,10 @@ impl ZellijPlugin for State {
             }
             let tab = tab_style(
                 tabname,
-                t.active,
+                t,
                 is_alternate_tab,
-                t.is_sync_panes_active,
                 self.mode_info.style.colors,
                 self.mode_info.capabilities,
-                t.other_focused_clients.as_slice(),
-                t.position,
             );
             is_alternate_tab = !is_alternate_tab;
             all_tabs.push(tab);

--- a/default-plugins/tab-bar/src/tab.rs
+++ b/default-plugins/tab-bar/src/tab.rs
@@ -24,6 +24,7 @@ pub fn render_tab(
     focused_clients: &[ClientId],
     active: bool,
     is_alternate_tab: bool,
+    tab_index: usize,
 ) -> LinePart {
     let separator_width = separator.width();
     let alternate_tab_color = match palette.theme_hue {
@@ -77,6 +78,7 @@ pub fn render_tab(
     LinePart {
         part: tab_styled_text,
         len: tab_text_len,
+        tab_index: Some(tab_index),
     }
 }
 
@@ -88,6 +90,7 @@ pub fn tab_style(
     palette: Palette,
     capabilities: PluginCapabilities,
     focused_clients: &[ClientId],
+    tab_index: usize,
 ) -> LinePart {
     let separator = tab_separator(capabilities);
     let mut tab_text = text;
@@ -107,5 +110,6 @@ pub fn tab_style(
         focused_clients,
         is_active_tab,
         is_alternate_tab,
+        tab_index,
     )
 }

--- a/default-plugins/tab-bar/src/tab.rs
+++ b/default-plugins/tab-bar/src/tab.rs
@@ -44,8 +44,7 @@ pub fn render_tab(
         ThemeHue::Light => palette.white,
     };
     let left_separator = style!(foreground_color, background_color).paint(separator);
-    let mut tab_text_len =
-        text.width() + (separator_width * 2) + separator_width * (separator_width * 2); // 2 for left and right separators, 2 for the text padding
+    let mut tab_text_len = text.width() + (separator_width * 2) + 2; // +2 for padding
     let tab_styled_text = style!(foreground_color, background_color)
         .bold()
         .paint(format!(" {} ", text));


### PR DESCRIPTION
Fixes #1603 , as well as another bigger issue. I noticed that clicking on a tab used index in the linepart vector, which will be incorrect for every tab if there's collapsed tabs. We have to save tab index in LinePart, and then use that to switch tabs.

Clicking on the collapsed tabs brings the user to the first hidden tab on that side.

Fixing the issue in #1603 was as discussed in the issue, as well switching the click comparison to be `click >= length && click < length` instead of `click > length && click <= length`