### PR TITLE
feat(layouts): edit panes

### DIFF
--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -557,7 +557,7 @@ impl Pty {
                             log::error!("Failed to spawn terminal: {}", e);
                         },
                     }
-                }
+                },
                 None => {
                     match self.bus.os_input.as_mut().unwrap().spawn_terminal(
                         default_shell.clone(),

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -536,6 +536,28 @@ impl Pty {
                         },
                     }
                 },
+                Some(Run::EditFile(path_to_file, line_number)) => {
+                    match self.bus.os_input.as_mut().unwrap().spawn_terminal(
+                        TerminalAction::OpenFile(path_to_file, line_number),
+                        quit_cb,
+                        self.default_editor.clone(),
+                    ) {
+                        Ok((terminal_id, pid_primary, child_fd)) => {
+                            self.id_to_child_pid.insert(terminal_id, child_fd);
+                            new_pane_pids.push((terminal_id, None, Ok(pid_primary)));
+                        },
+                        Err(SpawnTerminalError::CommandNotFound(terminal_id)) => {
+                            new_pane_pids.push((
+                                terminal_id,
+                                None,
+                                Err(SpawnTerminalError::CommandNotFound(terminal_id)),
+                            ));
+                        },
+                        Err(e) => {
+                            log::error!("Failed to spawn terminal: {}", e);
+                        },
+                    }
+                }
                 None => {
                     match self.bus.os_input.as_mut().unwrap().spawn_terminal(
                         default_shell.clone(),

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -95,11 +95,12 @@ impl Run {
                 }
                 Some(Run::Command(merged))
             },
-            (Some(Run::Command(base_run_command)), Some(Run::EditFile(file_to_edit, line_number))) => {
-                match &base_run_command.cwd {
-                    Some(cwd) => Some(Run::EditFile(cwd.join(&file_to_edit), *line_number)),
-                    None => Some(Run::EditFile(file_to_edit.clone(), *line_number))
-                }
+            (
+                Some(Run::Command(base_run_command)),
+                Some(Run::EditFile(file_to_edit, line_number)),
+            ) => match &base_run_command.cwd {
+                Some(cwd) => Some(Run::EditFile(cwd.join(&file_to_edit), *line_number)),
+                None => Some(Run::EditFile(file_to_edit.clone(), *line_number)),
             },
             (Some(Run::Cwd(cwd)), Some(Run::EditFile(file_to_edit, line_number))) => {
                 Some(Run::EditFile(cwd.join(&file_to_edit), *line_number))

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -62,11 +62,15 @@ pub enum Run {
     Plugin(RunPlugin),
     #[serde(rename = "command")]
     Command(RunCommand),
+    EditFile(PathBuf, Option<usize>), // TODO: merge this with TerminalAction::OpenFile
     Cwd(PathBuf),
 }
 
 impl Run {
     pub fn merge(base: &Option<Run>, other: &Option<Run>) -> Option<Run> {
+        // This method is necessary to merge between pane_templates and their consumers
+        // TODO: reconsider the way we parse command/edit/plugin pane_templates from layouts to prevent this
+        // madness
         // TODO: handle Plugin variants once there's a need
         match (base, other) {
             (Some(Run::Command(base_run_command)), Some(Run::Command(other_run_command))) => {
@@ -90,6 +94,15 @@ impl Run {
                     merged.cwd = Some(base_cwd.clone());
                 }
                 Some(Run::Command(merged))
+            },
+            (Some(Run::Command(base_run_command)), Some(Run::EditFile(file_to_edit, line_number))) => {
+                match &base_run_command.cwd {
+                    Some(cwd) => Some(Run::EditFile(cwd.join(&file_to_edit), *line_number)),
+                    None => Some(Run::EditFile(file_to_edit.clone(), *line_number))
+                }
+            },
+            (Some(Run::Cwd(cwd)), Some(Run::EditFile(file_to_edit, line_number))) => {
+                Some(Run::EditFile(cwd.join(&file_to_edit), *line_number))
             },
             (Some(_base), Some(other)) => Some(other.clone()),
             (Some(base), _) => Some(base.clone()),

--- a/zellij-utils/src/input/unit/layout_test.rs
+++ b/zellij-utils/src/input/unit/layout_test.rs
@@ -1283,6 +1283,38 @@ fn pane_template_with_bare_propagated_to_its_consumer_command_with_cwd() {
 }
 
 #[test]
+fn pane_template_with_bare_propagated_to_its_consumer_edit() {
+    let kdl_layout = r#"
+        layout {
+            cwd "/tmp"
+            pane_template name="tail" {
+                cwd "foo"
+            }
+            tail edit="bar"
+            // pane should have /tmp/foo/bar with the edit file variant
+        }
+    "#;
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
+    assert_snapshot!(format!("{:#?}", layout));
+}
+
+#[test]
+fn pane_template_with_command_propagated_to_its_consumer_edit() {
+    let kdl_layout = r#"
+        layout {
+            cwd "/tmp"
+            pane_template name="tail" command="not-vim" {
+                cwd "foo"
+            }
+            tail edit="bar"
+            // pane should have /tmp/foo/bar with the edit file variant
+        }
+    "#;
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
+    assert_snapshot!(format!("{:#?}", layout));
+}
+
+#[test]
 fn global_cwd_given_to_panes_without_cwd() {
     let kdl_layout = r#"
         layout {

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_bare_propagated_to_its_consumer_edit.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_bare_propagated_to_its_consumer_edit.snap
@@ -1,0 +1,37 @@
+---
+source: zellij-utils/src/input/./unit/layout_test.rs
+assertion_line: 1298
+expression: "format!(\"{:#?}\", layout)"
+---
+Layout {
+    tabs: [],
+    focused_tab_index: None,
+    template: Some(
+        PaneLayout {
+            children_split_direction: Horizontal,
+            name: None,
+            children: [
+                PaneLayout {
+                    children_split_direction: Horizontal,
+                    name: None,
+                    children: [],
+                    split_size: None,
+                    run: Some(
+                        EditFile(
+                            "/tmp/foo/bar",
+                            None,
+                        ),
+                    ),
+                    borderless: false,
+                    focus: None,
+                    external_children_index: None,
+                },
+            ],
+            split_size: None,
+            run: None,
+            borderless: false,
+            focus: None,
+            external_children_index: None,
+        },
+    ),
+}

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_command_propagated_to_its_consumer_edit.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_command_propagated_to_its_consumer_edit.snap
@@ -1,0 +1,37 @@
+---
+source: zellij-utils/src/input/./unit/layout_test.rs
+assertion_line: 1314
+expression: "format!(\"{:#?}\", layout)"
+---
+Layout {
+    tabs: [],
+    focused_tab_index: None,
+    template: Some(
+        PaneLayout {
+            children_split_direction: Horizontal,
+            name: None,
+            children: [
+                PaneLayout {
+                    children_split_direction: Horizontal,
+                    name: None,
+                    children: [],
+                    split_size: None,
+                    run: Some(
+                        EditFile(
+                            "/tmp/foo/bar",
+                            None,
+                        ),
+                    ),
+                    borderless: false,
+                    focus: None,
+                    external_children_index: None,
+                },
+            ],
+            split_size: None,
+            run: None,
+            borderless: false,
+            focus: None,
+            external_children_index: None,
+        },
+    ),
+}

--- a/zellij-utils/src/kdl/kdl_layout_parser.rs
+++ b/zellij-utils/src/kdl/kdl_layout_parser.rs
@@ -383,7 +383,7 @@ impl<'a> KdlLayoutParser<'a> {
                 },
                 Some(Run::EditFile(path_to_file, _line_number)) => {
                     *path_to_file = global_cwd.join(&path_to_file);
-                }
+                },
                 Some(Run::Cwd(pane_template_cwd)) => {
                     *pane_template_cwd = global_cwd.join(&pane_template_cwd);
                 },


### PR DESCRIPTION
This adds `edit` panes in layouts. These are panes that include a path to a file that will be opened with the user's default EDITOR (or `scrollback_editor` config item).

eg.
```kdl
layout {
    pane split_direction="vertical" {
        pane edit="./git_diff_side_a"
        pane edit="./git_diff_side_b"
    }
}
```

EDIT: Documentation added to https://github.com/zellij-org/zellij/pull/1759 where we keep that sort of thing for now.