### PR TITLE
Log `thread_bus` IPC messages only in debug mode

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -86,7 +86,9 @@ fn get_os_input<OsInputOutput>(
     }
 }
 
-pub(crate) fn start_server(path: PathBuf) {
+pub(crate) fn start_server(path: PathBuf, debug: bool) {
+    // Set instance-wide debug mode
+    zellij_utils::consts::DEBUG_MODE.set(debug).unwrap();
     let os_input = get_os_input(get_server_os_input);
     start_server_impl(Box::new(os_input), path);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,14 +7,12 @@ mod tests;
 use zellij_utils::{
     clap::Parser,
     cli::{CliAction, CliArgs, Command, Sessions},
-    consts::DEBUG_MODE,
     logging::*,
 };
 
 fn main() {
     configure_logger();
     let opts = CliArgs::parse();
-    DEBUG_MODE.set(opts.debug).unwrap();
 
     {
         if let Some(Command::Sessions(Sessions::Action(cli_action))) = opts.command {
@@ -76,7 +74,7 @@ fn main() {
     {
         commands::kill_session(target_session);
     } else if let Some(path) = opts.server {
-        commands::start_server(path);
+        commands::start_server(path, opts.debug);
     } else {
         commands::start_client(opts);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,12 +7,14 @@ mod tests;
 use zellij_utils::{
     clap::Parser,
     cli::{CliAction, CliArgs, Command, Sessions},
+    consts::DEBUG_MODE,
     logging::*,
 };
 
 fn main() {
     configure_logger();
     let opts = CliArgs::parse();
+    DEBUG_MODE.set(opts.debug).unwrap();
 
     {
         if let Some(Command::Sessions(Sessions::Action(cli_action))) = opts.command {

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -79,11 +79,15 @@ impl ErrorInstruction for ClientInstruction {
     }
 }
 
-fn spawn_server(socket_path: &Path) -> io::Result<()> {
-    let status = Command::new(current_exe()?)
-        .arg("--server")
-        .arg(socket_path)
-        .status()?;
+fn spawn_server(socket_path: &Path, debug: bool) -> io::Result<()> {
+    let mut cmd = Command::new(current_exe()?);
+    cmd.arg("--server");
+    cmd.arg(socket_path);
+    if debug {
+        cmd.arg("--debug");
+    }
+    let status = cmd.status()?;
+
     if status.success() {
         Ok(())
     } else {
@@ -168,7 +172,7 @@ pub fn start_client(
             envs::set_session_name(name);
             envs::set_initial_environment_vars();
 
-            spawn_server(&*ZELLIJ_IPC_PIPE).unwrap();
+            spawn_server(&*ZELLIJ_IPC_PIPE, opts.debug).unwrap();
 
             ClientToServerMsg::NewClient(
                 client_attributes,

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -11,6 +11,7 @@ pub const ZELLIJ_LAYOUT_DIR_ENV: &str = "ZELLIJ_LAYOUT_DIR";
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const DEFAULT_SCROLL_BUFFER_SIZE: usize = 10_000;
 pub static SCROLL_BUFFER_SIZE: OnceCell<usize> = OnceCell::new();
+pub static DEBUG_MODE: OnceCell<bool> = OnceCell::new();
 
 pub const SYSTEM_DEFAULT_CONFIG_DIR: &str = "/etc/zellij";
 pub const SYSTEM_DEFAULT_DATA_DIR_PREFIX: &str = system_default_data_dir();

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -547,10 +547,15 @@ mod not_wasm {
                 Ok(val) => crate::anyhow::Ok(val),
                 Err(e) => {
                     let (msg, context) = e.into_inner();
-                    Err(
-                        crate::anyhow::anyhow!("failed to send message to channel: {:#?}", msg)
-                            .context(context.to_string()),
-                    )
+                    if *crate::consts::DEBUG_MODE.get().unwrap_or(&true) {
+                        Err(
+                            crate::anyhow::anyhow!("failed to send message to channel: {:#?}", msg)
+                                .context(context.to_string()),
+                        )
+                    } else {
+                        Err(crate::anyhow::anyhow!("failed to send message to channel")
+                            .context(context.to_string()))
+                    }
                 },
             }
         }

--- a/zellij-utils/src/logging.rs
+++ b/zellij-utils/src/logging.rs
@@ -21,7 +21,7 @@ use log4rs::encode::pattern::PatternEncoder;
 use crate::consts::{ZELLIJ_TMP_DIR, ZELLIJ_TMP_LOG_DIR, ZELLIJ_TMP_LOG_FILE};
 use crate::shared::set_permissions;
 
-const LOG_MAX_BYTES: u64 = 1024 * 100;
+const LOG_MAX_BYTES: u64 = 1024 * 1024 * 16; // 16 MiB per log
 
 pub fn configure_logger() {
     atomic_create_dir(&*ZELLIJ_TMP_DIR).unwrap();


### PR DESCRIPTION
Adds a new static global variable `DEBUG_MODE`, accessible via `zellij_utils::consts`. It is set when the server is spawned and depends on whether the server was started with the `--debug` flag. This is automatically the case when the first client starting a session is started with the `--debug` flag.

The variable is stored globally to make it easily accessible from within error-handling functions without having to carry the option everywhere. Since it is set by the server upon creation, it is only set exactly once: When the session is started for the first time. Hence, clients connecting to a session with the `--debug` flag cannot override the `DEBUG_MODE` value.

Logging of the Instructions sent in the `zellij_server::thread_bus` will only happen when the server is running in `DEBUG_MODE`. Otherwise, the error message is still shown as before, but the Instruction isn't included.

This is done in an attempt to reduce flooding the terminal and logs for long instructions. Also increases the logsize to 16 MiB per file to keep it from filling up very quickly when a large instruction is dumped there.