### PR TITLE
feat(layouts): allow defining a tab cwd

### DIFF
--- a/zellij-utils/src/input/unit/layout_test.rs
+++ b/zellij-utils/src/input/unit/layout_test.rs
@@ -1379,3 +1379,104 @@ fn global_cwd_passed_from_layout_constructor_overrides_global_cwd_in_layout_file
     .unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
+
+#[test]
+fn global_cwd_with_tab_cwd_given_to_panes_without_cwd() {
+    let kdl_layout = r#"
+        layout {
+            cwd "/tmp"
+            tab cwd="./foo" {
+                pane
+                pane command="tail"
+            }
+            // both should have the /tmp/foo cwd
+        }
+    "#;
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
+    assert_snapshot!(format!("{:#?}", layout));
+}
+
+#[test]
+fn tab_cwd_given_to_panes_without_cwd() {
+    let kdl_layout = r#"
+        layout {
+            tab cwd="/tmp" {
+                pane
+                pane command="tail"
+            }
+            // both should have the /tmp cwd
+        }
+    "#;
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
+    assert_snapshot!(format!("{:#?}", layout));
+}
+
+#[test]
+fn tab_cwd_prepended_to_panes_with_cwd() {
+    let kdl_layout = r#"
+        layout {
+            tab cwd="/tmp" {
+                pane cwd="./foo"
+                pane command="tail" cwd="./foo"
+            }
+            // both should have the /tmp/foo cwd
+        }
+    "#;
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
+    assert_snapshot!(format!("{:#?}", layout));
+}
+
+#[test]
+fn global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd() {
+    let kdl_layout = r#"
+        layout {
+            cwd "/tmp"
+            tab cwd="./foo" {
+                pane // should have /tmp/foo
+                pane command="tail" cwd="./bar" // should have /tmp/foo/bar
+            }
+        }
+    "#;
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
+    assert_snapshot!(format!("{:#?}", layout));
+}
+
+#[test]
+fn global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd_in_pane_templates() {
+    let kdl_layout = r#"
+        layout {
+            cwd "/tmp"
+            pane_template name="my_pane_template" {
+                pane // should have /tmp/foo
+                pane command="tail" cwd="./bar" // should have /tmp/foo/bar
+                children
+            }
+            tab cwd="./foo" {
+                my_pane_template {
+                    pane // should have /tmp/foo
+                }
+            }
+        }
+    "#;
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
+    assert_snapshot!(format!("{:#?}", layout));
+}
+
+#[test]
+fn global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd_in_tab_templates() {
+    let kdl_layout = r#"
+        layout {
+            cwd "/tmp"
+            tab_template name="my_tab_template" {
+                pane // should have /tmp/foo
+                pane command="tail" cwd="./bar" // should have /tmp/foo/bar
+                children
+            }
+            my_tab_template cwd="./foo" {
+                pane // should have /tmp/foo
+            }
+        }
+    "#;
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None).unwrap();
+    assert_snapshot!(format!("{:#?}", layout));
+}

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd.snap
@@ -1,0 +1,75 @@
+---
+source: zellij-utils/src/input/./unit/layout_test.rs
+assertion_line: 1441
+expression: "format!(\"{:#?}\", layout)"
+---
+Layout {
+    tabs: [
+        (
+            None,
+            PaneLayout {
+                children_split_direction: Horizontal,
+                name: None,
+                children: [
+                    PaneLayout {
+                        children_split_direction: Horizontal,
+                        name: None,
+                        children: [],
+                        split_size: None,
+                        run: Some(
+                            Cwd(
+                                "/tmp/./foo",
+                            ),
+                        ),
+                        borderless: false,
+                        focus: None,
+                        external_children_index: None,
+                    },
+                    PaneLayout {
+                        children_split_direction: Horizontal,
+                        name: None,
+                        children: [],
+                        split_size: None,
+                        run: Some(
+                            Command(
+                                RunCommand {
+                                    command: "tail",
+                                    args: [],
+                                    cwd: Some(
+                                        "/tmp/./foo/./bar",
+                                    ),
+                                    hold_on_close: true,
+                                },
+                            ),
+                        ),
+                        borderless: false,
+                        focus: None,
+                        external_children_index: None,
+                    },
+                ],
+                split_size: None,
+                run: Some(
+                    Cwd(
+                        "/tmp/./foo",
+                    ),
+                ),
+                borderless: false,
+                focus: None,
+                external_children_index: None,
+            },
+        ),
+    ],
+    focused_tab_index: None,
+    template: Some(
+        PaneLayout {
+            children_split_direction: Horizontal,
+            name: None,
+            children: [],
+            split_size: None,
+            run: None,
+            borderless: false,
+            focus: None,
+            external_children_index: None,
+        },
+    ),
+}

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd_in_pane_templates.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd_in_pane_templates.snap
@@ -1,0 +1,119 @@
+---
+source: zellij-utils/src/input/./unit/layout_test.rs
+assertion_line: 1462
+expression: "format!(\"{:#?}\", layout)"
+---
+Layout {
+    tabs: [
+        (
+            None,
+            PaneLayout {
+                children_split_direction: Horizontal,
+                name: None,
+                children: [
+                    PaneLayout {
+                        children_split_direction: Horizontal,
+                        name: None,
+                        children: [
+                            PaneLayout {
+                                children_split_direction: Horizontal,
+                                name: None,
+                                children: [],
+                                split_size: None,
+                                run: Some(
+                                    Cwd(
+                                        "/tmp/./foo",
+                                    ),
+                                ),
+                                borderless: false,
+                                focus: None,
+                                external_children_index: None,
+                            },
+                            PaneLayout {
+                                children_split_direction: Horizontal,
+                                name: None,
+                                children: [],
+                                split_size: None,
+                                run: Some(
+                                    Command(
+                                        RunCommand {
+                                            command: "tail",
+                                            args: [],
+                                            cwd: Some(
+                                                "/tmp/./foo/./bar",
+                                            ),
+                                            hold_on_close: true,
+                                        },
+                                    ),
+                                ),
+                                borderless: false,
+                                focus: None,
+                                external_children_index: None,
+                            },
+                            PaneLayout {
+                                children_split_direction: Horizontal,
+                                name: None,
+                                children: [
+                                    PaneLayout {
+                                        children_split_direction: Horizontal,
+                                        name: None,
+                                        children: [],
+                                        split_size: None,
+                                        run: Some(
+                                            Cwd(
+                                                "/tmp/./foo",
+                                            ),
+                                        ),
+                                        borderless: false,
+                                        focus: None,
+                                        external_children_index: None,
+                                    },
+                                ],
+                                split_size: None,
+                                run: Some(
+                                    Cwd(
+                                        "/tmp/./foo",
+                                    ),
+                                ),
+                                borderless: false,
+                                focus: None,
+                                external_children_index: None,
+                            },
+                        ],
+                        split_size: None,
+                        run: Some(
+                            Cwd(
+                                "/tmp/./foo",
+                            ),
+                        ),
+                        borderless: false,
+                        focus: None,
+                        external_children_index: None,
+                    },
+                ],
+                split_size: None,
+                run: Some(
+                    Cwd(
+                        "/tmp/./foo",
+                    ),
+                ),
+                borderless: false,
+                focus: None,
+                external_children_index: None,
+            },
+        ),
+    ],
+    focused_tab_index: None,
+    template: Some(
+        PaneLayout {
+            children_split_direction: Horizontal,
+            name: None,
+            children: [],
+            split_size: None,
+            run: None,
+            borderless: false,
+            focus: None,
+            external_children_index: None,
+        },
+    ),
+}

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd_in_tab_templates.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd_in_tab_templates.snap
@@ -1,0 +1,104 @@
+---
+source: zellij-utils/src/input/./unit/layout_test.rs
+assertion_line: 1481
+expression: "format!(\"{:#?}\", layout)"
+---
+Layout {
+    tabs: [
+        (
+            None,
+            PaneLayout {
+                children_split_direction: Horizontal,
+                name: None,
+                children: [
+                    PaneLayout {
+                        children_split_direction: Horizontal,
+                        name: None,
+                        children: [],
+                        split_size: None,
+                        run: Some(
+                            Cwd(
+                                "/tmp/./foo",
+                            ),
+                        ),
+                        borderless: false,
+                        focus: None,
+                        external_children_index: None,
+                    },
+                    PaneLayout {
+                        children_split_direction: Horizontal,
+                        name: None,
+                        children: [],
+                        split_size: None,
+                        run: Some(
+                            Command(
+                                RunCommand {
+                                    command: "tail",
+                                    args: [],
+                                    cwd: Some(
+                                        "/tmp/./foo/./bar",
+                                    ),
+                                    hold_on_close: true,
+                                },
+                            ),
+                        ),
+                        borderless: false,
+                        focus: None,
+                        external_children_index: None,
+                    },
+                    PaneLayout {
+                        children_split_direction: Horizontal,
+                        name: None,
+                        children: [
+                            PaneLayout {
+                                children_split_direction: Horizontal,
+                                name: None,
+                                children: [],
+                                split_size: None,
+                                run: Some(
+                                    Cwd(
+                                        "/tmp/./foo",
+                                    ),
+                                ),
+                                borderless: false,
+                                focus: None,
+                                external_children_index: None,
+                            },
+                        ],
+                        split_size: None,
+                        run: Some(
+                            Cwd(
+                                "/tmp/./foo",
+                            ),
+                        ),
+                        borderless: false,
+                        focus: None,
+                        external_children_index: None,
+                    },
+                ],
+                split_size: None,
+                run: Some(
+                    Cwd(
+                        "/tmp/./foo",
+                    ),
+                ),
+                borderless: false,
+                focus: None,
+                external_children_index: None,
+            },
+        ),
+    ],
+    focused_tab_index: None,
+    template: Some(
+        PaneLayout {
+            children_split_direction: Horizontal,
+            name: None,
+            children: [],
+            split_size: None,
+            run: None,
+            borderless: false,
+            focus: None,
+            external_children_index: None,
+        },
+    ),
+}

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_with_tab_cwd_given_to_panes_without_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_with_tab_cwd_given_to_panes_without_cwd.snap
@@ -1,0 +1,75 @@
+---
+source: zellij-utils/src/input/./unit/layout_test.rs
+assertion_line: 1396
+expression: "format!(\"{:#?}\", layout)"
+---
+Layout {
+    tabs: [
+        (
+            None,
+            PaneLayout {
+                children_split_direction: Horizontal,
+                name: None,
+                children: [
+                    PaneLayout {
+                        children_split_direction: Horizontal,
+                        name: None,
+                        children: [],
+                        split_size: None,
+                        run: Some(
+                            Cwd(
+                                "/tmp/./foo",
+                            ),
+                        ),
+                        borderless: false,
+                        focus: None,
+                        external_children_index: None,
+                    },
+                    PaneLayout {
+                        children_split_direction: Horizontal,
+                        name: None,
+                        children: [],
+                        split_size: None,
+                        run: Some(
+                            Command(
+                                RunCommand {
+                                    command: "tail",
+                                    args: [],
+                                    cwd: Some(
+                                        "/tmp/./foo",
+                                    ),
+                                    hold_on_close: true,
+                                },
+                            ),
+                        ),
+                        borderless: false,
+                        focus: None,
+                        external_children_index: None,
+                    },
+                ],
+                split_size: None,
+                run: Some(
+                    Cwd(
+                        "/tmp/./foo",
+                    ),
+                ),
+                borderless: false,
+                focus: None,
+                external_children_index: None,
+            },
+        ),
+    ],
+    focused_tab_index: None,
+    template: Some(
+        PaneLayout {
+            children_split_direction: Horizontal,
+            name: None,
+            children: [],
+            split_size: None,
+            run: None,
+            borderless: false,
+            focus: None,
+            external_children_index: None,
+        },
+    ),
+}

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__tab_cwd_given_to_panes_without_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__tab_cwd_given_to_panes_without_cwd.snap
@@ -1,0 +1,75 @@
+---
+source: zellij-utils/src/input/./unit/layout_test.rs
+assertion_line: 1411
+expression: "format!(\"{:#?}\", layout)"
+---
+Layout {
+    tabs: [
+        (
+            None,
+            PaneLayout {
+                children_split_direction: Horizontal,
+                name: None,
+                children: [
+                    PaneLayout {
+                        children_split_direction: Horizontal,
+                        name: None,
+                        children: [],
+                        split_size: None,
+                        run: Some(
+                            Cwd(
+                                "/tmp",
+                            ),
+                        ),
+                        borderless: false,
+                        focus: None,
+                        external_children_index: None,
+                    },
+                    PaneLayout {
+                        children_split_direction: Horizontal,
+                        name: None,
+                        children: [],
+                        split_size: None,
+                        run: Some(
+                            Command(
+                                RunCommand {
+                                    command: "tail",
+                                    args: [],
+                                    cwd: Some(
+                                        "/tmp",
+                                    ),
+                                    hold_on_close: true,
+                                },
+                            ),
+                        ),
+                        borderless: false,
+                        focus: None,
+                        external_children_index: None,
+                    },
+                ],
+                split_size: None,
+                run: Some(
+                    Cwd(
+                        "/tmp",
+                    ),
+                ),
+                borderless: false,
+                focus: None,
+                external_children_index: None,
+            },
+        ),
+    ],
+    focused_tab_index: None,
+    template: Some(
+        PaneLayout {
+            children_split_direction: Horizontal,
+            name: None,
+            children: [],
+            split_size: None,
+            run: None,
+            borderless: false,
+            focus: None,
+            external_children_index: None,
+        },
+    ),
+}

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__tab_cwd_prepended_to_panes_with_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__tab_cwd_prepended_to_panes_with_cwd.snap
@@ -1,0 +1,75 @@
+---
+source: zellij-utils/src/input/./unit/layout_test.rs
+assertion_line: 1426
+expression: "format!(\"{:#?}\", layout)"
+---
+Layout {
+    tabs: [
+        (
+            None,
+            PaneLayout {
+                children_split_direction: Horizontal,
+                name: None,
+                children: [
+                    PaneLayout {
+                        children_split_direction: Horizontal,
+                        name: None,
+                        children: [],
+                        split_size: None,
+                        run: Some(
+                            Cwd(
+                                "/tmp/./foo",
+                            ),
+                        ),
+                        borderless: false,
+                        focus: None,
+                        external_children_index: None,
+                    },
+                    PaneLayout {
+                        children_split_direction: Horizontal,
+                        name: None,
+                        children: [],
+                        split_size: None,
+                        run: Some(
+                            Command(
+                                RunCommand {
+                                    command: "tail",
+                                    args: [],
+                                    cwd: Some(
+                                        "/tmp/./foo",
+                                    ),
+                                    hold_on_close: true,
+                                },
+                            ),
+                        ),
+                        borderless: false,
+                        focus: None,
+                        external_children_index: None,
+                    },
+                ],
+                split_size: None,
+                run: Some(
+                    Cwd(
+                        "/tmp",
+                    ),
+                ),
+                borderless: false,
+                focus: None,
+                external_children_index: None,
+            },
+        ),
+    ],
+    focused_tab_index: None,
+    template: Some(
+        PaneLayout {
+            children_split_direction: Horizontal,
+            name: None,
+            children: [],
+            split_size: None,
+            run: None,
+            borderless: false,
+            focus: None,
+            external_children_index: None,
+        },
+    ),
+}


### PR DESCRIPTION
Like the global `cwd` this tab `cwd` can be placed in tabs and prepended to the cwd of the panes. If a global `cwd` exists as well, it will be chained (global `cwd` / tab `cwd` / pane `cwd`).

EDIT: Documentation added to https://github.com/zellij-org/zellij/pull/1759