### PR TITLE
Reset dim SGR independently from bold

### DIFF
--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -540,9 +540,10 @@ impl Display for CharacterStyles {
                     write!(f, "\u{1b}[2m")?;
                 },
                 AnsiCode::Reset => {
-                    if let Some(AnsiCode::Reset) = self.bold {
-                        // we only reset dim if both dim and bold should be reset
-                        write!(f, "\u{1b}[22m")?;
+                    write!(f, "\u{1b}[22m")?;
+                    // ⬑ this SGR also clears bold, so reapply it
+                    if let Some(AnsiCode::On) = self.bold {
+                        write!(f, "\u{1b}[1m")?;
                     }
                 },
                 _ => {},


### PR DESCRIPTION
This PR fixes #1802 by simply applying the ansi code for normal intensity first and then reapplying bold if appropriate.

Should I write a test for this? I didn't quite find anything close to it to base a implementation on, but would be happy to do so with some help :grin:.

https://user-images.githubusercontent.com/12203476/196070255-27ed6064-653b-45e0-ae30-341bbe46c1a2.mp4