### PR TITLE
feat(panes): change floating window positions

### DIFF
--- a/zellij-server/src/panes/floating_panes/floating_pane_grid.rs
+++ b/zellij-server/src/panes/floating_panes/floating_pane_grid.rs
@@ -792,11 +792,31 @@ impl<'a> FloatingPaneGrid<'a> {
                 }
             };
         }
-        find_unoccupied_offset!(|offset| half_size_middle_geom(&self.viewport, offset), &self.viewport, &pane_geoms);
-        find_unoccupied_offset!(|offset| half_size_top_left_geom(&self.viewport, offset), &self.viewport, &pane_geoms);
-        find_unoccupied_offset!(|offset| half_size_top_right_geom(&self.viewport, offset), &self.viewport, &pane_geoms);
-        find_unoccupied_offset!(|offset| half_size_bottom_left_geom(&self.viewport, offset), &self.viewport, &pane_geoms);
-        find_unoccupied_offset!(|offset| half_size_bottom_right_geom(&self.viewport, offset), &self.viewport, &pane_geoms);
+        find_unoccupied_offset!(
+            |offset| half_size_middle_geom(&self.viewport, offset),
+            &self.viewport,
+            &pane_geoms
+        );
+        find_unoccupied_offset!(
+            |offset| half_size_top_left_geom(&self.viewport, offset),
+            &self.viewport,
+            &pane_geoms
+        );
+        find_unoccupied_offset!(
+            |offset| half_size_top_right_geom(&self.viewport, offset),
+            &self.viewport,
+            &pane_geoms
+        );
+        find_unoccupied_offset!(
+            |offset| half_size_bottom_left_geom(&self.viewport, offset),
+            &self.viewport,
+            &pane_geoms
+        );
+        find_unoccupied_offset!(
+            |offset| half_size_bottom_right_geom(&self.viewport, offset),
+            &self.viewport,
+            &pane_geoms
+        );
         return None;
     }
 }

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -145,6 +145,7 @@ impl Pane for TerminalPane {
     fn set_geom(&mut self, position_and_size: PaneGeom) {
         self.geom = position_and_size;
         self.reflow_lines();
+        self.render_full_viewport();
     }
     fn set_geom_override(&mut self, pane_geom: PaneGeom) {
         self.geom_override = Some(pane_geom);

--- a/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__drag_pane_with_mouse.snap
+++ b/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__drag_pane_with_mouse.snap
@@ -1,26 +1,26 @@
 ---
 source: zellij-server/src/tab/./unit/tab_integration_tests.rs
+assertion_line: 1252
 expression: snapshot
-
 ---
 00 (C): ┌ Pane #1 ──────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 01 (C): │                                                                                                                       │
-02 (C): │ ┌ Pane #3 ─────────────── SCROLL:  0/1 ┐                                     ┌ Pane #4 ─────────────── SCROLL:  0/1 ┐ │
-03 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-04 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-05 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-06 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-07 (C): │ └───────────────────────────────┌ Pane #2 ─────────────────────────────────────────────────┐────────────────────────┘ │
-08 (C): │                                 │                                                          │                          │
-09 (C): │                                 │                                                          │                          │
-10 (C): │                                 │                                                          │                          │
-11 (C): │                                 │                   I am scratch terminal                  │                          │
-12 (C): │ ┌ Pane #5 ─────────────── SCROLL│                                                          │────────── SCROLL:  0/1 ┐ │
-13 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                          │EEEEEEEEEEEEEEEEEEEEEEEE│ │
-14 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                          │EEEEEEEEEEEEEEEEEEEEEEEE│ │
-15 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                          │EEEEEEEEEEEEEEEEEEEEEEEE│ │
-16 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE└──────────────────────────────────────────────────────────┘EEEEEEEEEEEEEEEEEEEEEEEE│ │
-17 (C): │ └──────────────────────────────────────┘                                     └──────────────────────────────────────┘ │
-18 (C): │                                                                                                                       │
+02 (C): │ ┌ Pane #5 ─────────────── SCROLL:  0/1 ┐                                                                              │
+03 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                                              │
+04 (C): │ │E┌ Pane #6 ─────────────── SCROLL:  0/1 ┐                                                                            │
+05 (C): │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                                            │
+06 (C): │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                                            │
+07 (C): │ └─│EEEEEEEEEEEEEEEEEEEEEEEEEEEEE┌ Pane #2 ─────────────────────────────────────────────────┐                          │
+08 (C): │   │EEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                          │                          │
+09 (C): │   └─────────────────────────────│                                                          │                          │
+10 (C): │                               │E│                                                          │                          │
+11 (C): │                               │E│                   I am scratch terminal                  │                          │
+12 (C): │                               │E│                                                          │                          │
+13 (C): │                               │E│                                                          │                          │
+14 (C): │                               │E│                                                          │                          │
+15 (C): │                               │E│                                                          │                          │
+16 (C): │                               └─└──────────────────────────────────────────────────────────┘                          │
+17 (C): │                                 │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+18 (C): │                                 └──────────────────────────────────────────────────────────┘                          │
 19 (C): └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 

--- a/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__five_new_floating_panes.snap
+++ b/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__five_new_floating_panes.snap
@@ -1,26 +1,26 @@
 ---
 source: zellij-server/src/tab/./unit/tab_integration_tests.rs
+assertion_line: 682
 expression: snapshot
-
 ---
 00 (C): ┌ Pane #1 ──────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 01 (C): │                                                                                                                       │
-02 (C): │ ┌ Pane #3 ─────────────── SCROLL:  0/1 ┐                                     ┌ Pane #4 ─────────────── SCROLL:  0/1 ┐ │
-03 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-04 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-05 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│─────────────────────────────────────│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-06 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-07 (C): │ └──────────────────────────────────────┘                                     └──────────────────────────────────────┘ │
-08 (C): │                             │                                                          │                              │
-09 (C): │                             │                   I am scratch terminal                  │                              │
-10 (C): │                             │                                                          │                              │
-11 (C): │                             │                                                          │                              │
-12 (C): │ ┌ Pane #5 ─────────────── SCROLL:  0/1 ┐                                     ┌ Pane #6 ─────────────── SCROLL:  0/1 ┐ │
-13 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-14 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│─────────────────────────────────────│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-15 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-16 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-17 (C): │ └──────────────────────────────────────┘                                     └──────────────────────────────────────┘ │
-18 (C): │                                                                                                                       │
+02 (C): │ ┌ Pane #5 ─────────────── SCROLL:  0/1 ┐                                                                              │
+03 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                                              │
+04 (C): │ │E┌ Pane #6 ─────────────── SCROLL:  0/1 ┐                                                                            │
+05 (C): │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│─────────────────────────────────────────────┐                              │
+06 (C): │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                             │                              │
+07 (C): │ └─│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│───────────────────────────────── SCROLL:  0/1 ┐                            │
+08 (C): │   │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                            │
+09 (C): │   └──────────────────────────────────────┘─────────────────────────────────── SCROLL:  0/1 ┐                          │
+10 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+11 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+12 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+13 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+14 (C): │                             └─│E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+15 (C): │                               │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+16 (C): │                               └─│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+17 (C): │                                 │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+18 (C): │                                 └──────────────────────────────────────────────────────────┘                          │
 19 (C): └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 

--- a/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__mark_text_inside_floating_pane.snap
+++ b/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__mark_text_inside_floating_pane.snap
@@ -1,26 +1,26 @@
 ---
 source: zellij-server/src/tab/./unit/tab_integration_tests.rs
+assertion_line: 1318
 expression: snapshot
-
 ---
 00 (C): ┌ Pane #1 ──────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 01 (C): │                                                                                                                       │
-02 (C): │ ┌ Pane #3 ─────────────── SCROLL:  0/1 ┐                                     ┌ Pane #4 ─────────────── SCROLL:  0/1 ┐ │
-03 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-04 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-05 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE┌ Pane #2 ─────────────────────────────────────────────────┐EEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-06 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                          │EEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-07 (C): │ └───────────────────────────│                                                          │────────────────────────────┘ │
-08 (C): │                             │                                                          │                              │
-09 (C): │                             │                   I am scratch terminal                  │                              │
-10 (C): │                             │                                                          │                              │
-11 (C): │                             │                                                          │                              │
-12 (C): │ ┌ Pane #5 ─────────────── SC│                                                          │────────────── SCROLL:  0/1 ┐ │
-13 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                          │EEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-14 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE└──────────────────────────────────────────────────────────┘EEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-15 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-16 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-17 (C): │ └──────────────────────────────────────┘                                     └──────────────────────────────────────┘ │
-18 (C): │                                                                                                                       │
+02 (C): │ ┌ Pane #5 ─────────────── SCROLL:  0/1 ┐                                                                              │
+03 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                                              │
+04 (C): │ │E┌ Pane #6 ─────────────── SCROLL:  0/1 ┐                                                                            │
+05 (C): │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│─────────────────────────────────────────────┐                              │
+06 (C): │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                             │                              │
+07 (C): │ └─│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│───────────────────────────────── SCROLL:  0/1 ┐                            │
+08 (C): │   │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                            │
+09 (C): │   └──────────────────────────────────────┘─────────────────────────────────── SCROLL:  0/1 ┐                          │
+10 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+11 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+12 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+13 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+14 (C): │                             └─│E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+15 (C): │                               │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+16 (C): │                               └─│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+17 (C): │                                 │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+18 (C): │                                 └──────────────────────────────────────────────────────────┘                          │
 19 (C): └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 

--- a/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__move_floating_pane_focus_down.snap
+++ b/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__move_floating_pane_focus_down.snap
@@ -1,26 +1,26 @@
 ---
 source: zellij-server/src/tab/./unit/tab_integration_tests.rs
+assertion_line: 1078
 expression: snapshot
-
 ---
 00 (C): ┌ Pane #1 ──────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 01 (C): │                                                                                                                       │
-02 (C): │ ┌ Pane #3 ─────────────── SCROLL:  0/1 ┐                                     ┌ Pane #4 ─────────────── SCROLL:  0/1 ┐ │
-03 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-04 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-05 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE┌ Pane #2 ─────────────────────────────────────────────────┐EEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-06 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                          │EEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-07 (C): │ └───────────────────────────│                                                          │────────────────────────────┘ │
-08 (C): │                             │                                                          │                              │
-09 (C): │                             │                   I am scratch terminal                  │                              │
-10 (C): │                             │                                                          │                              │
-11 (C): │                             │                                                          │                              │
-12 (C): │ ┌ Pane #5 ─────────────── SC│                                                ┌ Pane #6 ─────────────── SCROLL:  0/1 ┐ │
-13 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-14 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE└────────────────────────────────────────────────│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-15 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-16 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-17 (C): │ └──────────────────────────────────────┘                                     └──────────────────────────────────────┘ │
-18 (C): │                                                                                                                       │
+02 (C): │ ┌ Pane #5 ─────────────── SCROLL:  0/1 ┐                                                                              │
+03 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                                              │
+04 (C): │ │E┌ Pane #6 ─────────────── SCROLL:  0/1 ┐                                                                            │
+05 (C): │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│─────────────────────────────────────────────┐                              │
+06 (C): │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                             │                              │
+07 (C): │ └─│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│───────────────────────────────── SCROLL:  0/1 ┐                            │
+08 (C): │   │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                            │
+09 (C): │   └──────────────────────────────────────┘─────────────────────────────────── SCROLL:  0/1 ┐                          │
+10 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+11 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+12 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+13 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+14 (C): │                             └─│E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+15 (C): │                               │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+16 (C): │                               └─│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+17 (C): │                                 │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+18 (C): │                                 └──────────────────────────────────────────────────────────┘                          │
 19 (C): └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 

--- a/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__move_floating_pane_focus_left.snap
+++ b/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__move_floating_pane_focus_left.snap
@@ -1,26 +1,26 @@
 ---
 source: zellij-server/src/tab/./unit/tab_integration_tests.rs
+assertion_line: 911
 expression: snapshot
-
 ---
 00 (C): ┌ Pane #1 ──────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 01 (C): │                                                                                                                       │
-02 (C): │ ┌ Pane #3 ─────────────── SCROLL:  0/1 ┐                                     ┌ Pane #4 ─────────────── SCROLL:  0/1 ┐ │
-03 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-04 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-05 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE┌ Pane #2 ─────────────────────────────────────────────────┐EEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-06 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                          │EEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-07 (C): │ └───────────────────────────│                                                          │────────────────────────────┘ │
-08 (C): │                             │                                                          │                              │
-09 (C): │                             │                   I am scratch terminal                  │                              │
-10 (C): │                             │                                                          │                              │
-11 (C): │                             │                                                          │                              │
-12 (C): │ ┌ Pane #5 ─────────────── SC│                                                          │────────────── SCROLL:  0/1 ┐ │
-13 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                          │EEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-14 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE└──────────────────────────────────────────────────────────┘EEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-15 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-16 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-17 (C): │ └──────────────────────────────────────┘                                     └──────────────────────────────────────┘ │
-18 (C): │                                                                                                                       │
+02 (C): │ ┌ Pane #5 ─────────────── SCROLL:  0/1 ┐                                                                              │
+03 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                                              │
+04 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ ┐                                                                            │
+05 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│E│─────────────────────────────────────────────┐                              │
+06 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│E│                                             │                              │
+07 (C): │ └──────────────────────────────────────┘E│───────────────────────────────── SCROLL:  0/1 ┐                            │
+08 (C): │   │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                            │
+09 (C): │   └──────────────────────────────────────┘─────────────────────────────────── SCROLL:  0/1 ┐                          │
+10 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+11 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+12 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+13 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+14 (C): │                             └─│E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+15 (C): │                               │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+16 (C): │                               └─│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+17 (C): │                                 │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+18 (C): │                                 └──────────────────────────────────────────────────────────┘                          │
 19 (C): └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 

--- a/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__move_floating_pane_focus_right.snap
+++ b/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__move_floating_pane_focus_right.snap
@@ -1,26 +1,26 @@
 ---
 source: zellij-server/src/tab/./unit/tab_integration_tests.rs
+assertion_line: 967
 expression: snapshot
-
 ---
 00 (C): ┌ Pane #1 ──────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 01 (C): │                                                                                                                       │
-02 (C): │ ┌ Pane #3 ─────────────── SCROLL:  0/1 ┐                                     ┌ Pane #4 ─────────────── SCROLL:  0/1 ┐ │
-03 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-04 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-05 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE┌ Pane #2 ───────────────────────────────────────│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-06 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-07 (C): │ └───────────────────────────│                                                └──────────────────────────────────────┘ │
-08 (C): │                             │                                                          │                              │
-09 (C): │                             │                   I am scratch terminal                  │                              │
-10 (C): │                             │                                                          │                              │
-11 (C): │                             │                                                          │                              │
-12 (C): │ ┌ Pane #5 ─────────────── SC│                                                          │────────────── SCROLL:  0/1 ┐ │
-13 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                          │EEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-14 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE└──────────────────────────────────────────────────────────┘EEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-15 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-16 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-17 (C): │ └──────────────────────────────────────┘                                     └──────────────────────────────────────┘ │
-18 (C): │                                                                                                                       │
+02 (C): │ ┌ Pane #5 ─────────────── SCROLL:  0/1 ┐                                                                              │
+03 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                                              │
+04 (C): │ │E┌ Pane #6 ─────────────── SCROLL:  0/1 ┐                                                                            │
+05 (C): │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│─────────────────────────────────────────────┐                              │
+06 (C): │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                             │                              │
+07 (C): │ └─│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│───────────────────────────────── SCROLL:  0/1 ┐                            │
+08 (C): │   │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                            │
+09 (C): │   └──────────────────────────────────────┘─────────────────────────────────── SCROLL:  0/1 ┐                          │
+10 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+11 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+12 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+13 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+14 (C): │                             └─│E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+15 (C): │                               │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+16 (C): │                               └─│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+17 (C): │                                 │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+18 (C): │                                 └──────────────────────────────────────────────────────────┘                          │
 19 (C): └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 

--- a/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__move_floating_pane_focus_up.snap
+++ b/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__move_floating_pane_focus_up.snap
@@ -1,26 +1,26 @@
 ---
 source: zellij-server/src/tab/./unit/tab_integration_tests.rs
+assertion_line: 1022
 expression: snapshot
-
 ---
 00 (C): ┌ Pane #1 ──────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 01 (C): │                                                                                                                       │
-02 (C): │ ┌ Pane #3 ─────────────── SCROLL:  0/1 ┐                                     ┌ Pane #4 ─────────────── SCROLL:  0/1 ┐ │
-03 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-04 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-05 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE┌ Pane #2 ─────────────────────────────────────────────────┐EEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-06 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                          │EEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-07 (C): │ └───────────────────────────│                                                          │────────────────────────────┘ │
-08 (C): │                             │                                                          │                              │
-09 (C): │                             │                   I am scratch terminal                  │                              │
-10 (C): │                             │                                                          │                              │
-11 (C): │                             │                                                          │                              │
-12 (C): │ ┌ Pane #5 ─────────────── SC│                                                          │────────────── SCROLL:  0/1 ┐ │
-13 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                          │EEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-14 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE└──────────────────────────────────────────────────────────┘EEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-15 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-16 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-17 (C): │ └──────────────────────────────────────┘                                     └──────────────────────────────────────┘ │
-18 (C): │                                                                                                                       │
+02 (C): │ ┌ Pane #5 ─────────────── SCROLL:  0/1 ┐                                                                              │
+03 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                                              │
+04 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ ┐                                                                            │
+05 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│E│─────────────────────────────────────────────┐                              │
+06 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│E│                                             │                              │
+07 (C): │ └──────────────────────────────────────┘E│───────────────────────────────── SCROLL:  0/1 ┐                            │
+08 (C): │   │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                            │
+09 (C): │   └──────────────────────────────────────┘─────────────────────────────────── SCROLL:  0/1 ┐                          │
+10 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+11 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+12 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+13 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+14 (C): │                             └─│E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+15 (C): │                               │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+16 (C): │                               └─│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+17 (C): │                                 │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+18 (C): │                                 └──────────────────────────────────────────────────────────┘                          │
 19 (C): └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 

--- a/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__move_floating_pane_focus_with_mouse.snap
+++ b/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__move_floating_pane_focus_with_mouse.snap
@@ -1,26 +1,26 @@
 ---
 source: zellij-server/src/tab/./unit/tab_integration_tests.rs
+assertion_line: 1136
 expression: snapshot
-
 ---
 00 (C): ┌ Pane #1 ──────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 01 (C): │                                                                                                                       │
-02 (C): │ ┌ Pane #3 ─────────────── SCROLL:  0/1 ┐                                     ┌ Pane #4 ─────────────── SCROLL:  0/1 ┐ │
-03 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-04 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-05 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE┌ Pane #2 ─────────────────────────────────────────────────┐EEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-06 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                          │EEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-07 (C): │ └───────────────────────────│                                                          │────────────────────────────┘ │
-08 (C): │                             │                                                          │                              │
-09 (C): │                             │                   I am scratch terminal                  │                              │
-10 (C): │                             │                                                          │                              │
-11 (C): │                             │                                                          │                              │
-12 (C): │ ┌ Pane #5 ─────────────── SC│                                                          │────────────── SCROLL:  0/1 ┐ │
-13 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                          │EEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-14 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEE└──────────────────────────────────────────────────────────┘EEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-15 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-16 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-17 (C): │ └──────────────────────────────────────┘                                     └──────────────────────────────────────┘ │
-18 (C): │                                                                                                                       │
+02 (C): │ ┌ Pane #5 ─────────────── SCROLL:  0/1 ┐                                                                              │
+03 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                                              │
+04 (C): │ │E┌ Pane #6 ─────────────── SCROLL:  0/1 ┐                                                                            │
+05 (C): │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│─────────────────────────────────────────────┐                              │
+06 (C): │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                             │                              │
+07 (C): │ └─│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│───────────────────────────────── SCROLL:  0/1 ┐                            │
+08 (C): │   │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                            │
+09 (C): │   └─────────────────────────────┌ Pane #4 ─────────────────────────────────── SCROLL:  0/1 ┐                          │
+10 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+11 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+12 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+13 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+14 (C): │                             └─│E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+15 (C): │                               │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+16 (C): │                               └─│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+17 (C): │                                 │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+18 (C): │                                 └──────────────────────────────────────────────────────────┘                          │
 19 (C): └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 

--- a/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__resize_tab_with_floating_panes.snap
+++ b/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__resize_tab_with_floating_panes.snap
@@ -1,18 +1,18 @@
 ---
 source: zellij-server/src/tab/./unit/tab_integration_tests.rs
+assertion_line: 1371
 expression: snapshot
-
 ---
-00 (C): ┌ Pane #1 ────────────────────┌ Pane #2 ─────────────────────────────────────────────────┐─────────┐                     
-01 (C): │                             │                                                          │         │                     
-02 (C): │ ┌ Pane #3 ─────────────── SCROLL:  0/1 ┐                  ┌ Pane #4 ─────────────── SCROLL:  0/1 ┐                     
-03 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                  │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                     
-04 (C): │ ┌ Pane #5 ─────────────── SCROLL:  0/1 ┐        I am scrat┌ Pane #6 ─────────────── SCROLL:  0/1 ┐                     
-05 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                  │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                     
-06 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                  │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                     
-07 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                  │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                     
-08 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                  │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                     
-09 (C): └─└──────────────────────────────────────┘──────────────────└──────────────────────────────────────┘                     
+00 (C): ┌ Pane #1 ────────────────────┌ ┌ ┌ Pane #4 ─────────────────────────────────── SCROLL:  0/1 ┐─────┐                     
+01 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│     │                     
+02 (C): │ ┌ Pane #5 ─────────────── SCROLL:  0/1 ┐EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│     │                     
+03 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│     │                     
+04 (C): │ │E┌ Pane #6 ─────────────── SCROLL:  0/1 ┐EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│     │                     
+05 (C): │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│     │                     
+06 (C): │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│     │                     
+07 (C): │ └─│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│     │                     
+08 (C): │   │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│     │                     
+09 (C): └───└──────────────────────────────────────┘─────────────────────────────────────────────────┘─────┘                     
 10 (C):                                                                                                                          
 11 (C):                                                                                                                          
 12 (C):                                                                                                                          

--- a/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__shrink_whole_tab_with_floating_panes_horizontally_and_vertically.snap
+++ b/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__shrink_whole_tab_with_floating_panes_horizontally_and_vertically.snap
@@ -1,18 +1,18 @@
 ---
 source: zellij-server/src/tab/./unit/tab_integration_tests.rs
+assertion_line: 1421
 expression: snapshot
-
 ---
-00 (C): ┌ Pane #1 ────────────────────┌ Pane #2 ─────────┐                                                                       
-01 (C): │                             │                  │                                                                       
-02 (C): │ ┌ Pane #┌ Pane #4 ─────────────── SCROLL:  0/1 ┐                                                                       
-03 (C): │ │EEEEEEE│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                                       
-04 (C): │ ┌ Pane #┌ Pane #6 ─────────────── SCROLL:  0/1 ┐                                                                       
-05 (C): │ │EEEEEEE│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                                       
-06 (C): │ │EEEEEEE│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                                       
-07 (C): │ │EEEEEEE│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                                       
-08 (C): │ │EEEEEEE│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                                       
-09 (C): └─└───────└──────────────────────────────────────┘                                                                       
+00 (C): ┌ Pane #1 ────────────────────┌ ┌ ┌ Pane #4 ── 0 ┐                                                                       
+01 (C): │                             │ │E│EEEEEEEEEEEEEE│                                                                       
+02 (C): │ ┌ Pane #5 ─────────────── SCROLL:  0/1 ┐EEEEEEE│                                                                       
+03 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│       │                                                                       
+04 (C): │ │E┌ Pane #6 ─────────────── SCROLL:  0/1 ┐EEEEE│                                                                       
+05 (C): │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│EEEEE│                                                                       
+06 (C): │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│EEEEE│                                                                       
+07 (C): │ └─│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│EEEEE│                                                                       
+08 (C): │   │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│     │                                                                       
+09 (C): └───└──────────────────────────────────────┘─────┘                                                                       
 10 (C):                                                                                                                          
 11 (C):                                                                                                                          
 12 (C):                                                                                                                          

--- a/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__shrink_whole_tab_with_floating_panes_horizontally_and_vertically_and_expand_back.snap
+++ b/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__shrink_whole_tab_with_floating_panes_horizontally_and_vertically_and_expand_back.snap
@@ -1,26 +1,26 @@
 ---
 source: zellij-server/src/tab/./unit/tab_integration_tests.rs
+assertion_line: 1475
 expression: snapshot
-
 ---
 00 (C): ┌ Pane #1 ──────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 01 (C): │                                                                                                                       │
-02 (C): │ ┌ Pane #3 ─────────────── SCROLL:  0/1 ┐                                     ┌ Pane #4 ─────────────── SCROLL:  0/1 ┐ │
-03 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-04 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-05 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│─────────────────────────────────────│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-06 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-07 (C): │ └──────────────────────────────────────┘                                     └──────────────────────────────────────┘ │
-08 (C): │                             │                                                          │                              │
-09 (C): │                             │                   I am scratch terminal                  │                              │
-10 (C): │                             │                                                          │                              │
-11 (C): │                             │                                                          │                              │
-12 (C): │ ┌ Pane #5 ─────────────── SCROLL:  0/1 ┐                                     ┌ Pane #6 ─────────────── SCROLL:  0/1 ┐ │
-13 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-14 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│─────────────────────────────────────│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-15 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-16 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                     │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│ │
-17 (C): │ └──────────────────────────────────────┘                                     └──────────────────────────────────────┘ │
-18 (C): │                                                                                                                       │
+02 (C): │ ┌ Pane #5 ─────────────── SCROLL:  0/1 ┐                                                                              │
+03 (C): │ │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                                                              │
+04 (C): │ │E┌ Pane #6 ─────────────── SCROLL:  0/1 ┐                                                                            │
+05 (C): │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│─────────────────────────────────────────────┐                              │
+06 (C): │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                                             │                              │
+07 (C): │ └─│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│───────────────────────────────── SCROLL:  0/1 ┐                            │
+08 (C): │   │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                            │
+09 (C): │   └──────────────────────────────────────┘─────────────────────────────────── SCROLL:  0/1 ┐                          │
+10 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+11 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+12 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+13 (C): │                             │ │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+14 (C): │                             └─│E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+15 (C): │                               │E│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+16 (C): │                               └─│EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+17 (C): │                                 │EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE│                          │
+18 (C): │                                 └──────────────────────────────────────────────────────────┘                          │
 19 (C): └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -904,7 +904,7 @@ fn move_floating_pane_focus_left() {
     );
     assert_eq!(
         cursor_coordinates,
-        Some((71, 9)),
+        Some((3, 3)),
         "cursor coordinates moved to the pane on the left"
     );
 
@@ -960,7 +960,7 @@ fn move_floating_pane_focus_right() {
     );
     assert_eq!(
         cursor_coordinates,
-        Some((80, 3)),
+        Some((5, 5)),
         "cursor coordinates moved to the pane on the right"
     );
 
@@ -1015,7 +1015,7 @@ fn move_floating_pane_focus_up() {
     );
     assert_eq!(
         cursor_coordinates,
-        Some((71, 9)),
+        Some((3, 3)),
         "cursor coordinates moved to the pane above"
     );
 
@@ -1071,7 +1071,7 @@ fn move_floating_pane_focus_down() {
     );
     assert_eq!(
         cursor_coordinates,
-        Some((80, 13)),
+        Some((5, 5)),
         "cursor coordinates moved to the pane below"
     );
 
@@ -1129,7 +1129,7 @@ fn move_floating_pane_focus_with_mouse() {
     );
     assert_eq!(
         cursor_coordinates,
-        Some((71, 9)),
+        Some((35, 10)),
         "cursor coordinates moved to the clicked pane"
     );
 
@@ -1290,13 +1290,13 @@ fn mark_text_inside_floating_pane() {
         .unwrap();
     tab.handle_pty_bytes(6, Vec::from("\u{1b}#8".as_bytes()))
         .unwrap();
-    tab.handle_left_click(&Position::new(9, 71), client_id)
+    tab.handle_left_click(&Position::new(6, 30), client_id)
         .unwrap();
     assert!(
         tab.selecting_with_mouse,
         "started selecting with mouse on click"
     );
-    tab.handle_left_mouse_release(&Position::new(8, 50), client_id)
+    tab.handle_left_mouse_release(&Position::new(5, 15), client_id)
         .unwrap();
     assert!(
         !tab.selecting_with_mouse,
@@ -1311,7 +1311,7 @@ fn mark_text_inside_floating_pane() {
     );
     assert_eq!(
         cursor_coordinates,
-        Some((71, 9)),
+        Some((5, 5)),
         "cursor coordinates stayed in clicked pane"
     );
 


### PR DESCRIPTION
This changes the order in which the floating panes are opened.
I find the new order to be more convenient, with floating panes grouped one above the other with a slight offset to make them visible, rather than seemingly unexpectedly being opened around the screen (in small and somewhat unusable sizes to boot).