### PR TITLE
improve error handling in route

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -275,7 +275,8 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                                             to_server,
                                             receiver,
                                             client_id,
-                                        ).fatal()
+                                        )
+                                        .fatal()
                                     })
                                     .unwrap(),
                             );

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -35,7 +35,6 @@ use crate::{
     wasm_vm::{wasm_thread_main, PluginInstruction},
 };
 use route::route_thread_main;
-use zellij_utils::errors::prelude::Context;
 use zellij_utils::{
     channels::{self, ChannelWithContext, SenderWithContext},
     cli::CliArgs,
@@ -276,10 +275,9 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                                             to_server,
                                             receiver,
                                             client_id,
-                                        )
+                                        ).fatal()
                                     })
-                                    .context("Failed to spawn server_router thread")
-                                    .fatal(),
+                                    .unwrap(),
                             );
                         },
                         Err(err) => {

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -35,6 +35,7 @@ use crate::{
     wasm_vm::{wasm_thread_main, PluginInstruction},
 };
 use route::route_thread_main;
+use zellij_utils::errors::prelude::Context;
 use zellij_utils::{
     channels::{self, ChannelWithContext, SenderWithContext},
     cli::CliArgs,
@@ -277,7 +278,8 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                                             client_id,
                                         )
                                     })
-                                    .unwrap(),
+                                    .context("Failed to spawn server_router thread")
+                                    .fatal(),
                             );
                         },
                         Err(err) => {

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -29,6 +29,7 @@ pub(crate) fn route_action(
     client_id: ClientId,
 ) -> Result<bool> {
     let mut should_break = false;
+    let err_context = || format!("failed to route action for client {client_id}");
 
     // forward the action to plugins unless it is a mousehold
     // this is a bit of a hack around the unfortunate architecture we use with plugins
@@ -36,11 +37,14 @@ pub(crate) fn route_action(
     match action {
         Action::MouseHoldLeft(..) | Action::MouseHoldRight(..) => {},
         _ => {
-            session.senders.send_to_plugin(PluginInstruction::Update(
-                None,
-                Some(client_id),
-                Event::InputReceived,
-            ))?;
+            session
+                .senders
+                .send_to_plugin(PluginInstruction::Update(
+                    None,
+                    Some(client_id),
+                    Event::InputReceived,
+                ))
+                .with_context(err_context)?;
         },
     }
 
@@ -48,24 +52,29 @@ pub(crate) fn route_action(
         Action::ToggleTab => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::ToggleTab(client_id))?;
+                .send_to_screen(ScreenInstruction::ToggleTab(client_id))
+                .with_context(err_context)?;
         },
         Action::Write(val) => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::ClearScroll(client_id))?;
+                .send_to_screen(ScreenInstruction::ClearScroll(client_id))
+                .with_context(err_context)?;
             session
                 .senders
-                .send_to_screen(ScreenInstruction::WriteCharacter(val, client_id))?;
+                .send_to_screen(ScreenInstruction::WriteCharacter(val, client_id))
+                .with_context(err_context)?;
         },
         Action::WriteChars(val) => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::ClearScroll(client_id))?;
+                .send_to_screen(ScreenInstruction::ClearScroll(client_id))
+                .with_context(err_context)?;
             let val = val.into_bytes();
             session
                 .senders
