### PR TITLE
errors: Don't unwrap in `server::os_input_output`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * feat: allow toggling mouse mode at runtime (https://github.com/zellij-org/zellij/pull/1883)
 * fix: display status bar properly if limited to only 1 line (https://github.com/zellij-org/zellij/pull/1875)
 * feat: allow starting command panes suspended (https://github.com/zellij-org/zellij/pull/1887)
+* debugging: Remove calls to unwrap in `zellij_server::os_input_output` (https://github.com/zellij-org/zellij/pull/1895)
 
 ## [0.32.0] - 2022-10-25
 

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -135,7 +135,7 @@ impl Drop for SessionMetaData {
 
 macro_rules! remove_client {
     ($client_id:expr, $os_input:expr, $session_state:expr) => {
-        $os_input.remove_client($client_id);
+        $os_input.remove_client($client_id).unwrap();
         $session_state.write().unwrap().remove_client($client_id);
     };
 }
@@ -260,7 +260,7 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                         Ok(stream) => {
                             let mut os_input = os_input.clone();
                             let client_id = session_state.write().unwrap().new_client();
-                            let receiver = os_input.new_client(client_id, stream);
+                            let receiver = os_input.new_client(client_id, stream).unwrap();
                             let session_data = session_data.clone();
                             let session_state = session_state.clone();
                             let to_server = to_server.clone();

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -31,7 +31,9 @@ macro_rules! resize_pty {
                 *pid,
                 $pane.get_content_columns() as u16,
                 $pane.get_content_rows() as u16,
-            );
+            )
+        } else {
+            Ok(())
         }
     };
 }
@@ -233,7 +235,7 @@ impl FloatingPanes {
             } else {
                 pane.set_content_offset(Offset::default());
             }
-            resize_pty!(pane, os_api);
+            resize_pty!(pane, os_api).unwrap();
         }
     }
     pub fn render(&mut self, output: &mut Output) -> Result<()> {
@@ -313,7 +315,7 @@ impl FloatingPanes {
     }
     pub fn resize_pty_all_panes(&mut self, os_api: &mut Box<dyn ServerOsApi>) {
         for pane in self.panes.values_mut() {
-            resize_pty!(pane, os_api);
+            resize_pty!(pane, os_api).unwrap();
         }
     }
     pub fn resize_active_pane_left(
@@ -333,7 +335,7 @@ impl FloatingPanes {
             );
             floating_pane_grid.resize_pane_left(active_floating_pane_id);
             for pane in self.panes.values_mut() {
-                resize_pty!(pane, os_api);
+                resize_pty!(pane, os_api).unwrap();
             }
             self.set_force_render();
             return true;
@@ -357,7 +359,7 @@ impl FloatingPanes {
             );
             floating_pane_grid.resize_pane_right(active_floating_pane_id);
             for pane in self.panes.values_mut() {
-                resize_pty!(pane, os_api);
+                resize_pty!(pane, os_api).unwrap();
             }
             self.set_force_render();
             return true;
@@ -381,7 +383,7 @@ impl FloatingPanes {
             );
             floating_pane_grid.resize_pane_down(active_floating_pane_id);
             for pane in self.panes.values_mut() {
-                resize_pty!(pane, os_api);
+                resize_pty!(pane, os_api).unwrap();
             }
             self.set_force_render();
             return true;
@@ -405,7 +407,7 @@ impl FloatingPanes {
             );
             floating_pane_grid.resize_pane_up(active_floating_pane_id);
             for pane in self.panes.values_mut() {
-                resize_pty!(pane, os_api);
+                resize_pty!(pane, os_api).unwrap();
             }
             self.set_force_render();
             return true;
@@ -429,7 +431,7 @@ impl FloatingPanes {
             );
             floating_pane_grid.resize_increase(active_floating_pane_id);
             for pane in self.panes.values_mut() {
-                resize_pty!(pane, os_api);
+                resize_pty!(pane, os_api).unwrap();
             }
             self.set_force_render();
             return true;
@@ -453,7 +455,7 @@ impl FloatingPanes {
             );
             floating_pane_grid.resize_decrease(active_floating_pane_id);
             for pane in self.panes.values_mut() {
-                resize_pty!(pane, os_api);
+                resize_pty!(pane, os_api).unwrap();
             }
             self.set_force_render();
             return true;

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -29,7 +29,9 @@ macro_rules! resize_pty {
                 *pid,
                 $pane.get_content_columns() as u16,
                 $pane.get_content_rows() as u16,
-            );
+            )
+        } else {
+            Ok(())
         }
     };
 }
@@ -263,7 +265,7 @@ impl TiledPanes {
                 pane.set_content_offset(Offset::shift(pane_rows_offset, pane_columns_offset));
             }
 
