### PR TITLE
plugins: Improve error handling on plugin version mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * feat: allow defining tab cwd in layouts (https://github.com/zellij-org/zellij/pull/1828)
 * debugging: Remove calls to `unwrap` from plugin WASM VM (https://github.com/zellij-org/zellij/pull/1827)
 * debugging: Improve error handling in `server/route` (https://github.com/zellij-org/zellij/pull/1808)
+* debugging: Detect plugin version mismatches (https://github.com/zellij-org/zellij/pull/1838)
 
 ## [0.31.4] - 2022-09-09
 * Terminal compatibility: improve vttest compliance (https://github.com/zellij-org/zellij/pull/1671)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3405,6 +3405,7 @@ dependencies = [
  "highway",
  "insta",
  "log",
+ "semver",
  "serde_json",
  "sixel-image",
  "sixel-tokenizer",

--- a/zellij-server/Cargo.toml
+++ b/zellij-server/Cargo.toml
@@ -31,6 +31,7 @@ sixel-tokenizer = "0.1.0"
 sixel-image = "0.1.0"
 arrayvec = "0.7.2"
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
+semver = "0.11.0"
 
 [dev-dependencies]
 insta = "1.6.0"

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -333,7 +333,11 @@ impl Pane for TerminalPane {
                 self.grid.ring_bell = false;
             }
             self.set_should_render(false);
-            Ok(Some((character_chunks, Some(raw_vte_output), sixel_image_chunks)))
+            Ok(Some((
+                character_chunks,
+                Some(raw_vte_output),
+                sixel_image_chunks,
+            )))
         } else {
             Ok(None)
         }

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -17,6 +17,7 @@ use zellij_utils::input::command::RunCommand;
 use zellij_utils::pane_size::Offset;
 use zellij_utils::{
     data::{InputMode, Palette, PaletteColor, Style},
+    errors::prelude::*,
     pane_size::SizeInPixels,
     pane_size::{Dimension, PaneGeom},
     position::Position,
@@ -272,7 +273,7 @@ impl Pane for TerminalPane {
     fn render(
         &mut self,
         _client_id: Option<ClientId>,
-    ) -> Option<(Vec<CharacterChunk>, Option<String>, Vec<SixelImageChunk>)> {
+    ) -> Result<Option<(Vec<CharacterChunk>, Option<String>, Vec<SixelImageChunk>)>> {
         if self.should_render() {
             let mut raw_vte_output = String::new();
             let content_x = self.get_content_x();
@@ -332,9 +333,9 @@ impl Pane for TerminalPane {
                 self.grid.ring_bell = false;
             }
             self.set_should_render(false);
-            Some((character_chunks, Some(raw_vte_output), sixel_image_chunks))
+            Ok(Some((character_chunks, Some(raw_vte_output), sixel_image_chunks)))
         } else {
-            None
+            Ok(None)
         }
     }
     fn render_frame(

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -142,7 +142,7 @@ pub trait Pane {
     fn render(
         &mut self,
         client_id: Option<ClientId>,
-    ) -> Option<(Vec<CharacterChunk>, Option<String>, Vec<SixelImageChunk>)>; // TODO: better
+    ) -> Result<Option<(Vec<CharacterChunk>, Option<String>, Vec<SixelImageChunk>)>>; // TODO: better
     fn render_frame(
         &mut self,
         client_id: ClientId,

--- a/zellij-server/src/ui/pane_contents_and_ui.rs
+++ b/zellij-server/src/ui/pane_contents_and_ui.rs
@@ -45,7 +45,8 @@ impl<'a> PaneContentsAndUi<'a> {
         &mut self,
         clients: impl Iterator<Item = ClientId>,
     ) {
-        if let Some((character_chunks, raw_vte_output, sixel_image_chunks)) = self.pane.render(None)
+        if let Some((character_chunks, raw_vte_output, sixel_image_chunks)) =
+            self.pane.render(None).unwrap()
         {
             let clients: Vec<ClientId> = clients.collect();
             self.output.add_character_chunks_to_multiple_clients(
@@ -73,7 +74,7 @@ impl<'a> PaneContentsAndUi<'a> {
     }
     pub fn render_pane_contents_for_client(&mut self, client_id: ClientId) {
         if let Some((character_chunks, raw_vte_output, sixel_image_chunks)) =
-            self.pane.render(Some(client_id))
+            self.pane.render(Some(client_id)).unwrap()
         {
             self.output
                 .add_character_chunks_to_client(client_id, character_chunks, self.z_index);

--- a/zellij-server/src/wasm_vm.rs
+++ b/zellij-server/src/wasm_vm.rs
@@ -497,6 +497,7 @@ pub(crate) fn zellij_exports(store: &Store, plugin_env: &PluginEnv) -> ImportObj
         host_switch_tab_to,
         host_set_timeout,
         host_exec_cmd,
+        host_report_panic,
     }
 }
 
@@ -616,6 +617,16 @@ fn host_exec_cmd(plugin_env: &PluginEnv) {
         .args(cmdline)
         .spawn()
         .unwrap();
+}
+
+// Custom panic handler for plugins.
+//
+// This is called when a panic occurs in a plugin. Since most panics will likely originate in the
+// code trying to deserialize an `Event` upon a plugin state update, we read some panic message,
+// formatted as string from the plugin.
+fn host_report_panic(plugin_env: &PluginEnv) {
+    let msg = wasi_read_string(&plugin_env.wasi_env);
+    panic!("{}", msg);
 }
 
 // Helper Functions ---------------------------------------------------------------------------------------------------

--- a/zellij-server/src/wasm_vm.rs
+++ b/zellij-server/src/wasm_vm.rs
@@ -222,7 +222,16 @@ pub(crate) fn wasm_thread_main(
                             .get_function("update")
                             .with_context(err_context)?;
                         wasi_write_object(&plugin_env.wasi_env, &event);
-                        update.call(&[]).with_context(err_context)?;
+                        update.call(&[]).or_else::<anyError, _>(|e| {
+                            match e.downcast::<serde_json::Error>() {
+                                Ok(_) => panic!("{}", 
+                                    anyError::new(VersionMismatchError::new(
+                                        VERSION,
+                                        "Unavailable",
+                                        &plugin_env.plugin.path
+                                    ))),
+                                Err(e) => Err(e).with_context(err_context)
+                            }})?;
                     }
                 }
                 drop(bus.senders.send_to_screen(ScreenInstruction::Render));

--- a/zellij-server/src/wasm_vm.rs
+++ b/zellij-server/src/wasm_vm.rs
@@ -68,7 +68,7 @@ impl fmt::Display for VersionMismatchError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "If you're seeing this error your plugin versions don't match your current
+            "If you're seeing this error the plugin versions don't match the current
 zellij version. Detected versions:
 
 - Plugin version: {}

--- a/zellij-server/src/wasm_vm.rs
+++ b/zellij-server/src/wasm_vm.rs
@@ -438,7 +438,7 @@ fn start_plugin(
     let zellij_version = Version::parse(VERSION)
         .context("failed to parse zellij version")
         .with_context(err_context)?;
-    if plugin_version < zellij_version {
+    if plugin_version != zellij_version {
         panic!(
             "{}",
             anyError::new(VersionMismatchError::new(

--- a/zellij-server/src/wasm_vm.rs
+++ b/zellij-server/src/wasm_vm.rs
@@ -224,14 +224,17 @@ pub(crate) fn wasm_thread_main(
                         wasi_write_object(&plugin_env.wasi_env, &event);
                         update.call(&[]).or_else::<anyError, _>(|e| {
                             match e.downcast::<serde_json::Error>() {
-                                Ok(_) => panic!("{}", 
+                                Ok(_) => panic!(
+                                    "{}",
                                     anyError::new(VersionMismatchError::new(
                                         VERSION,
                                         "Unavailable",
                                         &plugin_env.plugin.path
-                                    ))),
-                                Err(e) => Err(e).with_context(err_context)
-                            }})?;
+                                    ))
+                                ),
+                                Err(e) => Err(e).with_context(err_context),
+                            }
+                        })?;
                     }
                 }
                 drop(bus.senders.send_to_screen(ScreenInstruction::Render));

--- a/zellij-tile/src/lib.rs
+++ b/zellij-tile/src/lib.rs
@@ -18,6 +18,11 @@ macro_rules! register_plugin {
         }
 
         fn main() {
+            // Register custom panic handler
+            std::panic::set_hook(Box::new(|info| {
+                report_panic(info);
+            }));
+
             STATE.with(|state| {
                 state.borrow_mut().load();
             });

--- a/zellij-tile/src/lib.rs
+++ b/zellij-tile/src/lib.rs
@@ -11,7 +11,7 @@ pub trait ZellijPlugin {
 }
 
 pub const PLUGIN_MISMATCH: &str =
-"An error occured in a plugin while receiving an Event from zellij. This means
+    "An error occured in a plugin while receiving an Event from zellij. This means
 that your plugins aren't compatible with your zellij version.
 
 The most likely explanation for this is that you're running either a
@@ -48,9 +48,7 @@ macro_rules! register_plugin {
                 .unwrap();
 
             STATE.with(|state| {
-                state
-                    .borrow_mut()
-                    .update(object);
+                state.borrow_mut().update(object);
             });
         }
 
@@ -65,7 +63,5 @@ macro_rules! register_plugin {
         pub fn plugin_version() {
             println!("{}", $crate::prelude::VERSION);
         }
-
     };
 }
-

--- a/zellij-tile/src/lib.rs
+++ b/zellij-tile/src/lib.rs
@@ -12,7 +12,7 @@ pub trait ZellijPlugin {
 
 pub const PLUGIN_MISMATCH: &str =
     "An error occured in a plugin while receiving an Event from zellij. This means
-that your plugins aren't compatible with your zellij version.
+that the plugins aren't compatible with the current zellij version.
 
 The most likely explanation for this is that you're running either a
 self-compiled zellij or plugin version. Please make sure that, while developing,

--- a/zellij-tile/src/lib.rs
+++ b/zellij-tile/src/lib.rs
@@ -38,5 +38,10 @@ macro_rules! register_plugin {
                 state.borrow_mut().render(rows as usize, cols as usize);
             });
         }
+
+        #[no_mangle]
+        pub fn plugin_version() {
+            println!("{}", $crate::prelude::VERSION);
+        }
     };
 }

--- a/zellij-tile/src/lib.rs
+++ b/zellij-tile/src/lib.rs
@@ -11,8 +11,8 @@ pub trait ZellijPlugin {
 }
 
 pub const PLUGIN_MISMATCH: &str =
-"An error occured while receiving an Event from zellij. This is most likely
-caused by your plugins not matching your current zellij version.
+"An error occured in a plugin while receiving an Event from zellij. This means
+that your plugins aren't compatible with your zellij version.
 
 The most likely explanation for this is that you're running either a
 self-compiled zellij or plugin version. Please make sure that, while developing,

--- a/zellij-tile/src/prelude.rs
+++ b/zellij-tile/src/prelude.rs
@@ -1,6 +1,6 @@
 pub use crate::shim::*;
 pub use crate::*;
+pub use zellij_utils::consts::VERSION;
 pub use zellij_utils::data::*;
 pub use zellij_utils::errors::prelude::*;
 pub use zellij_utils::input::actions;
-pub use zellij_utils::consts::VERSION;

--- a/zellij-tile/src/prelude.rs
+++ b/zellij-tile/src/prelude.rs
@@ -1,5 +1,6 @@
 pub use crate::shim::*;
 pub use crate::*;
 pub use zellij_utils::data::*;
+pub use zellij_utils::errors::prelude::*;
 pub use zellij_utils::input::actions;
 pub use zellij_utils::consts::VERSION;

--- a/zellij-tile/src/prelude.rs
+++ b/zellij-tile/src/prelude.rs
@@ -2,3 +2,4 @@ pub use crate::shim::*;
 pub use crate::*;
 pub use zellij_utils::data::*;
 pub use zellij_utils::input::actions;
+pub use zellij_utils::consts::VERSION;

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -1,6 +1,7 @@
 use serde::{de::DeserializeOwned, Serialize};
 use std::{io, path::Path};
 use zellij_utils::data::*;
+use zellij_utils::errors::prelude::*;
 
 // Subscription Handling
 
@@ -60,10 +61,12 @@ pub fn report_panic(info: &std::panic::PanicInfo) {
 // Internal Functions
 
 #[doc(hidden)]
-pub fn object_from_stdin<T: DeserializeOwned>() -> Result<T, serde_json::Error> {
+pub fn object_from_stdin<T: DeserializeOwned>() -> Result<T> {
+    let err_context = || "failed to deserialize object from stdin".to_string();
+
     let mut json = String::new();
-    io::stdin().read_line(&mut json).unwrap();
-    serde_json::from_str(&json)
+    io::stdin().read_line(&mut json).with_context(err_context)?;
+    serde_json::from_str(&json).with_context(err_context)
 }
 
 #[doc(hidden)]

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -50,6 +50,13 @@ pub fn exec_cmd(cmd: &[&str]) {
     unsafe { host_exec_cmd() };
 }
 
+pub fn report_panic(info: &std::panic::PanicInfo) {
+    println!("");
+    println!("A panic occured in a plugin");
+    println!("{:#?}", info);
+    unsafe { host_report_panic() };
+}
+
 // Internal Functions
 
 #[doc(hidden)]
@@ -75,4 +82,5 @@ extern "C" {
     fn host_switch_tab_to(tab_idx: u32);
     fn host_set_timeout(secs: f64);
     fn host_exec_cmd();
+    fn host_report_panic();
 }

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -112,11 +112,7 @@ pub trait LoggableError<T>: Sized {
 impl<T> LoggableError<T> for anyhow::Result<T> {
     fn print_error<F: Fn(&str)>(self, fun: F) -> Self {
         if let Err(ref err) = self {
-            let mut msg = format!("ERROR: {}", err);
-            for cause in err.chain().skip(1) {
-                msg = format!("{msg}\nbecause: {cause}");
-            }
-            fun(&msg);
+            fun(&format!("{:?}", err));
         }
         self
     }

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -27,8 +27,8 @@ pub mod prelude {
     pub use anyhow::anyhow;
     pub use anyhow::bail;
     pub use anyhow::Context;
-    pub use anyhow::Result;
     pub use anyhow::Error as anyError;
+    pub use anyhow::Result;
 }
 
 pub trait ErrorInstruction {

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -28,6 +28,7 @@ pub mod prelude {
     pub use anyhow::bail;
     pub use anyhow::Context;
     pub use anyhow::Result;
+    pub use anyhow::Error as anyError;
 }
 
 pub trait ErrorInstruction {


### PR DESCRIPTION
This PR picks up a long-standing issue with respect to the plugin system. Since we do not make guarantees about plugin version compatibility, we always require the plugin versions to match the zellij version.


## Current situation

This is usually not an issue for people that only install zellij from official releases, because in this case zellij takes care of updating the plugins proper itself. Things start to get hairy when developing zellij, because once a user has built the plugins themselves from `main`, they will not be updated on the next release automatically.

Previously we had no mechanism to check for this: The plugins were just loaded and executed. Errors always cropped up in the plugins `update` functions, where an `Event` is deserialized from stdin on the plugin side (i.e. in the WASM sandbox/VM). At this point, the serde error is `unwrap`ped, and the plugin crashes along with the application.

Symptomatic for this sort of failure are multiple things:

1. The actual `unwrap` inside the plugin is masked by `WASM`, which is evident from the logs where messages like this would occur (Note the log level "DEBUG"):
```
DEBUG  |tab-bar                  | 2022-08-27 19:56:48.928 [id: 0     ] thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error("invalid type: sequence, expected a string", line: 1, column: 53)', default-plugins/tab-bar/src/main.rs:29:1 
```
2. The error shown on stdout contains lots of garbage:
```
called `Result::unwrap()` on an `Err` value: RuntimeError { source: Trap(UnreachableCodeReached), wasm_trace: [FrameInfo { module_name: "<module>", func_index: 196, function_name: None,
      func_start: SourceLoc(118399), instr: SourceLoc(121927) }, FrameInfo { module_name: "<module>", func_index: 97, function_name: None, func_start: SourceLoc(59952), instr: SourceLoc(60199) },
      FrameInfo { module_name: "<module>", func_index: 102, function_name: None, func_start: SourceLoc(61748), instr: SourceLoc(61869) }, FrameInfo { module_name: "<module>", func_index: 509,
      function_name: None, func_start: SourceLoc(409244), instr: SourceLoc(427678) }], native_trace:    0: <unknown>
         1: <unknown>
         2: <unknown>
         3: <unknown>
         4: <unknown>
         5: <unknown>
         6: <unknown>
       }
```
3. We have no way of handling this, because in the code WASM gives us some obscure type of `RuntimeError` without any further information.

2 above is particularly annoying because it's the only hint the user has to go on and it starts with `Trap(UnreachableCodeReached)`. Not helpful.


## Improving the situation

This PR approaches the problem in a number of ways.


### Don't mask the underlying error cause

#1827 laid the groundwork for this PR, in that it first dealt with the issue of version mismatches and reporting them. This was achieved by appending a descriptive error message before unwrapping on a failed call to `update` a plugin. Unfortunately, in the stdout that was shown to the user, this error was frequently covered by a related crash happening in the `screen` thread when trying to `render` the offending plugins pane. What happens there is that we dispatch a request to the plugin to render its output, and expect to receive a message [here][1]. However, the plugin may already have crashed at this point, closing the `mpsc::Channel` we're trying to receive from.

What we now do instead is:

- Attach a context to the `RecvError`,
- Print the error to the zellij logs, and
- show a default text "No output from plugin received. See logs" in the plugin pane

This keeps the `screen` thread from crashing and allows us to display the real error cause on stdout.


### Check zellij/plugin version compatibility

Furthermore, in order to prevent such situations from happening in the first place, we're now embedding a plugin version into the plugins at build time. As of currently, this is the zellij version (taken from `zellij_utils::consts::VERSION`), taken from the version in the `Cargo.toml`.

Since we're not making guarantees about backwards compatibility yet, the requirement is that Plugin version == Zellij version. We check the versions when starting the plugin (after loading it, but before updating it for the first time). If this check fails, we output an error such as this:

```
$ ./target/debug/zellij

Error occurred in server:

  × Thread 'wasm' panicked.
  ├─▶ Originating Thread(s)
  │   	1. ipc_server: NewClient
  │   	2. pty_thread: NewTab
  │   	3. screen_thread: NewTab
  │   	4. plugin_thread: Load
  │   
  ├─▶ At zellij-server/src/wasm_vm.rs:433:19
  ╰─▶ If you're seeing this error your plugin versions don't match your current
      zellij version. Detected versions:
      
      - Plugin version: Unavailable
      - Zellij version: 0.32.0
      - Offending plugin: tab-bar
      
      If you're a user:
          Please contact the distributor of your zellij version and report this error
          to them.
      
      If you're a developer:
          Please run zellij with the updated plugins. The easiest way to achieve this
          is to build zellij with `cargo make install`. Also refer to the docs:
          https://github.com/zellij-org/zellij/blob/main/CONTRIBUTING.md#building
      
      A possible fix for this error is to remove all contents of the 'PLUGIN DIR'
      folder from the output of the `zellij setup --check` command.
      
  help: If you are seeing this message, it means that something went wrong.
        Please report this error to the github issue.
        (https://github.com/zellij-org/zellij/issues)
        
        Also, if you want to see the backtrace, you can set the `RUST_BACKTRACE` environment variable to `1`.
```

In this case, I tried to run `zellij` compiled from main against plugins compiled on v0.31.4. Since the old plugins don't have any version information, we show the plugin version as "Unavailable".


### Catching mismatches during development

The previous method of catching errors works wonderfully for users that just update their application from release to release. However, developers compiling zellij off of main will not update the zellij application version after every compilation. This is particularly tricky, as one may spend multiple hours developing on the latest main before performing commits, so a comparison such as "zellij git-rev" == "plugin git-rev" won't do the trick either. However, every modification increases the chance of a change in the `Event` serialization structure, making the plugins incompatible.

As mentioned above, the typical symptom tor this error is that deserialization of the `Event` on the plugin fails. At this point it would have been amazing if wasmer could propagate errors from an exported WASM function called inside the plugin onto the host. The WASM docs do not talk about this at all, and it isn't considered an error when one does change the called function inside the WASM module (plugin) to return a `Result`. As far as I could gather, however, this `Result` is silently dropped.

It is stated somewhere on the wasmer GitHub that a `panic` inside a WASM module will be converted to a `RuntimeError`, and there is even a `RuntimeError::downcast`, but that also doesn't give any hints about the underlying error cause.

Instead, we're overriding the [panic hook][2] to send a message (as string) to the host. Overriding the panic hook is okay in this case, because the default wasmer panic hook in our case doesn't contribute any meaningful information (likely due to `wasm-opt` used during building). Also, sending the panic message as string is the only sensible way to go: Since a panic is likely to occur upon deserialization, we obviously cannot expect to match the hosts data types any more. Hence, serializing to some other type and deserializing on the host successfully likely isn't possible at all.

Here's the resulting error for this error case:

```
$ ./target/debug/zellij -l devel

Error occurred in server:

  × Thread 'wasm' panicked.
  ├─▶ Originating Thread(s)
  │   	1. ipc_server: NewClient
  │   	2. pty_thread: NewTab
  │   	3. screen_thread: NewTab
  │   	4. plugin_thread: Update
  │   
  ├─▶ At zellij-server/src/wasm_vm.rs:629:5
  ╰─▶ 
      An error occured while receiving an Event from zellij. This is most likely
      caused by your plugins not matching your current zellij version.
      
      The most likely explanation for this is that you're running either a
      self-compiled zellij or plugin version. Please make sure that, while developing,
      you also rebuild the plugins in order to pick up changes to the plugin code.
      
      Please refer to the documentation for further information:
          https://github.com/zellij-org/zellij/blob/main/CONTRIBUTING.md#building
      
      
      Caused by:
          0: failed to deserialize object from stdin
          1: unknown variant `Foo`, expected one of `PageDown`, `PageUp`, `Left`, `Down`, `Up`, `Right`, `Home`, `End`, `Backspace`, `Delete`, `Insert`, `F`, `Char`, `Alt`, `Ctrl`, `BackTab`,
      `Null`, `Esc` at line 1 column 3476
```

The error in this case was provoked by introducing a new key "Foo", that the plugins didn't know about. As an added bonus compared to the previous situation, we now also get to see why exactly the deserialization failed in the output of stdout (no more hiding as "DEBUG" message in the logs).


[1]: https://github.com/zellij-org/zellij/blob/788bcd6151431222325800e0a46c58384fe0bd22/zellij-server/src/panes/plugin_pane.rs#L165
[2]: https://doc.rust-lang.org/stable/std/panic/fn.set_hook.html