-                .send_to_screen(ScreenInstruction::WriteCharacter(val, client_id))?;
+                .send_to_screen(ScreenInstruction::WriteCharacter(val, client_id))
+                .with_context(err_context)?;
         },
         Action::SwitchToMode(mode) => {
             let attrs = &session.client_attributes;
@@ -73,18 +82,25 @@ pub(crate) fn route_action(
             // this is left here as a stop gap measure until we shift some code around
             // to allow for this
             // TODO: Need access to `ClientAttributes` here
-            session.senders.send_to_plugin(PluginInstruction::Update(
-                None,
-                Some(client_id),
-                Event::ModeUpdate(get_mode_info(mode, attrs, session.capabilities)),
-            ))?;
+            session
+                .senders
+                .send_to_plugin(PluginInstruction::Update(
+                    None,
+                    Some(client_id),
+                    Event::ModeUpdate(get_mode_info(mode, attrs, session.capabilities)),
+                ))
+                .with_context(err_context)?;
             session
                 .senders
                 .send_to_screen(ScreenInstruction::ChangeMode(
                     get_mode_info(mode, attrs, session.capabilities),
                     client_id,
-                ))?;
-            session.senders.send_to_screen(ScreenInstruction::Render)?;
+                ))
+                .with_context(err_context)?;
+            session
+                .senders
+                .send_to_screen(ScreenInstruction::Render)
+                .with_context(err_context)?;
         },
         Action::Resize(direction) => {
             let screen_instr = match direction {
@@ -95,17 +111,26 @@ pub(crate) fn route_action(
                 ResizeDirection::Increase => ScreenInstruction::ResizeIncrease(client_id),
                 ResizeDirection::Decrease => ScreenInstruction::ResizeDecrease(client_id),
             };
-            session.senders.send_to_screen(screen_instr)?;
+            session.senders.send_to_screen(screen_instr).with_context(err_context)?;
         },
-        Action::SwitchFocus => session
-            .senders
-            .send_to_screen(ScreenInstruction::SwitchFocus(client_id))?,
-        Action::FocusNextPane => session
-            .senders
-            .send_to_screen(ScreenInstruction::FocusNextPane(client_id))?,
-        Action::FocusPreviousPane => session
-            .senders
-            .send_to_screen(ScreenInstruction::FocusPreviousPane(client_id))?,
+        Action::SwitchFocus => {
+            session
+                .senders
+                .send_to_screen(ScreenInstruction::SwitchFocus(client_id))
+                .with_context(err_context)?;
+        },
+        Action::FocusNextPane => {
+            session
+                .senders
+                .send_to_screen(ScreenInstruction::FocusNextPane(client_id))
+                .with_context(err_context)?;
+        },
+        Action::FocusPreviousPane => {
+            session
+                .senders
+                .send_to_screen(ScreenInstruction::FocusPreviousPane(client_id))
+                .with_context(err_context)?;
+        },
         Action::MoveFocus(direction) => {
             let screen_instr = match direction {
                 Direction::Left => ScreenInstruction::MoveFocusLeft(client_id),
@@ -113,7 +138,7 @@ pub(crate) fn route_action(
                 Direction::Up => ScreenInstruction::MoveFocusUp(client_id),
                 Direction::Down => ScreenInstruction::MoveFocusDown(client_id),
             };
-            session.senders.send_to_screen(screen_instr)?;
+            session.senders.send_to_screen(screen_instr).with_context(err_context)?;
         },
         Action::MoveFocusOrTab(direction) => {
             let screen_instr = match direction {
@@ -122,7 +147,7 @@ pub(crate) fn route_action(
                 Direction::Up => ScreenInstruction::SwitchTabNext(client_id),
                 Direction::Down => ScreenInstruction::SwitchTabPrev(client_id),
             };
-            session.senders.send_to_screen(screen_instr)?;
+            session.senders.send_to_screen(screen_instr).with_context(err_context)?;
         },
         Action::MovePane(direction) => {
             let screen_instr = match direction {
@@ -132,72 +157,85 @@ pub(crate) fn route_action(
                 Some(Direction::Down) => ScreenInstruction::MovePaneDown(client_id),
                 None => ScreenInstruction::MovePane(client_id),
             };
-            session.senders.send_to_screen(screen_instr)?;
+            session.senders.send_to_screen(screen_instr).with_context(err_context)?;
         },
-        Action::DumpScreen(val) => {
+        Action::DumpScreen(val, full) => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::DumpScreen(val, client_id))?;
+                .send_to_screen(ScreenInstruction::DumpScreen(val, client_id, full))
+                .with_context(err_context)?;
         },
         Action::EditScrollback => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::EditScrollback(client_id))?;
+                .send_to_screen(ScreenInstruction::EditScrollback(client_id))
+                .with_context(err_context)?;
         },
         Action::ScrollUp => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::ScrollUp(client_id))?;
+                .send_to_screen(ScreenInstruction::ScrollUp(client_id))
+                .with_context(err_context)?;
         },
         Action::ScrollUpAt(point) => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::ScrollUpAt(point, client_id))?;
+                .send_to_screen(ScreenInstruction::ScrollUpAt(point, client_id))
+                .with_context(err_context)?;
         },
         Action::ScrollDown => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::ScrollDown(client_id))?;