-            resize_pty!(pane, self.os_api);
+            resize_pty!(pane, self.os_api).unwrap();
         }
     }
     pub fn can_split_pane_horizontally(&mut self, client_id: ClientId) -> bool {
@@ -507,7 +509,7 @@ impl TiledPanes {
             );
             pane_grid.resize_pane_left(&active_pane_id);
             for pane in self.panes.values_mut() {
-                resize_pty!(pane, self.os_api);
+                resize_pty!(pane, self.os_api).unwrap();
             }
         }
     }
@@ -521,7 +523,7 @@ impl TiledPanes {
             );
             pane_grid.resize_pane_right(&active_pane_id);
             for pane in self.panes.values_mut() {
-                resize_pty!(pane, self.os_api);
+                resize_pty!(pane, self.os_api).unwrap();
             }
         }
     }
@@ -535,7 +537,7 @@ impl TiledPanes {
             );
             pane_grid.resize_pane_up(&active_pane_id);
             for pane in self.panes.values_mut() {
-                resize_pty!(pane, self.os_api);
+                resize_pty!(pane, self.os_api).unwrap();
             }
         }
     }
@@ -549,7 +551,7 @@ impl TiledPanes {
             );
             pane_grid.resize_pane_down(&active_pane_id);
             for pane in self.panes.values_mut() {
-                resize_pty!(pane, self.os_api);
+                resize_pty!(pane, self.os_api).unwrap();
             }
         }
     }
@@ -563,7 +565,7 @@ impl TiledPanes {
             );
             pane_grid.resize_increase(&active_pane_id);
             for pane in self.panes.values_mut() {
-                resize_pty!(pane, self.os_api);
+                resize_pty!(pane, self.os_api).unwrap();
             }
         }
     }
@@ -577,7 +579,7 @@ impl TiledPanes {
             );
             pane_grid.resize_decrease(&active_pane_id);
             for pane in self.panes.values_mut() {
-                resize_pty!(pane, self.os_api);
+                resize_pty!(pane, self.os_api).unwrap();
             }
         }
     }
