### PR TITLE
fix: resolve setup --clean panic

### DIFF
--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -48,15 +48,6 @@ pub struct CliArgs {
     pub debug: bool,
 }
 
-impl CliArgs {
-    pub fn should_clean_config(&self) -> bool {
-        match &self.command {
-            Some(Command::Setup(ref setup)) => setup.clean,
-            _ => false,
-        }
-    }
-}
-
 #[derive(Debug, Subcommand, Clone, Serialize, Deserialize)]
 pub enum Command {
     /// Change the behaviour of zellij

--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -211,14 +211,9 @@ impl Setup {
     ///    (`layout.yaml` / `zellij --layout`)
     /// 3. config options (`config.yaml`)
     pub fn from_cli_args(cli_args: &CliArgs) -> Result<(Config, Layout, Options), ConfigError> {
-        let clean = cli_args.should_clean_config();
         // note that this can potentially exit the process
         Setup::handle_setup_commands(cli_args);
-        let config = if clean {
-            Config::default()
-        } else {
-            Config::try_from(cli_args)?
-        };
+        let config = Config::try_from(cli_args)?;
         let cli_config_options: Option<Options> =
             if let Some(Command::Options(options)) = cli_args.command.clone() {
                 Some(options.into())


### PR DESCRIPTION
fix #1854

Do not use Config::default(), since default() has empty plugins config and that does not work with the default layout.
Use Config::try_from() instead, since it already handles the clean flag.
Also, do not check the clean flag twice.