### PR TITLE
docs: Describe how to handle Options as errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,21 @@ something interesting to work on and guide through.
 [discord-invite-link]: https://discord.gg/feHDHahHCz 
 [good-first-issue]: https://github.com/zellij-org/zellij/labels/good%20first%20issue
 
+
+## Tips for Code Contributions
+
+### Prefer returning `Result`s instead of `unwrap`ing
+
+- Add `use zellij_utils::errors::prelude::*;` to the file
+- Make the function return `Result<T>`, with an appropriate `T` (Use `()` if there's nothing to return)
+- Append `.context()` to any `Result` you get with a sensible error description (see [the docs][error-docs-context])
+- Generate ad-hoc errors with `anyhow!(<SOME MESSAGE>)`
+- *Further reading*: [See here][error-docs-result]
+
+[error-docs-context]: https://github.com/zellij-org/zellij/blob/main/docs/ERROR_HANDLING.md#attaching-context
+[error-docs-result]: https://github.com/zellij-org/zellij/blob/main/docs/ERROR_HANDLING.md#converting-a-function-to-return-a-result-type
+
+
 ## Filing Issues
 
 Bugs and enhancement suggestions are tracked as GitHub issues.


### PR DESCRIPTION
Extend the error handling documentation.

@imsnif: You said you wanted to mention the bit about returning an `anyhow::Result` mentioned in `CONTRIBUTING.md`. I'm honestly not sure where it fits in there, and I don't want to bloat it needlessly... So I extended the error handling docs and added a `TL;DR`:

![image](https://user-images.githubusercontent.com/99636919/196228425-ce407058-961a-4df3-9e6e-786480a4692e.png)

Is that alright for you, too?