### PR TITLE
allow terminating char to clear search term

### DIFF
--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -2607,8 +2607,8 @@ impl Tab {
 
     pub fn update_search_term(&mut self, buf: Vec<u8>, client_id: ClientId) -> Result<()> {
         if let Some(active_pane) = self.get_active_pane_or_floating_pane_mut(client_id) {
-            // It only allows printable unicode, delete and backspace keys.
-            let is_updatable = buf.iter().all(|u| matches!(u, 0x20..=0x7E | 0x08 | 0x7F));
+            // It only allows terminating char(\0), printable unicode, delete and backspace keys.
+            let is_updatable = buf.iter().all(|u| matches!(u, 0x00 | 0x20..=0x7E | 0x08 | 0x7F));
             if is_updatable {
                 let s = str::from_utf8(&buf).with_context(|| {
                     format!("failed to update search term to '{buf:?}' for client {client_id}")

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -2608,7 +2608,9 @@ impl Tab {
     pub fn update_search_term(&mut self, buf: Vec<u8>, client_id: ClientId) -> Result<()> {
         if let Some(active_pane) = self.get_active_pane_or_floating_pane_mut(client_id) {
             // It only allows terminating char(\0), printable unicode, delete and backspace keys.
-            let is_updatable = buf.iter().all(|u| matches!(u, 0x00 | 0x20..=0x7E | 0x08 | 0x7F));
+            let is_updatable = buf
+                .iter()
+                .all(|u| matches!(u, 0x00 | 0x20..=0x7E | 0x08 | 0x7F));
             if is_updatable {
                 let s = str::from_utf8(&buf).with_context(|| {
                     format!("failed to update search term to '{buf:?}' for client {client_id}")


### PR DESCRIPTION
Hi @imsnif, I found something interesting after I walked around the code base.
Because `\0` is not allowed here,
https://github.com/zellij-org/zellij/blob/5793af7655b327f6cbd6f68a26afe59e470dc366/zellij-server/src/tab/mod.rs#L2610-L2611
it wouldn't step in this branch below.
https://github.com/zellij-org/zellij/blob/5793af7655b327f6cbd6f68a26afe59e470dc366/zellij-server/src/panes/terminal_pane.rs#L653-L656
I don't know if this is on purpose or just an oversight, if this is on purpose, I will close this pr, thanks.

Related to #1817 