### PR TITLE
Feature: key passthrough

### DIFF
--- a/default-plugins/status-bar/src/first_line.rs
+++ b/default-plugins/status-bar/src/first_line.rs
@@ -864,4 +864,36 @@ mod tests {
 
         assert_eq!(ret, " Ctrl +  a  b  c ".to_string());
     }
+
+    #[test]
+    fn first_line_passthrough_wide() {
+        #[rustfmt::skip]
+        let mode_info = ModeInfo{
+            mode: InputMode::Passthrough,
+            keybinds : vec![
+            ],
+            ..ModeInfo::default()
+        };
+
+        let ret = first_line(&mode_info, 30, "");
+        let ret = unstyle(ret);
+
+        assert_eq!(ret, " PASSTHROUGH ".to_string());
+    }
+
+    #[test]
+    fn first_line_passthrough_narrow() {
+        #[rustfmt::skip]
+        let mode_info = ModeInfo{
+            mode: InputMode::Passthrough,
+            keybinds : vec![
+            ],
+            ..ModeInfo::default()
+        };
+
+        let ret = first_line(&mode_info, 10, "");
+        let ret = unstyle(ret);
+
+        assert_eq!(ret, "".to_string());
+    }
 }

--- a/default-plugins/status-bar/src/main.rs
+++ b/default-plugins/status-bar/src/main.rs
@@ -242,6 +242,8 @@ impl State {
             text_copied_hint(&self.mode_info.style.colors, copy_destination)
         } else if self.display_system_clipboard_failure {
             system_clipboard_error(&self.mode_info.style.colors)
+        } else if self.mode_info.mode == InputMode::Passthrough {
+            second_line::passthrough(&self.mode_info.style.colors, cols)
         } else if let Some(active_tab) = active_tab {
             if active_tab.is_fullscreen_active {
                 match self.mode_info.mode {

--- a/default-plugins/status-bar/src/second_line.rs
+++ b/default-plugins/status-bar/src/second_line.rs
@@ -522,6 +522,43 @@ pub fn locked_floating_panes_are_visible(palette: &Palette) -> LinePart {
     }
 }
 
+pub fn passthrough(palette: &Palette, cols: usize) -> LinePart {
+    let text_color = palette_match!(match palette.theme_hue {
+        ThemeHue::Dark => palette.white,
+        ThemeHue::Light => palette.black,
+    });
+
+    let long_text = " Next key-combination is passed directly to the application";
+    let line_part = LinePart {
+        part: Style::new()
+            .fg(text_color)
+            .bold()
+            .paint(long_text)
+            .to_string(),
+        len: long_text.chars().count(),
+    };
+
+    let line_part = if line_part.len > cols {
+        let short_text = " Next key is passed through";
+        LinePart {
+            part: Style::new()
+                .fg(text_color)
+                .bold()
+                .paint(short_text)
+                .to_string(),
+            len: short_text.chars().count(),
+        }
+    } else {
+        line_part
+    };
+
+    if line_part.len > cols {
+        LinePart::default()
+    } else {
+        line_part
+    }
+}
+
 #[cfg(test)]
 /// Unit tests.
 ///

--- a/default-plugins/status-bar/src/second_line.rs
+++ b/default-plugins/status-bar/src/second_line.rs
@@ -798,4 +798,24 @@ mod tests {
 
         assert_eq!(ret, " Ctrl + <a|ENTER|1|SPACE> Move focus / <BACKSPACE> New / <ESC> Close / <END> Fullscreen");
     }
+
+    #[test]
+    fn passthrough_hint_short() {
+        let palette = get_palette();
+
+        let ret = passthrough(&palette, 35);
+        let ret = unstyle(ret);
+
+        assert!(ret.len() <= 35);
+    }
+
+    #[test]
+    fn passthrough_hint_no_space() {
+        let palette = get_palette();
+
+        let ret = passthrough(&palette, 10);
+        let ret = unstyle(ret);
+
+        assert_eq!(ret, "");
+    }
 }

--- a/default-plugins/status-bar/src/tip/data/key_passthrough.rs
+++ b/default-plugins/status-bar/src/tip/data/key_passthrough.rs
@@ -1,0 +1,61 @@
+use ansi_term::{unstyled_len, ANSIString, ANSIStrings, Style};
+
+use crate::LinePart;
+use crate::{action_key, style_key_with_modifier};
+use zellij_tile::prelude::{actions::Action, *};
+
+macro_rules! strings {
+    ($ANSIStrings:expr) => {{
+        let strings: &[ANSIString] = $ANSIStrings;
+
+        let ansi_strings = ANSIStrings(strings);
+
+        LinePart {
+            part: format!("{}", ansi_strings),
+            len: unstyled_len(&ansi_strings),
+        }
+    }};
+}
+
+pub fn key_passthrough_full(help: &ModeInfo) -> LinePart {
+    // Tip: Do your zellij keybindings collide with applications?
+    // Press Ctrl + <z> to pass keys through directly
+    let mut bits = vec![
+        Style::new().paint(" Tip: "),
+        Style::new().paint("Do your zellij keybindings collide with applications? Press "),
+    ];
+    bits.extend(add_keybinds(help));
+    bits.push(Style::new().paint(" to pass keys through directly"));
+    strings!(&bits)
+}
+
+pub fn key_passthrough_medium(help: &ModeInfo) -> LinePart {
+    // Tip: To send keys to applications without zellij interfering, prefix them with Ctrl + <z>
+    let mut bits = vec![
+        Style::new().paint(" Tip: "),
+        Style::new()
+            .paint("To send keys to applications without zellij interfering, prefix them with "),
+    ];
+    bits.extend(add_keybinds(help));
+    strings!(&bits)
+}
+
+pub fn key_passthrough_short(help: &ModeInfo) -> LinePart {
+    // Send keys to applications directly: Prefix with Ctrl + <z>
+    let mut bits = vec![Style::new().paint("Send keys to applications directly: Prefix with ")];
+    bits.extend(add_keybinds(help));
+    strings!(&bits)
+}
+
+fn add_keybinds(help: &ModeInfo) -> Vec<ANSIString> {
+    let passthrough = action_key(
+        &help.get_keybinds_for_mode(InputMode::Normal),
+        &[Action::SwitchToMode(InputMode::Passthrough)],
+    );
+
+    if passthrough.is_empty() {
+        return vec![Style::new().bold().paint("UNBOUND")];
+    }
+
+    style_key_with_modifier(&passthrough, &help.style.colors)
+}

--- a/default-plugins/status-bar/src/tip/data/mod.rs
+++ b/default-plugins/status-bar/src/tip/data/mod.rs
@@ -7,6 +7,7 @@ use crate::tip::TipBody;
 mod compact_layout;
 mod edit_scrollbuffer;
 mod floating_panes_mouse;
+mod key_passthrough;
 mod move_focus_hjkl_tab_switch;
 mod quicknav;
 mod send_mouse_click_to_terminal;
@@ -86,6 +87,14 @@ lazy_static! {
                 short: compact_layout::compact_layout_short,
                 medium: compact_layout::compact_layout_medium,
                 full: compact_layout::compact_layout_full,
+            }
+        ),
+        (
+            "key_passthrough",
+            TipBody {
+                short: key_passthrough::key_passthrough_short,
+                medium: key_passthrough::key_passthrough_medium,
+                full: key_passthrough::key_passthrough_full,
             }
         ),
     ]);