@@ -808,7 +810,7 @@ impl TiledPanes {
         if let Some(geom) = prev_geom_override {
             new_position.set_geom_override(geom);
         }
-        resize_pty!(new_position, self.os_api);
+        resize_pty!(new_position, self.os_api).unwrap();
         new_position.set_should_render(true);
 
         let current_position = self.panes.get_mut(&active_pane_id).unwrap();
@@ -816,7 +818,7 @@ impl TiledPanes {
         if let Some(geom) = next_geom_override {
             current_position.set_geom_override(geom);
         }
-        resize_pty!(current_position, self.os_api);
+        resize_pty!(current_position, self.os_api).unwrap();
         current_position.set_should_render(true);
     }
     pub fn move_active_pane_down(&mut self, client_id: ClientId) {
@@ -841,7 +843,7 @@ impl TiledPanes {
                 if let Some(geom) = prev_geom_override {
                     new_position.set_geom_override(geom);
                 }
-                resize_pty!(new_position, self.os_api);
+                resize_pty!(new_position, self.os_api).unwrap();
                 new_position.set_should_render(true);
 
                 let current_position = self.panes.get_mut(active_pane_id).unwrap();
@@ -849,7 +851,7 @@ impl TiledPanes {
                 if let Some(geom) = next_geom_override {
                     current_position.set_geom_override(geom);
                 }
-                resize_pty!(current_position, self.os_api);
+                resize_pty!(current_position, self.os_api).unwrap();
                 current_position.set_should_render(true);
             }
         }
@@ -876,7 +878,7 @@ impl TiledPanes {
                 if let Some(geom) = prev_geom_override {
                     new_position.set_geom_override(geom);
                 }
-                resize_pty!(new_position, self.os_api);
+                resize_pty!(new_position, self.os_api).unwrap();
                 new_position.set_should_render(true);
 
                 let current_position = self.panes.get_mut(active_pane_id).unwrap();
@@ -884,7 +886,7 @@ impl TiledPanes {
                 if let Some(geom) = next_geom_override {
                     current_position.set_geom_override(geom);
                 }
-                resize_pty!(current_position, self.os_api);
+                resize_pty!(current_position, self.os_api).unwrap();
                 current_position.set_should_render(true);
             }
         }
@@ -911,7 +913,7 @@ impl TiledPanes {
                 if let Some(geom) = prev_geom_override {
                     new_position.set_geom_override(geom);
                 }
-                resize_pty!(new_position, self.os_api);
+                resize_pty!(new_position, self.os_api).unwrap();
                 new_position.set_should_render(true);
 
                 let current_position = self.panes.get_mut(active_pane_id).unwrap();
@@ -919,7 +921,7 @@ impl TiledPanes {
                 if let Some(geom) = next_geom_override {
                     current_position.set_geom_override(geom);
                 }
-                resize_pty!(current_position, self.os_api);
+                resize_pty!(current_position, self.os_api).unwrap();
                 current_position.set_should_render(true);
             }
         }
@@ -946,7 +948,7 @@ impl TiledPanes {
                 if let Some(geom) = prev_geom_override {
                     new_position.set_geom_override(geom);
                 }
-                resize_pty!(new_position, self.os_api);
+                resize_pty!(new_position, self.os_api).unwrap();
                 new_position.set_should_render(true);
 
                 let current_position = self.panes.get_mut(active_pane_id).unwrap();
@@ -954,7 +956,7 @@ impl TiledPanes {
                 if let Some(geom) = next_geom_override {
                     current_position.set_geom_override(geom);
                 }
-                resize_pty!(current_position, self.os_api);
+                resize_pty!(current_position, self.os_api).unwrap();
                 current_position.set_should_render(true);
             }
         }

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -1,4 +1,3 @@
-use crate::os_input_output::SpawnTerminalError;
 use crate::terminal_bytes::TerminalBytes;
 use crate::{
     panes::PaneId,
@@ -107,7 +106,10 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                     ),
                     _ => (false, None, name),
                 };
-                match pty.spawn_terminal(terminal_action, client_or_tab_index) {
+                match pty
+                    .spawn_terminal(terminal_action, client_or_tab_index)
+                    .with_context(err_context)
+                {
                     Ok((pid, starts_held)) => {
                         let hold_for_command = if starts_held { run_command } else { None };
                         pty.bus
@@ -121,35 +123,33 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                             ))
                             .with_context(err_context)?;
                     },
-                    Err(SpawnTerminalError::CommandNotFound(pid)) => {
-                        if hold_on_close {
-                            let hold_for_command = None; // we do not hold an "error" pane
-                            pty.bus
-                                .senders
-                                .send_to_screen(ScreenInstruction::NewPane(
-                                    PaneId::Terminal(pid),
-                                    pane_title,
-                                    should_float,
-                                    hold_for_command,
-                                    client_or_tab_index,
-                                ))
-                                .with_context(err_context)?;
-                            if let Some(run_command) = run_command {
-                                send_command_not_found_to_screen(
-                                    pty.bus.senders.clone(),
-                                    pid,
-                                    run_command.clone(),
-                                )
-                                .with_context(err_context)?;
+                    Err(err) => match err.downcast_ref::<ZellijError>() {
+                        Some(ZellijError::CommandNotFound { terminal_id, .. }) => {
+                            if hold_on_close {
+                                pty.bus
+                                    .senders
+                                    .send_to_screen(ScreenInstruction::NewPane(
+                                        PaneId::Terminal(*terminal_id),
+                                        pane_title,
+                                        should_float,
+                                        client_or_tab_index,
+                                    ))
+                                    .with_context(err_context)?;
+                                if let Some(run_command) = run_command {
+                                    send_command_not_found_to_screen(
+                                        pty.bus.senders.clone(),
+                                        *terminal_id,
+                                        run_command.clone(),
+                                    )
+                                    .with_context(err_context)?;
+                                }
+                            } else {
+                                log::error!("Failed to spawn terminal: command not found");
+                                pty.close_pane(PaneId::Terminal(*terminal_id))
+                                    .with_context(err_context)?;
                             }
-                        } else {
-                            log::error!("Failed to spawn terminal: command not found");
-                            pty.close_pane(PaneId::Terminal(pid))
-                                .with_context(err_context)?;
-                        }
-                    },
-                    Err(e) => {
-                        log::error!("Failed to spawn terminal: {}", e);
+                        },
+                        _ => Err::<(), _>(err).non_fatal(),
                     },
                 }
             },
@@ -181,7 +181,10 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                     ),
                     _ => (false, None, name),
                 };
-                match pty.spawn_terminal(terminal_action, ClientOrTabIndex::ClientId(client_id)) {
+                match pty
+                    .spawn_terminal(terminal_action, ClientOrTabIndex::ClientId(client_id))
+                    .with_context(err_context)
+                {
                     Ok((pid, starts_held)) => {
                         let hold_for_command = if starts_held { run_command } else { None };
                         pty.bus
@@ -194,45 +197,43 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                             ))
                             .with_context(err_context)?;
                     },
