### PR TITLE
zellij/commands: Prevent recursive sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix: error on mixed nodes in layouts (https://github.com/zellij-org/zellij/pull/1791)
 * fix: error on duplicate pane_template / tab_template definitions in layouts (https://github.com/zellij-org/zellij/pull/1792)
 * fix: accept session-name through the cli properly (https://github.com/zellij-org/zellij/pull/1793)
+* fix: Prevent recursive sessions from layout files (https://github.com/zellij-org/zellij/pull/1766)
 
 ## [0.31.4] - 2022-09-09
 * Terminal compatibility: improve vttest compliance (https://github.com/zellij-org/zellij/pull/1671)


### PR DESCRIPTION
with session names specified in layout files. A "recursive session" is created when, while running inside some zellij session, a user attempts to spawn zellij and make it attach to that same session.

When attaching via CLI (`zellij attach`) we explicitly check for this condition and error out when needed.

However, besides `zellij attach` it is also possible to declare the session to attach to in layout files like so:

```yaml
session:
  name: "foo"
```

This takes a different codepath when starting zellij, and hence bypases the checks we already have in place to avoid recursive sessions. Hence, we implement the check in the other codepath, too, and prevent recursive sessions from happening for good.

Fixes: #1735