### PR TITLE
feat(#195): display current path in the strider

### DIFF
--- a/default-plugins/strider/src/main.rs
+++ b/default-plugins/strider/src/main.rs
@@ -58,10 +58,14 @@ impl ZellijPlugin for State {
                 Mouse::ScrollUp(_) => {
                     *self.selected_mut() = self.selected().saturating_sub(1);
                 },
-                Mouse::Release(line, _) => {
-                    if line < 0 {
+                Mouse::Release(mut line, _) => {
+                    // we need to shift the line with line -=1 because one line
+                    // is occupied by the current path, and all clicks on it are
+                    // to be ignored
+                    if line < 1 {
                         return;
                     }
+                    line -= 1;
                     let mut should_select = true;
                     if let Some((Event::Mouse(Mouse::Release(prev_line, _)), t)) = prev_event {
                         if prev_line == line
@@ -85,7 +89,14 @@ impl ZellijPlugin for State {
     }
 
     fn render(&mut self, rows: usize, cols: usize) {
-        for i in 0..rows {
+        let display_current_dir = FsEntry::DisplayDir(self.current_dir.clone())
+            .as_line(cols)
+            .normal()
+            .on_yellow()
+            .black();
+        println!("{}", display_current_dir);
+
+        for i in 0..rows - 1 {
             if self.selected() < self.scroll() {
                 *self.scroll_mut() = self.selected();
             }

--- a/default-plugins/strider/src/state.rs
+++ b/default-plugins/strider/src/state.rs
@@ -15,6 +15,7 @@ pub struct State {
     pub cursor_hist: HashMap<PathBuf, (usize, usize)>,
     pub hide_hidden_files: bool,
     pub ev_history: VecDeque<(Event, Instant)>, // stores last event, can be expanded in future
+    pub current_dir: PathBuf,
 }
 
 impl State {
@@ -41,6 +42,7 @@ impl State {
                     refresh_directory(self);
                 },
                 FsEntry::File(p, _) => open_file(p.strip_prefix(ROOT).unwrap()),
+                FsEntry::DisplayDir(_) => {},
             }
         }
     }
@@ -50,6 +52,7 @@ impl State {
 pub enum FsEntry {
     Dir(PathBuf, usize),
     File(PathBuf, u64),
+    DisplayDir(PathBuf),
 }
 
 impl FsEntry {
@@ -57,23 +60,72 @@ impl FsEntry {
         let path = match self {
             FsEntry::Dir(p, _) => p,
             FsEntry::File(p, _) => p,
+            FsEntry::DisplayDir(p) => p,
         };
-        path.file_name().unwrap().to_string_lossy().into_owned()
+        match self {
+            FsEntry::File(..) | FsEntry::Dir(..) => {
+                // only use the filename
+                path.file_name().unwrap().to_string_lossy().into_owned()
+            },
+            FsEntry::DisplayDir(..) => {
+                // use full path, but we need to remove the host part
+                let path = path.to_string_lossy().into_owned().replace("/host", "");
+                ".".to_string() + &path
+            },
+        }
     }
 
     pub fn as_line(&self, width: usize) -> String {
+        let name = self.name();
         let info = match self {
             FsEntry::Dir(_, s) => s.to_string(),
             FsEntry::File(_, s) => pb::convert(*s as f64),
+            FsEntry::DisplayDir(..) => {
+                let current_path = name.clone();
+                FsEntry::display_with_shortened_name_start(current_path, width)
+            },
         };
-        let space = width.saturating_sub(info.len());
-        let name = self.name();
-        if space.saturating_sub(1) < name.len() {
-            [&name[..space.saturating_sub(2)], &info].join("~ ")
+        // + 1 since we want to have a space between name and info
+        let content_width = name.len() + info.len() + 1;
+        if width < content_width {
+            // The content doesn't fit on the screen
+            match self {
+                FsEntry::File(..) | FsEntry::Dir(..) => {
+                    FsEntry::display_with_shortened_name_end(name, info, width)
+                },
+                FsEntry::DisplayDir(..) => {
+                    let current_path = name;
+                    FsEntry::display_with_shortened_name_start(current_path, width)
+                },
+            }
         } else {
-            let padding = " ".repeat(space - name.len());
-            [name, padding, info].concat()
+            // The content does fit on the screen
+            FsEntry::display_with_padding(name, info, width)
         }
+    }
+
+    fn display_with_shortened_name_end(name: String, extra_info: String, width: usize) -> String {
+        const ENDING: &str = "~ ";
+        let shortened_name_len = width.saturating_sub(ENDING.len() + extra_info.len());
+        let shortened_name = &name[..shortened_name_len];
+        [shortened_name, &extra_info].join(ENDING)
+    }
+
+    fn display_with_shortened_name_start(current_path: String, width: usize) -> String {
+        const FRONT: &str = "./...";
+        const END: &str = " ";
+        const NEEDED_SPACE: usize = FRONT.len() + END.len();
+        let current_path_len = current_path.len();
+        let displayed_path_len = width.saturating_sub(NEEDED_SPACE);
+        let display_path_start_index = current_path_len.saturating_sub(displayed_path_len);
+        let shortened_path = &current_path[display_path_start_index..];
+        [FRONT, shortened_path, END].join("")
+    }
+
+    fn display_with_padding(name: String, extra_info: String, width: usize) -> String {
+        let content_len = name.len() + extra_info.len();
+        let padding = " ".repeat(width - content_len);
+        [name, padding, extra_info].concat()
     }
 
     pub fn is_hidden_file(&self) -> bool {
@@ -82,6 +134,7 @@ impl FsEntry {
 }
 
 pub(crate) fn refresh_directory(state: &mut State) {
+    state.current_dir = state.path.clone();
     state.files = read_dir(Path::new(ROOT).join(&state.path))
         .unwrap()
         .filter_map(|res| {


### PR DESCRIPTION
This pull request addresses the #195 issue and resolves the problem of @RobWalt's solution with clicks 1-row offset.  

As in Rob's PR, the path displayed is a relative path from the `zellij`'s start location.

Display the current path on top of the directory files in the strider default plugin. As of now, no configuration
is available for this feature.

Examples of how it looks:

<img width="1220" alt="image" src="https://user-images.githubusercontent.com/24596796/185718863-d8731d17-fe72-4d96-9171-48dde0d6b190.png">

<img width="1218" alt="image" src="https://user-images.githubusercontent.com/24596796/185718905-e994d9b5-a7e6-4abf-be9d-d80139abe395.png">
