### PR TITLE
fix(terminal): reset scroll region when clearing screen

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -2258,6 +2258,7 @@ impl Perform for Grid {
                 } else if clear_type == 1 {
                     self.clear_all_before_cursor(char_to_replace);
                 } else if clear_type == 2 {
+                    self.set_scroll_region_to_viewport_size();
                     self.fill_viewport(char_to_replace);
                 } else if clear_type == 3 {
                     self.clear_lines_above();

--- a/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__vttest2_6.snap
+++ b/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__vttest2_6.snap
@@ -1,47 +1,47 @@
 ---
 source: zellij-server/src/panes/./unit/grid_tests.rs
+assertion_line: 305
 expression: "format!(\"{:?}\", grid)"
-
 ---
-00 (C):                                                                                                               
-01 (C):                                                                                                               
-02 (C):                                                                                                               
-03 (C):                                                                                                               
-04 (C):                                                                                                               
-05 (C):                                                                                                               
-06 (C):                                                                                                               
-07 (C):                                                                                                               
-08 (C):                                                                                                               
-09 (C):                                                                                                               
-10 (C):                                                                                                               
-11 (W): Push <RETURN>
-12 (W): Soft scroll down region [12..13] size 2 Line 29
-13 (C):                                                                                                               
-14 (C):                                                                                                               
-15 (C):                                                                                                               
-16 (C):                                                                                                               
-17 (C):                                                                                                               
-18 (C):                                                                                                               
-19 (C):                                                                                                               
-20 (C):                                                                                                               
-21 (C):                                                                                                               
-22 (C):                                                                                                               
-23 (C):                                                                                                               
-24 (C):                                                                                                               
-25 (C):                                                                                                               
-26 (C):                                                                                                               
-27 (C):                                                                                                               
-28 (C):                                                                                                               
-29 (C):                                                                                                               
-30 (C):                                                                                                               
-31 (C):                                                                                                               
-32 (C):                                                                                                               
-33 (C):                                                                                                               
-34 (C):                                                                                                               
-35 (C):                                                                                                               
-36 (C):                                                                                                               
-37 (C):                                                                                                               
-38 (C):                                                                                                               
-39 (C):                                                                                                               
-40 (C):                                                                                                               
+00 (W): Push <RETURN>
+01 (W): Soft scroll down region [12..13] size 2 Line 29
+02 (W): Soft scroll down region [12..13] size 2 Line 28
+03 (W): Soft scroll down region [12..13] size 2 Line 27
+04 (W): Soft scroll down region [12..13] size 2 Line 26
+05 (W): Soft scroll down region [12..13] size 2 Line 25
+06 (W): Soft scroll down region [12..13] size 2 Line 24
+07 (W): Soft scroll down region [12..13] size 2 Line 23
+08 (W): Soft scroll down region [12..13] size 2 Line 22
+09 (W): Soft scroll down region [12..13] size 2 Line 21
+10 (W): Soft scroll down region [12..13] size 2 Line 20
+11 (W): Soft scroll down region [12..13] size 2 Line 19
+12 (W): Soft scroll down region [12..13] size 2 Line 18
+13 (C): Soft scroll down region [12..13] size 2 Line 17                                                               
+14 (C): Soft scroll down region [12..13] size 2 Line 16                                                               
+15 (C): Soft scroll down region [12..13] size 2 Line 15                                                               
+16 (C): Soft scroll down region [12..13] size 2 Line 14                                                               
+17 (C): Soft scroll down region [12..13] size 2 Line 13                                                               
+18 (C): Soft scroll down region [12..13] size 2 Line 12                                                               
+19 (C): Soft scroll down region [12..13] size 2 Line 11                                                               
+20 (C): Soft scroll down region [12..13] size 2 Line 10                                                               
+21 (C): Soft scroll down region [12..13] size 2 Line 9                                                                
+22 (C): Soft scroll down region [12..13] size 2 Line 8                                                                
+23 (C): Soft scroll down region [12..13] size 2 Line 7                                                                
+24 (C): Soft scroll down region [12..13] size 2 Line 6                                                                
+25 (C): Soft scroll down region [12..13] size 2 Line 5                                                                
+26 (C): Soft scroll down region [12..13] size 2 Line 4                                                                
+27 (C): Soft scroll down region [12..13] size 2 Line 3                                                                
+28 (C): Soft scroll down region [12..13] size 2 Line 2                                                                
+29 (C): Soft scroll down region [12..13] size 2 Line 1                                                                
+30 (C): Soft scroll up region [12..13] size 2 Line 7                                                                  
+31 (C): Soft scroll up region [12..13] size 2 Line 8                                                                  
+32 (C): Soft scroll up region [12..13] size 2 Line 9                                                                  
+33 (C): Soft scroll up region [12..13] size 2 Line 10                                                                 
+34 (C): Soft scroll up region [12..13] size 2 Line 11                                                                 
+35 (C): Soft scroll up region [12..13] size 2 Line 12                                                                 
+36 (C): Soft scroll up region [12..13] size 2 Line 13                                                                 
+37 (C): Soft scroll up region [12..13] size 2 Line 14                                                                 
+38 (C): Soft scroll up region [12..13] size 2 Line 15                                                                 
+39 (C): Soft scroll up region [12..13] size 2 Line 16                                                                 
+40 (C): Soft scroll up region [12..13] size 2 Line 17                                                                 
 

--- a/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__vttest2_7.snap
+++ b/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__vttest2_7.snap
@@ -1,7 +1,7 @@
 ---
 source: zellij-server/src/panes/./unit/grid_tests.rs
+assertion_line: 327
 expression: "format!(\"{:?}\", grid)"
-
 ---
 00 (W): Push <RETURN>
 01 (W): Soft scroll down region [1..24] size 24 Line 29
@@ -16,32 +16,32 @@ expression: "format!(\"{:?}\", grid)"
 10 (W): Soft scroll down region [1..24] size 24 Line 20
 11 (W): Soft scroll down region [1..24] size 24 Line 19
 12 (W): Soft scroll down region [1..24] size 24 Line 18
-13 (W): Soft scroll down region [1..24] size 24 Line 17
-14 (W): Soft scroll down region [1..24] size 24 Line 16
-15 (W): Soft scroll down region [1..24] size 24 Line 15
-16 (W): Soft scroll down region [1..24] size 24 Line 14
-17 (W): Soft scroll down region [1..24] size 24 Line 13
-18 (W): Soft scroll down region [1..24] size 24 Line 12
-19 (W): Soft scroll down region [1..24] size 24 Line 11
-20 (W): Soft scroll down region [1..24] size 24 Line 10
-21 (W): Soft scroll down region [1..24] size 24 Line 9
-22 (W): Soft scroll down region [1..24] size 24 Line 8
-23 (W): Soft scroll down region [1..24] size 24 Line 7
-24 (C):                                                                                                               
-25 (C):                                                                                                               
-26 (C):                                                                                                               
-27 (C):                                                                                                               
-28 (C):                                                                                                               
-29 (C):                                                                                                               
-30 (C):                                                                                                               
-31 (C):                                                                                                               
-32 (C):                                                                                                               
-33 (C):                                                                                                               
-34 (C):                                                                                                               
-35 (C):                                                                                                               
-36 (C):                                                                                                               
-37 (C):                                                                                                               
-38 (C):                                                                                                               
-39 (C):                                                                                                               
-40 (C):                                                                                                               
+13 (C): Soft scroll down region [1..24] size 24 Line 17                                                               
+14 (C): Soft scroll down region [1..24] size 24 Line 16                                                               
+15 (C): Soft scroll down region [1..24] size 24 Line 15                                                               
+16 (C): Soft scroll down region [1..24] size 24 Line 14                                                               
+17 (C): Soft scroll down region [1..24] size 24 Line 13                                                               
+18 (C): Soft scroll down region [1..24] size 24 Line 12                                                               
+19 (C): Soft scroll down region [1..24] size 24 Line 11                                                               
+20 (C): Soft scroll down region [1..24] size 24 Line 10                                                               
+21 (C): Soft scroll down region [1..24] size 24 Line 9                                                                
+22 (C): Soft scroll down region [1..24] size 24 Line 8                                                                
+23 (C): Soft scroll down region [1..24] size 24 Line 7                                                                
+24 (C): Soft scroll down region [1..24] size 24 Line 6                                                                
+25 (C): Soft scroll down region [1..24] size 24 Line 5                                                                
+26 (C): Soft scroll down region [1..24] size 24 Line 4                                                                
+27 (C): Soft scroll down region [1..24] size 24 Line 3                                                                
+28 (C): Soft scroll down region [1..24] size 24 Line 2                                                                
+29 (C): Soft scroll down region [1..24] size 24 Line 1                                                                
+30 (C): Soft scroll up region [1..24] size 24 Line 7                                                                  
+31 (C): Soft scroll up region [1..24] size 24 Line 8                                                                  
+32 (C): Soft scroll up region [1..24] size 24 Line 9                                                                  
+33 (C): Soft scroll up region [1..24] size 24 Line 10                                                                 
+34 (C): Soft scroll up region [1..24] size 24 Line 11                                                                 
+35 (C): Soft scroll up region [1..24] size 24 Line 12                                                                 
+36 (C): Soft scroll up region [1..24] size 24 Line 13                                                                 
+37 (C): Soft scroll up region [1..24] size 24 Line 14                                                                 
+38 (C): Soft scroll up region [1..24] size 24 Line 15                                                                 
+39 (C): Soft scroll up region [1..24] size 24 Line 16                                                                 
+40 (C): Soft scroll up region [1..24] size 24 Line 17                                                                 
 

--- a/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__vttest2_8.snap
+++ b/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__vttest2_8.snap
@@ -1,47 +1,47 @@
 ---
 source: zellij-server/src/panes/./unit/grid_tests.rs
+assertion_line: 349
 expression: "format!(\"{:?}\", grid)"
-
 ---
-00 (C):                                                                                                               
-01 (C):                                                                                                               
-02 (C):                                                                                                               
-03 (C):                                                                                                               
-04 (C):                                                                                                               
-05 (C):                                                                                                               
-06 (C):                                                                                                               
-07 (C):                                                                                                               
-08 (C):                                                                                                               
-09 (C):                                                                                                               
-10 (C):                                                                                                               
-11 (W): Push <RETURN>
-12 (W): Jump scroll down region [12..13] size 2 Line 29
-13 (C):                                                                                                               
-14 (C):                                                                                                               
-15 (C):                                                                                                               
-16 (C):                                                                                                               
-17 (C):                                                                                                               
-18 (C):                                                                                                               
-19 (C):                                                                                                               
-20 (C):                                                                                                               
-21 (C):                                                                                                               
-22 (C):                                                                                                               
-23 (C):                                                                                                               
-24 (C):                                                                                                               
-25 (C):                                                                                                               
-26 (C):                                                                                                               
-27 (C):                                                                                                               
-28 (C):                                                                                                               
-29 (C):                                                                                                               
-30 (C):                                                                                                               
-31 (C):                                                                                                               
-32 (C):                                                                                                               
-33 (C):                                                                                                               
-34 (C):                                                                                                               
-35 (C):                                                                                                               
-36 (C):                                                                                                               
-37 (C):                                                                                                               
-38 (C):                                                                                                               
-39 (C):                                                                                                               
-40 (C):                                                                                                               
+00 (W): Push <RETURN>
+01 (W): Jump scroll down region [12..13] size 2 Line 29
+02 (W): Jump scroll down region [12..13] size 2 Line 28
+03 (W): Jump scroll down region [12..13] size 2 Line 27
+04 (W): Jump scroll down region [12..13] size 2 Line 26
+05 (W): Jump scroll down region [12..13] size 2 Line 25
+06 (W): Jump scroll down region [12..13] size 2 Line 24
+07 (W): Jump scroll down region [12..13] size 2 Line 23
+08 (W): Jump scroll down region [12..13] size 2 Line 22
+09 (W): Jump scroll down region [12..13] size 2 Line 21
+10 (W): Jump scroll down region [12..13] size 2 Line 20
+11 (W): Jump scroll down region [12..13] size 2 Line 19
+12 (W): Jump scroll down region [12..13] size 2 Line 18
+13 (C): Jump scroll down region [12..13] size 2 Line 17                                                               
+14 (C): Jump scroll down region [12..13] size 2 Line 16                                                               
+15 (C): Jump scroll down region [12..13] size 2 Line 15                                                               
+16 (C): Jump scroll down region [12..13] size 2 Line 14                                                               
+17 (C): Jump scroll down region [12..13] size 2 Line 13                                                               
+18 (C): Jump scroll down region [12..13] size 2 Line 12                                                               
+19 (C): Jump scroll down region [12..13] size 2 Line 11                                                               
+20 (C): Jump scroll down region [12..13] size 2 Line 10                                                               
+21 (C): Jump scroll down region [12..13] size 2 Line 9                                                                
+22 (C): Jump scroll down region [12..13] size 2 Line 8                                                                
+23 (C): Jump scroll down region [12..13] size 2 Line 7                                                                
+24 (C): Jump scroll down region [12..13] size 2 Line 6                                                                
+25 (C): Jump scroll down region [12..13] size 2 Line 5                                                                
+26 (C): Jump scroll down region [12..13] size 2 Line 4                                                                
+27 (C): Jump scroll down region [12..13] size 2 Line 3                                                                
+28 (C): Jump scroll down region [12..13] size 2 Line 2                                                                
+29 (C): Jump scroll down region [12..13] size 2 Line 1                                                                
+30 (C): Jump scroll up region [12..13] size 2 Line 7                                                                  
+31 (C): Jump scroll up region [12..13] size 2 Line 8                                                                  
+32 (C): Jump scroll up region [12..13] size 2 Line 9                                                                  
+33 (C): Jump scroll up region [12..13] size 2 Line 10                                                                 
+34 (C): Jump scroll up region [12..13] size 2 Line 11                                                                 
+35 (C): Jump scroll up region [12..13] size 2 Line 12                                                                 
+36 (C): Jump scroll up region [12..13] size 2 Line 13                                                                 
+37 (C): Jump scroll up region [12..13] size 2 Line 14                                                                 
+38 (C): Jump scroll up region [12..13] size 2 Line 15                                                                 
+39 (C): Jump scroll up region [12..13] size 2 Line 16                                                                 
+40 (C): Jump scroll up region [12..13] size 2 Line 17                                                                 
 

--- a/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__vttest2_9.snap
+++ b/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__vttest2_9.snap
@@ -1,7 +1,7 @@
 ---
 source: zellij-server/src/panes/./unit/grid_tests.rs
+assertion_line: 371
 expression: "format!(\"{:?}\", grid)"
-
 ---
 00 (W): Push <RETURN>
 01 (W): Jump scroll down region [1..24] size 24 Line 29
@@ -16,32 +16,32 @@ expression: "format!(\"{:?}\", grid)"
 10 (W): Jump scroll down region [1..24] size 24 Line 20
 11 (W): Jump scroll down region [1..24] size 24 Line 19
 12 (W): Jump scroll down region [1..24] size 24 Line 18
-13 (W): Jump scroll down region [1..24] size 24 Line 17
-14 (W): Jump scroll down region [1..24] size 24 Line 16
-15 (W): Jump scroll down region [1..24] size 24 Line 15
-16 (W): Jump scroll down region [1..24] size 24 Line 14
-17 (W): Jump scroll down region [1..24] size 24 Line 13
-18 (W): Jump scroll down region [1..24] size 24 Line 12
-19 (W): Jump scroll down region [1..24] size 24 Line 11
-20 (W): Jump scroll down region [1..24] size 24 Line 10
-21 (W): Jump scroll down region [1..24] size 24 Line 9
-22 (W): Jump scroll down region [1..24] size 24 Line 8
-23 (W): Jump scroll down region [1..24] size 24 Line 7
-24 (C):                                                                                                               
-25 (C):                                                                                                               
-26 (C):                                                                                                               
-27 (C):                                                                                                               
-28 (C):                                                                                                               
-29 (C):                                                                                                               
-30 (C):                                                                                                               
-31 (C):                                                                                                               
-32 (C):                                                                                                               
-33 (C):                                                                                                               
-34 (C):                                                                                                               
-35 (C):                                                                                                               
-36 (C):                                                                                                               
-37 (C):                                                                                                               
-38 (C):                                                                                                               
-39 (C):                                                                                                               
-40 (C):                                                                                                               
+13 (C): Jump scroll down region [1..24] size 24 Line 17                                                               
+14 (C): Jump scroll down region [1..24] size 24 Line 16                                                               
+15 (C): Jump scroll down region [1..24] size 24 Line 15                                                               
+16 (C): Jump scroll down region [1..24] size 24 Line 14                                                               
+17 (C): Jump scroll down region [1..24] size 24 Line 13                                                               
+18 (C): Jump scroll down region [1..24] size 24 Line 12                                                               
+19 (C): Jump scroll down region [1..24] size 24 Line 11                                                               
+20 (C): Jump scroll down region [1..24] size 24 Line 10                                                               
+21 (C): Jump scroll down region [1..24] size 24 Line 9                                                                
+22 (C): Jump scroll down region [1..24] size 24 Line 8                                                                
+23 (C): Jump scroll down region [1..24] size 24 Line 7                                                                
+24 (C): Jump scroll down region [1..24] size 24 Line 6                                                                
+25 (C): Jump scroll down region [1..24] size 24 Line 5                                                                
+26 (C): Jump scroll down region [1..24] size 24 Line 4                                                                
+27 (C): Jump scroll down region [1..24] size 24 Line 3                                                                
+28 (C): Jump scroll down region [1..24] size 24 Line 2                                                                
+29 (C): Jump scroll down region [1..24] size 24 Line 1                                                                
+30 (C): Jump scroll up region [1..24] size 24 Line 7                                                                  
+31 (C): Jump scroll up region [1..24] size 24 Line 8                                                                  
+32 (C): Jump scroll up region [1..24] size 24 Line 9                                                                  
+33 (C): Jump scroll up region [1..24] size 24 Line 10                                                                 
+34 (C): Jump scroll up region [1..24] size 24 Line 11                                                                 
+35 (C): Jump scroll up region [1..24] size 24 Line 12                                                                 
+36 (C): Jump scroll up region [1..24] size 24 Line 13                                                                 
+37 (C): Jump scroll up region [1..24] size 24 Line 14                                                                 
+38 (C): Jump scroll up region [1..24] size 24 Line 15                                                                 
+39 (C): Jump scroll up region [1..24] size 24 Line 16                                                                 
+40 (C): Jump scroll up region [1..24] size 24 Line 17                                                                 
 


### PR DESCRIPTION
This was discovered through an edge case where the a vim window gets a SIGWINCH in certain situations.