### PR TITLE
chore(ci): remove msrv check

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -26,23 +26,3 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: |
           nix build || nix build --substituters 'https://cache.nixos.org' --extra-substituters ''
-  build-msrv:
-    runs-on: ubuntu-latest
-    name: "build msrv"
-    timeout-minutes: 35
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          # Nix Flakes doesn't work on shallow clones
-          fetch-depth: 0
-      - uses: cachix/install-nix-action@v18
-      - uses: cachix/cachix-action@v12
-        with:
-          name: zellij
-          # If you chose API tokens for write access OR if you have a private cache
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: |
-          nix build .#zellij-msrv || nix build .#zellij-msrv --substituters 'https://cache.nixos.org' --extra-substituters ''
-      - if: ${{ failure() }}
-        run: |
-          echo "::error :: If this is the only ci step failing, it is likely that the MSRV needs to be bumped."


### PR DESCRIPTION
Continuing the conversation from: https://github.com/zellij-org/zellij/pull/1896

This will remove the MSRV CI check.