### PR TITLE
fix(router): gracefully handle client crashes

### DIFF
--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -54,7 +54,7 @@ fn assert_socket(name: &str) -> bool {
     match LocalSocketStream::connect(path) {
         Ok(stream) => {
             let mut sender = IpcSenderWithContext::new(stream);
-            sender.send(ClientToServerMsg::ConnStatus);
+            let _ = sender.send(ClientToServerMsg::ConnStatus);
             let mut receiver: IpcReceiverWithContext<ServerToClientMsg> = sender.get_receiver();
             match receiver.recv() {
                 Some((ServerToClientMsg::Connected, _)) => true,
@@ -115,7 +115,7 @@ pub(crate) fn kill_session(name: &str) {
     let path = &*ZELLIJ_SOCK_DIR.join(name);
     match LocalSocketStream::connect(path) {
         Ok(stream) => {
-            IpcSenderWithContext::new(stream).send(ClientToServerMsg::KillSession);
+            let _ = IpcSenderWithContext::new(stream).send(ClientToServerMsg::KillSession);
         },
         Err(e) => {
             eprintln!("Error occurred: {:?}", e);

--- a/zellij-client/src/os_input_output.rs
+++ b/zellij-client/src/os_input_output.rs
@@ -145,7 +145,9 @@ impl ClientOsApi for ClientOsInputOutput {
     }
 
     fn send_to_server(&self, msg: ClientToServerMsg) {
-        self.send_instructions_to_server
+        // TODO: handle the error here, right now we silently ignore it
+        let _ = self
+            .send_instructions_to_server
             .lock()
             .unwrap()
             .as_mut()

--- a/zellij-client/src/sessions.rs
+++ b/zellij-client/src/sessions.rs
@@ -8,7 +8,7 @@ pub(crate) fn kill_session(name: &str) {
     let path = &*ZELLIJ_SOCK_DIR.join(name);
     match LocalSocketStream::connect(path) {
         Ok(stream) => {
-            IpcSenderWithContext::new(stream).send(ClientToServerMsg::KillSession);
+            let _ = IpcSenderWithContext::new(stream).send(ClientToServerMsg::KillSession);
         },
         Err(e) => {
             eprintln!("Error occurred: {:?}", e);

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -382,7 +382,6 @@ impl ServerOsApi for ServerOsInputOutput {
         client_id: ClientId,
         msg: ServerToClientMsg,
     ) -> Result<(), &'static str> {
-        log::info!("send_to_client: {:?}", client_id);
         if let Some(sender) = self.client_senders.lock().unwrap().get_mut(&client_id) {
             sender.send(msg)
         } else {

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -316,7 +316,11 @@ pub trait ServerOsApi: Send + Sync {
     fn force_kill(&self, pid: Pid) -> Result<(), nix::Error>;
     /// Returns a [`Box`] pointer to this [`ServerOsApi`] struct.
     fn box_clone(&self) -> Box<dyn ServerOsApi>;
-    fn send_to_client(&self, client_id: ClientId, msg: ServerToClientMsg);
+    fn send_to_client(
+        &self,
+        client_id: ClientId,
+        msg: ServerToClientMsg,
+    ) -> Result<(), &'static str>;
     fn new_client(
         &mut self,
         client_id: ClientId,
@@ -373,9 +377,16 @@ impl ServerOsApi for ServerOsInputOutput {
         let _ = kill(pid, Some(Signal::SIGKILL));
         Ok(())
     }
-    fn send_to_client(&self, client_id: ClientId, msg: ServerToClientMsg) {
+    fn send_to_client(
+        &self,
+        client_id: ClientId,
+        msg: ServerToClientMsg,
+    ) -> Result<(), &'static str> {
+        log::info!("send_to_client: {:?}", client_id);
         if let Some(sender) = self.client_senders.lock().unwrap().get_mut(&client_id) {
-            sender.send(msg);
+            sender.send(msg)
+        } else {
+            Ok(())
         }
     }
     fn new_client(

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -72,7 +72,11 @@ impl ServerOsApi for FakeInputOutput {
     fn box_clone(&self) -> Box<dyn ServerOsApi> {
         Box::new((*self).clone())
     }
-    fn send_to_client(&self, _client_id: ClientId, _msg: ServerToClientMsg) {
+    fn send_to_client(
+        &self,
+        _client_id: ClientId,
+        _msg: ServerToClientMsg,
+    ) -> Result<(), &'static str> {
         unimplemented!()
     }
     fn new_client(

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -63,7 +63,11 @@ impl ServerOsApi for FakeInputOutput {
     fn box_clone(&self) -> Box<dyn ServerOsApi> {
         Box::new((*self).clone())
     }
-    fn send_to_client(&self, _client_id: ClientId, _msg: ServerToClientMsg) {
+    fn send_to_client(
+        &self,
+        _client_id: ClientId,
+        _msg: ServerToClientMsg,
+    ) -> Result<(), &'static str> {
         unimplemented!()
     }
     fn new_client(

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -59,7 +59,11 @@ impl ServerOsApi for FakeInputOutput {
     fn box_clone(&self) -> Box<dyn ServerOsApi> {
         Box::new((*self).clone())
     }
-    fn send_to_client(&self, _client_id: ClientId, _msg: ServerToClientMsg) {
+    fn send_to_client(
+        &self,
+        _client_id: ClientId,
+        _msg: ServerToClientMsg,
+    ) -> Result<(), &'static str> {
         unimplemented!()
     }
     fn new_client(

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -158,10 +158,7 @@ impl<T: Serialize> IpcSenderWithContext<T> {
     /// Sends an event, along with the current [`ErrorContext`], on this [`IpcSenderWithContext`]'s socket.
     pub fn send(&mut self, msg: T) -> Result<(), &'static str> {
         let err_ctx = get_current_ctx();
-        // rmp_serde::encode::write(&mut self.sender, &(msg, err_ctx)).unwrap();
-        if let Err(e) = rmp_serde::encode::write(&mut self.sender, &(msg, err_ctx)) {
-            // panic!("aaa!~!!");
-            log::error!("Failed to send ipc message: {:?}", e);
+        if rmp_serde::encode::write(&mut self.sender, &(msg, err_ctx)).is_err() {
             Err("Failed to send message to client")
         } else {
             // TODO: unwrapping here can cause issues when the server disconnects which we don't mind


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/1684

With this PR, whenever the server is unable to send messages to the client - instead of crashing - it either marks the client as disconnected (removes it from its state) or does nothing (if for example it's already shutting down or the client is in the process of disconnecting already).