### PR TITLE
Don't send the server an exit signal when client crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 * debugging: Improve error handling in screen thread (https://github.com/zellij-org/zellij/pull/1670)
+* fix: Server exits when client panics (https://github.com/zellij-org/zellij/pull/1731)
 
 ## [0.31.4] - 2022-09-09
 * Terminal compatibility: improve vttest compliance (https://github.com/zellij-org/zellij/pull/1671)

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -356,7 +356,6 @@ pub fn start_client(
                 break;
             },
             ClientInstruction::Error(backtrace) => {
-                let _ = os_input.send_to_server(ClientToServerMsg::Action(Action::Quit, None));
                 handle_error(backtrace);
             },
             ClientInstruction::Render(output) => {

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -26,7 +26,7 @@ use zellij_utils::{
     data::{ClientId, InputMode, Style},
     envs,
     errors::{ClientContext, ContextType, ErrorInstruction},
-    input::{actions::Action, config::Config, options::Options},
+    input::{config::Config, options::Options},
     ipc::{ClientAttributes, ClientToServerMsg, ExitReason, ServerToClientMsg},
     termwiz::input::InputEvent,
 };


### PR DESCRIPTION
fix #1532
Server was closed when the client panics which does not make sense to me, as explained in https://github.com/zellij-org/zellij/issues/1532#issuecomment-1245667341