### PR TITLE
Fixing YAML => KDL conversion with backslash hotkey.

### DIFF
--- a/zellij-client/src/old_config_converter/old_config.rs
+++ b/zellij-client/src/old_config_converter/old_config.rs
@@ -424,7 +424,7 @@ fn keybinds_yaml_to_keybinds_kdl(keybinds_yaml: &OldKeybindsFromYaml) -> String 
                         let actions = &key_action.action;
                         let key_string: String = keys
                             .iter()
-                            .map(|k| format!("\"{}\"", k))
+                            .map(|k| if k == &OldKey::Char('\\') { format!("r\"{}\"", k)  } else { format!("\"{}\"", k) })
                             .collect::<Vec<String>>()
                             .join(" ");
                         let actions_string: String = actions


### PR DESCRIPTION
Previously if the hotkey of backslash was used the yaml => kdl conversion would create a KDL statement like so: `bind "\" {...}`. That is incorrect kdl syntax since the backslash escapes the following quote character. A way to get proper KDL is `bind r"\" {...}`. This commit changes if the old HotKey is a backslash a properly creates KDL syntax to address the backslash character.

This PR is meant to address : https://github.com/zellij-org/zellij/issues/1850