### PR TITLE
fix(various): minor fixes before 32

### DIFF
--- a/zellij-utils/assets/completions/comp.bash
+++ b/zellij-utils/assets/completions/comp.bash
@@ -1,4 +1,4 @@
-function zp () { zellij run --name "$*" -- bash -c "$*";} # zellij pane
-function zpf () { zellij run --name "$*" --floating -- bash -c "$*";} # zellij pane floating
-function zo () { zellij edit "$*";} # zellij open
-function zof () { zellij edit --floating "$*";} # zellij open floating
+function zr () { zellij run --name "$*" -- bash -ic "$*";}
+function zrf () { zellij run --name "$*" --floating -- bash -ic "$*";}
+function ze () { zellij edit "$*";}
+function zef () { zellij edit --floating "$*";}

--- a/zellij-utils/assets/completions/comp.fish
+++ b/zellij-utils/assets/completions/comp.fish
@@ -6,19 +6,15 @@ complete -c zellij -n "__fish_seen_subcommand_from a" -f -a "(__fish_complete_se
 complete -c zellij -n "__fish_seen_subcommand_from kill-session" -f -a "(__fish_complete_sessions)" -d "Session"
 complete -c zellij -n "__fish_seen_subcommand_from k" -f -a "(__fish_complete_sessions)" -d "Session"
 complete -c zellij -n "__fish_seen_subcommand_from setup" -l "generate-completion" -x -a "bash elvish fish zsh powershell" -d "Shell"
-function zp
-  # zellij pane
+function zr
   command zellij run --name "$argv" -- fish -c "$argv"
 end
-function zpf
-  # zellij pane floating
+function zrf
   command zellij run --name "$argv" --floating -- fish -c "$argv"
 end
-function zo
-  # zellij open
+function ze
   command zellij edit $argv
 end
-function zof
-  # zellij open floating
+function zef
   command zellij edit --floating $argv
 end

--- a/zellij-utils/assets/completions/comp.zsh
+++ b/zellij-utils/assets/completions/comp.zsh
@@ -1,4 +1,4 @@
-function zp () { zellij run --name "$*" -- zsh -c "$*";} # zellij pane
-function zpf () { zellij run --name "$*" --floating -- zsh -c "$*";} # zellij pane floating
-function zo () { zellij edit "$*";} # zellij open
-function zof () { zellij edit --floating "$*";} # zellij open floating
+function zr () { zellij run --name "$*" -- zsh -ic "$*";}
+function zrf () { zellij run --name "$*" --floating -- zsh -ic "$*";}
+function ze () { zellij edit "$*";}
+function zef () { zellij edit --floating "$*";}

