### PR TITLE
fix(editor): default to vi when no editor is set

### DIFF
--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -245,15 +245,8 @@ fn spawn_terminal(
     let mut failover_cmd_args = None;
     let cmd = match terminal_action {
         TerminalAction::OpenFile(file_to_open, line_number) => {
-            if default_editor.is_none()
-                && env::var("EDITOR").is_err()
-                && env::var("VISUAL").is_err()
-            {
-                return Err(SpawnTerminalError::NoEditorFound);
-            }
-
             let mut command = default_editor.unwrap_or_else(|| {
-                PathBuf::from(env::var("EDITOR").unwrap_or_else(|_| env::var("VISUAL").unwrap()))
+                PathBuf::from(env::var("EDITOR").unwrap_or_else(|_| env::var("VISUAL").unwrap_or_else(|_| "vi".into())))
             });
 
             let mut args = vec![];

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -246,7 +246,10 @@ fn spawn_terminal(
     let cmd = match terminal_action {
         TerminalAction::OpenFile(file_to_open, line_number) => {
             let mut command = default_editor.unwrap_or_else(|| {
-                PathBuf::from(env::var("EDITOR").unwrap_or_else(|_| env::var("VISUAL").unwrap_or_else(|_| "vi".into())))
+                PathBuf::from(
+                    env::var("EDITOR")
+                        .unwrap_or_else(|_| env::var("VISUAL").unwrap_or_else(|_| "vi".into())),
+                )
             });
 
             let mut args = vec![];

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -136,6 +136,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) {
                                 );
                             }
                         } else {
+                            log::error!("Failed to spawn terminal: command not found");
                             pty.close_pane(PaneId::Terminal(pid));
                         }
                     },


### PR DESCRIPTION
When no editor is set in the config, and Zellij can't find one in either `$EDITOR` or `$VISUAL` it will default to `vi` which should be available on most systems. This is what git does.