+                .send_to_screen(ScreenInstruction::ScrollDown(client_id))
+                .with_context(err_context)?;
         },
         Action::ScrollDownAt(point) => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::ScrollDownAt(point, client_id))?;
+                .send_to_screen(ScreenInstruction::ScrollDownAt(point, client_id))
+                .with_context(err_context)?;
         },
         Action::ScrollToBottom => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::ScrollToBottom(client_id))?;
+                .send_to_screen(ScreenInstruction::ScrollToBottom(client_id))
+                .with_context(err_context)?;
         },
         Action::PageScrollUp => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::PageScrollUp(client_id))?;
+                .send_to_screen(ScreenInstruction::PageScrollUp(client_id))
+                .with_context(err_context)?;
         },
         Action::PageScrollDown => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::PageScrollDown(client_id))?;
+                .send_to_screen(ScreenInstruction::PageScrollDown(client_id))
+                .with_context(err_context)?;
         },
         Action::HalfPageScrollUp => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::HalfPageScrollUp(client_id))?;
+                .send_to_screen(ScreenInstruction::HalfPageScrollUp(client_id))
+                .with_context(err_context)?;
         },
         Action::HalfPageScrollDown => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::HalfPageScrollDown(client_id))?;
+                .send_to_screen(ScreenInstruction::HalfPageScrollDown(client_id))
+                .with_context(err_context)?;
         },
         Action::ToggleFocusFullscreen => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::ToggleActiveTerminalFullscreen(client_id))?;
+                .send_to_screen(ScreenInstruction::ToggleActiveTerminalFullscreen(client_id))
+                .with_context(err_context)?;
         },
         Action::TogglePaneFrames => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::TogglePaneFrames)?;
+                .send_to_screen(ScreenInstruction::TogglePaneFrames)
+                .with_context(err_context)?;
         },
         Action::NewPane(direction, name) => {
             let shell = session.default_shell.clone();
@@ -222,7 +260,7 @@ pub(crate) fn route_action(
                     ClientOrTabIndex::ClientId(client_id),
                 ),
             };
-            session.senders.send_to_pty(pty_instr)?;
+            session.senders.send_to_pty(pty_instr).with_context(err_context)?;
         },
         Action::EditFile(path_to_file, line_number, split_direction, should_float) => {
             let title = format!("Editing: {}", path_to_file.display());
@@ -252,34 +290,41 @@ pub(crate) fn route_action(
                     ClientOrTabIndex::ClientId(client_id),
                 ),
             };
-            session.senders.send_to_pty(pty_instr)?;
+            session.senders.send_to_pty(pty_instr).with_context(err_context)?;
         },
         Action::SwitchModeForAllClients(input_mode) => {
             let attrs = &session.client_attributes;
-            session.senders.send_to_plugin(PluginInstruction::Update(
-                None,
-                None,
-                Event::ModeUpdate(get_mode_info(input_mode, attrs, session.capabilities)),
-            ))?;
+            session
+                .senders
+                .send_to_plugin(PluginInstruction::Update(
+                    None,
+                    None,
+                    Event::ModeUpdate(get_mode_info(input_mode, attrs, session.capabilities)),
+                ))
+                .with_context(err_context)?;
             session
                 .senders
                 .send_to_screen(ScreenInstruction::ChangeModeForAllClients(get_mode_info(
                     input_mode,
                     attrs,
                     session.capabilities,
-                )))?;
+                )))
+                .with_context(err_context)?;
         },
         Action::NewFloatingPane(run_command, name) => {
             let should_float = true;
             let run_cmd = run_command
                 .map(|cmd| TerminalAction::RunCommand(cmd.into()))
                 .or_else(|| session.default_shell.clone());
-            session.senders.send_to_pty(PtyInstruction::SpawnTerminal(
-                run_cmd,
-                Some(should_float),
-                name,
-                ClientOrTabIndex::ClientId(client_id),
-            ))?;
+            session
+                .senders
+                .send_to_pty(PtyInstruction::SpawnTerminal(
+                    run_cmd,
+                    Some(should_float),
+                    name,
+                    ClientOrTabIndex::ClientId(client_id),
+                ))
+                .with_context(err_context)?;
         },
         Action::NewTiledPane(direction, run_command, name) => {
             let should_float = false;
@@ -307,12 +352,13 @@ pub(crate) fn route_action(
                     ClientOrTabIndex::ClientId(client_id),
                 ),
             };