-                    Err(SpawnTerminalError::CommandNotFound(pid)) => {
-                        if hold_on_close {
-                            let hold_for_command = None; // error panes are never held
-                            pty.bus
-                                .senders
-                                .send_to_screen(ScreenInstruction::VerticalSplit(
-                                    PaneId::Terminal(pid),
-                                    pane_title,
-                                    hold_for_command,
-                                    client_id,
-                                ))
-                                .with_context(err_context)?;
-                            if let Some(run_command) = run_command {
+                    Err(err) => match err.downcast_ref::<ZellijError>() {
+                        Some(ZellijError::CommandNotFound { terminal_id, .. }) => {
+                            if hold_on_close {
                                 pty.bus
                                     .senders
-                                    .send_to_screen(ScreenInstruction::PtyBytes(
-                                        pid,
-                                        format!(
-                                            "Command not found: {}",
-                                            run_command.command.display()
-                                        )
-                                        .as_bytes()
-                                        .to_vec(),
+                                    .send_to_screen(ScreenInstruction::VerticalSplit(
+                                        PaneId::Terminal(*terminal_id),
+                                        pane_title,
+                                        client_id,
                                     ))
                                     .with_context(err_context)?;
-                                pty.bus
-                                    .senders
-                                    .send_to_screen(ScreenInstruction::HoldPane(
-                                        PaneId::Terminal(pid),
-                                        Some(2), // exit status
-                                        run_command,
-                                        None,
-                                    ))
-                                    .with_context(err_context)?;
+                                if let Some(run_command) = run_command {
+                                    pty.bus
+                                        .senders
+                                        .send_to_screen(ScreenInstruction::PtyBytes(
+                                            *terminal_id,
+                                            format!(
+                                                "Command not found: {}",
+                                                run_command.command.display()
+                                            )
+                                            .as_bytes()
+                                            .to_vec(),
+                                        ))
+                                        .with_context(err_context)?;
+                                    pty.bus
+                                        .senders
+                                        .send_to_screen(ScreenInstruction::HoldPane(
+                                            PaneId::Terminal(*terminal_id),
+                                            Some(2), // exit status
+                                            run_command,
+                                            None,
+                                        ))
+                                        .with_context(err_context)?;
+                                }
                             }
-                        }
-                    },
-                    Err(e) => {
-                        log::error!("Failed to spawn terminal: {}", e);
+                        },
+                        _ => Err::<(), _>(err).non_fatal(),
                     },
                 }
             },
@@ -245,7 +246,10 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                     ),
                     _ => (false, None, name),
                 };
-                match pty.spawn_terminal(terminal_action, ClientOrTabIndex::ClientId(client_id)) {
+                match pty
+                    .spawn_terminal(terminal_action, ClientOrTabIndex::ClientId(client_id))
+                    .with_context(err_context)
+                {
                     Ok((pid, starts_held)) => {
                         let hold_for_command = if starts_held { run_command } else { None };
                         pty.bus
@@ -258,45 +262,43 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                             ))
                             .with_context(err_context)?;
                     },
