### PR TITLE
Fix: better error reporting when failing to load plugins (#1912)

### DIFF
--- a/zellij-server/src/wasm_vm.rs
+++ b/zellij-server/src/wasm_vm.rs
@@ -351,7 +351,6 @@ fn start_plugin(
     // The plugins blob as stored on the filesystem
     let wasm_bytes = plugin
         .resolve_wasm_bytes(&data_dir.join("plugins/"))
-        .context("cannot resolve wasm bytes")
         .with_context(err_context)
         .fatal();
 


### PR DESCRIPTION
Improves error output when failing to load plugins for some reason. Instead of merely stating that "resolving wasm bytes" failed, we preserve the `io::Error` thrown by the `std` functions involved in trying to read the plugin.

Converts the previous error output:

```
  ╰─▶ Program terminates: a fatal error occured

      Caused by:
          0: failed to start plugin PluginConfig {
                 path: "/home/user/code/zellij.nvim/mode-logger/target/wasm32-wasi/debug/mode-logger.wasm",
                 run: Pane(
                     None,
                 ),
                 _allow_exec_host_cmd: false,
                 location: File(
                     "/home/user/code/zellij.nvim/mode-logger/target/wasm32-wasi/debug/mode-logger.wasm",
                 ),
             } for client 1
          1: cannot resolve wasm bytes
```

Into something a bit more user friendly:

```
  ╰─▶ Program terminates: a fatal error occured
      
      Caused by:
          0: failed to start plugin PluginConfig {
                 path: "/var/home/user/repos/3_extras/zellij/target/wasm32-wasi/debug/tab-ba",
                 run: Pane(
                     None,
                 ),
                 _allow_exec_host_cmd: false,
                 location: File(
                     "/var/home/user/repos/3_extras/zellij/target/wasm32-wasi/debug/tab-ba",
                 ),
             } for client 1
          1: No such file or directory (os error 2): '/var/home/user/repos/3_extras/zellij/target/wasm32-wasi/debug/tab-ba.wasm'
          2: No such file or directory (os error 2): '/var/home/user/repos/3_extras/zellij/target/wasm32-wasi/debug/tab-ba'
          3: failed to load plugin from disk
```

or (note the "Permission denied"):

```
  ╰─▶ Program terminates: a fatal error occured
      
      Caused by:
          0: failed to start plugin PluginConfig {
                 path: "/var/home/user/repos/3_extras/zellij/target/wasm32-wasi/debug/status-bar",
                 run: Pane(
                     None,
                 ),
                 _allow_exec_host_cmd: false,
                 location: File(
                     "/var/home/user/repos/3_extras/zellij/target/wasm32-wasi/debug/status-bar",
                 ),
             } for client 1
          1: Permission denied (os error 13): '/var/home/user/repos/3_extras/zellij/target/wasm32-wasi/debug/status-bar.wasm'
          2: No such file or directory (os error 2): '/var/home/user/repos/3_extras/zellij/target/wasm32-wasi/debug/status-bar'
          3: failed to load plugin from disk
```