--- a/zellij-utils/assets/config/default.kdl
+++ b/zellij-utils/assets/config/default.kdl
@@ -1,3 +1,4 @@
+// If you'd like to override the default keybindings completely, be sure to change "keybinds" to "keybinds clear-defaults=true"
 keybinds {
     normal {
         // uncomment this and adjust key if using copy_on_select=false

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -357,6 +357,7 @@ impl Action {
                                     src: Some(NamedSource::new(layout_path.as_path().as_os_str().to_string_lossy().to_string(), String::from(raw_layout))),
                                     offset: Some(kdl_error.span.offset()),
                                     len: Some(kdl_error.span.len()),
+                                    help_message: None,
                                 };
                                 let report: Report = kdl_error.into();
                                 format!("{:?}", report)

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -284,7 +284,7 @@ impl LayoutParts {
                 panes.insert(index, layout);
                 Ok(())
             },
-            LayoutParts::Tabs(_tabs) => Err(ConfigError::new_kdl_error(
+            LayoutParts::Tabs(_tabs) => Err(ConfigError::new_layout_kdl_error(
                 "Trying to insert a pane into a tab layout".into(),
                 0,
                 0,

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__keybinds__keybinds_test__error_received_on_unknown_input_mode.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__keybinds__keybinds_test__error_received_on_unknown_input_mode.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/keybinds_test.rs
-assertion_line: 476
+assertion_line: 529
 expression: "format!(\"{:?}\", config_error)"
 ---
-KdlError(KdlError { error_message: "Invalid mode: 'i_do_not_exist'", src: None, offset: Some(32), len: Some(14) })
+KdlError(KdlError { error_message: "Invalid mode: 'i_do_not_exist'", src: None, offset: Some(32), len: Some(14), help_message: None })

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__keybinds__keybinds_test__error_received_on_unknown_key_instruction.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__keybinds__keybinds_test__error_received_on_unknown_key_instruction.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/keybinds_test.rs
-assertion_line: 490
+assertion_line: 543
 expression: "format!(\"{:?}\", config_error)"
 ---
-KdlError(KdlError { error_message: "Unknown keybind instruction: 'i_am_not_bind_or_unbind'", src: None, offset: Some(55), len: Some(23) })
+KdlError(KdlError { error_message: "Unknown keybind instruction: 'i_am_not_bind_or_unbind'", src: None, offset: Some(55), len: Some(23), help_message: None })

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__error_on_more_than_one_focused_tab.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__error_on_more_than_one_focused_tab.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 979
+assertion_line: 1015
 expression: "format!(\"{:?}\", layout_error)"
 ---
-KdlError(KdlError { error_message: "Only one tab can be focused", src: Some(NamedSource { name: "layout_file_name", source: "<redacted>"), offset: Some(0), len: Some(98) })
+KdlError(KdlError { error_message: "Only one tab can be focused", src: Some(NamedSource { name: "layout_file_name", source: "<redacted>"), offset: Some(0), len: Some(98), help_message: Some("For more information, please see our layout guide: https://zellij.dev/documentation/creating-a-layout.html") })

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__error_on_multiple_layout_nodes_in_file.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__error_on_multiple_layout_nodes_in_file.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 879
+assertion_line: 901
 expression: "format!(\"{:?}\", layout_error)"
 ---
-KdlError(KdlError { error_message: "Only one layout node per file allowed", src: Some(NamedSource { name: "layout_file_name", source: "<redacted>"), offset: Some(0), len: Some(31) })
+KdlError(KdlError { error_message: "Only one layout node per file allowed", src: Some(NamedSource { name: "layout_file_name", source: "<redacted>"), offset: Some(0), len: Some(31), help_message: Some("For more information, please see our layout guide: https://zellij.dev/documentation/creating-a-layout.html") })

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__error_on_pane_templates_without_a_name.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__error_on_pane_templates_without_a_name.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 951
+assertion_line: 985
 expression: "format!(\"{:?}\", layout_error)"
 ---
-KdlError(KdlError { error_message: "Pane templates must have a name", src: Some(NamedSource { name: "layout_file_name", source: "<redacted>"), offset: Some(30), len: Some(96) })
+KdlError(KdlError { error_message: "Pane templates must have a name", src: Some(NamedSource { name: "layout_file_name", source: "<redacted>"), offset: Some(30), len: Some(96), help_message: Some("For more information, please see our layout guide: https://zellij.dev/documentation/creating-a-layout.html") })

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__error_on_tab_templates_without_a_name.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__error_on_tab_templates_without_a_name.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 966
+assertion_line: 1002
 expression: "format!(\"{:?}\", layout_error)"
 ---
-KdlError(KdlError { error_message: "Tab templates must have a name", src: Some(NamedSource { name: "layout_file_name", source: "<redacted>"), offset: Some(30), len: Some(95) })
+KdlError(KdlError { error_message: "Tab templates must have a name", src: Some(NamedSource { name: "layout_file_name", source: "<redacted>"), offset: Some(30), len: Some(95), help_message: Some("For more information, please see our layout guide: https://zellij.dev/documentation/creating-a-layout.html") })

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__error_on_unknown_layout_node.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__error_on_unknown_layout_node.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 892
+assertion_line: 916
 expression: "format!(\"{:?}\", layout_error)"
 ---
-KdlError(KdlError { error_message: "Unknown layout node: 'i_am_not_a_proper_node'", src: Some(NamedSource { name: "layout_file_name", source: "<redacted>"), offset: Some(47), len: Some(22) })
+KdlError(KdlError { error_message: "Unknown layout node: 'i_am_not_a_proper_node'", src: Some(NamedSource { name: "layout_file_name", source: "<redacted>"), offset: Some(47), len: Some(22), help_message: Some("For more information, please see our layout guide: https://zellij.dev/documentation/creating-a-layout.html") })

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__error_on_unknown_layout_pane_property.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__error_on_unknown_layout_pane_property.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 926
+assertion_line: 929
 expression: "format!(\"{:?}\", layout_error)"
 ---
-KdlError(KdlError { error_message: "Unknown pane property: spit_size", src: Some(NamedSource { name: "layout_file_name", source: "<redacted>"), offset: Some(35), len: Some(11) })
+KdlError(KdlError { error_message: "Unknown pane property: spit_size", src: Some(NamedSource { name: "layout_file_name", source: "<redacted>"), offset: Some(35), len: Some(11), help_message: Some("For more information, please see our layout guide: https://zellij.dev/documentation/creating-a-layout.html") })

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__error_on_unknown_layout_pane_template_property.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__error_on_unknown_layout_pane_template_property.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 939
+assertion_line: 942
 expression: "format!(\"{:?}\", layout_error)"
 ---
-KdlError(KdlError { error_message: "Unknown pane property: spit_size", src: Some(NamedSource { name: "layout_file_name", source: "<redacted>"), offset: Some(68), len: Some(11) })
+KdlError(KdlError { error_message: "Unknown pane property: spit_size", src: Some(NamedSource { name: "layout_file_name", source: "<redacted>"), offset: Some(68), len: Some(11), help_message: Some("For more information, please see our layout guide: https://zellij.dev/documentation/creating-a-layout.html") })

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__error_on_unknown_layout_tab_property.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__error_on_unknown_layout_tab_property.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 925
+assertion_line: 955
 expression: "format!(\"{:?}\", layout_error)"
 ---
-KdlError(KdlError { error_message: "Invalid tab property 'spit_size'", src: Some(NamedSource { name: "layout_file_name", source: "<redacted>"), offset: Some(30), len: Some(15) })
+KdlError(KdlError { error_message: "Invalid tab property 'spit_size'", src: Some(NamedSource { name: "layout_file_name", source: "<redacted>"), offset: Some(30), len: Some(15), help_message: Some("For more information, please see our layout guide: https://zellij.dev/documentation/creating-a-layout.html") })

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__error_on_unknown_layout_tab_template_property.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__error_on_unknown_layout_tab_template_property.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 936
+assertion_line: 968
 expression: "format!(\"{:?}\", layout_error)"
 ---
-KdlError(KdlError { error_message: "Invalid tab property 'spit_size'", src: Some(NamedSource { name: "layout_file_name", source: "<redacted>"), offset: Some(30), len: Some(48) })
+KdlError(KdlError { error_message: "Invalid tab property 'spit_size'", src: Some(NamedSource { name: "layout_file_name", source: "<redacted>"), offset: Some(30), len: Some(48), help_message: Some("For more information, please see our layout guide: https://zellij.dev/documentation/creating-a-layout.html") })

--- a/zellij-utils/src/kdl/kdl_layout_parser.rs
+++ b/zellij-utils/src/kdl/kdl_layout_parser.rs
@@ -82,13 +82,13 @@ impl<'a> KdlLayoutParser<'a> {
     }
     fn assert_legal_node_name(&self, name: &str, kdl_node: &KdlNode) -> Result<(), ConfigError> {
         if name.contains(char::is_whitespace) {
-            Err(ConfigError::new_kdl_error(
+            Err(ConfigError::new_layout_kdl_error(
                 format!("Node names ({}) cannot contain whitespace.", name),
                 kdl_node.span().offset(),
                 kdl_node.span().len(),
             ))
         } else if self.is_a_reserved_word(&name) {
-            Err(ConfigError::new_kdl_error(
+            Err(ConfigError::new_layout_kdl_error(
                 format!("Node name '{}' is a reserved word.", name),
                 kdl_node.span().offset(),
                 kdl_node.span().len(),
@@ -103,13 +103,13 @@ impl<'a> KdlLayoutParser<'a> {
         kdl_node: &KdlNode,
     ) -> Result<(), ConfigError> {
         if name.is_empty() {
-            Err(ConfigError::new_kdl_error(
+            Err(ConfigError::new_layout_kdl_error(
                 format!("Template names cannot be empty"),
                 kdl_node.span().offset(),
                 kdl_node.span().len(),
             ))
         } else if name.contains(')') || name.contains('(') {
-            Err(ConfigError::new_kdl_error(
+            Err(ConfigError::new_layout_kdl_error(
                 format!("Template names cannot contain parantheses"),
                 kdl_node.span().offset(),
                 kdl_node.span().len(),
@@ -120,7 +120,7 @@ impl<'a> KdlLayoutParser<'a> {
             .map(|first_char| first_char.is_numeric())
             .unwrap_or(false)
         {
-            Err(ConfigError::new_kdl_error(
+            Err(ConfigError::new_layout_kdl_error(
                 format!("Template names cannot start with numbers"),
                 kdl_node.span().offset(),
                 kdl_node.span().len(),
@@ -170,21 +170,21 @@ impl<'a> KdlLayoutParser<'a> {
                 .unwrap_or(false);
         let string_url =
             kdl_get_string_property_or_child_value_with_error!(plugin_block, "location").ok_or(
-                ConfigError::new_kdl_error(
+                ConfigError::new_layout_kdl_error(
                     "Plugins must have a location".into(),
                     plugin_block.span().offset(),
                     plugin_block.span().len(),
                 ),
             )?;
         let url_node = kdl_get_property_or_child!(plugin_block, "location").ok_or(
-            ConfigError::new_kdl_error(
+            ConfigError::new_layout_kdl_error(
                 "Plugins must have a location".into(),
                 plugin_block.span().offset(),
                 plugin_block.span().len(),
             ),
         )?;
         let url = Url::parse(string_url).map_err(|e| {
-            ConfigError::new_kdl_error(
+            ConfigError::new_layout_kdl_error(
                 format!("Failed to parse url: {:?}", e),
                 url_node.span().offset(),
                 url_node.span().len(),
@@ -239,7 +239,7 @@ impl<'a> KdlLayoutParser<'a> {
         let args = self.parse_args(pane_node)?;
         match (command, edit, cwd, args, is_template) {
             (None, None, Some(cwd), _, _) => Ok(Some(Run::Cwd(cwd))),
-            (None, _, _, Some(_args), false) => Err(ConfigError::new_kdl_error(
+            (None, _, _, Some(_args), false) => Err(ConfigError::new_layout_kdl_error(
                 "args can only be set if a command was specified".into(),
                 pane_node.span().offset(),
                 pane_node.span().len(),
@@ -252,7 +252,7 @@ impl<'a> KdlLayoutParser<'a> {
             }))),
             (None, Some(edit), Some(cwd), _, _) => Ok(Some(Run::EditFile(cwd.join(edit), None))),
             (None, Some(edit), None, _, _) => Ok(Some(Run::EditFile(edit, None))),
-            (Some(_command), Some(_edit), _, _, _) => Err(ConfigError::new_kdl_error(
+            (Some(_command), Some(_edit), _, _, _) => Err(ConfigError::new_layout_kdl_error(
                 "cannot have both a command and an edit instruction for the same pane".into(),
                 pane_node.span().offset(),
                 pane_node.span().len(),
@@ -273,7 +273,7 @@ impl<'a> KdlLayoutParser<'a> {
                 })
                 .unwrap_or(false);
             if has_non_cwd_run_prop {
-                return Err(ConfigError::new_kdl_error(
+                return Err(ConfigError::new_layout_kdl_error(
                     "Cannot have both a command/edit and a plugin block for a single pane".into(),
                     plugin_block.span().offset(),
                     plugin_block.span().len(),
@@ -296,7 +296,7 @@ impl<'a> KdlLayoutParser<'a> {
                 })
                 .unwrap_or(false);
             if has_non_cwd_run_prop {
-                return Err(ConfigError::new_kdl_error(
+                return Err(ConfigError::new_layout_kdl_error(
                     "Cannot have both a command/edit and a plugin block for a single pane".into(),
                     plugin_block.span().offset(),
                     plugin_block.span().len(),
@@ -430,7 +430,7 @@ impl<'a> KdlLayoutParser<'a> {
         self.assert_valid_pane_properties(kdl_node)?;
         let template_name = kdl_get_string_property_or_child_value!(kdl_node, "name")
             .map(|s| s.to_string())
-            .ok_or(ConfigError::new_kdl_error(
+            .ok_or(ConfigError::new_layout_kdl_error(
                 "Pane templates must have a name".into(),
                 kdl_node.span().offset(),
                 kdl_node.span().len(),
@@ -508,13 +508,13 @@ impl<'a> KdlLayoutParser<'a> {
                     &pane_template_kdl_node,
                 )?);
             } else if self.is_a_valid_tab_property(kdl_name!(child)) {
-                return Err(ConfigError::new_kdl_error(
+                return Err(ConfigError::new_layout_kdl_error(
                     format!("Tab property '{}' must be placed on the tab title line and not in the child braces", kdl_name!(child)),
                     child.span().offset(),
                     child.span().len()
                 ));
             } else {
-                return Err(ConfigError::new_kdl_error(
+                return Err(ConfigError::new_layout_kdl_error(
                     format!("Invalid tab property: {}", kdl_name!(child)),
                     child.span().offset(),
                     child.span().len(),
@@ -540,7 +540,7 @@ impl<'a> KdlLayoutParser<'a> {
                 let node_has_child_nodes = child.children().map(|c| !c.is_empty()).unwrap_or(false);
                 let node_has_entries = !child.entries().is_empty();
                 if node_has_child_nodes || node_has_entries {
-                    return Err(ConfigError::new_kdl_error(
+                    return Err(ConfigError::new_layout_kdl_error(
                         format!("The `children` node must be bare. All properties should be places on the node consuming this template."),
                         child.span().offset(),
                         child.span().len(),
@@ -556,7 +556,7 @@ impl<'a> KdlLayoutParser<'a> {
                     &pane_template_kdl_node,
                 )?);
             } else if !self.is_a_valid_pane_property(kdl_name!(child)) {
-                return Err(ConfigError::new_kdl_error(
+                return Err(ConfigError::new_layout_kdl_error(
                     format!("Unknown pane property: {}", kdl_name!(child)),
                     child.span().offset(),
                     child.span().len(),
@@ -606,7 +606,7 @@ impl<'a> KdlLayoutParser<'a> {
     ) -> Result<(), ConfigError> {
         let children_block_count = layout.children_block_count();
         if children_block_count != 1 {
-            return Err(ConfigError::new_kdl_error(format!("This template has {} children blocks, only 1 is allowed when used to insert child panes", children_block_count), kdl_node.span().offset(), kdl_node.span().len()));
+            return Err(ConfigError::new_layout_kdl_error(format!("This template has {} children blocks, only 1 is allowed when used to insert child panes", children_block_count), kdl_node.span().offset(), kdl_node.span().len()));
         }
         Ok(())
     }
@@ -619,7 +619,7 @@ impl<'a> KdlLayoutParser<'a> {
             {
                 Some(string_name) => {
                     if !self.is_a_valid_pane_property(string_name) {
-                        return Err(ConfigError::new_kdl_error(
+                        return Err(ConfigError::new_layout_kdl_error(
                             format!("Unknown pane property: {}", string_name),
                             entry.span().offset(),
                             entry.span().len(),
@@ -627,7 +627,7 @@ impl<'a> KdlLayoutParser<'a> {
                     }
                 },
                 None => {
-                    return Err(ConfigError::new_kdl_error(
+                    return Err(ConfigError::new_layout_kdl_error(
                         "Unknown pane property".into(),
                         entry.span().offset(),
                         entry.span().len(),
@@ -641,7 +641,7 @@ impl<'a> KdlLayoutParser<'a> {
         let all_property_names = kdl_property_names!(pane_node);
         for name in all_property_names {
             if !self.is_a_valid_tab_property(name) {
-                return Err(ConfigError::new_kdl_error(
+                return Err(ConfigError::new_layout_kdl_error(
                     format!("Invalid tab property '{}'", name),
                     pane_node.span().offset(),
                     pane_node.span().len(),
@@ -684,7 +684,7 @@ impl<'a> KdlLayoutParser<'a> {
             if has_cwd_prop {
                 offending_nodes.push("cwd");
             }
-            Err(ConfigError::new_kdl_error(
+            Err(ConfigError::new_layout_kdl_error(
                 format!(
                     "Cannot have both properties ({}) and nested children",
                     offending_nodes.join(", ")
@@ -704,7 +704,7 @@ impl<'a> KdlLayoutParser<'a> {
     ) -> Result<(), ConfigError> {
         let successfully_inserted = layout.insert_children_layout(&mut child_panes_layout)?;
         if !successfully_inserted {
-            Err(ConfigError::new_kdl_error(
+            Err(ConfigError::new_layout_kdl_error(
                 "This template does not have children".into(),
                 kdl_node.span().offset(),
                 kdl_node.span().len(),
@@ -758,7 +758,7 @@ impl<'a> KdlLayoutParser<'a> {
     fn populate_one_tab_template(&mut self, kdl_node: &KdlNode) -> Result<(), ConfigError> {
         let template_name = kdl_get_string_property_or_child_value_with_error!(kdl_node, "name")
             .map(|s| s.to_string())
-            .ok_or(ConfigError::new_kdl_error(
+            .ok_or(ConfigError::new_layout_kdl_error(
                 "Tab templates must have a name".into(),
                 kdl_node.span().offset(),
                 kdl_node.span().len(),
@@ -766,7 +766,7 @@ impl<'a> KdlLayoutParser<'a> {
         self.assert_legal_node_name(&template_name, kdl_node)?;
         self.assert_legal_template_name(&template_name, kdl_node)?;
         if self.tab_templates.contains_key(&template_name) {
-            return Err(ConfigError::new_kdl_error(
+            return Err(ConfigError::new_layout_kdl_error(
                 format!(
                     "Duplicate definition of the \"{}\" tab_template",
                     template_name
@@ -776,7 +776,7 @@ impl<'a> KdlLayoutParser<'a> {
             ));
         }
         if self.pane_templates.contains_key(&template_name) {
-            return Err(ConfigError::new_kdl_error(
+            return Err(ConfigError::new_layout_kdl_error(
                 format!("There is already a pane_template with the name \"{}\" - can't have a tab_template with the same name", template_name),
                 kdl_node.span().offset(),
                 kdl_node.span().len(),
@@ -807,7 +807,7 @@ impl<'a> KdlLayoutParser<'a> {
                         child.children().map(|c| !c.is_empty()).unwrap_or(false);
                     let node_has_entries = !child.entries().is_empty();
                     if node_has_child_nodes || node_has_entries {
-                        return Err(ConfigError::new_kdl_error(
+                        return Err(ConfigError::new_layout_kdl_error(
                             format!("The `children` node must be bare. All properties should be places on the node consuming this template."),
                             child.span().offset(),
                             child.span().len(),
@@ -823,13 +823,13 @@ impl<'a> KdlLayoutParser<'a> {
                         &pane_template_kdl_node,
                     )?);
                 } else if self.is_a_valid_tab_property(kdl_name!(child)) {
-                    return Err(ConfigError::new_kdl_error(
+                    return Err(ConfigError::new_layout_kdl_error(
                         format!("Tab property '{}' must be placed on the tab_template title line and not in the child braces", kdl_name!(child)),
                         child.span().offset(),
                         child.span().len()
                     ));
                 } else {
-                    return Err(ConfigError::new_kdl_error(
+                    return Err(ConfigError::new_layout_kdl_error(
                         format!("Invalid tab_template property: {}", kdl_name!(child)),
                         child.span().offset(),
                         child.span().len(),
@@ -867,7 +867,7 @@ impl<'a> KdlLayoutParser<'a> {
         for child in kdl_children {
             if kdl_name!(child) == "pane_template" {
                 let template_name = kdl_get_string_property_or_child_value!(child, "name").ok_or(
-                    ConfigError::new_kdl_error(
+                    ConfigError::new_layout_kdl_error(
                         "Pane templates must have a name".into(),
                         child.span().offset(),
                         child.span().len(),
@@ -876,7 +876,7 @@ impl<'a> KdlLayoutParser<'a> {
                 let mut template_children = HashSet::new();
                 self.get_pane_template_dependencies(child, &mut template_children)?;
                 if dependency_tree.contains_key(template_name) {
-                    return Err(ConfigError::new_kdl_error(
+                    return Err(ConfigError::new_layout_kdl_error(
                         format!(
                             "Duplicate definition of the \"{}\" pane_template",
                             template_name
@@ -957,7 +957,7 @@ impl<'a> KdlLayoutParser<'a> {
                 }
             }
             if candidates.is_empty() {
-                return Err(ConfigError::new_kdl_error(
+                return Err(ConfigError::new_layout_kdl_error(
                     "Circular dependency detected between pane templates.".into(),
                     kdl_layout.span().offset(),
                     kdl_layout.span().len(),
@@ -1043,7 +1043,7 @@ impl<'a> KdlLayoutParser<'a> {
         let child_name = kdl_name!(child);
         if child_name == "pane" {
             if !child_tabs.is_empty() {
-                return Err(ConfigError::new_kdl_error(
+                return Err(ConfigError::new_layout_kdl_error(
                     "Cannot have both tabs and panes in the same node".into(),
                     child.span().offset(),
                     child.span().len(),
@@ -1056,7 +1056,7 @@ impl<'a> KdlLayoutParser<'a> {
             child_panes.push(pane_node);
         } else if child_name == "tab" {
             if !child_panes.is_empty() {
-                return Err(ConfigError::new_kdl_error(
+                return Err(ConfigError::new_layout_kdl_error(
                     "Cannot have both tabs and panes in the same node".into(),
                     child.span().offset(),
                     child.span().len(),
@@ -1079,7 +1079,7 @@ impl<'a> KdlLayoutParser<'a> {
             self.tab_templates.get(child_name).cloned()
         {
             if !child_panes.is_empty() {
-                return Err(ConfigError::new_kdl_error(
+                return Err(ConfigError::new_layout_kdl_error(
                     "Cannot have both tabs and panes in the same node".into(),
                     child.span().offset(),
                     child.span().len(),
@@ -1094,7 +1094,7 @@ impl<'a> KdlLayoutParser<'a> {
             self.pane_templates.get(child_name).cloned()
         {
             if !child_tabs.is_empty() {
-                return Err(ConfigError::new_kdl_error(
+                return Err(ConfigError::new_layout_kdl_error(
                     "Cannot have both tabs and panes in the same node".into(),
                     child.span().offset(),
                     child.span().len(),
@@ -1107,7 +1107,7 @@ impl<'a> KdlLayoutParser<'a> {
             }
             child_panes.push(pane_template);
         } else if !self.is_a_reserved_word(child_name) {
-            return Err(ConfigError::new_kdl_error(
+            return Err(ConfigError::new_layout_kdl_error(
                 format!("Unknown layout node: '{}'", child_name),
                 child.span().offset(),
                 child.span().len(),
@@ -1121,7 +1121,7 @@ impl<'a> KdlLayoutParser<'a> {
             .nodes()
             .iter()
             .find(|n| kdl_name!(n) == "layout")
-            .ok_or(ConfigError::new_kdl_error(
+            .ok_or(ConfigError::new_layout_kdl_error(
                 "No layout found".into(),
                 kdl_layout.span().offset(),
                 kdl_layout.span().len(),
@@ -1133,7 +1133,7 @@ impl<'a> KdlLayoutParser<'a> {
             .count()
             > 1;
         if has_multiple_layout_nodes {
-            return Err(ConfigError::new_kdl_error(
+            return Err(ConfigError::new_layout_kdl_error(
                 "Only one layout node per file allowed".into(),
                 kdl_layout.span().offset(),
                 kdl_layout.span().len(),
@@ -1156,7 +1156,7 @@ impl<'a> KdlLayoutParser<'a> {
                 .count()
                 > 1;
             if has_more_than_one_focused_tab {
-                return Err(ConfigError::new_kdl_error(
+                return Err(ConfigError::new_layout_kdl_error(
                     "Only one tab can be focused".into(),
                     kdl_layout.span().offset(),
                     kdl_layout.span().len(),

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -1290,6 +1290,7 @@ impl Layout {
                         src: Some(NamedSource::new(file_name, String::from(raw_layout))),
                         offset: Some(kdl_error.span.offset()),
                         len: Some(kdl_error.span.len()),
+                        help_message: None,
                     };
                     ConfigError::KdlError(kdl_error)
                 },


### PR DESCRIPTION
A bunch of minor fixes before tomorrow's release:
1. Properly link to the layout documentation for layout errors instead of the general configuration documentation
2. Add a comment in the config file about `clear-defaults` for clarity
3. Add the `-i` flag to the bash / zsh aliases (thanks @raphCode !)
4. Change the aliases to be named `zr` => zellij run, `zrf` => zellij run floating, `ze` => zellij edit, `zef` => zellij edit floating.