-            session.senders.send_to_pty(pty_instr)?;
+            session.senders.send_to_pty(pty_instr).with_context(err_context)?;
         },
         Action::TogglePaneEmbedOrFloating => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::TogglePaneEmbedOrFloating(client_id))?;
+                .send_to_screen(ScreenInstruction::TogglePaneEmbedOrFloating(client_id))
+                .with_context(err_context)?;
         },
         Action::ToggleFloatingPanes => {
             session
@@ -320,17 +366,20 @@ pub(crate) fn route_action(
                 .send_to_screen(ScreenInstruction::ToggleFloatingPanes(
                     client_id,
                     session.default_shell.clone(),
-                ))?;
+                ))
+                .with_context(err_context)?;
         },
         Action::PaneNameInput(c) => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::UpdatePaneName(c, client_id))?;
+                .send_to_screen(ScreenInstruction::UpdatePaneName(c, client_id))
+                .with_context(err_context)?;
         },
         Action::UndoRenamePane => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::UndoRenamePane(client_id))?;
+                .send_to_screen(ScreenInstruction::UndoRenamePane(client_id))
+                .with_context(err_context)?;
         },
         Action::Run(command) => {
             let run_cmd = Some(TerminalAction::RunCommand(command.clone().into()));
@@ -355,126 +404,155 @@ pub(crate) fn route_action(
                     ClientOrTabIndex::ClientId(client_id),
                 ),
             };
-            session.senders.send_to_pty(pty_instr)?;
+            session.senders.send_to_pty(pty_instr).with_context(err_context)?;
         },
         Action::CloseFocus => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::CloseFocusedPane(client_id))?;
+                .send_to_screen(ScreenInstruction::CloseFocusedPane(client_id))
+                .with_context(err_context)?;
         },
         Action::NewTab(tab_layout, tab_name) => {
             let shell = session.default_shell.clone();
-            session.senders.send_to_pty(PtyInstruction::NewTab(
-                shell, tab_layout, tab_name, client_id,
-            ))?;
+            session
+                .senders
+                .send_to_pty(PtyInstruction::NewTab(
+                    shell, tab_layout, tab_name, client_id,
+                ))
+                .with_context(err_context)?;
         },
         Action::GoToNextTab => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::SwitchTabNext(client_id))?;
+                .send_to_screen(ScreenInstruction::SwitchTabNext(client_id))
+                .with_context(err_context)?;
         },
         Action::GoToPreviousTab => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::SwitchTabPrev(client_id))?;
+                .send_to_screen(ScreenInstruction::SwitchTabPrev(client_id))
+                .with_context(err_context)?;
         },
         Action::ToggleActiveSyncTab => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::ToggleActiveSyncTab(client_id))?;
+                .send_to_screen(ScreenInstruction::ToggleActiveSyncTab(client_id))
+                .with_context(err_context)?;
         },
         Action::CloseTab => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::CloseTab(client_id))?;
+                .send_to_screen(ScreenInstruction::CloseTab(client_id))
+                .with_context(err_context)?;
         },
         Action::GoToTab(i) => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::GoToTab(i, Some(client_id)))?;
+                .send_to_screen(ScreenInstruction::GoToTab(i, Some(client_id)))
+                .with_context(err_context)?;
         },
         Action::TabNameInput(c) => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::UpdateTabName(c, client_id))?;
+                .send_to_screen(ScreenInstruction::UpdateTabName(c, client_id))
+                .with_context(err_context)?;
         },
         Action::UndoRenameTab => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::UndoRenameTab(client_id))?;
+                .send_to_screen(ScreenInstruction::UndoRenameTab(client_id))
+                .with_context(err_context)?;
         },
         Action::Quit => {
-            to_server.send(ServerInstruction::ClientExit(client_id))?;
+            to_server
+                .send(ServerInstruction::ClientExit(client_id))
+                .with_context(err_context)?;
             should_break = true;
         },
         Action::Detach => {
-            to_server.send(ServerInstruction::DetachSession(vec![client_id]))?;
+            to_server
+                .send(ServerInstruction::DetachSession(vec![client_id]))
+                .with_context(err_context)?;
             should_break = true;
         },
         Action::LeftClick(point) => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::LeftClick(point, client_id))?;