--- a/zellij-utils/assets/config/default.yaml
+++ b/zellij-utils/assets/config/default.yaml
@@ -26,6 +26,8 @@ keybinds:
           key: [Ctrl: 'b',]
         - action: [Quit,]
           key: [Ctrl: 'q',]
+        - action: [SwitchToMode: Passthrough,]
+          key: [Ctrl: 'z',]
         - action: [NewPane: ]
           key: [ Alt: 'n',]
         - action: [MoveFocusOrTab: Left,]

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -200,6 +200,9 @@ pub enum InputMode {
     /// `Tmux` mode allows for basic tmux keybindings functionality
     #[serde(alias = "tmux")]
     Tmux,
+    /// `Passthrough` mode passes the next key-sequence to the pane as raw bytes
+    #[serde(alias = "passthrough")]
+    Passthrough,
 }
 
 impl Default for InputMode {

--- a/zellij-utils/src/input/keybinds.rs
+++ b/zellij-utils/src/input/keybinds.rs
@@ -225,6 +225,10 @@ impl Keybinds {
             InputMode::Normal | InputMode::Locked => {
                 mode_keybind_or_action(Action::Write(raw_bytes))
             },
+            InputMode::Passthrough => vec![
+                Action::Write(raw_bytes),
+                Action::SwitchToMode(InputMode::Normal),
+            ],
             InputMode::RenameTab => mode_keybind_or_action(Action::TabNameInput(raw_bytes)),
             InputMode::RenamePane => mode_keybind_or_action(Action::PaneNameInput(raw_bytes)),
             InputMode::EnterSearch => mode_keybind_or_action(Action::SearchInput(raw_bytes)),


### PR DESCRIPTION
The idea for this feature came to my mind after reading through #1607, #775, #418 and #387. I'm sure there are more open issues that may benefit from having this "fix", but I don't feel like combing through all of them at this very moment. :)

*The following discussion about keybindings etc. assumes you use the default keybindings as of the moment of writing this.*


## Description

This PR adds a new input mode called `Passthrough`, which does exactly what it says: It passes the next key-combination you enter through to the application, verbatim.

It is currently bound to `Ctrl+z`, but that's just a proposal and open for discussion.


## The underlying problem

Unlike other terminal multiplexers like tmux, zellij doesn't have the notion of a **prefix key**.

**In tmux**, this prefix key *must* be pressed before performing any tmux-specific action (such as creating a split, a new tab, detaching, etc). This means that, conversely, any key-combination entered by the user that isn't the prefix key is passed directly to the currently active pane. Hence, there is only one real collision in the keybindings: When the underlying application has a keybindings that is identical to the tmux prefix key.

This is usually worked around in one of two ways:

1. Declare a keybinding that performs the `send-prefix` "command", and sends the prefix key to the nested application, or
2. Declare a custom keybinding that acts as prefix key for the inner session directly


**Zellij** takes a different approach in this regard: It has a plethora of keybindings that are directly accessible without having to press a prefix key first. While this makes a lot of tasks quicker to execute by default (e.g. changing focus = `Alt + <hjkl>`, for example), it also creates much more collisions for application keybindings.

This issue becomes even more apparent when nesting zellij sessions: Assuming both sessions use the same keybinding, controlling the inner session is only sensibly possible when entering Locked mode in the outer session. Note that it is currently **impossible** to send the Locked mode binding to an application. Hence, the inner zellij session cannot be locked. Also, changing focus in the inner session while leaving control to the outer session requires the user to press `Ctrl+g, Alt+<hjkl>, Ctrl+g`, which is very awkward.


## Limitations of this solution

- In its current implementation, the outermost zellij session is dropped back into normal mode after using the passthrough mode, regardless of the input mode the user was in previously.
- It doesn't scale: One level of nesting is perfectly manageable this way, but anything below that becomes unwieldy. Think of having three zellij sessions nested, to send `Alt + h` to the innermost one requires the following input: `Ctrl+z, Ctrl+z, Ctrl+z, Alt+h`.

Still I think that it's a good step in the right direction and will likely benefit most users already.

Feedback is very welcome!