### PR TITLE
errors: Remove `log::error` in server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix: allow cli actions to be run outside of a tty environment (https://github.com/zellij-org/zellij/pull/1905)
 * Terminal compatibility: send focus in/out events to terminal panes (https://github.com/zellij-org/zellij/pull/1908)
 * fix: various bugs with no-frames and floating panes (https://github.com/zellij-org/zellij/pull/1909)
+* debugging: Improve error logging in server (https://github.com/zellij-org/zellij/pull/1881)
 
 ## [0.32.0] - 2022-10-25
 

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -573,11 +573,6 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
             },
             ServerInstruction::ActiveClients(client_id) => {
                 let client_ids = session_state.read().unwrap().client_ids();
-                log::error!(
-                    "Sending client_ids {:?} to client {}",
-                    client_ids,
-                    client_id
-                );
                 send_to_client!(
                     client_id,
                     os_input,

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -437,8 +437,9 @@ impl ServerOsApi for ServerOsInputOutput {
                 }
             },
             _ => {
-                return Err(anyhow!("failed to find terminal fd for id {id}"))
-                    .with_context(err_context);
+                Err::<(), _>(anyhow!("failed to find terminal fd for id {id}"))
+                    .with_context(err_context)
+                    .non_fatal();
             },
         }
         Ok(())

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -1,44 +1,43 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
-use std::{fs::File, io::Write};
+use crate::{panes::PaneId, ClientId};
 
-use crate::panes::PaneId;
-use zellij_utils::tempfile::tempfile;
-
-use std::env;
-use std::os::unix::io::RawFd;
-use std::os::unix::process::CommandExt;
-use std::path::PathBuf;
-use std::process::{Child, Command};
-use std::sync::{Arc, Mutex};
-
-use zellij_utils::errors::prelude::*;
-use zellij_utils::{async_std, interprocess, libc, nix, signal_hook};
-
-use async_std::fs::File as AsyncFile;
-use async_std::os::unix::io::FromRawFd;
+use async_std::{fs::File as AsyncFile, io::ReadExt, os::unix::io::FromRawFd};
 use interprocess::local_socket::LocalSocketStream;
-
-use sysinfo::{ProcessExt, ProcessRefreshKind, System, SystemExt};
-
-use nix::pty::{openpty, OpenptyResult, Winsize};
-use nix::sys::signal::{kill, Signal};
-use nix::sys::termios;
-
-use nix::unistd;
+use nix::{
+    pty::{openpty, OpenptyResult, Winsize},
+    sys::{
+        signal::{kill, Signal},
+        termios,
+    },
+    unistd,
+};
 use signal_hook::consts::*;
+use sysinfo::{ProcessExt, ProcessRefreshKind, System, SystemExt};
 use zellij_utils::{
+    async_std,
     data::Palette,
+    errors::prelude::*,
     input::command::{RunCommand, TerminalAction},
+    interprocess,
     ipc::{ClientToServerMsg, IpcReceiverWithContext, IpcSenderWithContext, ServerToClientMsg},
+    libc, nix,
     shared::default_palette,
+    signal_hook,
+    tempfile::tempfile,
 };
 
-use async_std::io::ReadExt;
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    env,
+    fs::File,
+    io::Write,
+    os::unix::{io::RawFd, process::CommandExt},
+    path::PathBuf,
+    process::{Child, Command},
+    sync::{Arc, Mutex},
+};
+
 pub use async_trait::async_trait;
-
 pub use nix::unistd::Pid;
-
-use crate::ClientId;
 
 fn set_terminal_size_using_fd(fd: RawFd, columns: u16, rows: u16) {
     // TODO: do this with the nix ioctl

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -1,27 +1,27 @@
 mod pane_resizer;
 mod tiled_pane_grid;
 
-use crate::tab::{Pane, MIN_TERMINAL_HEIGHT, MIN_TERMINAL_WIDTH};
-use tiled_pane_grid::{split, TiledPaneGrid};
-
 use crate::{
     os_input_output::ServerOsApi,
     output::Output,
     panes::{ActivePanes, PaneId},
-    ui::boundaries::Boundaries,
-    ui::pane_contents_and_ui::PaneContentsAndUi,
+    tab::{Pane, MIN_TERMINAL_HEIGHT, MIN_TERMINAL_WIDTH},
+    ui::{boundaries::Boundaries, pane_contents_and_ui::PaneContentsAndUi},
     ClientId,
 };
-use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap, HashSet};
-use std::rc::Rc;
-use std::time::Instant;
-use zellij_utils::errors::prelude::*;
+use tiled_pane_grid::{split, TiledPaneGrid};
 use zellij_utils::{
     data::{ModeInfo, Style},
-    input::command::RunCommand,
-    input::layout::SplitDirection,
+    errors::prelude::*,
+    input::{command::RunCommand, layout::SplitDirection},
     pane_size::{Offset, PaneGeom, Size, SizeInPixels, Viewport},
+};
+
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, HashMap, HashSet},
+    rc::Rc,
+    time::Instant,
 };
 
 macro_rules! resize_pty {

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -148,7 +148,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                     .with_context(err_context)?;
                                 }
                             } else {
-                                log::error!("Failed to spawn terminal: command not found");
+                                log::error!("Failed to spawn terminal: {:?}", err);
                                 pty.close_pane(PaneId::Terminal(*terminal_id))
                                     .with_context(err_context)?;
                             }

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -87,7 +87,6 @@ pub(crate) struct Pty {
 }
 
 pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