+                .send_to_screen(ScreenInstruction::LeftClick(point, client_id))
+                .with_context(err_context)?;
         },
         Action::RightClick(point) => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::RightClick(point, client_id))?;
+                .send_to_screen(ScreenInstruction::RightClick(point, client_id))
+                .with_context(err_context)?;
         },
         Action::MiddleClick(point) => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::MiddleClick(point, client_id))?;
+                .send_to_screen(ScreenInstruction::MiddleClick(point, client_id))
+                .with_context(err_context)?;
         },
         Action::LeftMouseRelease(point) => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::LeftMouseRelease(point, client_id))?;
+                .send_to_screen(ScreenInstruction::LeftMouseRelease(point, client_id))
+                .with_context(err_context)?;
         },
         Action::RightMouseRelease(point) => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::RightMouseRelease(point, client_id))?;
+                .send_to_screen(ScreenInstruction::RightMouseRelease(point, client_id))
+                .with_context(err_context)?;
         },
         Action::MiddleMouseRelease(point) => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::MiddleMouseRelease(point, client_id))?;
+                .send_to_screen(ScreenInstruction::MiddleMouseRelease(point, client_id))
+                .with_context(err_context)?;
         },
         Action::MouseHoldLeft(point) => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::MouseHoldLeft(point, client_id))?;
+                .send_to_screen(ScreenInstruction::MouseHoldLeft(point, client_id))
+                .with_context(err_context)?;
         },
         Action::MouseHoldRight(point) => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::MouseHoldRight(point, client_id))?;
+                .send_to_screen(ScreenInstruction::MouseHoldRight(point, client_id))
+                .with_context(err_context)?;
         },
         Action::MouseHoldMiddle(point) => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::MouseHoldMiddle(point, client_id))?;
+                .send_to_screen(ScreenInstruction::MouseHoldMiddle(point, client_id))
+                .with_context(err_context)?;
         },
         Action::Copy => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::Copy(client_id))?;
+                .send_to_screen(ScreenInstruction::Copy(client_id))
+                .with_context(err_context)?;
         },
         Action::Confirm => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::ConfirmPrompt(client_id))?;
+                .send_to_screen(ScreenInstruction::ConfirmPrompt(client_id))
+                .with_context(err_context)?;
         },
         Action::Deny => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::DenyPrompt(client_id))?;
