### PR TITLE
fix osc params 1024 bytes limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix: bracketed paste handling regression (https://github.com/zellij-org/zellij/pull/1689)
 * fix: occasional startup crashes (https://github.com/zellij-org/zellij/pull/1706)
 * fix: gracefully handle SSH disconnects (https://github.com/zellij-org/zellij/pull/1710)
+* fix: handle osc params larger than 1024 bytes (https://github.com/zellij-org/zellij/pull/1711)
 
 ## [0.31.3] - 2022-08-18
 * HOTFIX: fix up-arrow regression

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,7 +2352,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
 dependencies = [
- "vte",
+ "vte 0.10.1",
 ]
 
 [[package]]
@@ -2819,6 +2819,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
 dependencies = [
  "arrayvec 0.5.2",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aae21c12ad2ec2d168c236f369c38ff332bc1134f7246350dca641437365045"
+dependencies = [
  "utf8parse",
  "vte_generate_state_changes",
 ]
@@ -3405,7 +3415,7 @@ dependencies = [
  "thiserror",
  "unicode-width",
  "url",
- "vte",
+ "vte 0.11.0",
 ]
 
 [[package]]

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -30,7 +30,7 @@ strum = "0.20.0"
 strum_macros = "0.20.1"
 thiserror = "1.0.30"
 url = { version = "2.2.2", features = ["serde"] }
-vte = "0.10.1"
+vte = { version = "0.11.0", default-features = false }
 log = "0.4.17"
 unicode-width = "0.1.8"
 miette = { version = "3.3.0", features = ["fancy"] }


### PR DESCRIPTION
turn off default-features for vte, since default includes no_std, and in that case the osc params buffer is capped at 1024 bytes.

Fixes #1709 