### PR TITLE
fix(nix) missing frameworks on darwin

### DIFF
--- a/.nix/crate2nix.nix
+++ b/.nix/crate2nix.nix
@@ -13,6 +13,10 @@
     (import "${crate2nix}/tools.nix" {inherit pkgs;})
     generatedCargoNix
     ;
+  darwinBuildInputs = pkgs.lib.optionals pkgs.stdenv.isDarwin [
+      pkgs.darwin.apple_sdk.frameworks.DiskArbitration
+      pkgs.darwin.apple_sdk.frameworks.Foundation
+  ];
 
   project =
     import
@@ -29,6 +33,10 @@
               # Crate dependency overrides go here
               zellij = attrs: {
                 inherit postInstall desktopItems meta name nativeBuildInputs patchPhase;
+                buildInputs = darwinBuildInputs;
+              };
+              sysinfo = attrs: {
+                buildInputs = darwinBuildInputs;
               };
             };
         };

--- a/.nix/zellij.nix
+++ b/.nix/zellij.nix
@@ -74,7 +74,12 @@ flake-utils.lib.eachSystem [
   buildInputs = [
     # in order to run tests
     pkgs.openssl
-  ];
+  ] ++ (
+    pkgs.lib.optionals pkgs.stdenv.isDarwin [
+          pkgs.darwin.apple_sdk.frameworks.DiskArbitration
+          pkgs.darwin.apple_sdk.frameworks.Foundation
+    ]
+   );
 
   nativeBuildInputs = [
     # for openssl/openssl-sys


### PR DESCRIPTION
Zellij would not link without the DiskArbitraction and Foundation frameworks on macos (Big Sur). It seems sysinfo requires them. They must be passed as `buildInputs` in the nix flake.