### PR TITLE
fix(keybinds): remove space key from shared_except

### DIFF
--- a/zellij-utils/assets/config/default.kdl
+++ b/zellij-utils/assets/config/default.kdl
@@ -139,7 +139,7 @@ keybinds {
         bind "Alt -" { Resize "Decrease"; }
     }
     shared_except "normal" "locked" {
-        bind "Enter" "Space" "Esc" { SwitchToMode "Normal"; }
+        bind "Enter" "Esc" { SwitchToMode "Normal"; }
     }
     shared_except "pane" "locked" {
         bind "Ctrl p" { SwitchToMode "Pane"; }

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/setup.rs
-assertion_line: 503
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -209,13 +208,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -469,13 +461,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -794,13 +779,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -1161,13 +1139,6 @@ Config {
                 ),
             ],
             Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
                 'd',
             ): [
                 HalfPageScrollDown,
@@ -1412,13 +1383,6 @@ Config {
                     Search,
                 ),
             ],
-            Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
             Alt(
                 Char(
                     '+',
@@ -1623,13 +1587,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -1895,13 +1852,6 @@ Config {
                     Normal,
                 ),
             ],
-            Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
             Alt(
                 Char(
                     '+',
@@ -2094,13 +2044,6 @@ Config {
                     Normal,
                 ),
             ],
-            Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
             Alt(
                 Char(
                     '+',
@@ -2288,13 +2231,6 @@ Config {
         Session: {
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -2512,13 +2448,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -2756,13 +2685,6 @@ Config {
                     Normal,
                 ),
             ],
-            Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
             Alt(
                 Char(
                     '+',
@@ -2974,13 +2896,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/setup.rs
-assertion_line: 561
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -209,13 +208,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -469,13 +461,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -794,13 +779,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -1161,13 +1139,6 @@ Config {
                 ),
             ],
             Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
                 'd',
             ): [
                 HalfPageScrollDown,
@@ -1412,13 +1383,6 @@ Config {
                     Search,
                 ),
             ],
-            Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
             Alt(
                 Char(
                     '+',
@@ -1623,13 +1587,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -1895,13 +1852,6 @@ Config {
                     Normal,
                 ),
             ],
-            Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
             Alt(
                 Char(
                     '+',
@@ -2094,13 +2044,6 @@ Config {
                     Normal,
                 ),
             ],
-            Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
             Alt(
                 Char(
                     '+',
@@ -2288,13 +2231,6 @@ Config {
         Session: {
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -2512,13 +2448,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -2756,13 +2685,6 @@ Config {
                     Normal,
                 ),
             ],
-            Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
             Alt(
                 Char(
                     '+',
@@ -2974,13 +2896,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_plugins_override_config_plugins.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_plugins_override_config_plugins.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/setup.rs
-assertion_line: 589
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -209,13 +208,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -469,13 +461,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -794,13 +779,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -1161,13 +1139,6 @@ Config {
                 ),
             ],
             Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
                 'd',
             ): [
                 HalfPageScrollDown,
@@ -1412,13 +1383,6 @@ Config {
                     Search,
                 ),
             ],
-            Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
             Alt(
                 Char(
                     '+',
@@ -1623,13 +1587,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -1895,13 +1852,6 @@ Config {
                     Normal,
                 ),
             ],
-            Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
             Alt(
                 Char(
                     '+',
@@ -2094,13 +2044,6 @@ Config {
                     Normal,
                 ),
             ],
-            Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
             Alt(
                 Char(
                     '+',
@@ -2288,13 +2231,6 @@ Config {
         Session: {
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -2512,13 +2448,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -2756,13 +2685,6 @@ Config {
                     Normal,
                 ),
             ],
-            Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
             Alt(
                 Char(
                     '+',
@@ -2974,13 +2896,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/setup.rs
-assertion_line: 603
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -209,13 +208,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -469,13 +461,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -794,13 +779,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -1161,13 +1139,6 @@ Config {
                 ),
             ],
             Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
                 'd',
             ): [
                 HalfPageScrollDown,
@@ -1412,13 +1383,6 @@ Config {
                     Search,
                 ),
             ],
-            Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
             Alt(
                 Char(
                     '+',
@@ -1623,13 +1587,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -1895,13 +1852,6 @@ Config {
                     Normal,
                 ),
             ],
-            Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
             Alt(
                 Char(
                     '+',
@@ -2094,13 +2044,6 @@ Config {
                     Normal,
                 ),
             ],
-            Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
             Alt(
                 Char(
                     '+',
@@ -2288,13 +2231,6 @@ Config {
         Session: {
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -2512,13 +2448,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -2756,13 +2685,6 @@ Config {
                     Normal,
                 ),
             ],
-            Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
             Alt(
                 Char(
                     '+',
@@ -2974,13 +2896,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/setup.rs
-assertion_line: 575
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -209,13 +208,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -469,13 +461,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -794,13 +779,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -1161,13 +1139,6 @@ Config {
                 ),
             ],
             Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
                 'd',
             ): [
                 HalfPageScrollDown,
@@ -1412,13 +1383,6 @@ Config {
                     Search,
                 ),
             ],
-            Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
             Alt(
                 Char(
                     '+',
@@ -1623,13 +1587,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -1895,13 +1852,6 @@ Config {
                     Normal,
                 ),
             ],
-            Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
             Alt(
                 Char(
                     '+',
@@ -2094,13 +2044,6 @@ Config {
                     Normal,
                 ),
             ],
-            Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
             Alt(
                 Char(
                     '+',
@@ -2288,13 +2231,6 @@ Config {
         Session: {
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -2512,13 +2448,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,
@@ -2756,13 +2685,6 @@ Config {
                     Normal,
                 ),
             ],
-            Char(
-                ' ',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
             Alt(
                 Char(
                     '+',
@@ -2974,13 +2896,6 @@ Config {
             ],
             Char(
                 '\n',
-            ): [
-                SwitchToMode(
-                    Normal,
-                ),
-            ],
-            Char(
-                ' ',
             ): [
                 SwitchToMode(
                     Normal,


### PR DESCRIPTION
fix #1862 

In Rename mode, the space key is registered in the shared except, so it seems to be a problem that the key cannot be used.

@imsnif `shared_except` seems to be a new feature during kdl conversion.
Is this the correct solution? Or should I see this as an unintended bug?