+                .send_to_screen(ScreenInstruction::DenyPrompt(client_id))
+                .with_context(err_context)?;
         },
         #[allow(clippy::single_match)]
         Action::SkipConfirm(action) => match *action {
             Action::Quit => {
-                to_server.send(ServerInstruction::ClientExit(client_id))?;
+                to_server
+                    .send(ServerInstruction::ClientExit(client_id))
+                    .with_context(err_context)?;
                 should_break = true;
             },
             _ => {},
@@ -483,14 +561,15 @@ pub(crate) fn route_action(
         Action::SearchInput(c) => {
             session
                 .senders
-                .send_to_screen(ScreenInstruction::UpdateSearch(c, client_id))?;
+                .send_to_screen(ScreenInstruction::UpdateSearch(c, client_id))
+                .with_context(err_context)?;
         },
         Action::Search(d) => {
             let instruction = match d {
                 SearchDirection::Down => ScreenInstruction::SearchDown(client_id),
                 SearchDirection::Up => ScreenInstruction::SearchUp(client_id),
             };
-            session.senders.send_to_screen(instruction)?;
+            session.senders.send_to_screen(instruction).with_context(err_context)?;
         },
         Action::SearchToggleOption(o) => {
             let instruction = match o {
@@ -500,7 +579,7 @@ pub(crate) fn route_action(
                 SearchOption::WholeWord => ScreenInstruction::SearchToggleWholeWord(client_id),
                 SearchOption::Wrap => ScreenInstruction::SearchToggleWrap(client_id),
             };
-            session.senders.send_to_screen(instruction)?;
+            session.senders.send_to_screen(instruction).with_context(err_context)?;
         },
     }
     Ok(should_break)
@@ -532,6 +611,7 @@ pub(crate) fn route_thread_main(
     client_id: ClientId,
 ) -> Result<()> {
     let mut retry_queue = vec![];
+    let err_context = ||format!("failed to handle instruction for client {client_id}");
     'route_loop: loop {
         match receiver.recv() {
             Some((instruction, err_ctx)) => {
@@ -635,12 +715,12 @@ pub(crate) fn route_thread_main(
                                 client_id,
                                 plugin_config,
                             );
-                            to_server.send(new_client_instruction).unwrap();
+                            to_server.send(new_client_instruction).with_context(err_context)?;
                         },
                         ClientToServerMsg::AttachClient(client_attributes, opts) => {
                             let attach_client_instruction =
                                 ServerInstruction::AttachClient(client_attributes, opts, client_id);
-                            to_server.send(attach_client_instruction).unwrap();
+                            to_server.send(attach_client_instruction).with_context(err_context)?;
                         },
                         ClientToServerMsg::ClientExited => {
                             // we don't unwrap this because we don't really care if there's an error here (eg.
@@ -649,7 +729,7 @@ pub(crate) fn route_thread_main(
                             return Ok(true);
                         },
                         ClientToServerMsg::KillSession => {
-                            to_server.send(ServerInstruction::KillSession).unwrap();
+                            to_server.send(ServerInstruction::KillSession).with_context(err_context)?;
                         },
                         ClientToServerMsg::ConnStatus => {
                             let _ = to_server.send(ServerInstruction::ConnStatus(client_id));

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -111,7 +111,10 @@ pub(crate) fn route_action(
                 ResizeDirection::Increase => ScreenInstruction::ResizeIncrease(client_id),
                 ResizeDirection::Decrease => ScreenInstruction::ResizeDecrease(client_id),
             };
-            session.senders.send_to_screen(screen_instr).with_context(err_context)?;
+            session
+                .senders
+                .send_to_screen(screen_instr)
+                .with_context(err_context)?;
         },
         Action::SwitchFocus => {
             session
@@ -138,7 +141,10 @@ pub(crate) fn route_action(
                 Direction::Up => ScreenInstruction::MoveFocusUp(client_id),
                 Direction::Down => ScreenInstruction::MoveFocusDown(client_id),
             };
-            session.senders.send_to_screen(screen_instr).with_context(err_context)?;
+            session
+                .senders
+                .send_to_screen(screen_instr)
+                .with_context(err_context)?;
         },
         Action::MoveFocusOrTab(direction) => {
             let screen_instr = match direction {
@@ -147,7 +153,10 @@ pub(crate) fn route_action(
                 Direction::Up => ScreenInstruction::SwitchTabNext(client_id),
                 Direction::Down => ScreenInstruction::SwitchTabPrev(client_id),
             };
-            session.senders.send_to_screen(screen_instr).with_context(err_context)?;
+            session
+                .senders
+                .send_to_screen(screen_instr)
+                .with_context(err_context)?;
         },
         Action::MovePane(direction) => {
             let screen_instr = match direction {
@@ -157,7 +166,10 @@ pub(crate) fn route_action(
                 Some(Direction::Down) => ScreenInstruction::MovePaneDown(client_id),
                 None => ScreenInstruction::MovePane(client_id),
             };
-            session.senders.send_to_screen(screen_instr).with_context(err_context)?;
+            session
+                .senders
+                .send_to_screen(screen_instr)
+                .with_context(err_context)?;
         },
         Action::DumpScreen(val, full) => {
             session
@@ -260,7 +272,10 @@ pub(crate) fn route_action(
                     ClientOrTabIndex::ClientId(client_id),
                 ),
             };
-            session.senders.send_to_pty(pty_instr).with_context(err_context)?;
+            session
+                .senders
+                .send_to_pty(pty_instr)
+                .with_context(err_context)?;
         },
         Action::EditFile(path_to_file, line_number, split_direction, should_float) => {
             let title = format!("Editing: {}", path_to_file.display());
@@ -290,7 +305,10 @@ pub(crate) fn route_action(
                     ClientOrTabIndex::ClientId(client_id),
                 ),
             };
-            session.senders.send_to_pty(pty_instr).with_context(err_context)?;
+            session
+                .senders
+                .send_to_pty(pty_instr)
+                .with_context(err_context)?;
         },
         Action::SwitchModeForAllClients(input_mode) => {
             let attrs = &session.client_attributes;
@@ -352,7 +370,10 @@ pub(crate) fn route_action(
                     ClientOrTabIndex::ClientId(client_id),
                 ),
             };
-            session.senders.send_to_pty(pty_instr).with_context(err_context)?;
+            session
+                .senders
+                .send_to_pty(pty_instr)
+                .with_context(err_context)?;
         },
         Action::TogglePaneEmbedOrFloating => {
             session
@@ -404,7 +425,10 @@ pub(crate) fn route_action(
                     ClientOrTabIndex::ClientId(client_id),
                 ),
             };
-            session.senders.send_to_pty(pty_instr).with_context(err_context)?;
+            session
+                .senders
+                .send_to_pty(pty_instr)
+                .with_context(err_context)?;
         },
         Action::CloseFocus => {
             session
@@ -569,7 +593,10 @@ pub(crate) fn route_action(
                 SearchDirection::Down => ScreenInstruction::SearchDown(client_id),
                 SearchDirection::Up => ScreenInstruction::SearchUp(client_id),
             };
-            session.senders.send_to_screen(instruction).with_context(err_context)?;
+            session
+                .senders
+                .send_to_screen(instruction)
+                .with_context(err_context)?;
         },
         Action::SearchToggleOption(o) => {
             let instruction = match o {
@@ -579,7 +606,10 @@ pub(crate) fn route_action(
                 SearchOption::WholeWord => ScreenInstruction::SearchToggleWholeWord(client_id),
                 SearchOption::Wrap => ScreenInstruction::SearchToggleWrap(client_id),
             };
-            session.senders.send_to_screen(instruction).with_context(err_context)?;
+            session
+                .senders
+                .send_to_screen(instruction)
+                .with_context(err_context)?;
         },
     }
     Ok(should_break)
@@ -611,7 +641,7 @@ pub(crate) fn route_thread_main(
     client_id: ClientId,
 ) -> Result<()> {
     let mut retry_queue = vec![];
-    let err_context = ||format!("failed to handle instruction for client {client_id}");
+    let err_context = || format!("failed to handle instruction for client {client_id}");
     'route_loop: loop {
         match receiver.recv() {
             Some((instruction, err_ctx)) => {
@@ -715,12 +745,16 @@ pub(crate) fn route_thread_main(
                                 client_id,
                                 plugin_config,
                             );
-                            to_server.send(new_client_instruction).with_context(err_context)?;
+                            to_server
+                                .send(new_client_instruction)
+                                .with_context(err_context)?;
                         },
                         ClientToServerMsg::AttachClient(client_attributes, opts) => {
                             let attach_client_instruction =
                                 ServerInstruction::AttachClient(client_attributes, opts, client_id);
-                            to_server.send(attach_client_instruction).with_context(err_context)?;
+                            to_server
+                                .send(attach_client_instruction)
+                                .with_context(err_context)?;
                         },
                         ClientToServerMsg::ClientExited => {
                             // we don't unwrap this because we don't really care if there's an error here (eg.
@@ -729,7 +763,9 @@ pub(crate) fn route_thread_main(
                             return Ok(true);
                         },
                         ClientToServerMsg::KillSession => {
-                            to_server.send(ServerInstruction::KillSession).with_context(err_context)?;
+                            to_server
+                                .send(ServerInstruction::KillSession)
+                                .with_context(err_context)?;
                         },
                         ClientToServerMsg::ConnStatus => {
                             let _ = to_server.send(ServerInstruction::ConnStatus(client_id));

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -686,13 +686,13 @@ pub(crate) fn route_thread_main(
                                 .read()
                                 .unwrap()
                                 .min_client_terminal_size()
-                                .unwrap();
+                                .with_context(err_context)?;
                             rlocked_sessions
                                 .as_ref()
                                 .unwrap()
                                 .senders
                                 .send_to_screen(ScreenInstruction::TerminalResize(min_size))
-                                .unwrap();
+                                .with_context(err_context)?;
                         },
                         ClientToServerMsg::TerminalPixelDimensions(pixel_dimensions) => {
                             send_to_screen_or_retry_queue!(

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -115,7 +115,8 @@ fn send_cli_action_to_server(
             &*os_input,
             &to_server.clone(),
             client_id,
-        );
+        )
+        .unwrap();
     }
 }
 


### PR DESCRIPTION
Replacing `unwrap` in `route.rs` with error propagation.

Related to #1753 