### PR TITLE
errors: Don't unwrap in `server::terminal_bytes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * debugging: Remove calls to unwrap in `zellij_server::ui::*` (https://github.com/zellij-org/zellij/pull/1870)
 * debugging: Remove calls to unwrap in `zellij_server::pty_writer` (https://github.com/zellij-org/zellij/pull/1872)
 * docs(example): update the format of the themes for the example directory (https://github.com/zellij-org/zellij/pull/1877)
+* debugging: Remove calls to unwrap in `zellij_server::terminal_bytes` (https://github.com/zellij-org/zellij/pull/1876)
 
 ## [0.32.0] - 2022-10-25
 


### PR DESCRIPTION
and return `Result`s instead, where appropriate.