### PR TITLE
fix: bracketed paste input not getting adjusted properly

### DIFF
--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -189,17 +189,15 @@ impl Pane for TerminalPane {
                 END_KEY => {
                     return AnsiEncoding::End.as_vec_bytes();
                 },
-                BRACKETED_PASTE_BEGIN | BRACKETED_PASTE_END => {
-                    if !self.grid.bracketed_paste_mode {
-                        // Zellij itself operates in bracketed paste mode, so the terminal sends these
-                        // instructions (bracketed paste start and bracketed paste end respectively)
-                        // when pasting input. We only need to make sure not to send them to terminal
-                        // panes who do not work in this mode
-                        return vec![];
-                    }
-                },
                 _ => {},
             };
+        }
+
+        if !self.grid.bracketed_paste_mode {
+            match input_bytes.as_slice() {
+                BRACKETED_PASTE_BEGIN | BRACKETED_PASTE_END => return vec![],
+                _ => {},
+            }
         }
         input_bytes
     }

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -194,6 +194,10 @@ impl Pane for TerminalPane {
         }
 
         if !self.grid.bracketed_paste_mode {
+            // Zellij itself operates in bracketed paste mode, so the terminal sends these
+            // instructions (bracketed paste start and bracketed paste end respectively)
+            // when pasting input. We only need to make sure not to send them to terminal
+            // panes who do not work in this mode
             match input_bytes.as_slice() {
                 BRACKETED_PASTE_BEGIN | BRACKETED_PASTE_END => return vec![],
                 _ => {},


### PR DESCRIPTION
fix #1687

ensure the check for removing bracketed paste begin/end sequences is run when not in bracketed paste mode