### PR TITLE
zellij-server: improve thread_bus error handling

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -971,7 +971,6 @@ impl Screen {
                     Some(*client_id),
                     Event::TabUpdate(tab_data),
                 ))
-                .to_anyhow()
                 .context("failed to update tabs")?;
         }
         Ok(())
@@ -1167,7 +1166,6 @@ impl Screen {
         self.bus
             .senders
             .send_to_server(ServerInstruction::UnblockInputThread)
-            .context("failed to send message to server")
             .context("failed to unblock input")
     }
 }
@@ -1871,7 +1869,6 @@ pub(crate) fn screen_thread_main(
                         .bus
                         .senders
                         .send_to_server(*instruction)
-                        .context("failed to send message to server")
                         .context("failed to confirm prompt")?;
                 }
                 screen.unblock_input()?;

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -497,7 +497,6 @@ impl Tab {
                 let pane_title = run.location.to_string();
                 self.senders
                     .send_to_plugin(PluginInstruction::Load(pid_tx, run, tab_index, client_id))
-                    .to_anyhow()
                     .with_context(err_context)?;
                 let pid = pid_rx.recv().with_context(err_context)?;
                 let mut new_plugin = PluginPane::new(
@@ -588,7 +587,6 @@ impl Tab {
                     Some(*client_id),
                     Event::ModeUpdate(mode_info.clone()),
                 ))
-                .to_anyhow()
                 .with_context(|| {
                     format!(
                         "failed to update plugins with mode info {:?}",
@@ -1169,7 +1167,6 @@ impl Tab {
                 for key in parse_keys(&input_bytes) {
                     self.senders
                         .send_to_plugin(PluginInstruction::Update(Some(pid), None, Event::Key(key)))
-                        .to_anyhow()
                         .with_context(err_context)?;
                 }
             },
@@ -2390,7 +2387,6 @@ impl Tab {
                     None,
                     Event::CopyToClipboard(self.clipboard_provider.as_copy_destination()),
                 ))
-                .to_anyhow()
                 .with_context(|| {
                     format!("failed to inform plugins about copy selection for client {client_id}")
                 })
@@ -2424,7 +2420,6 @@ impl Tab {
             };
         self.senders
             .send_to_plugin(PluginInstruction::Update(None, None, clipboard_event))
-            .to_anyhow()
             .context("failed to notify plugins about new clipboard event")
             .non_fatal();
 
@@ -2466,7 +2461,6 @@ impl Tab {
                     None,
                     Event::Visible(visible),
                 ))
-                .to_anyhow()
                 .with_context(|| format!("failed to set visibility of tab to {visible}"))?;
         }
         Ok(())

--- a/zellij-server/src/thread_bus.rs
+++ b/zellij-server/src/thread_bus.rs
@@ -4,6 +4,7 @@ use crate::{
     os_input_output::ServerOsApi, pty::PtyInstruction, pty_writer::PtyWriteInstruction,
     screen::ScreenInstruction, wasm_vm::PluginInstruction, ServerInstruction,
 };
+use zellij_utils::errors::prelude::*;
 use zellij_utils::{channels, channels::SenderWithContext, errors::ErrorContext};
 
 /// A container for senders to the different threads in zellij on the server side
@@ -20,10 +21,7 @@ pub(crate) struct ThreadSenders {
 }
 
 impl ThreadSenders {
-    pub fn send_to_screen(
-        &self,
-        instruction: ScreenInstruction,
-    ) -> Result<(), channels::SendError<(ScreenInstruction, ErrorContext)>> {
+    pub fn send_to_screen(&self, instruction: ScreenInstruction) -> Result<()> {
         if self.should_silently_fail {
             let _ = self
                 .to_screen
@@ -32,14 +30,16 @@ impl ThreadSenders {
                 .unwrap_or_else(|| Ok(()));
             Ok(())
         } else {
-            self.to_screen.as_ref().unwrap().send(instruction)
+            self.to_screen
+                .as_ref()
+                .unwrap()
+                .send(instruction)
+                .to_anyhow()
+                .context("failed to send message to screen")
         }
     }
 
-    pub fn send_to_pty(
-        &self,
-        instruction: PtyInstruction,
-    ) -> Result<(), channels::SendError<(PtyInstruction, ErrorContext)>> {
+    pub fn send_to_pty(&self, instruction: PtyInstruction) -> Result<()> {
         if self.should_silently_fail {
             let _ = self
                 .to_pty
@@ -48,14 +48,16 @@ impl ThreadSenders {
                 .unwrap_or_else(|| Ok(()));
             Ok(())
         } else {
-            self.to_pty.as_ref().unwrap().send(instruction)
+            self.to_pty
+                .as_ref()
+                .unwrap()
+                .send(instruction)
+                .to_anyhow()
+                .context("failed to send message to pty")
         }
     }
 
-    pub fn send_to_plugin(
-        &self,
-        instruction: PluginInstruction,
-    ) -> Result<(), channels::SendError<(PluginInstruction, ErrorContext)>> {
+    pub fn send_to_plugin(&self, instruction: PluginInstruction) -> Result<()> {
         if self.should_silently_fail {
             let _ = self
                 .to_plugin
@@ -64,14 +66,16 @@ impl ThreadSenders {
                 .unwrap_or_else(|| Ok(()));
             Ok(())
         } else {
-            self.to_plugin.as_ref().unwrap().send(instruction)
+            self.to_plugin
+                .as_ref()
+                .unwrap()
+                .send(instruction)
+                .to_anyhow()
+                .context("failed to send message to plugin")
         }
     }
 
-    pub fn send_to_server(
-        &self,
-        instruction: ServerInstruction,
-    ) -> Result<(), channels::SendError<(ServerInstruction, ErrorContext)>> {
+    pub fn send_to_server(&self, instruction: ServerInstruction) -> Result<()> {
         if self.should_silently_fail {
             let _ = self
                 .to_server
@@ -80,13 +84,15 @@ impl ThreadSenders {
                 .unwrap_or_else(|| Ok(()));
             Ok(())
         } else {
-            self.to_server.as_ref().unwrap().send(instruction)
+            self.to_server
+                .as_ref()
+                .unwrap()
+                .send(instruction)
+                .to_anyhow()
+                .context("failed to send message to server")
         }
     }
-    pub fn send_to_pty_writer(
-        &self,
-        instruction: PtyWriteInstruction,
-    ) -> Result<(), channels::SendError<(PtyWriteInstruction, ErrorContext)>> {
+    pub fn send_to_pty_writer(&self, instruction: PtyWriteInstruction) -> Result<()> {
         if self.should_silently_fail {
             let _ = self
                 .to_pty_writer
@@ -95,7 +101,12 @@ impl ThreadSenders {
                 .unwrap_or_else(|| Ok(()));
             Ok(())
         } else {
-            self.to_pty_writer.as_ref().unwrap().send(instruction)
+            self.to_pty_writer
+                .as_ref()
+                .unwrap()
+                .send(instruction)
+                .to_anyhow()
+                .context("failed to send message to pty writer")
         }
     }
 

--- a/zellij-server/src/thread_bus.rs
+++ b/zellij-server/src/thread_bus.rs
@@ -32,7 +32,7 @@ impl ThreadSenders {
         } else {
             self.to_screen
                 .as_ref()
-                .unwrap()
+                .context("failed to get screen sender")?
                 .send(instruction)
                 .to_anyhow()
                 .context("failed to send message to screen")
@@ -50,7 +50,7 @@ impl ThreadSenders {
         } else {
             self.to_pty
                 .as_ref()
-                .unwrap()
+                .context("failed to get pty sender")?
                 .send(instruction)
                 .to_anyhow()
                 .context("failed to send message to pty")
@@ -68,7 +68,7 @@ impl ThreadSenders {
         } else {
             self.to_plugin
                 .as_ref()
-                .unwrap()
+                .context("failed to get plugin sender")?
                 .send(instruction)
                 .to_anyhow()
                 .context("failed to send message to plugin")
@@ -86,7 +86,7 @@ impl ThreadSenders {
         } else {
             self.to_server
                 .as_ref()
-                .unwrap()
+                .context("failed to get server sender")?
                 .send(instruction)
                 .to_anyhow()
                 .context("failed to send message to server")
@@ -103,7 +103,7 @@ impl ThreadSenders {
         } else {
             self.to_pty_writer
                 .as_ref()
-                .unwrap()
+                .context("failed to get pty writer sender")?
                 .send(instruction)
                 .to_anyhow()
                 .context("failed to send message to pty writer")

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -546,7 +546,7 @@ mod not_wasm {
                 Err(e) => {
                     let (msg, context) = e.into_inner();
                     Err(
-                        crate::anyhow::anyhow!("failed to send message to client: {:#?}", msg)
+                        crate::anyhow::anyhow!("failed to send message to channel: {:#?}", msg)
                             .context(context.to_string()),
                     )
                 },


### PR DESCRIPTION
WIP: #1753 

As suggested in my previous [PR](https://github.com/zellij-org/zellij/pull/1770#issuecomment-1266518037), moving thread_bus error changes to a separate one