### PR TITLE
cargo: Don't strip release binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * debugging: Improve error logging in server (https://github.com/zellij-org/zellij/pull/1881)
 * docs: add kanagawa theme (https://github.com/zellij-org/zellij/pull/1913)
 * fix: use 'temp_dir' instead of hard-coded '/tmp/' (https://github.com/zellij-org/zellij/pull/1898)
+* debugging: Don't strip debug symbols from release binaries (https://github.com/zellij-org/zellij/pull/1916)
 
 ## [0.32.0] - 2022-10-25
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ members = [
 
 [profile.release]
 lto = true
+# Keep debug symbols so we see function names in backtraces
+strip = false
 
 [package.metadata.deb]
 depends = "$auto"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ members = [
 
 [profile.release]
 lto = true
-strip = true
 
 [package.metadata.deb]
 depends = "$auto"


### PR DESCRIPTION
because the lack of debug symbols makes the panic backtrace completely useless. It will show a long list of unknown locations then.

Except for a minor space saving of 3-4 MB, debug symbols don't have any negative side-effects for our application that we're aware of.

Note that while the presence of debug symbols allows for backtraces that name the functions involved in the error, they don't contain the exact location in the source files where the error originated (line/column numbers). To enable this, the [`debug`][1] profile setting must be enabled, which will increase the binary size dramatically (>80 MB in my tests). We don't do that, because the current situation is good enough for our debugging purposes.

[1]: https://doc.rust-lang.org/cargo/reference/profiles.html#debug