### PR TITLE
Fix: issue 1734

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 * debugging: Improve error handling in screen thread (https://github.com/zellij-org/zellij/pull/1670)
 * fix: Server exits when client panics (https://github.com/zellij-org/zellij/pull/1731)
+* fix: Server panics when writing to suppressed pane (https://github.com/zellij-org/zellij/pull/1749)
 
 ## [0.31.4] - 2022-09-09
 * Terminal compatibility: improve vttest compliance (https://github.com/zellij-org/zellij/pull/1671)

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1032,7 +1032,9 @@ impl Tab {
                 let active_terminal = self
                     .floating_panes
                     .get(&pane_id)
-                    .unwrap_or_else(|| self.tiled_panes.get_pane(pane_id).unwrap());
+                    .or_else(|| self.tiled_panes.get_pane(pane_id))
+                    .or_else(|| self.suppressed_panes.get(&pane_id))
+                    .unwrap();
                 let adjusted_input = active_terminal.adjust_input_to_terminal(input_bytes);
 
                 self.senders

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -193,6 +193,25 @@ fn create_new_tab_with_cell_size(
 }
 
 #[test]
+fn write_to_suppressed_pane() {
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let mut tab = create_new_tab(size);
+    tab.vertical_split(PaneId::Terminal(2), 1);
+
+    // Suppress pane 2 and remove it from active panes
+    tab.suppress_active_pane(PaneId::Terminal(2), 1);
+    tab.tiled_panes.remove_pane(PaneId::Terminal(2));
+
+    // Make sure it's suppressed now
+    tab.suppressed_panes.get(&PaneId::Terminal(2)).unwrap();
+    // Write content to it
+    tab.write_to_pane_id(vec![34, 127, 31, 82, 17, 182], PaneId::Terminal(2));
+}
+
+#[test]
 fn split_panes_vertically() {
     let size = Size {
         cols: 121,


### PR DESCRIPTION
Prevent server from crashing when trying to write bytes to a terminal pane that is suppressed. Closes #1734.