### PR TITLE
fix(router): startup race

### DIFF
--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -558,7 +558,9 @@ pub(crate) fn route_thread_main(
                         ClientToServerMsg::BackgroundColor(ref background_color_instruction) => {
                             send_to_screen_or_retry_queue!(
                                 rlocked_sessions,
-                                ScreenInstruction::TerminalBackgroundColor(background_color_instruction.clone()),
+                                ScreenInstruction::TerminalBackgroundColor(
+                                    background_color_instruction.clone()
+                                ),
                                 instruction,
                                 retry_queue
                             );
@@ -566,7 +568,9 @@ pub(crate) fn route_thread_main(
                         ClientToServerMsg::ForegroundColor(ref foreground_color_instruction) => {
                             send_to_screen_or_retry_queue!(
                                 rlocked_sessions,
-                                ScreenInstruction::TerminalForegroundColor(foreground_color_instruction.clone()),
+                                ScreenInstruction::TerminalForegroundColor(
+                                    foreground_color_instruction.clone()
+                                ),
                                 instruction,
                                 retry_queue
                             );

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -474,6 +474,7 @@ fn route_action(
     should_break
 }
 
+// this should only be used for one-off startup instructions
 macro_rules! send_to_screen_or_retry_queue {
     ($rlocked_sessions:expr, $message:expr, $instruction: expr, $retry_queue:expr) => {{
         match $rlocked_sessions.as_ref() {
@@ -547,7 +548,6 @@ pub(crate) fn route_thread_main(
                                 .unwrap();
                         },
                         ClientToServerMsg::TerminalPixelDimensions(pixel_dimensions) => {
-                            // this is experimental, please be cautious implementing this elsewhere
                             send_to_screen_or_retry_queue!(
                                 rlocked_sessions,
                                 ScreenInstruction::TerminalPixelDimensions(pixel_dimensions),
@@ -555,35 +555,29 @@ pub(crate) fn route_thread_main(
                                 retry_queue
                             );
                         },
-                        ClientToServerMsg::BackgroundColor(background_color_instruction) => {
-                            rlocked_sessions
-                                .as_ref()
-                                .unwrap()
-                                .senders
-                                .send_to_screen(ScreenInstruction::TerminalBackgroundColor(
-                                    background_color_instruction,
-                                ))
-                                .unwrap();
+                        ClientToServerMsg::BackgroundColor(ref background_color_instruction) => {
+                            send_to_screen_or_retry_queue!(
+                                rlocked_sessions,
+                                ScreenInstruction::TerminalBackgroundColor(background_color_instruction.clone()),
+                                instruction,
+                                retry_queue
+                            );
                         },
-                        ClientToServerMsg::ForegroundColor(foreground_color_instruction) => {
-                            rlocked_sessions
-                                .as_ref()
-                                .unwrap()
-                                .senders
-                                .send_to_screen(ScreenInstruction::TerminalForegroundColor(
-                                    foreground_color_instruction,
-                                ))
-                                .unwrap();
+                        ClientToServerMsg::ForegroundColor(ref foreground_color_instruction) => {
+                            send_to_screen_or_retry_queue!(
+                                rlocked_sessions,
+                                ScreenInstruction::TerminalForegroundColor(foreground_color_instruction.clone()),
+                                instruction,
+                                retry_queue
+                            );
                         },
-                        ClientToServerMsg::ColorRegisters(color_registers) => {
-                            rlocked_sessions
-                                .as_ref()
-                                .unwrap()
-                                .senders
-                                .send_to_screen(ScreenInstruction::TerminalColorRegisters(
-                                    color_registers,
-                                ))
-                                .unwrap();
+                        ClientToServerMsg::ColorRegisters(ref color_registers) => {
+                            send_to_screen_or_retry_queue!(
+                                rlocked_sessions,
+                                ScreenInstruction::TerminalColorRegisters(color_registers.clone()),
+                                instruction,
+                                retry_queue
+                            );
                         },
                         ClientToServerMsg::NewClient(
                             client_attributes,


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/1696 and https://github.com/zellij-org/zellij/issues/1705

This now uses the same (no longer experimental) retry mechanism we used for one startup message (pixel/cell dimensions) for all startup messages.