### PR TITLE
feat(layouts): global cwd

### DIFF
--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -140,8 +140,11 @@ fn handle_openpty(
             let cmd = cmd.clone();
             let command = &mut Command::new(cmd.command);
             if let Some(current_dir) = cmd.cwd {
-                if current_dir.exists() {
+                if current_dir.exists() && current_dir.is_dir() {
                     command.current_dir(current_dir);
+                } else {
+                    // TODO: propagate this to the user
+                    log::error!("Failed to set CWD for new pane. {} does not exist or is not a folder", current_dir.display());
                 }
             }
             command

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -144,7 +144,10 @@ fn handle_openpty(
                     command.current_dir(current_dir);
                 } else {
                     // TODO: propagate this to the user
-                    log::error!("Failed to set CWD for new pane. {} does not exist or is not a folder", current_dir.display());
+                    log::error!(
+                        "Failed to set CWD for new pane. {} does not exist or is not a folder",
+                        current_dir.display()
+                    );
                 }
             }
             command

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -535,7 +535,7 @@ impl Pty {
                             log::error!("Failed to spawn terminal: {}", e);
                         },
                     }
-                }
+                },
                 None => {
                     match self.bus.os_input.as_mut().unwrap().spawn_terminal(
                         default_shell.clone(),
@@ -560,7 +560,6 @@ impl Pty {
                 },
                 // Investigate moving plugin loading to here.
                 Some(Run::Plugin(_)) => {},
-
             }
         }
         let new_tab_pane_ids: Vec<u32> = new_pane_pids

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -251,7 +251,7 @@ fn create_new_tab_with_layout(size: Size, default_mode: ModeInfo, layout: &str) 
     let copy_options = CopyOptions::default();
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let sixel_image_store = Rc::new(RefCell::new(SixelImageStore::default()));
-    let layout = Layout::from_str(layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_str(layout, "layout_file_name".into(), None).unwrap();
     let tab_layout = layout.new_tab();
     let mut tab = Tab::new(
         index,

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -2207,6 +2207,7 @@ pub fn send_cli_new_tab_action_default_params() {
     let new_tab_action = CliAction::NewTab {
         name: None,
         layout: None,
+        cwd: None,
     };
     send_cli_action_to_server(
         &session_metadata,
@@ -2242,6 +2243,7 @@ pub fn send_cli_new_tab_action_with_name_and_layout() {
             "{}/src/unit/fixtures/layout-with-three-panes.kdl",
             env!("CARGO_MANIFEST_DIR")
         ))),
+        cwd: None,
     };
     send_cli_action_to_server(
         &session_metadata,

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -253,5 +253,7 @@ pub enum CliAction {
         layout: Option<PathBuf>,
         #[clap(short, long, value_parser)]
         name: Option<String>,
+        #[clap(short, long, value_parser, requires("layout"))]
+        cwd: Option<PathBuf>,
     },
 }

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -344,12 +344,12 @@ impl Action {
                 Action::TabNameInput(name.as_bytes().to_vec()),
             ]),
             CliAction::UndoRenameTab => Ok(vec![Action::UndoRenameTab]),
