### PR TITLE
Display controls line of status-bar plugin if pane size=1

### DIFF
--- a/default-plugins/status-bar/src/main.rs
+++ b/default-plugins/status-bar/src/main.rs
@@ -204,7 +204,7 @@ impl ZellijPlugin for State {
         }
     }
 
-    fn render(&mut self, _rows: usize, cols: usize) {
+    fn render(&mut self, rows: usize, cols: usize) {
         let supports_arrow_fonts = !self.mode_info.capabilities.arrow_fonts;
         let separator = if supports_arrow_fonts {
             ARROW_SEPARATOR
@@ -230,7 +230,10 @@ impl ZellijPlugin for State {
                 println!("{}\u{1b}[48;5;{}m\u{1b}[0K", first_line, color);
             },
         }
-        println!("\u{1b}[m{}\u{1b}[0K", second_line);
+
+        if rows > 1 {
+            println!("\u{1b}[m{}\u{1b}[0K", second_line);
+        }
     }
 }
 


### PR DESCRIPTION
Ref https://github.com/zellij-org/zellij/issues/1864

This PR will display only the controls line of status bar plugin if its pane has `size=1` instead of tip line.

The tip line is still displayed if `size=2`.

![image](https://user-images.githubusercontent.com/773875/198583259-c82fbdf9-e80a-45ab-bfc2-193daa0359be.png)


(FYI: it's my 1st PR on a Rust project, if it miss something let me know)