### PR TITLE
improve error handling in ui module

### DIFF
--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -231,10 +231,10 @@ impl Pane for PluginPane {
         _client_id: ClientId,
         frame_params: FrameParams,
         input_mode: InputMode,
-    ) -> Option<(Vec<CharacterChunk>, Option<String>)> {
+    ) -> Result<Option<(Vec<CharacterChunk>, Option<String>)>> {
         // FIXME: This is a hack that assumes all fixed-size panes are borderless. This
         // will eventually need fixing!
-        if self.frame && !(self.geom.rows.is_fixed() || self.geom.cols.is_fixed()) {
+        let res = if self.frame && !(self.geom.rows.is_fixed() || self.geom.cols.is_fixed()) {
             let pane_title = if self.pane_name.is_empty()
                 && input_mode == InputMode::RenamePane
                 && frame_params.is_main_client
@@ -251,10 +251,15 @@ impl Pane for PluginPane {
                 pane_title,
                 frame_params,
             );
-            Some(frame.render())
+            Some(
+                frame
+                    .render()
+                    .with_context(|| format!("failed to render frame form client {_client_id}"))?,
+            )
         } else {
             None
-        }
+        };
+        Ok(res)
     }
     fn render_fake_cursor(
         &mut self,

--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -254,7 +254,7 @@ impl Pane for PluginPane {
             Some(
                 frame
                     .render()
-                    .with_context(|| format!("failed to render frame form client {_client_id}"))?,
+                    .with_context(|| format!("failed to render frame for client {_client_id}"))?,
             )
         } else {
             None

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -348,6 +348,7 @@ impl Pane for TerminalPane {
         frame_params: FrameParams,
         input_mode: InputMode,
     ) -> Result<Option<(Vec<CharacterChunk>, Option<String>)>> {
+        let err_context = || format!("failed to render frame for client {client_id}");
         // TODO: remove the cursor stuff from here
         let pane_title = if self.pane_name.is_empty()
             && input_mode == InputMode::RenamePane
@@ -398,7 +399,6 @@ impl Pane for TerminalPane {
             frame.add_exit_status(exit_status.as_ref().copied());
         }
 
-        let err_context = || format!("failed to render frame for client {client_id}");
         let res = match self.frame.get(&client_id) {
             // TODO: use and_then or something?
             Some(last_frame) => {

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -347,7 +347,7 @@ impl Pane for TerminalPane {
         client_id: ClientId,
         frame_params: FrameParams,
         input_mode: InputMode,
-    ) -> Option<(Vec<CharacterChunk>, Option<String>)> {
+    ) -> Result<Option<(Vec<CharacterChunk>, Option<String>)>> {
         // TODO: remove the cursor stuff from here
         let pane_title = if self.pane_name.is_empty()
             && input_mode == InputMode::RenamePane
@@ -398,12 +398,13 @@ impl Pane for TerminalPane {
             frame.add_exit_status(exit_status.as_ref().copied());
         }
 
-        match self.frame.get(&client_id) {
+        let err_context = || format!("failed to render frame for client {client_id}");
+        let res = match self.frame.get(&client_id) {
             // TODO: use and_then or something?
             Some(last_frame) => {
                 if &frame != last_frame {
                     if !self.borderless {
-                        let frame_output = frame.render();
+                        let frame_output = frame.render().with_context(err_context)?;
                         self.frame.insert(client_id, frame);
                         Some(frame_output)
                     } else {
@@ -415,14 +416,15 @@ impl Pane for TerminalPane {
             },
             None => {
                 if !self.borderless {
-                    let frame_output = frame.render();
+                    let frame_output = frame.render().with_context(err_context)?;
                     self.frame.insert(client_id, frame);
                     Some(frame_output)
                 } else {
                     None
                 }
             },
-        }
+        };
+        Ok(res)
     }
     fn render_fake_cursor(
         &mut self,

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -380,7 +380,7 @@ impl TiledPanes {
         !self.panes.is_empty()
     }
     pub fn render(&mut self, output: &mut Output, floating_panes_are_visible: bool) -> Result<()> {
-        let err_context = || "failed to render output based on visible";
+        let err_context = || "failed to render tiled panes";
         let connected_clients: Vec<ClientId> =
             { self.connected_clients.borrow().iter().copied().collect() };
         let multiple_users_exist_in_session = { self.connected_clients_in_app.borrow().len() > 1 };
@@ -411,9 +411,8 @@ impl TiledPanes {
                         .get(client_id)
                         .unwrap_or(&self.default_mode_info)
                         .mode;
-                    let err_context = || {
-                        format!("failed to render output based on visible for client {client_id}")
-                    };
+                    let err_context =
+                        || format!("failed to render tiled panes for client {client_id}");
                     if let PaneId::Plugin(..) = kind {
                         pane_contents_and_ui
                             .render_pane_contents_for_client(*client_id)

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -452,7 +452,7 @@ impl Pty {
             .bus
             .os_input
             .as_mut()
-            .unwrap()
+            .ok_or_else(|| SpawnTerminalError::GenericSpawnError("os input is none"))?
             .spawn_terminal(terminal_action, quit_cb, self.default_editor.clone())?;
         let terminal_bytes = task::spawn({
             let err_context = || format!("failed to run async task for terminal {terminal_id}");

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -736,7 +736,7 @@ impl Screen {
         let overlay = self.overlay.clone();
         for (tab_index, tab) in &mut self.tabs {
             if tab.has_selectable_tiled_panes() {
-                let vte_overlay = overlay.generate_overlay(size);
+                let vte_overlay = overlay.generate_overlay(size).context(err_context)?;
                 tab.render(&mut output, Some(vte_overlay))
                     .context(err_context)?;
             } else {

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -148,7 +148,7 @@ pub trait Pane {
         client_id: ClientId,
         frame_params: FrameParams,
         input_mode: InputMode,
-    ) -> Option<(Vec<CharacterChunk>, Option<String>)>; // TODO: better
+    ) -> Result<Option<(Vec<CharacterChunk>, Option<String>)>>; // TODO: better
     fn render_fake_cursor(
         &mut self,
         cursor_color: PaletteColor,
@@ -1329,9 +1329,12 @@ impl Tab {
 
         self.hide_cursor_and_clear_display_as_needed(output);
         self.tiled_panes
-            .render(output, self.floating_panes.panes_are_visible());
+            .render(output, self.floating_panes.panes_are_visible())
+            .with_context(err_context)?;
         if self.floating_panes.panes_are_visible() && self.floating_panes.has_active_panes() {
-            self.floating_panes.render(output);
+            self.floating_panes
+                .render(output)
+                .with_context(err_context)?;
         }
 
         // FIXME: Once clients can be distinguished

--- a/zellij-server/src/ui/boundaries.rs
+++ b/zellij-server/src/ui/boundaries.rs
@@ -52,12 +52,17 @@ impl BoundarySymbol {
         let tc = if self.invisible {
             EMPTY_TERMINAL_CHARACTER
         } else {
-            let character = self.boundary_type.chars().next().with_context(|| {
-                format!(
-                    "failed to as terminal character for boundary type {}",
-                    self.boundary_type
-                )
-            })?;
+            let character = self
+                .boundary_type
+                .chars()
+                .next()
+                .context("no boundary symbols defined")
+                .with_context(|| {
+                    format!(
+                        "failed to convert boundary symbol {} into terminal character",
+                        self.boundary_type
+                    )
+                })?;
             TerminalCharacter {
                 character,
                 width: 1,

--- a/zellij-server/src/ui/overlay/mod.rs
+++ b/zellij-server/src/ui/overlay/mod.rs
@@ -33,7 +33,7 @@ impl Overlayable for OverlayType {
         match &self {
             OverlayType::Prompt(prompt) => prompt
                 .generate_overlay(size)
-                .context("failed to generate overlay for overlay type"),
+                .context("failed to generate VTE output from overlay type"),
         }
     }
 }
@@ -54,7 +54,7 @@ impl Overlayable for OverlayWindow {
         for overlay in &self.overlay_stack {
             let vte_output = overlay
                 .generate_overlay(size)
-                .context("failed to generate overlay for overlay window")?;
+                .context("failed to generate VTE output from overlay window")?;
             output.push_str(&vte_output);
         }
         Ok(output)
@@ -78,7 +78,7 @@ impl Overlayable for Overlay {
     fn generate_overlay(&self, size: Size) -> Result<String> {
         self.overlay_type
             .generate_overlay(size)
-            .context("failed to generate overlay for overlay")
+            .context("failed to generate VTE output from overlay")
     }
 }
 

--- a/zellij-server/src/ui/overlay/mod.rs
+++ b/zellij-server/src/ui/overlay/mod.rs
@@ -9,6 +9,7 @@
 pub mod prompt;
 
 use crate::ServerInstruction;
+use zellij_utils::errors::prelude::*;
 use zellij_utils::pane_size::Size;
 
 #[derive(Clone, Debug)]
@@ -19,7 +20,7 @@ pub struct Overlay {
 pub trait Overlayable {
     /// Generates vte_output that can be passed into
     /// the `render()` function
-    fn generate_overlay(&self, size: Size) -> String;
+    fn generate_overlay(&self, size: Size) -> Result<String>;
 }
 
 #[derive(Clone, Debug)]
@@ -28,9 +29,11 @@ pub enum OverlayType {
 }
 
 impl Overlayable for OverlayType {
-    fn generate_overlay(&self, size: Size) -> String {
+    fn generate_overlay(&self, size: Size) -> Result<String> {
         match &self {
-            OverlayType::Prompt(prompt) => prompt.generate_overlay(size),
+            OverlayType::Prompt(prompt) => prompt
+                .generate_overlay(size)
+                .context("failed to generate overlay for overlay type"),
         }
     }
 }
@@ -44,15 +47,17 @@ pub struct OverlayWindow {
 }
 
 impl Overlayable for OverlayWindow {
-    fn generate_overlay(&self, size: Size) -> String {
+    fn generate_overlay(&self, size: Size) -> Result<String> {
         let mut output = String::new();
         //let clear_display = "\u{1b}[2J";
         //output.push_str(&clear_display);
         for overlay in &self.overlay_stack {
-            let vte_output = overlay.generate_overlay(size);
+            let vte_output = overlay
+                .generate_overlay(size)
+                .context("failed to generate overlay for overlay window")?;
             output.push_str(&vte_output);
         }
-        output
+        Ok(output)
     }
 }
 
@@ -70,8 +75,10 @@ impl Overlay {
 }
 
 impl Overlayable for Overlay {
-    fn generate_overlay(&self, size: Size) -> String {
-        self.overlay_type.generate_overlay(size)
+    fn generate_overlay(&self, size: Size) -> Result<String> {
+        self.overlay_type
+            .generate_overlay(size)
+            .context("failed to generate overlay for overlay")
     }
 }
 

--- a/zellij-server/src/ui/overlay/prompt.rs
+++ b/zellij-server/src/ui/overlay/prompt.rs
@@ -2,6 +2,7 @@ use zellij_utils::pane_size::Size;
 
 use super::{Overlay, OverlayType, Overlayable};
 use crate::{ClientId, ServerInstruction};
+use zellij_utils::errors::prelude::*;
 
 use std::fmt::Write;
 
@@ -33,7 +34,7 @@ impl Prompt {
 }
 
 impl Overlayable for Prompt {
-    fn generate_overlay(&self, size: Size) -> String {
+    fn generate_overlay(&self, size: Size) -> Result<String> {
         let mut output = String::new();
         let rows = size.rows;
         let mut vte_output = self.message.clone();
@@ -46,9 +47,9 @@ impl Overlayable for Prompt {
                 x + 1,
                 h,
             )
-            .unwrap();
+            .context("failed to generate overlay for prompt")?;
         }
-        output
+        Ok(output)
     }
 }
 

--- a/zellij-server/src/ui/overlay/prompt.rs
+++ b/zellij-server/src/ui/overlay/prompt.rs
@@ -47,7 +47,7 @@ impl Overlayable for Prompt {
                 x + 1,
                 h,
             )
-            .context("failed to generate overlay for prompt")?;
+            .context("failed to generate VTE output from prompt")?;
         }
         Ok(output)
     }

--- a/zellij-server/src/ui/pane_boundaries_frame.rs
+++ b/zellij-server/src/ui/pane_boundaries_frame.rs
@@ -607,13 +607,13 @@ impl PaneFrame {
         self.render_title_middle(total_title_length)
             .map(|(middle, middle_length)| self.title_line_with_middle(middle, &middle_length))
             .or_else(|| Some(self.title_line_without_middle()))
-            .with_context(|| format!("failed to render title {}", self.title))
+            .with_context(|| format!("failed to render title '{}'", self.title))
     }
     fn render_held_undertitle(&self) -> Result<Vec<TerminalCharacter>> {
         let max_undertitle_length = self.geom.cols.saturating_sub(2); // 2 for the left and right corners
         let exit_status = self
             .exit_status
-            .with_context(|| format!("failed to render held under title {}", self.title))?; // unwrap is safe because we only call this if
+            .with_context(|| format!("failed to render command pane status '{}'", self.title))?; // unwrap is safe because we only call this if
 
         let (mut first_part, first_part_len) = self.first_held_title_part_full(exit_status);
         let mut left_boundary =
@@ -672,7 +672,7 @@ impl PaneFrame {
         Ok(res)
     }
     pub fn render(&self) -> Result<(Vec<CharacterChunk>, Option<String>)> {
-        let err_context = || "failed to render";
+        let err_context = || "failed to render pane frame";
         let mut character_chunks = vec![];
         for row in 0..self.geom.rows {
             if row == 0 {


### PR DESCRIPTION
Replacing unwrap in `ui` module with error propagation.

Related to #1753 