### PR TITLE
add(config): send ^g in session mode

### DIFF
--- a/zellij-utils/assets/config/default.yaml
+++ b/zellij-utils/assets/config/default.yaml
@@ -467,6 +467,8 @@ keybinds:
           key: [Ctrl: 'o', Char: "\n", Char: ' ', Esc]
         - action: [SwitchToMode: Scroll,]
           key: [Ctrl: 's']
+        - action: [Write: [7,], SwitchToMode: Normal]
+          key: [Ctrl: 'g']
         - action: [Quit,]
           key: [Ctrl: 'q',]
         - action: [Detach,]


### PR DESCRIPTION
Bind sending `^g` to the session mode of the default configuration.
That way analogous to how the tmux mode can be nested, now the locked
mode can also be nested in the default configuration.

Example: `^o-^g` Will lock/unlock the inner session, if running the
default layout.

[send^g.webm](https://user-images.githubusercontent.com/65275785/184886869-63774628-3f62-4912-a940-1d21b5dd293e.webm)
