### PR TITLE
feature(mouse): allow toggling mouse mode at runtime

### DIFF
--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -14,6 +14,7 @@ use std::path::Path;
 use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::thread;
+use zellij_utils::errors::FatalError;
 
 use crate::stdin_ansi_parser::{AnsiStdinInstruction, StdinAnsiParser};
 use crate::{
@@ -324,7 +325,7 @@ pub fn start_client(
         os_input.unset_raw_mode(0).unwrap();
         let goto_start_of_last_line = format!("\u{1b}[{};{}H", full_screen_ws.rows, 1);
         let restore_snapshot = "\u{1b}[?1049l";
-        os_input.disable_mouse();
+        os_input.disable_mouse().non_fatal();
         let error = format!(
             "{}\n{}{}\n",
             restore_snapshot, goto_start_of_last_line, backtrace
@@ -389,7 +390,7 @@ pub fn start_client(
         goto_start_of_last_line, restore_snapshot, reset_style, show_cursor, exit_msg
     );
 
-    os_input.disable_mouse();
+    os_input.disable_mouse().non_fatal();
     info!("{}", exit_msg);
     os_input.unset_raw_mode(0).unwrap();
     let mut stdout = os_input.get_stdout_writer();

--- a/zellij-client/src/unit/stdin_tests.rs
+++ b/zellij-client/src/unit/stdin_tests.rs
@@ -1,6 +1,7 @@
 use super::input_loop;
 use crate::stdin_ansi_parser::StdinAnsiParser;
 use crate::stdin_loop;
+use zellij_utils::anyhow::Result;
 use zellij_utils::data::{InputMode, Palette};
 use zellij_utils::input::actions::{Action, Direction};
 use zellij_utils::input::config::Config;
@@ -181,8 +182,12 @@ impl ClientOsApi for FakeClientOsApi {
     fn load_palette(&self) -> Palette {
         unimplemented!()
     }
-    fn enable_mouse(&self) {}
-    fn disable_mouse(&self) {}
+    fn enable_mouse(&self) -> Result<()> {
+        Ok(())
+    }
+    fn disable_mouse(&self) -> Result<()> {
+        Ok(())
+    }
     fn stdin_poller(&self) -> StdinPoller {
         unimplemented!()
     }

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -611,6 +611,7 @@ pub(crate) fn route_action(
                 .send_to_screen(instruction)
                 .with_context(err_context)?;
         },
+        Action::ToggleMouseMode => {}, // Handled client side
     }
     Ok(should_break)
 }

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -224,6 +224,7 @@ pub enum Action {
     Search(SearchDirection),
     /// Toggle case sensitivity of search
     SearchToggleOption(SearchOption),
+    ToggleMouseMode,
 }
 
 impl Action {

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -65,6 +65,7 @@ macro_rules! parse_kdl_action_arguments {
                 "Copy" => Ok(Action::Copy),
                 "Confirm" => Ok(Action::Confirm),
                 "Deny" => Ok(Action::Deny),
+                "ToggleMouseMode" => Ok(Action::ToggleMouseMode),
                 _ => Err(ConfigError::new_kdl_error(
                     format!("Unsupported action: {:?}", $action_name),
                     $action_node.span().offset(),
@@ -651,6 +652,9 @@ impl TryFrom<&KdlNode> for Action {
             "CloseTab" => parse_kdl_action_arguments!(action_name, action_arguments, kdl_action),
             "ToggleTab" => parse_kdl_action_arguments!(action_name, action_arguments, kdl_action),
             "UndoRenameTab" => {
+                parse_kdl_action_arguments!(action_name, action_arguments, kdl_action)
+            },
+            "ToggleMouseMode" => {
                 parse_kdl_action_arguments!(action_name, action_arguments, kdl_action)
             },
             "Detach" => parse_kdl_action_arguments!(action_name, action_arguments, kdl_action),


### PR DESCRIPTION
Partially address #1712

Add the ability to toggle mouse mode on/off at runtime via keybindings.

For the time being it does not work with `zellij action` since actions get sent to the server only, while in this case it is handled client side.

This does not implement any ui indicator for mouse mode as suggested in the issue, but all of the terminal emulators I tested this on change their mouse cursor when mouse mode gets toggled, so I think it's already pretty clear.