-                    Err(SpawnTerminalError::CommandNotFound(pid)) => {
-                        if hold_on_close {
-                            let hold_for_command = None; // error panes are never held
-                            pty.bus
-                                .senders
-                                .send_to_screen(ScreenInstruction::HorizontalSplit(
-                                    PaneId::Terminal(pid),
-                                    pane_title,
-                                    hold_for_command,
-                                    client_id,
-                                ))
-                                .with_context(err_context)?;
-                            if let Some(run_command) = run_command {
+                    Err(err) => match err.downcast_ref::<ZellijError>() {
+                        Some(ZellijError::CommandNotFound { terminal_id, .. }) => {
+                            if hold_on_close {
                                 pty.bus
                                     .senders
-                                    .send_to_screen(ScreenInstruction::PtyBytes(
-                                        pid,
-                                        format!(
-                                            "Command not found: {}",
-                                            run_command.command.display()
-                                        )
-                                        .as_bytes()
-                                        .to_vec(),
+                                    .send_to_screen(ScreenInstruction::HorizontalSplit(
+                                        PaneId::Terminal(*terminal_id),
+                                        pane_title,
+                                        client_id,
                                     ))
                                     .with_context(err_context)?;
-                                pty.bus
-                                    .senders
-                                    .send_to_screen(ScreenInstruction::HoldPane(
-                                        PaneId::Terminal(pid),
-                                        Some(2), // exit status
-                                        run_command,
-                                        None,
-                                    ))
-                                    .with_context(err_context)?;
+                                if let Some(run_command) = run_command {
+                                    pty.bus
+                                        .senders
+                                        .send_to_screen(ScreenInstruction::PtyBytes(
+                                            *terminal_id,
+                                            format!(
+                                                "Command not found: {}",
+                                                run_command.command.display()
+                                            )
+                                            .as_bytes()
+                                            .to_vec(),
+                                        ))
+                                        .with_context(err_context)?;
+                                    pty.bus
+                                        .senders
+                                        .send_to_screen(ScreenInstruction::HoldPane(
+                                            PaneId::Terminal(*terminal_id),
+                                            Some(2), // exit status
+                                            run_command,
+                                            None,
+                                        ))
+                                        .with_context(err_context)?;
+                                }
                             }
-                        }
-                    },
-                    Err(e) => {
-                        log::error!("Failed to spawn terminal: {}", e);
+                        },
+                        _ => Err::<(), _>(err).non_fatal(),
                     },
                 }
             },
@@ -347,32 +349,38 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                     .with_context(err_context)?;
             },
             PtyInstruction::ReRunCommandInPane(pane_id, run_command) => {
-                match pty.rerun_command_in_pane(pane_id, run_command.clone()) {
+                match pty
+                    .rerun_command_in_pane(pane_id, run_command.clone())
+                    .with_context(err_context)
+                {
                     Ok(..) => {},
-                    Err(SpawnTerminalError::CommandNotFound(pid)) => {
-                        if run_command.hold_on_close {
-                            pty.bus
-                                .senders
-                                .send_to_screen(ScreenInstruction::PtyBytes(
-                                    pid,
-                                    format!("Command not found: {}", run_command.command.display())
+                    Err(err) => match err.downcast_ref::<ZellijError>() {
+                        Some(ZellijError::CommandNotFound { terminal_id, .. }) => {
+                            if run_command.hold_on_close {
+                                pty.bus
+                                    .senders
+                                    .send_to_screen(ScreenInstruction::PtyBytes(
+                                        *terminal_id,
+                                        format!(
+                                            "Command not found: {}",
+                                            run_command.command.display()
+                                        )
                                         .as_bytes()
                                         .to_vec(),
-                                ))
-                                .with_context(err_context)?;
-                            pty.bus
-                                .senders
-                                .send_to_screen(ScreenInstruction::HoldPane(
-                                    PaneId::Terminal(pid),
-                                    Some(2), // exit status
-                                    run_command,
-                                    None,
-                                ))
-                                .with_context(err_context)?;
-                        }
-                    },
-                    Err(e) => {
-                        log::error!("Failed to spawn terminal: {}", e);
+                                    ))
+                                    .with_context(err_context)?;
+                                pty.bus
+                                    .senders
+                                    .send_to_screen(ScreenInstruction::HoldPane(
+                                        PaneId::Terminal(*terminal_id),
+                                        Some(2), // exit status
+                                        run_command,
+                                        None,
+                                    ))
+                                    .with_context(err_context)?;
+                            }
+                        },
+                        _ => Err::<(), _>(err).non_fatal(),
                     },
                 }
             },
@@ -429,8 +437,10 @@ impl Pty {
         &mut self,
         terminal_action: Option<TerminalAction>,
         client_or_tab_index: ClientOrTabIndex,
-    ) -> Result<(u32, bool), SpawnTerminalError> {
+    ) -> Result<(u32, bool)> {
         // bool is starts_held
+        let err_context = || format!("failed to spawn terminal for {:?}", client_or_tab_index);
+
         // returns the terminal id
         let terminal_action = match client_or_tab_index {
             ClientOrTabIndex::ClientId(client_id) => {
@@ -476,8 +486,11 @@ impl Pty {
             .bus
             .os_input
             .as_mut()
-            .ok_or_else(|| SpawnTerminalError::GenericSpawnError("os input is none"))?
-            .spawn_terminal(terminal_action, quit_cb, self.default_editor.clone())?;
+            .context("no OS I/O interface found")
+            .and_then(|os_input| {
+                os_input.spawn_terminal(terminal_action, quit_cb, self.default_editor.clone())
+            })
+            .with_context(err_context)?;
         let terminal_bytes = task::spawn({
             let err_context =
                 |terminal_id: u32| format!("failed to run async task for terminal {terminal_id}");
@@ -511,18 +524,14 @@ impl Pty {
         client_id: ClientId,
     ) -> Result<()> {
         let err_context = || format!("failed to spawn terminals for layout for client {client_id}");
+
         let mut default_shell = default_shell.unwrap_or_else(|| self.get_default_terminal(None));
         self.fill_cwd(&mut default_shell, client_id);
         let extracted_run_instructions = layout.extract_run_instructions();
-        let mut new_pane_pids: Vec<(
-            u32,
-            bool,
-            Option<RunCommand>,
-            Result<RawFd, SpawnTerminalError>,
-        )> = vec![]; // (terminal_id,
-                     // starts_held,
-                     // run_command,
-                     // file_descriptor)
+        let mut new_pane_pids: Vec<(u32, bool, Option<RunCommand>, Result<RawFd>)> = vec![]; // (terminal_id,
+                                                                                             // starts_held,
+                                                                                             // run_command,
+                                                                                             // file_descriptor)
         for run_instruction in extracted_run_instructions {
             let quit_cb = Box::new({
                 let senders = self.bus.senders.clone();
@@ -553,7 +562,14 @@ impl Pty {
                     let cmd = TerminalAction::RunCommand(command.clone());
                     if starts_held {
                         // we don't actually open a terminal in this case, just wait for the user to run it
-                        match self.bus.os_input.as_mut().unwrap().reserve_terminal_id() {
+                        match self
+                            .bus
+                            .os_input
+                            .as_mut()
+                            .context("no OS I/O interface found")
+                            .with_context(err_context)?
+                            .reserve_terminal_id()
+                        {
                             Ok(terminal_id) => {
                                 new_pane_pids.push((
                                     terminal_id,
@@ -572,29 +588,30 @@ impl Pty {
                             .bus
                             .os_input
                             .as_mut()
+                            .context("no OS I/O interface found")
                             .with_context(err_context)?
                             .spawn_terminal(cmd, quit_cb, self.default_editor.clone())
+                            .with_context(err_context)
                         {
                             Ok((terminal_id, pid_primary, child_fd)) => {
                                 self.id_to_child_pid.insert(terminal_id, child_fd);
                                 new_pane_pids.push((
                                     terminal_id,
-                                    starts_held,
                                     Some(command.clone()),
                                     Ok(pid_primary),
                                 ));
                             },
-                            Err(SpawnTerminalError::CommandNotFound(terminal_id)) => {
-                                let starts_held = false; // we do not hold error panes
-                                new_pane_pids.push((
-                                    terminal_id,
-                                    starts_held,
-                                    Some(command.clone()),
-                                    Err(SpawnTerminalError::CommandNotFound(terminal_id)),
-                                ));
-                            },
-                            Err(e) => {
-                                log::error!("Failed to spawn terminal: {}", e);
+                            Err(err) => match err.downcast_ref::<ZellijError>() {
+                                Some(ZellijError::CommandNotFound { terminal_id, .. }) => {
+                                    new_pane_pids.push((
+                                        *terminal_id,
+                                        Some(command.clone()),
+                                        Err(err),
+                                    ));
+                                },
+                                _ => {
+                                    Err::<(), _>(err).non_fatal();
+                                },
                             },
                         }
                     }
@@ -606,23 +623,22 @@ impl Pty {
                         .bus
                         .os_input
                         .as_mut()
+                        .context("no OS I/O interface found")
                         .with_context(err_context)?
                         .spawn_terminal(shell, quit_cb, self.default_editor.clone())
+                        .with_context(err_context)
                     {
                         Ok((terminal_id, pid_primary, child_fd)) => {
                             self.id_to_child_pid.insert(terminal_id, child_fd);
                             new_pane_pids.push((terminal_id, starts_held, None, Ok(pid_primary)));
                         },
-                        Err(SpawnTerminalError::CommandNotFound(terminal_id)) => {
-                            new_pane_pids.push((
-                                terminal_id,
-                                starts_held,
-                                None,
-                                Err(SpawnTerminalError::CommandNotFound(terminal_id)),
-                            ));
-                        },
-                        Err(e) => {
-                            log::error!("Failed to spawn terminal: {}", e);
+                        Err(err) => match err.downcast_ref::<ZellijError>() {
+                            Some(ZellijError::CommandNotFound { terminal_id, .. }) => {
+                                new_pane_pids.push((*terminal_id, starts_held, None, Err(err)));
+                            },
+                            _ => {
+                                Err::<(), _>(err).non_fatal();
+                            },
                         },
                     }
                 },
@@ -632,27 +648,26 @@ impl Pty {
                         .bus
                         .os_input
                         .as_mut()
+                        .context("no OS I/O interface found")
                         .with_context(err_context)?
                         .spawn_terminal(
                             TerminalAction::OpenFile(path_to_file, line_number),
                             quit_cb,
                             self.default_editor.clone(),
-                        ) {
+                        )
+                        .with_context(err_context)
+                    {
                         Ok((terminal_id, pid_primary, child_fd)) => {
                             self.id_to_child_pid.insert(terminal_id, child_fd);
                             new_pane_pids.push((terminal_id, starts_held, None, Ok(pid_primary)));
                         },
-                        Err(SpawnTerminalError::CommandNotFound(terminal_id)) => {
-                            let starts_held = false; // we do not hold error panes
-                            new_pane_pids.push((
-                                terminal_id,
-                                starts_held,
-                                None,
-                                Err(SpawnTerminalError::CommandNotFound(terminal_id)),
-                            ));
-                        },
-                        Err(e) => {
-                            log::error!("Failed to spawn terminal: {}", e);
+                        Err(err) => match err.downcast_ref::<ZellijError>() {
+                            Some(ZellijError::CommandNotFound { terminal_id, .. }) => {
+                                new_pane_pids.push((*terminal_id, starts_held, None, Err(err)));
+                            },
+                            _ => {
+                                Err::<(), _>(err).non_fatal();
+                            },
                         },
                     }
                 },
@@ -662,23 +677,22 @@ impl Pty {
                         .bus
                         .os_input
                         .as_mut()
+                        .context("no OS I/O interface found")
                         .with_context(err_context)?
                         .spawn_terminal(default_shell.clone(), quit_cb, self.default_editor.clone())
+                        .with_context(err_context)
                     {
                         Ok((terminal_id, pid_primary, child_fd)) => {
                             self.id_to_child_pid.insert(terminal_id, child_fd);
                             new_pane_pids.push((terminal_id, starts_held, None, Ok(pid_primary)));
                         },
-                        Err(SpawnTerminalError::CommandNotFound(terminal_id)) => {
-                            new_pane_pids.push((
-                                terminal_id,
-                                starts_held,
-                                None,
-                                Err(SpawnTerminalError::CommandNotFound(terminal_id)),
-                            ));
-                        },
-                        Err(e) => {
-                            log::error!("Failed to spawn terminal: {}", e);
+                        Err(err) => match err.downcast_ref::<ZellijError>() {
+                            Some(ZellijError::CommandNotFound { terminal_id, .. }) => {
+                                new_pane_pids.push((*terminal_id, starts_held, None, Err(err)));
+                            },
+                            _ => {
+                                Err::<(), _>(err).non_fatal();
+                            },
                         },
                     }
                 },
@@ -781,8 +795,9 @@ impl Pty {
                 self.bus
                     .os_input
                     .as_ref()
-                    .with_context(err_context)?
-                    .clear_terminal_id(id);
+                    .context("no OS I/O interface found")
+                    .and_then(|os_input| os_input.clear_terminal_id(id))
+                    .with_context(err_context)?;
             },
             PaneId::Plugin(pid) => drop(
                 self.bus
@@ -808,7 +823,9 @@ impl Pty {
         &mut self,
         pane_id: PaneId,
         run_command: RunCommand,
-    ) -> Result<(), SpawnTerminalError> {
+    ) -> Result<()> {
+        let err_context = || format!("failed to rerun command in pane {:?}", pane_id);
+
         match pane_id {
             PaneId::Terminal(id) => {
                 let _ = self.task_handles.remove(&id); // if all is well, this shouldn't be here
@@ -835,8 +852,11 @@ impl Pty {
                     .bus
                     .os_input
                     .as_mut()
-                    .ok_or_else(|| SpawnTerminalError::GenericSpawnError("os input is none"))?
-                    .re_run_command_in_terminal(id, run_command, quit_cb)?;
+                    .context("no OS I/O interface found")
+                    .and_then(|os_input| {
+                        os_input.re_run_command_in_terminal(id, run_command, quit_cb)
+                    })
+                    .with_context(err_context)?;
                 let terminal_bytes = task::spawn({
                     let err_context =
                         |pane_id| format!("failed to run async task for pane {pane_id:?}");
@@ -862,9 +882,7 @@ impl Pty {
                 self.id_to_child_pid.insert(id, child_fd);
                 Ok(())
             },
-            _ => Err(SpawnTerminalError::GenericSpawnError(
-                "Cannot respawn plugin panes",
-            )),
+            _ => Err(anyhow!("cannot respawn plugin panes")).with_context(err_context),
         }
     }
 }

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1507,7 +1507,8 @@ pub(crate) fn screen_thread_main(
                         Some(file.to_string()),
                         client_id,
                         full
-                    )
+                    ),
+                    ?
                 );
                 screen.render()?;
                 screen.unblock_input()?;

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -2,12 +2,13 @@ use super::Tab;
 use crate::panes::sixel::SixelImageStore;
 use crate::screen::CopyOptions;
 use crate::{
-    os_input_output::{AsyncReader, Pid, ServerOsApi, SpawnTerminalError},
+    os_input_output::{AsyncReader, Pid, ServerOsApi},
     panes::PaneId,
     thread_bus::ThreadSenders,
     ClientId,
 };
 use std::path::PathBuf;
+use zellij_utils::errors::prelude::*;
 use zellij_utils::input::layout::PaneLayout;
 use zellij_utils::ipc::IpcReceiverWithContext;
 use zellij_utils::pane_size::{Size, SizeInPixels};
@@ -16,8 +17,6 @@ use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::os::unix::io::RawFd;
 use std::rc::Rc;
-
-use zellij_utils::nix;
 
 use zellij_utils::{
     data::{ModeInfo, Palette, Style},
@@ -30,53 +29,50 @@ use zellij_utils::{
 struct FakeInputOutput {}
 
 impl ServerOsApi for FakeInputOutput {
-    fn set_terminal_size_using_terminal_id(&self, _id: u32, _cols: u16, _rows: u16) {
+    fn set_terminal_size_using_terminal_id(&self, _id: u32, _cols: u16, _rows: u16) -> Result<()> {
         // noop
+        Ok(())
     }
     fn spawn_terminal(
         &self,
         _file_to_open: TerminalAction,
         _quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>,
         _default_editor: Option<PathBuf>,
-    ) -> Result<(u32, RawFd, RawFd), SpawnTerminalError> {
+    ) -> Result<(u32, RawFd, RawFd)> {
         unimplemented!()
     }
-    fn read_from_tty_stdout(&self, _fd: RawFd, _buf: &mut [u8]) -> Result<usize, nix::Error> {
+    fn read_from_tty_stdout(&self, _fd: RawFd, _buf: &mut [u8]) -> Result<usize> {
         unimplemented!()
     }
     fn async_file_reader(&self, _fd: RawFd) -> Box<dyn AsyncReader> {
         unimplemented!()
     }
-    fn write_to_tty_stdin(&self, _id: u32, _buf: &[u8]) -> Result<usize, nix::Error> {
+    fn write_to_tty_stdin(&self, _id: u32, _buf: &[u8]) -> Result<usize> {
         unimplemented!()
     }
-    fn tcdrain(&self, _id: u32) -> Result<(), nix::Error> {
+    fn tcdrain(&self, _id: u32) -> Result<()> {
         unimplemented!()
     }
-    fn kill(&self, _pid: Pid) -> Result<(), nix::Error> {
+    fn kill(&self, _pid: Pid) -> Result<()> {
         unimplemented!()
     }
-    fn force_kill(&self, _pid: Pid) -> Result<(), nix::Error> {
+    fn force_kill(&self, _pid: Pid) -> Result<()> {
         unimplemented!()
     }
     fn box_clone(&self) -> Box<dyn ServerOsApi> {
         Box::new((*self).clone())
     }
-    fn send_to_client(
-        &self,
-        _client_id: ClientId,
-        _msg: ServerToClientMsg,
-    ) -> Result<(), &'static str> {
+    fn send_to_client(&self, _client_id: ClientId, _msg: ServerToClientMsg) -> Result<()> {
         unimplemented!()
     }
     fn new_client(
         &mut self,
         _client_id: ClientId,
         _stream: LocalSocketStream,
-    ) -> IpcReceiverWithContext<ClientToServerMsg> {
+    ) -> Result<IpcReceiverWithContext<ClientToServerMsg>> {
         unimplemented!()
     }
-    fn remove_client(&mut self, _client_id: ClientId) {
+    fn remove_client(&mut self, _client_id: ClientId) -> Result<()> {
         unimplemented!()
     }
     fn load_palette(&self) -> Palette {
@@ -86,7 +82,7 @@ impl ServerOsApi for FakeInputOutput {
         unimplemented!()
     }
 
-    fn write_to_file(&mut self, _buf: String, _name: Option<String>) {
+    fn write_to_file(&mut self, _buf: String, _name: Option<String>) -> Result<()> {
         unimplemented!()
     }
     fn re_run_command_in_terminal(
@@ -94,10 +90,10 @@ impl ServerOsApi for FakeInputOutput {
         _terminal_id: u32,
         _run_command: RunCommand,
         _quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>, // u32 is the exit status
-    ) -> Result<(RawFd, RawFd), SpawnTerminalError> {
+    ) -> Result<(RawFd, RawFd)> {
         unimplemented!()
     }
-    fn clear_terminal_id(&self, _terminal_id: u32) {
+    fn clear_terminal_id(&self, _terminal_id: u32) -> Result<()> {
         unimplemented!()
     }
 }

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -24,6 +24,7 @@ pub mod prelude {
     pub use super::LoggableError;
     #[cfg(not(target_family = "wasm"))]
     pub use super::ToAnyhow;
+    pub use super::ZellijError;
     pub use anyhow::anyhow;
     pub use anyhow::bail;
     pub use anyhow::Context;
@@ -374,6 +375,25 @@ pub enum ServerContext {
 pub enum PtyWriteContext {
     Write,
     Exit,
+}
+
+use thiserror::Error;
+#[derive(Debug, Error)]
+pub enum ZellijError {
+    #[error("could not find command '{command}' for terminal {terminal_id}")]
+    CommandNotFound { terminal_id: u32, command: String },
+
+    #[error("could not determine default editor")]
+    NoEditorFound,
+
+    #[error("failed to allocate another terminal id")]
+    NoMoreTerminalIds,
+
+    #[error("failed to start PTY")]
+    FailedToStartPty,
+
+    #[error("an error occured")]
+    GenericError { source: anyhow::Error },
 }
 
 #[cfg(not(target_family = "wasm"))]

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -2,7 +2,7 @@
 use crate::{
     cli::CliArgs,
     data::{ClientId, InputMode, Style},
-    errors::{get_current_ctx, ErrorContext},
+    errors::{get_current_ctx, prelude::*, ErrorContext},
     input::keybinds::Keybinds,
     input::{actions::Action, layout::Layout, options::Options, plugins::PluginsConfig},
     pane_size::{Size, SizeInPixels},
@@ -154,10 +154,10 @@ impl<T: Serialize> IpcSenderWithContext<T> {
     }
 
     /// Sends an event, along with the current [`ErrorContext`], on this [`IpcSenderWithContext`]'s socket.
-    pub fn send(&mut self, msg: T) -> Result<(), &'static str> {
+    pub fn send(&mut self, msg: T) -> Result<()> {
         let err_ctx = get_current_ctx();
         if rmp_serde::encode::write(&mut self.sender, &(msg, err_ctx)).is_err() {
-            Err("Failed to send message to client")
+            Err(anyhow!("failed to send message to client"))
         } else {
             // TODO: unwrapping here can cause issues when the server disconnects which we don't mind
             // do we need to handle errors here in other cases?


### PR DESCRIPTION
Rewrites the `os_input_output` module to handle/propagate errors with `anyhow::Error` instead of unwrapping on all `Result` types. Also unifies all error types regarding this module to by `anyhow::Error`.

As part of this PR the previously existing `SpawnTerminalError` is entirely removed and replaced with a new `ZellijError`. Better documentation on that will follow in a subsequent PR.