-            CliAction::NewTab { name, layout } => {
+            CliAction::NewTab { name, layout, cwd } => {
                 if let Some(layout_path) = layout {
                     let (path_to_raw_layout, raw_layout) =
                         Layout::stringified_from_path_or_default(Some(&layout_path), None)
                             .map_err(|e| format!("Failed to load layout: {}", e))?;
-                    let layout = Layout::from_str(&raw_layout, path_to_raw_layout).map_err(|e| {
+                    let layout = Layout::from_str(&raw_layout, path_to_raw_layout, cwd).map_err(|e| {
                         let stringified_error = match e {
                             ConfigError::KdlError(kdl_error) => {
                                 let error = kdl_error.add_src(layout_path.as_path().as_os_str().to_string_lossy().to_string(), String::from(raw_layout));

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -287,12 +287,12 @@ impl Layout {
     ) -> Result<(Layout, Config), ConfigError> {
         let (path_to_raw_layout, raw_layout) =
             Layout::stringified_from_path_or_default(layout_path, layout_dir)?;
-        let layout = Layout::from_kdl(&raw_layout, path_to_raw_layout)?;
+        let layout = Layout::from_kdl(&raw_layout, path_to_raw_layout, None)?;
         let config = Config::from_kdl(&raw_layout, Some(config))?; // this merges the two config, with
         Ok((layout, config))
     }
-    pub fn from_str(raw: &str, path_to_raw_layout: String) -> Result<Layout, ConfigError> {
-        Layout::from_kdl(raw, path_to_raw_layout)
+    pub fn from_str(raw: &str, path_to_raw_layout: String, cwd: Option<PathBuf>) -> Result<Layout, ConfigError> {
+        Layout::from_kdl(raw, path_to_raw_layout, cwd)
     }
     pub fn stringified_from_dir(
         layout: &PathBuf,

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -78,23 +78,23 @@ impl Run {
                     merged.args = base_run_command.args.clone();
                 }
                 Some(Run::Command(merged))
-            }
+            },
             (Some(Run::Command(base_run_command)), Some(Run::Cwd(other_cwd))) => {
                 let mut merged = base_run_command.clone();
                 merged.cwd = Some(other_cwd.clone());
                 Some(Run::Command(merged))
-            }
+            },
             (Some(Run::Cwd(base_cwd)), Some(Run::Command(other_command))) => {
                 let mut merged = other_command.clone();
                 if merged.cwd.is_none() {
                     merged.cwd = Some(base_cwd.clone());
                 }
                 Some(Run::Command(merged))
-            }
+            },
             (Some(_base), Some(other)) => Some(other.clone()),
             (Some(base), _) => Some(base.clone()),
             (None, Some(other)) => Some(other.clone()),
-            (None, None) => None
+            (None, None) => None,
         }
     }
 }
@@ -291,7 +291,11 @@ impl Layout {
         let config = Config::from_kdl(&raw_layout, Some(config))?; // this merges the two config, with
         Ok((layout, config))
     }
-    pub fn from_str(raw: &str, path_to_raw_layout: String, cwd: Option<PathBuf>) -> Result<Layout, ConfigError> {
+    pub fn from_str(
+        raw: &str,
+        path_to_raw_layout: String,
+        cwd: Option<PathBuf>,
+    ) -> Result<Layout, ConfigError> {
         Layout::from_kdl(raw, path_to_raw_layout, cwd)
     }
     pub fn stringified_from_dir(

--- a/zellij-utils/src/input/unit/layout_test.rs
+++ b/zellij-utils/src/input/unit/layout_test.rs
@@ -4,7 +4,7 @@ use insta::assert_snapshot;
 #[test]
 fn empty_layout() {
     let kdl_layout = "layout";
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     let expected_layout = Layout {
         template: Some(PaneLayout::default()),
         ..Default::default()
@@ -19,7 +19,7 @@ fn layout_with_one_pane() {
             pane
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     let expected_layout = Layout {
         template: Some(PaneLayout {
             children: vec![PaneLayout::default()],
@@ -39,7 +39,7 @@ fn layout_with_multiple_panes() {
             pane
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     let expected_layout = Layout {
         template: Some(PaneLayout {
             children: vec![
@@ -68,7 +68,7 @@ fn layout_with_nested_panes() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     let expected_layout = Layout {
         template: Some(PaneLayout {
             children: vec![
@@ -96,7 +96,7 @@ fn layout_with_tabs() {
             tab
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     let expected_layout = Layout {
         tabs: vec![(None, PaneLayout::default())],
         template: Some(PaneLayout::default()),
@@ -120,7 +120,7 @@ fn layout_with_nested_differing_tabs() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     let expected_layout = Layout {
         tabs: vec![
             (
@@ -160,7 +160,7 @@ fn layout_with_panes_in_different_mixed_split_sizes() {
             pane size=2;
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     let expected_layout = Layout {
         template: Some(PaneLayout {
             children: vec![
@@ -195,7 +195,7 @@ fn layout_with_command_panes() {
             pane command="htop"
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     let expected_layout = Layout {
         template: Some(PaneLayout {
             children: vec![PaneLayout {
@@ -220,7 +220,7 @@ fn layout_with_command_panes_and_cwd() {
             pane command="htop" cwd="/path/to/my/cwd"
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     let expected_layout = Layout {
         template: Some(PaneLayout {
             children: vec![PaneLayout {
@@ -248,7 +248,7 @@ fn layout_with_command_panes_and_cwd_and_args() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     let expected_layout = Layout {
         template: Some(PaneLayout {
             children: vec![PaneLayout {
@@ -280,7 +280,7 @@ fn layout_with_plugin_panes() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     let expected_layout = Layout {
         template: Some(PaneLayout {
             children: vec![
@@ -313,7 +313,7 @@ fn layout_with_borderless_panes() {
             pane borderless=true
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     let expected_layout = Layout {
         template: Some(PaneLayout {
             children: vec![PaneLayout {
@@ -334,7 +334,7 @@ fn layout_with_focused_panes() {
             pane focus=true
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     let expected_layout = Layout {
         template: Some(PaneLayout {
             children: vec![PaneLayout {
@@ -355,7 +355,7 @@ fn layout_with_pane_names() {
             pane name="my awesome pane"
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     let expected_layout = Layout {
         template: Some(PaneLayout {
             children: vec![PaneLayout {
@@ -377,7 +377,7 @@ fn layout_with_tab_names() {
             tab name="my cool tab name 2"
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     let expected_layout = Layout {
         tabs: vec![
             (
@@ -410,7 +410,7 @@ fn layout_with_focused_tab() {
             tab
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     let expected_layout = Layout {
         tabs: vec![
             (None, PaneLayout::default()),
@@ -444,7 +444,7 @@ fn layout_with_tab_templates() {
             one-above-one-below
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     let expected_layout = Layout {
         tabs: vec![
             (
@@ -518,7 +518,7 @@ fn layout_with_default_tab_template() {
             tab
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -545,7 +545,7 @@ fn layout_with_pane_templates() {
             left-and-right
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -566,7 +566,7 @@ fn layout_with_tab_and_pane_templates() {
             left-right-and-htop
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -587,7 +587,7 @@ fn layout_with_nested_pane_templates() {
             left-and-right
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -613,7 +613,7 @@ fn layout_with_nested_branched_pane_templates() {
             left-and-right
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -637,7 +637,7 @@ fn circular_dependency_pane_templates_error() {
             one
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into());
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None);
     assert!(layout.is_err(), "circular dependency detected");
 }
 
@@ -659,7 +659,7 @@ fn children_not_as_first_child_of_tab_template() {
             horizontal-with-vertical-top
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -682,7 +682,7 @@ fn error_on_more_than_one_children_block_in_tab_template() {
             horizontal-with-vertical-top
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into());
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None);
     assert!(
         layout.is_err(),
         "error provided for more than one children block"
@@ -707,7 +707,7 @@ fn children_not_as_first_child_of_pane_template() {
             horizontal-with-vertical-top
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -730,7 +730,7 @@ fn error_on_more_than_one_children_block_in_pane_template() {
             horizontal-with-vertical-top
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into());
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None);
     assert!(
         layout.is_err(),
         "error provided for more than one children block"
@@ -759,7 +759,7 @@ fn combined_tab_and_pane_template_both_with_children() {
             horizontal-with-vertical-top
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -775,7 +775,7 @@ fn cannot_define_tab_template_name_with_space() {
             pane
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into());
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None);
     assert!(layout.is_err(), "error provided for tab name with space");
 }
 
@@ -791,7 +791,7 @@ fn cannot_define_pane_template_name_with_space() {
             pane
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into());
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None);
     assert!(layout.is_err(), "error provided for tab name with space");
 }
 
@@ -805,7 +805,7 @@ fn cannot_define_panes_and_tabs_on_same_level() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into());
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None);
     assert!(
         layout.is_err(),
         "error provided for tab and pane on the same level"
@@ -839,7 +839,7 @@ fn cannot_define_tab_template_names_as_keywords() {
         ",
             keyword
         );
-        let layout = Layout::from_kdl(&kdl_layout, "layout_file_name".into());
+        let layout = Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None);
         assert!(
             layout.is_err(),
             "{}",
@@ -877,7 +877,7 @@ fn cannot_define_pane_template_names_as_keywords() {
         ",
             keyword
         );
-        let layout = Layout::from_kdl(&kdl_layout, "layout_file_name".into());
+        let layout = Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None);
         assert!(
             layout.is_err(),
             "{}",
@@ -897,7 +897,7 @@ fn error_on_multiple_layout_nodes_in_file() {
         layout
     "
     );
-    let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into()).unwrap_err();
+    let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
@@ -912,7 +912,7 @@ fn error_on_unknown_layout_node() {
         }}
     "
     );
-    let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into()).unwrap_err();
+    let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
@@ -925,7 +925,7 @@ fn error_on_unknown_layout_pane_property() {
         }}
     "
     );
-    let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into()).unwrap_err();
+    let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
@@ -938,7 +938,7 @@ fn error_on_unknown_layout_pane_template_property() {
         }}
     "
     );
-    let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into()).unwrap_err();
+    let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
@@ -951,7 +951,7 @@ fn error_on_unknown_layout_tab_property() {
         }}
     "
     );
-    let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into()).unwrap_err();
+    let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
@@ -964,7 +964,7 @@ fn error_on_unknown_layout_tab_template_property() {
         }}
     "
     );
-    let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into()).unwrap_err();
+    let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
@@ -981,7 +981,7 @@ fn error_on_pane_templates_without_a_name() {
         }}
     "
     );
-    let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into()).unwrap_err();
+    let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
@@ -998,7 +998,7 @@ fn error_on_tab_templates_without_a_name() {
         }}
     "
     );
-    let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into()).unwrap_err();
+    let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
@@ -1011,7 +1011,7 @@ fn error_on_more_than_one_focused_tab() {
             tab
         }
     "#;
-    let layout_error = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap_err();
+    let layout_error = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
@@ -1029,7 +1029,7 @@ fn args_override_args_in_template() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1046,7 +1046,7 @@ fn args_added_to_args_in_template() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1064,7 +1064,7 @@ fn cwd_override_cwd_in_template() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1081,7 +1081,7 @@ fn cwd_added_to_cwd_in_template() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1094,7 +1094,7 @@ fn error_on_mixed_command_and_child_panes() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into());
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None);
     assert!(layout.is_err(), "error provided");
 }
 
@@ -1107,7 +1107,7 @@ fn error_on_bare_args_without_command() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into());
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None);
     assert!(layout.is_err(), "error provided");
 }
 
@@ -1121,7 +1121,7 @@ fn error_on_bare_args_in_template_without_command() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into());
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None);
     assert!(layout.is_err(), "error provided");
 }
 
@@ -1140,7 +1140,7 @@ fn pane_template_command_with_cwd_overriden_by_its_consumers_command_cwd() {
             // pane should have /tmp/foo and not /tmp/bar as cwd
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1157,7 +1157,7 @@ fn pane_template_command_with_cwd_remains_when_its_consumer_command_does_not_hav
             // pane should have /tmp/bar as its cwd with the pwd command
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1175,7 +1175,7 @@ fn pane_template_command_without_cwd_is_overriden_by_its_consumers_cwd() {
             // pane should have /tmp/bar as its cwd with the pwd command
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1194,7 +1194,7 @@ fn pane_template_command_with_cwd_is_overriden_by_its_consumers_bare_cwd() {
             // pane should have /tmp/bar as its cwd with the tail command
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1212,7 +1212,7 @@ fn pane_template_command_without_cwd_receives_its_consumers_bare_cwd() {
             // pane should have /tmp/bar as its cwd with the tail command
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1230,7 +1230,7 @@ fn pane_template_with_bare_cwd_overriden_by_its_consumers_bare_cwd() {
             // pane should have /tmp/foo without a command
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1246,7 +1246,7 @@ fn pane_template_with_bare_propagated_to_its_consumer_command_without_cwd() {
             // pane should have /tmp/foo with the tail command
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1264,7 +1264,7 @@ fn pane_template_with_bare_propagated_to_its_consumer_command_with_cwd() {
             // pane should have /tmp/bar with the tail command
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1278,7 +1278,7 @@ fn global_cwd_given_to_panes_without_cwd() {
             // both should have the /tmp cwd
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1291,6 +1291,35 @@ fn global_cwd_prepended_to_panes_with_cwd() {
             pane command="tail" cwd="/home/foo" // should be /home/foo because its an absolute path
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into()).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
+    assert_snapshot!(format!("{:#?}", layout));
+}
+
+#[test]
+fn global_cwd_passed_from_layout_constructor() {
+    // this is used by the new-tab cli action with --cwd
+    let kdl_layout = r#"
+        layout {
+            pane
+            pane command="tail"
+            // both should have the /tmp cwd
+        }
+    "#;
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), Some(PathBuf::from("/tmp"))).unwrap();
+    assert_snapshot!(format!("{:#?}", layout));
+}
+
+#[test]
+fn global_cwd_passed_from_layout_constructor_overrides_global_cwd_in_layout_file() {
+    // this is used by the new-tab cli action with --cwd
+    let kdl_layout = r#"
+        layout {
+            cwd "/home"
+            pane
+            pane command="tail"
+            // both should have the /tmp cwd
+        }
+    "#;
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), Some(PathBuf::from("/tmp"))).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }

--- a/zellij-utils/src/input/unit/layout_test.rs
+++ b/zellij-utils/src/input/unit/layout_test.rs
@@ -1305,7 +1305,12 @@ fn global_cwd_passed_from_layout_constructor() {
             // both should have the /tmp cwd
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), Some(PathBuf::from("/tmp"))).unwrap();
+    let layout = Layout::from_kdl(
+        kdl_layout,
+        "layout_file_name".into(),
+        Some(PathBuf::from("/tmp")),
+    )
+    .unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1320,6 +1325,11 @@ fn global_cwd_passed_from_layout_constructor_overrides_global_cwd_in_layout_file
             // both should have the /tmp cwd
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), Some(PathBuf::from("/tmp"))).unwrap();
+    let layout = Layout::from_kdl(
+        kdl_layout,
+        "layout_file_name".into(),
+        Some(PathBuf::from("/tmp")),
+    )
+    .unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }

--- a/zellij-utils/src/input/unit/layout_test.rs
+++ b/zellij-utils/src/input/unit/layout_test.rs
@@ -1099,6 +1099,20 @@ fn error_on_mixed_command_and_child_panes() {
 }
 
 #[test]
+fn error_on_mixed_cwd_and_child_panes() {
+    let kdl_layout = r#"
+        layout {
+            pane cwd="/tmp" {
+                pane
+                pane
+            }
+        }
+    "#;
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None);
+    assert!(layout.is_err(), "error provided");
+}
+
+#[test]
 fn error_on_bare_args_without_command() {
     let kdl_layout = r#"
         layout {

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_given_to_panes_without_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_given_to_panes_without_cwd.snap
@@ -1,0 +1,57 @@
+---
+source: zellij-utils/src/input/./unit/layout_test.rs
+assertion_line: 1283
+expression: "format!(\"{:#?}\", layout)"
+---
+Layout {
+    tabs: [],
+    focused_tab_index: None,
+    template: Some(
+        PaneLayout {
+            children_split_direction: Horizontal,
+            name: None,
+            children: [
+                PaneLayout {
+                    children_split_direction: Horizontal,
+                    name: None,
+                    children: [],
+                    split_size: None,
+                    run: Some(
+                        Cwd(
+                            "/tmp",
+                        ),
+                    ),
+                    borderless: false,
+                    focus: None,
+                    external_children_index: None,
+                },
+                PaneLayout {
+                    children_split_direction: Horizontal,
+                    name: None,
+                    children: [],
+                    split_size: None,
+                    run: Some(
+                        Command(
+                            RunCommand {
+                                command: "tail",
+                                args: [],
+                                cwd: Some(
+                                    "/tmp",
+                                ),
+                                hold_on_close: true,
+                            },
+                        ),
+                    ),
+                    borderless: false,
+                    focus: None,
+                    external_children_index: None,
+                },
+            ],
+            split_size: None,
+            run: None,
+            borderless: false,
+            focus: None,
+            external_children_index: None,
+        },
+    ),
+}

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_passed_from_layout_constructor.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_passed_from_layout_constructor.snap
@@ -1,0 +1,57 @@
+---
+source: zellij-utils/src/input/./unit/layout_test.rs
+assertion_line: 1309
+expression: "format!(\"{:#?}\", layout)"
+---
+Layout {
+    tabs: [],
+    focused_tab_index: None,
+    template: Some(
+        PaneLayout {
+            children_split_direction: Horizontal,
+            name: None,
+            children: [
+                PaneLayout {
+                    children_split_direction: Horizontal,
+                    name: None,
+                    children: [],
+                    split_size: None,
+                    run: Some(
+                        Cwd(
+                            "/tmp",
+                        ),
+                    ),
+                    borderless: false,
+                    focus: None,
+                    external_children_index: None,
+                },
+                PaneLayout {
+                    children_split_direction: Horizontal,
+                    name: None,
+                    children: [],
+                    split_size: None,
+                    run: Some(
+                        Command(
+                            RunCommand {
+                                command: "tail",
+                                args: [],
+                                cwd: Some(
+                                    "/tmp",
+                                ),
+                                hold_on_close: true,
+                            },
+                        ),
+                    ),
+                    borderless: false,
+                    focus: None,
+                    external_children_index: None,
+                },
+            ],
+            split_size: None,
+            run: None,
+            borderless: false,
+            focus: None,
+            external_children_index: None,
+        },
+    ),
+}

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_passed_from_layout_constructor_overrides_global_cwd_in_layout_file.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_passed_from_layout_constructor_overrides_global_cwd_in_layout_file.snap
@@ -1,0 +1,57 @@
+---
+source: zellij-utils/src/input/./unit/layout_test.rs
+assertion_line: 1324
+expression: "format!(\"{:#?}\", layout)"
+---
+Layout {
+    tabs: [],
+    focused_tab_index: None,
+    template: Some(
+        PaneLayout {
+            children_split_direction: Horizontal,
+            name: None,
+            children: [
+                PaneLayout {
+                    children_split_direction: Horizontal,
+                    name: None,
+                    children: [],
+                    split_size: None,
+                    run: Some(
+                        Cwd(
+                            "/tmp",
+                        ),
+                    ),
+                    borderless: false,
+                    focus: None,
+                    external_children_index: None,
+                },
+                PaneLayout {
+                    children_split_direction: Horizontal,
+                    name: None,
+                    children: [],
+                    split_size: None,
+                    run: Some(
+                        Command(
+                            RunCommand {
+                                command: "tail",
+                                args: [],
+                                cwd: Some(
+                                    "/tmp",
+                                ),
+                                hold_on_close: true,
+                            },
+                        ),
+                    ),
+                    borderless: false,
+                    focus: None,
+                    external_children_index: None,
+                },
+            ],
+            split_size: None,
+            run: None,
+            borderless: false,
+            focus: None,
+            external_children_index: None,
+        },
+    ),
+}

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_prepended_to_panes_with_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_prepended_to_panes_with_cwd.snap
@@ -1,0 +1,57 @@
+---
+source: zellij-utils/src/input/./unit/layout_test.rs
+assertion_line: 1295
+expression: "format!(\"{:#?}\", layout)"
+---
+Layout {
+    tabs: [],
+    focused_tab_index: None,
+    template: Some(
+        PaneLayout {
+            children_split_direction: Horizontal,
+            name: None,
+            children: [
+                PaneLayout {
+                    children_split_direction: Horizontal,
+                    name: None,
+                    children: [],
+                    split_size: None,
+                    run: Some(
+                        Cwd(
+                            "/tmp/foo",
+                        ),
+                    ),
+                    borderless: false,
+                    focus: None,
+                    external_children_index: None,
+                },
+                PaneLayout {
+                    children_split_direction: Horizontal,
+                    name: None,
+                    children: [],
+                    split_size: None,
+                    run: Some(
+                        Command(
+                            RunCommand {
+                                command: "tail",
+                                args: [],
+                                cwd: Some(
+                                    "/home/foo",
+                                ),
+                                hold_on_close: true,
+                            },
+                        ),
+                    ),
+                    borderless: false,
+                    focus: None,
+                    external_children_index: None,
+                },
+            ],
+            split_size: None,
+            run: None,
+            borderless: false,
+            focus: None,
+            external_children_index: None,
+        },
+    ),
+}

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_with_cwd_is_overriden_by_its_consumers_bare_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_with_cwd_is_overriden_by_its_consumers_bare_cwd.snap
@@ -1,0 +1,43 @@
+---
+source: zellij-utils/src/input/./unit/layout_test.rs
+assertion_line: 1199
+expression: "format!(\"{:#?}\", layout)"
+---
+Layout {
+    tabs: [],
+    focused_tab_index: None,
+    template: Some(
+        PaneLayout {
+            children_split_direction: Horizontal,
+            name: None,
+            children: [
+                PaneLayout {
+                    children_split_direction: Horizontal,
+                    name: None,
+                    children: [],
+                    split_size: None,
+                    run: Some(
+                        Command(
+                            RunCommand {
+                                command: "tail",
+                                args: [],
+                                cwd: Some(
+                                    "/tmp/bar",
+                                ),
+                                hold_on_close: true,
+                            },
+                        ),
+                    ),
+                    borderless: false,
+                    focus: None,
+                    external_children_index: None,
+                },
+            ],
+            split_size: None,
+            run: None,
+            borderless: false,
+            focus: None,
+            external_children_index: None,
+        },
+    ),
+}

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_with_cwd_overriden_by_its_consumers_command_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_with_cwd_overriden_by_its_consumers_command_cwd.snap
@@ -1,0 +1,43 @@
+---
+source: zellij-utils/src/input/./unit/layout_test.rs
+assertion_line: 1144
+expression: "format!(\"{:#?}\", layout)"
+---
+Layout {
+    tabs: [],
+    focused_tab_index: None,
+    template: Some(
+        PaneLayout {
+            children_split_direction: Horizontal,
+            name: None,
+            children: [
+                PaneLayout {
+                    children_split_direction: Horizontal,
+                    name: None,
+                    children: [],
+                    split_size: None,
+                    run: Some(
+                        Command(
+                            RunCommand {
+                                command: "pwd",
+                                args: [],
+                                cwd: Some(
+                                    "/tmp/foo",
+                                ),
+                                hold_on_close: true,
+                            },
+                        ),
+                    ),
+                    borderless: false,
+                    focus: None,
+                    external_children_index: None,
+                },
+            ],
+            split_size: None,
+            run: None,
+            borderless: false,
+            focus: None,
+            external_children_index: None,
+        },
+    ),
+}

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_with_cwd_remains_when_its_consumer_command_does_not_have_a_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_with_cwd_remains_when_its_consumer_command_does_not_have_a_cwd.snap
@@ -1,0 +1,43 @@
+---
+source: zellij-utils/src/input/./unit/layout_test.rs
+assertion_line: 1161
+expression: "format!(\"{:#?}\", layout)"
+---
+Layout {
+    tabs: [],
+    focused_tab_index: None,
+    template: Some(
+        PaneLayout {
+            children_split_direction: Horizontal,
+            name: None,
+            children: [
+                PaneLayout {
+                    children_split_direction: Horizontal,
+                    name: None,
+                    children: [],
+                    split_size: None,
+                    run: Some(
+                        Command(
+                            RunCommand {
+                                command: "pwd",
+                                args: [],
+                                cwd: Some(
+                                    "/tmp/bar",
+                                ),
+                                hold_on_close: true,
+                            },
+                        ),
+                    ),
+                    borderless: false,
+                    focus: None,
+                    external_children_index: None,
+                },
+            ],
+            split_size: None,
+            run: None,
+            borderless: false,
+            focus: None,
+            external_children_index: None,
+        },
+    ),
+}

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_without_cwd_is_overriden_by_its_consumers_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_without_cwd_is_overriden_by_its_consumers_cwd.snap
@@ -1,0 +1,43 @@
+---
+source: zellij-utils/src/input/./unit/layout_test.rs
+assertion_line: 1180
+expression: "format!(\"{:#?}\", layout)"
+---
+Layout {
+    tabs: [],
+    focused_tab_index: None,
+    template: Some(
+        PaneLayout {
+            children_split_direction: Horizontal,
+            name: None,
+            children: [
+                PaneLayout {
+                    children_split_direction: Horizontal,
+                    name: None,
+                    children: [],
+                    split_size: None,
+                    run: Some(
+                        Command(
+                            RunCommand {
+                                command: "pwd",
+                                args: [],
+                                cwd: Some(
+                                    "/tmp/bar",
+                                ),
+                                hold_on_close: true,
+                            },
+                        ),
+                    ),
+                    borderless: false,
+                    focus: None,
+                    external_children_index: None,
+                },
+            ],
+            split_size: None,
+            run: None,
+            borderless: false,
+            focus: None,
+            external_children_index: None,
+        },
+    ),
+}

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_without_cwd_receives_its_consumers_bare_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_without_cwd_receives_its_consumers_bare_cwd.snap
@@ -1,0 +1,43 @@
+---
+source: zellij-utils/src/input/./unit/layout_test.rs
+assertion_line: 1216
+expression: "format!(\"{:#?}\", layout)"
+---
+Layout {
+    tabs: [],
+    focused_tab_index: None,
+    template: Some(
+        PaneLayout {
+            children_split_direction: Horizontal,
+            name: None,
+            children: [
+                PaneLayout {
+                    children_split_direction: Horizontal,
+                    name: None,
+                    children: [],
+                    split_size: None,
+                    run: Some(
+                        Command(
+                            RunCommand {
+                                command: "tail",
+                                args: [],
+                                cwd: Some(
+                                    "/tmp/bar",
+                                ),
+                                hold_on_close: true,
+                            },
+                        ),
+                    ),
+                    borderless: false,
+                    focus: None,
+                    external_children_index: None,
+                },
+            ],
+            split_size: None,
+            run: None,
+            borderless: false,
+            focus: None,
+            external_children_index: None,
+        },
+    ),
+}

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_bare_cwd_overriden_by_its_consumers_bare_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_bare_cwd_overriden_by_its_consumers_bare_cwd.snap
@@ -1,0 +1,36 @@
+---
+source: zellij-utils/src/input/./unit/layout_test.rs
+assertion_line: 1235
+expression: "format!(\"{:#?}\", layout)"
+---
+Layout {
+    tabs: [],
+    focused_tab_index: None,
+    template: Some(
+        PaneLayout {
+            children_split_direction: Horizontal,
+            name: None,
+            children: [
+                PaneLayout {
+                    children_split_direction: Horizontal,
+                    name: None,
+                    children: [],
+                    split_size: None,
+                    run: Some(
+                        Cwd(
+                            "/tmp/bar",
+                        ),
+                    ),
+                    borderless: false,
+                    focus: None,
+                    external_children_index: None,
+                },
+            ],
+            split_size: None,
+            run: None,
+            borderless: false,
+            focus: None,
+            external_children_index: None,
+        },
+    ),
+}

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_bare_propagated_to_its_consumer_command_with_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_bare_propagated_to_its_consumer_command_with_cwd.snap
@@ -1,0 +1,43 @@
+---
+source: zellij-utils/src/input/./unit/layout_test.rs
+assertion_line: 1269
+expression: "format!(\"{:#?}\", layout)"
+---
+Layout {
+    tabs: [],
+    focused_tab_index: None,
+    template: Some(
+        PaneLayout {
+            children_split_direction: Horizontal,
+            name: None,
+            children: [
+                PaneLayout {
+                    children_split_direction: Horizontal,
+                    name: None,
+                    children: [],
+                    split_size: None,
+                    run: Some(
+                        Command(
+                            RunCommand {
+                                command: "tail",
+                                args: [],
+                                cwd: Some(
+                                    "/tmp/bar",
+                                ),
+                                hold_on_close: true,
+                            },
+                        ),
+                    ),
+                    borderless: false,
+                    focus: None,
+                    external_children_index: None,
+                },
+            ],
+            split_size: None,
+            run: None,
+            borderless: false,
+            focus: None,
+            external_children_index: None,
+        },
+    ),
+}

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_bare_propagated_to_its_consumer_command_without_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_bare_propagated_to_its_consumer_command_without_cwd.snap
@@ -1,0 +1,43 @@
+---
+source: zellij-utils/src/input/./unit/layout_test.rs
+assertion_line: 1251
+expression: "format!(\"{:#?}\", layout)"
+---
+Layout {
+    tabs: [],
+    focused_tab_index: None,
+    template: Some(
+        PaneLayout {
+            children_split_direction: Horizontal,
+            name: None,
+            children: [
+                PaneLayout {
+                    children_split_direction: Horizontal,
+                    name: None,
+                    children: [],
+                    split_size: None,
+                    run: Some(
+                        Command(
+                            RunCommand {
+                                command: "tail",
+                                args: [],
+                                cwd: Some(
+                                    "/tmp/foo",
+                                ),
+                                hold_on_close: true,
+                            },
+                        ),
+                    ),
+                    borderless: false,
+                    focus: None,
+                    external_children_index: None,
+                },
+            ],
+            split_size: None,
+            run: None,
+            borderless: false,
+            focus: None,
+            external_children_index: None,
+        },
+    ),
+}

--- a/zellij-utils/src/kdl/kdl_layout_parser.rs
+++ b/zellij-utils/src/kdl/kdl_layout_parser.rs
@@ -32,13 +32,13 @@ pub struct KdlLayoutParser<'a> {
 }
 
 impl<'a> KdlLayoutParser<'a> {
-    pub fn new(raw_layout: &'a str) -> Self {
+    pub fn new(raw_layout: &'a str, global_cwd: Option<PathBuf>) -> Self {
         KdlLayoutParser {
             raw_layout,
             tab_templates: HashMap::new(),
             pane_templates: HashMap::new(),
             default_tab_template: None,
-            global_cwd: None,
+            global_cwd,
         }
     }
     fn is_a_reserved_word(&self, word: &str) -> bool {
@@ -861,8 +861,11 @@ impl<'a> KdlLayoutParser<'a> {
         Ok(())
     }
     fn populate_global_cwd(&mut self, layout_node: &KdlNode) -> Result<(), ConfigError> {
-        if let Some(global_cwd) = kdl_get_string_property_or_child_value_with_error!(layout_node, "cwd") {
-            self.global_cwd = Some(PathBuf::from(global_cwd));
+        // we only populate global cwd from the layout file if another wasn't explicitly passed to us
+        if self.global_cwd.is_none() {
+            if let Some(global_cwd) = kdl_get_string_property_or_child_value_with_error!(layout_node, "cwd") {
+                self.global_cwd = Some(PathBuf::from(global_cwd));
+            }
         }
         Ok(())
     }

--- a/zellij-utils/src/kdl/kdl_layout_parser.rs
+++ b/zellij-utils/src/kdl/kdl_layout_parser.rs
@@ -622,6 +622,8 @@ impl<'a> KdlLayoutParser<'a> {
             kdl_get_bool_property_or_child_value_with_error!(kdl_node, "borderless").is_some();
         let has_focus_prop =
             kdl_get_bool_property_or_child_value_with_error!(kdl_node, "focus").is_some();
+        let has_cwd_prop =
+            kdl_get_string_property_or_child_value_with_error!(kdl_node, "cwd").is_some();
         let has_non_cwd_run_prop = self
             .parse_command_or_plugin_block(kdl_node)?
             .map(|r| match r {
@@ -631,7 +633,7 @@ impl<'a> KdlLayoutParser<'a> {
             .unwrap_or(false);
         let has_nested_nodes_or_children_block = self.has_child_panes_tabs_or_templates(kdl_node);
         if has_nested_nodes_or_children_block
-            && (has_borderless_prop || has_focus_prop || has_non_cwd_run_prop)
+            && (has_borderless_prop || has_focus_prop || has_non_cwd_run_prop || has_cwd_prop)
         {
             let mut offending_nodes = vec![];
             if has_borderless_prop {
@@ -642,6 +644,9 @@ impl<'a> KdlLayoutParser<'a> {
             }
             if has_non_cwd_run_prop {
                 offending_nodes.push("command/plugin");
+            }
+            if has_cwd_prop {
+                offending_nodes.push("cwd");
             }
             Err(ConfigError::new_kdl_error(
                 format!(

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -1266,8 +1266,8 @@ impl RunPlugin {
     }
 }
 impl Layout {
-    pub fn from_kdl(raw_layout: &str, file_name: String) -> Result<Self, ConfigError> {
-        KdlLayoutParser::new(raw_layout).parse().map_err(|e| {
+    pub fn from_kdl(raw_layout: &str, file_name: String, cwd: Option<PathBuf>) -> Result<Self, ConfigError> {
+        KdlLayoutParser::new(raw_layout, cwd).parse().map_err(|e| {
             match e {
                 ConfigError::KdlError(kdl_error) => ConfigError::KdlError(kdl_error.add_src(file_name, String::from(raw_layout))),
                 ConfigError::KdlDeserializationError(kdl_error) => {

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -1266,7 +1266,11 @@ impl RunPlugin {
     }
 }
 impl Layout {
-    pub fn from_kdl(raw_layout: &str, file_name: String, cwd: Option<PathBuf>) -> Result<Self, ConfigError> {
+    pub fn from_kdl(
+        raw_layout: &str,
+        file_name: String,
+        cwd: Option<PathBuf>,
+    ) -> Result<Self, ConfigError> {
         KdlLayoutParser::new(raw_layout, cwd).parse().map_err(|e| {
             match e {
                 ConfigError::KdlError(kdl_error) => ConfigError::KdlError(kdl_error.add_src(file_name, String::from(raw_layout))),


### PR DESCRIPTION
This change does two things:
1. It allows defining a `cwd` for non-command "normal" terminal panes too. So that we can define panes that start at a certain folder.
2. It allows defining a global `cwd` per layout. This cwd will be given to all panes in the layout. If they have a relative cwd, it will be appended to this cwd, if this have an absolute cwd it will override this cwd.
3. When opening a new tab from the cli with a layout using the `zellij action new-tab --layout /path/to/my/layout.kdl`, we can now add a `--cwd` flag that will be used just like the global `cwd` in 2, and override it if present. This should allow much more flexibility when creating custom layouts.

Thanks @har7an for suggesting this feature!

EDIT: updated the documentation in https://github.com/zellij-org/zellij/pull/1759 - which is where we currently keep our docs for this until release time.