-    let err_context = || "failed in pty thread main".to_string();
     loop {
         let (event, mut err_ctx) = pty.bus.recv().expect("failed to receive event on channel");
         err_ctx.add_call(ContextType::Pty((&event).into()));
@@ -98,6 +97,9 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                 name,
                 client_or_tab_index,
             ) => {
+                let err_context =
+                    || format!("failed to spawn terminal for {:?}", client_or_tab_index);
+
                 let (hold_on_close, run_command, pane_title) = match &terminal_action {
                     Some(TerminalAction::RunCommand(run_command)) => (
                         run_command.hold_on_close,
@@ -156,6 +158,9 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                 }
             },
             PtyInstruction::OpenInPlaceEditor(temp_file, line_number, client_id) => {
+                let err_context =
+                    || format!("failed to open in-place editor for client {}", client_id);
+
                 match pty.spawn_terminal(
                     Some(TerminalAction::OpenFile(temp_file, line_number)),
                     ClientOrTabIndex::ClientId(client_id),
@@ -170,11 +175,14 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                             .with_context(err_context)?;
                     },
                     Err(e) => {
-                        log::error!("Failed to open editor: {}", e);
+                        Err::<(), _>(e).with_context(err_context).non_fatal();
                     },
                 }
             },
             PtyInstruction::SpawnTerminalVertically(terminal_action, name, client_id) => {
+                let err_context =
+                    || format!("failed to spawn terminal vertically for client {client_id}");
+
                 let (hold_on_close, run_command, pane_title) = match &terminal_action {
                     Some(TerminalAction::RunCommand(run_command)) => (
                         run_command.hold_on_close,
@@ -242,6 +250,9 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                 }
             },
             PtyInstruction::SpawnTerminalHorizontally(terminal_action, name, client_id) => {
+                let err_context =
+                    || format!("failed to spawn terminal horizontally for client {client_id}");
+
                 let (hold_on_close, run_command, pane_title) = match &terminal_action {
                     Some(TerminalAction::RunCommand(run_command)) => (
                         run_command.hold_on_close,
@@ -315,9 +326,13 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                 pty.bus
                     .senders
                     .send_to_screen(ScreenInstruction::GoToTab(tab_index, Some(client_id)))
-                    .with_context(err_context)?;
+                    .with_context(|| {
+                        format!("failed to move client {} to tab {}", client_id, tab_index)
+                    })?;
             },
             PtyInstruction::NewTab(terminal_action, tab_layout, tab_name, client_id) => {
+                let err_context = || format!("failed to open new tab for client {}", client_id);
+
                 pty.spawn_terminals_for_layout(
                     tab_layout.unwrap_or_else(|| layout.new_tab()),
                     terminal_action.clone(),
@@ -341,20 +356,26 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                 }
             },
             PtyInstruction::ClosePane(id) => {
-                pty.close_pane(id).with_context(err_context)?;
-                pty.bus
-                    .senders
-                    .send_to_server(ServerInstruction::UnblockInputThread)
-                    .with_context(err_context)?;
+                pty.close_pane(id)
+                    .and_then(|_| {
+                        pty.bus
+                            .senders
+                            .send_to_server(ServerInstruction::UnblockInputThread)
+                    })
+                    .with_context(|| format!("failed to close pane {:?}", id))?;
             },
             PtyInstruction::CloseTab(ids) => {
-                pty.close_tab(ids).with_context(err_context)?;
-                pty.bus
-                    .senders
-                    .send_to_server(ServerInstruction::UnblockInputThread)
-                    .with_context(err_context)?;
+                pty.close_tab(ids)
+                    .and_then(|_| {
+                        pty.bus
+                            .senders
+                            .send_to_server(ServerInstruction::UnblockInputThread)
+                    })
+                    .context("failed to close tabs")?;
             },
             PtyInstruction::ReRunCommandInPane(pane_id, run_command) => {
+                let err_context = || format!("failed to rerun command in pane {:?}", pane_id);
+
                 match pty
                     .rerun_command_in_pane(pane_id, run_command.clone())
                     .with_context(err_context)
@@ -585,9 +606,7 @@ impl Pty {
                                                             // stripped later
                                 ));
                             },
-                            Err(e) => {
-                                log::error!("Failed to spawn terminal: {}", e);
-                            },
+                            Err(e) => Err::<(), _>(e).with_context(err_context).non_fatal(),
                         }
                     } else {
                         match self

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -795,14 +795,15 @@ pub(crate) fn route_thread_main(
                 }
             },
             None => {
-                log::error!("Received empty message from client");
                 let _ = os_input.send_to_client(
                     client_id,
                     ServerToClientMsg::Exit(ExitReason::Error(
                         "Received empty message".to_string(),
                     )),
                 );
-                break;
+
+                return Err(anyhow!("received empty message from client"))
+                    .with_context(err_context);
             },
         }
     }

--- a/zellij-server/src/wasm_vm.rs
+++ b/zellij-server/src/wasm_vm.rs
@@ -149,7 +149,9 @@ pub(crate) fn wasm_thread_main(
     let plugin_global_data_dir = plugin_dir.join("data");
 
     #[cfg(not(feature = "disable_automatic_asset_installation"))]
-    fs::create_dir_all(&plugin_global_data_dir).unwrap_or_else(|e| log::error!("{:?}", e));
+    fs::create_dir_all(&plugin_global_data_dir)
+        .context("failed to create plugin asset directory")
+        .non_fatal();
 
     loop {
         let (event, mut err_ctx) = bus.recv().expect("failed to receive event on channel");


### PR DESCRIPTION
and replace it with variations of `Err....non_fatal()` to preserve more information in the error log messages.