### PR TITLE
fix: use `temp_dir` for getting temp folder

### DIFF
--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -45,7 +45,7 @@ mod unix_only {
     use crate::shared::set_permissions;
     use lazy_static::lazy_static;
     use nix::unistd::Uid;
-    use std::fs;
+    use std::{env::temp_dir, fs};
 
     lazy_static! {
         static ref UID: Uid = Uid::current();
@@ -56,7 +56,7 @@ mod unix_only {
             sock_dir.push(envs::get_session_name().unwrap());
             sock_dir
         };
-        pub static ref ZELLIJ_TMP_DIR: PathBuf = PathBuf::from(format!("/tmp/zellij-{}", *UID));
+        pub static ref ZELLIJ_TMP_DIR: PathBuf = temp_dir().join(format!("zellij-{}", *UID));
         pub static ref ZELLIJ_TMP_LOG_DIR: PathBuf = ZELLIJ_TMP_DIR.join("zellij-log");
         pub static ref ZELLIJ_TMP_LOG_FILE: PathBuf = ZELLIJ_TMP_LOG_DIR.join("zellij.log");
         pub static ref ZELLIJ_SOCK_DIR: PathBuf = {


### PR DESCRIPTION
The temp folder for storing logs etc. is currently hard-coded to `/tmp`, which is not very portable as this directory doesn't exist on some platforms (e.g. Android). This PR changes to use `temp_dir` from `std::env`, which uses the exact same path as we do now on non-Android Unix systems, but a special Termux path on Android.

This helps with #1021.