### PR TITLE
Fix: cargo clippy lints

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -83,7 +83,8 @@ args = [
 
 # Simple clippy tweak
 [tasks.clippy]
-args = ["clippy", "--all-targets", "--all-features", "@@split(CARGO_MAKE_TASK_ARGS,;)"]
+args = ["clippy", "--all-targets", "--all-features", "--", "--deny",
+"warnings", "@@split(CARGO_MAKE_TASK_ARGS,;)"]
 
 # Release building and installing Zellij
 [tasks.install]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -306,7 +306,9 @@ fn attach_with_session_name(
                 eprintln!("No active zellij sessions found.");
                 process::exit(1);
             },
-            ActiveSession::One(session_name) => ClientInfo::Attach(session_name, Box::new(config_options)),
+            ActiveSession::One(session_name) => {
+                ClientInfo::Attach(session_name, Box::new(config_options))
+            },
             ActiveSession::Many => {
                 println!("Please specify the session to attach to, either by using the full name or a unique prefix.\nThe following sessions are active:");
                 print_sessions(get_sessions().unwrap());

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -109,7 +109,7 @@ fn find_indexed_session(
     create: bool,
 ) -> ClientInfo {
     match sessions.get(index) {
-        Some(session) => ClientInfo::Attach(session.clone(), config_options),
+        Some(session) => ClientInfo::Attach(session.clone(), Box::new(config_options)),
         None if create => create_new_client(),
         None => {
             println!(
@@ -278,14 +278,14 @@ fn attach_with_session_name(
     match &session_name {
         Some(session) if create => {
             if session_exists(session).unwrap() {
-                ClientInfo::Attach(session_name.unwrap(), config_options)
+                ClientInfo::Attach(session_name.unwrap(), Box::new(config_options))
             } else {
                 ClientInfo::New(session_name.unwrap())
             }
         },
         Some(prefix) => match match_session_name(prefix).unwrap() {
             SessionNameMatch::UniquePrefix(s) | SessionNameMatch::Exact(s) => {
-                ClientInfo::Attach(s, config_options)
+                ClientInfo::Attach(s, Box::new(config_options))
             },
             SessionNameMatch::AmbiguousPrefix(sessions) => {
                 println!(
@@ -306,7 +306,7 @@ fn attach_with_session_name(
                 eprintln!("No active zellij sessions found.");
                 process::exit(1);
             },
-            ActiveSession::One(session_name) => ClientInfo::Attach(session_name, config_options),
+            ActiveSession::One(session_name) => ClientInfo::Attach(session_name, Box::new(config_options)),
             ActiveSession::Many => {
                 println!("Please specify the session to attach to, either by using the full name or a unique prefix.\nThe following sessions are active:");
                 print_sessions(get_sessions().unwrap());

--- a/zellij-client/src/cli_client.rs
+++ b/zellij-client/src/cli_client.rs
@@ -23,12 +23,9 @@ pub fn start_cli_client(os_input: Box<dyn ClientOsApi>, session_name: &str, acti
         os_input.send_to_server(msg);
     }
     loop {
-        match os_input.recv_from_server() {
-            Some((ServerToClientMsg::UnblockInputThread, _)) => {
-                os_input.send_to_server(ClientToServerMsg::ClientExited);
-                process::exit(0);
-            },
-            _ => {},
+        if let Some((ServerToClientMsg::UnblockInputThread, _)) = os_input.recv_from_server() {
+            os_input.send_to_server(ClientToServerMsg::ClientExited);
+            process::exit(0);
         }
     }
 }

--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -324,7 +324,7 @@ pub(crate) fn input_loop(
     default_mode: InputMode,
     receive_input_instructions: Receiver<(InputInstruction, ErrorContext)>,
 ) {
-    let _handler = InputHandler::new(
+    InputHandler::new(
         os_input,
         command_is_executing,
         config,

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -103,7 +103,7 @@ fn spawn_server(socket_path: &Path, debug: bool) -> io::Result<()> {
 
 #[derive(Debug, Clone)]
 pub enum ClientInfo {
-    Attach(String, Options),
+    Attach(String, Box<Options>),
     New(String),
 }
 
@@ -166,7 +166,7 @@ pub fn start_client(
         ClientInfo::Attach(name, config_options) => {
             envs::set_session_name(name);
 
-            ClientToServerMsg::AttachClient(client_attributes, config_options)
+            ClientToServerMsg::AttachClient(client_attributes, *config_options)
         },
         ClientInfo::New(name) => {
             envs::set_session_name(name);
@@ -332,7 +332,7 @@ pub fn start_client(
             .get_stdout_writer()
             .write(error.as_bytes())
             .unwrap();
-        let _ = os_input.get_stdout_writer().flush().unwrap();
+        os_input.get_stdout_writer().flush().unwrap();
         std::process::exit(1);
     };
 

--- a/zellij-client/src/old_config_converter/old_config.rs
+++ b/zellij-client/src/old_config_converter/old_config.rs
@@ -369,7 +369,7 @@ fn theme_config_yaml_to_theme_config_kdl(
         .collect();
     themes.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
     for (theme_name, theme) in themes {
-        writeln!(kdl_theme_config,"    {} {{", theme_name).unwrap();
+        writeln!(kdl_theme_config, "    {} {{", theme_name).unwrap();
         theme_color!(theme, fg, "fg", kdl_theme_config);
         theme_color!(theme, bg, "bg", kdl_theme_config);
         theme_color!(theme, black, "black", kdl_theme_config);
@@ -418,7 +418,7 @@ fn keybinds_yaml_to_keybinds_kdl(keybinds_yaml: &OldKeybindsFromYaml) -> String 
                 .map(|k| format!("\"{}\"", k))
                 .collect::<Vec<String>>()
                 .join(" ");
-            writeln!(kdl_keybinds,"    unbind {}", key_string).unwrap();
+            writeln!(kdl_keybinds, "    unbind {}", key_string).unwrap();
         },
         OldUnbind::All(should_unbind_all_defaults) => {
             if *should_unbind_all_defaults {
@@ -454,10 +454,12 @@ fn keybinds_yaml_to_keybinds_kdl(keybinds_yaml: &OldKeybindsFromYaml) -> String 
                             .map(|a| format!("{};", a))
                             .collect::<Vec<String>>()
                             .join(" ");
-                        writeln!(kdl_mode_keybinds,
+                        writeln!(
+                            kdl_mode_keybinds,
                             "        bind {} {{ {} }}",
                             key_string, actions_string
-                        ).unwrap();
+                        )
+                        .unwrap();
                     },
                     OldKeyActionUnbind::Unbind(unbind) => match &unbind.unbind {
                         OldUnbind::Keys(keys_to_unbind) => {
@@ -466,7 +468,7 @@ fn keybinds_yaml_to_keybinds_kdl(keybinds_yaml: &OldKeybindsFromYaml) -> String 
                                 .map(|k| format!("\"{}\"", k))
                                 .collect::<Vec<String>>()
                                 .join(" ");
-                            writeln!(kdl_mode_keybinds,"        unbind {}", key_string).unwrap();
+                            writeln!(kdl_mode_keybinds, "        unbind {}", key_string).unwrap();
                         },
                         OldUnbind::All(unbind_all) => {
                             if *unbind_all {
@@ -477,9 +479,9 @@ fn keybinds_yaml_to_keybinds_kdl(keybinds_yaml: &OldKeybindsFromYaml) -> String 
                 }
             }
             if should_clear_mode_defaults {
-                writeln!(kdl_keybinds,"    {} clear-defaults=true {{", mode).unwrap();
+                writeln!(kdl_keybinds, "    {} clear-defaults=true {{", mode).unwrap();
             } else {
-                writeln!(kdl_keybinds,"    {} {{", mode).unwrap();
+                writeln!(kdl_keybinds, "    {} {{", mode).unwrap();
             }
             kdl_keybinds.push_str(&kdl_mode_keybinds);
             kdl_keybinds.push_str("    }\n");

--- a/zellij-client/src/old_config_converter/old_layout.rs
+++ b/zellij-client/src/old_config_converter/old_layout.rs
@@ -158,7 +158,8 @@ fn stringify_template(
         ));
     } else if !template.parts.is_empty() {
         if !is_base {
-            write!(stringified,
+            write!(
+                stringified,
                 "{}{} {{",
                 indentation,
                 pane_line_with_children(
@@ -168,7 +169,8 @@ fn stringify_template(
                     template.borderless,
                     template.direction
                 )
-            ).unwrap();
+            )
+            .unwrap();
         }
         for part in &template.parts {
             let child_indentation = format!("{}    ", &indentation);
@@ -187,7 +189,8 @@ fn stringify_template(
     } else {
         match template.run.as_ref() {
             Some(OldRunFromYaml::Plugin(plugin_from_yaml)) => {
-                writeln!(stringified,
+                writeln!(
+                    stringified,
                     "{}{} {{",
                     &indentation,
                     pane_line(
@@ -196,15 +199,19 @@ fn stringify_template(
                         template.focus,
                         template.borderless
                     )
-                ).unwrap();
-                writeln!(stringified, 
+                )
+                .unwrap();
+                writeln!(
+                    stringified,
                     "{}    plugin location=\"{}\"",
                     &indentation, plugin_from_yaml.location
-                ).unwrap();
+                )
+                .unwrap();
                 write!(stringified, "{}}}", &indentation).unwrap();
             },
             Some(OldRunFromYaml::Command(command_from_yaml)) => {
-                write!(stringified,
+                write!(
+                    stringified,
                     "{}{}",
                     &indentation,
                     &pane_command_line(
@@ -214,13 +221,15 @@ fn stringify_template(
                         template.borderless,
                         &command_from_yaml.command
                     )
-                ).unwrap();
+                )
+                .unwrap();
                 if let Some(cwd) = command_from_yaml.cwd.as_ref() {
                     write!(stringified, " cwd={:?}", cwd).unwrap();
                 }
                 if !command_from_yaml.args.is_empty() {
                     stringified.push_str(" {\n");
-                    writeln!(stringified,
+                    writeln!(
+                        stringified,
                         "{}    args {}",
                         &indentation,
                         command_from_yaml
@@ -231,12 +240,14 @@ fn stringify_template(
                             .map(|s| format!("{:?}", s))
                             .collect::<Vec<String>>()
                             .join(" ")
-                    ).unwrap();
+                    )
+                    .unwrap();
                     write!(stringified, "{}}}", &indentation).unwrap();
                 }
             },
             None => {
-                write!(stringified,
+                write!(
+                    stringified,
                     "{}{}",
                     &indentation,
                     pane_line(
@@ -245,7 +256,8 @@ fn stringify_template(
                         template.focus,
                         template.borderless
                     )
-                ).unwrap();
+                )
+                .unwrap();
             },
         };
     }

--- a/zellij-client/src/old_config_converter/old_layout.rs
+++ b/zellij-client/src/old_config_converter/old_layout.rs
@@ -5,7 +5,10 @@
 use super::old_config::{config_yaml_to_config_kdl, OldConfigFromYaml, OldRunCommand};
 use serde::{Deserialize, Serialize};
 use std::vec::Vec;
-use std::{fmt, path::PathBuf};
+use std::{
+    fmt::{self, Write},
+    path::PathBuf,
+};
 use url::Url;
 
 fn pane_line(
@@ -14,16 +17,16 @@ fn pane_line(
     focus: Option<bool>,
     borderless: bool,
 ) -> String {
-    let mut pane_line = format!("pane");
+    let mut pane_line = "pane".to_string();
     if let Some(pane_name) = pane_name {
         // we use debug print here so that quotes and backslashes will be escaped
-        pane_line.push_str(&format!(" name={:?}", pane_name));
+        write!(pane_line, " name={:?}", pane_name).unwrap();
     }
     if let Some(split_size) = split_size {
-        pane_line.push_str(&format!(" size={}", split_size));
+        write!(pane_line, " size={}", split_size).unwrap();
     }
     if let Some(focus) = focus {
-        pane_line.push_str(&format!(" focus={}", focus));
+        write!(pane_line, " focus={}", focus).unwrap();
     }
     if borderless {
         pane_line.push_str(" borderless=true");
@@ -37,16 +40,16 @@ fn tab_line(
     focus: Option<bool>,
     borderless: bool,
 ) -> String {
-    let mut pane_line = format!("tab");
+    let mut pane_line = "tab".to_string();
     if let Some(pane_name) = pane_name {
         // we use debug print here so that quotes and backslashes will be escaped
-        pane_line.push_str(&format!(" name={:?}", pane_name));
+        write!(pane_line, " name={:?}", pane_name).unwrap();
     }
     if let Some(split_size) = split_size {
-        pane_line.push_str(&format!(" size={}", split_size));
+        write!(pane_line, " size={}", split_size).unwrap();
     }
     if let Some(focus) = focus {
-        pane_line.push_str(&format!(" focus={}", focus));
+        write!(pane_line, " focus={}", focus).unwrap();
     }
     if borderless {
         pane_line.push_str(" borderless=true");
@@ -61,18 +64,18 @@ fn pane_line_with_children(
     borderless: bool,
     split_direction: OldDirection,
 ) -> String {
-    let mut pane_line = format!("pane");
+    let mut pane_line = "pane".to_string();
     if let Some(pane_name) = pane_name {
         // we use debug print here so that quotes and backslashes will be escaped
-        pane_line.push_str(&format!(" name={:?}", pane_name));
+        write!(pane_line, " name={:?}", pane_name).unwrap();
     }
     if let Some(split_size) = split_size {
-        pane_line.push_str(&format!(" size={}", split_size));
+        write!(pane_line, " size={}", split_size).unwrap();
     }
     if let Some(focus) = focus {
-        pane_line.push_str(&format!(" focus={}", focus));
+        write!(pane_line, " focus={}", focus).unwrap();
     }
-    pane_line.push_str(&format!(" split_direction=\"{}\"", split_direction));
+    write!(pane_line, " split_direction=\"{}\"", split_direction).unwrap();
     if borderless {
         pane_line.push_str(" borderless=true");
     }
@@ -89,13 +92,13 @@ fn pane_command_line(
     let mut pane_line = format!("pane command={:?}", command);
     if let Some(pane_name) = pane_name {
         // we use debug print here so that quotes and backslashes will be escaped
-        pane_line.push_str(&format!(" name={:?}", pane_name));
+        write!(pane_line, " name={:?}", pane_name).unwrap();
     }
     if let Some(split_size) = split_size {
-        pane_line.push_str(&format!(" size={}", split_size));
+        write!(pane_line, " size={}", split_size).unwrap();
     }
     if let Some(focus) = focus {
-        pane_line.push_str(&format!(" focus={}", focus));
+        write!(pane_line, " focus={}", focus).unwrap();
     }
     if borderless {
         pane_line.push_str(" borderless=true");
@@ -110,18 +113,18 @@ fn tab_line_with_children(
     borderless: bool,
     split_direction: OldDirection,
 ) -> String {
-    let mut pane_line = format!("tab");
+    let mut pane_line = "tab".to_string();
     if let Some(pane_name) = pane_name {
         // we use debug print here so that quotes and backslashes will be escaped
-        pane_line.push_str(&format!(" name={:?}", pane_name));
+        write!(pane_line, " name={:?}", pane_name).unwrap();
     }
     if let Some(split_size) = split_size {
-        pane_line.push_str(&format!(" size={}", split_size));
+        write!(pane_line, " size={}", split_size).unwrap();
     }
     if let Some(focus) = focus {
-        pane_line.push_str(&format!(" focus={}", focus));
+        write!(pane_line, " focus={}", focus).unwrap();
     }
-    pane_line.push_str(&format!(" split_direction=\"{}\"", split_direction));
+    write!(pane_line, " split_direction=\"{}\"", split_direction).unwrap();
     if borderless {
         pane_line.push_str(" borderless=true");
     }
@@ -155,7 +158,7 @@ fn stringify_template(
         ));
     } else if !template.parts.is_empty() {
         if !is_base {
-            stringified.push_str(&format!(
+            write!(stringified,
                 "{}{} {{",
                 indentation,
                 pane_line_with_children(
@@ -165,27 +168,27 @@ fn stringify_template(
                     template.borderless,
                     template.direction
                 )
-            ));
+            ).unwrap();
         }
         for part in &template.parts {
             let child_indentation = format!("{}    ", &indentation);
             stringified.push_str(&stringify_template(
-                &part,
+                part,
                 child_indentation,
                 has_no_tabs,
                 false,
             ));
         }
         if !is_base {
-            stringified.push_str(&format!("\n{}}}", indentation));
+            write!(stringified, "\n{}}}", indentation).unwrap();
         }
     } else if template.body && !has_no_tabs {
-        stringified.push_str(&format!("{}children", indentation));
+        write!(stringified, "{}children", indentation).unwrap();
     } else {
         match template.run.as_ref() {
             Some(OldRunFromYaml::Plugin(plugin_from_yaml)) => {
-                stringified.push_str(&format!(
-                    "{}{} {{\n",
+                writeln!(stringified,
+                    "{}{} {{",
                     &indentation,
                     pane_line(
                         template.pane_name.as_ref(),
@@ -193,15 +196,15 @@ fn stringify_template(
                         template.focus,
                         template.borderless
                     )
-                ));
-                stringified.push_str(&format!(
-                    "{}    plugin location=\"{}\"\n",
+                ).unwrap();
+                writeln!(stringified, 
+                    "{}    plugin location=\"{}\"",
                     &indentation, plugin_from_yaml.location
-                ));
-                stringified.push_str(&format!("{}}}", &indentation));
+                ).unwrap();
+                write!(stringified, "{}}}", &indentation).unwrap();
             },
             Some(OldRunFromYaml::Command(command_from_yaml)) => {
-                stringified.push_str(&format!(
+                write!(stringified,
                     "{}{}",
                     &indentation,
                     &pane_command_line(
@@ -211,14 +214,14 @@ fn stringify_template(
                         template.borderless,
                         &command_from_yaml.command
                     )
-                ));
+                ).unwrap();
                 if let Some(cwd) = command_from_yaml.cwd.as_ref() {
-                    stringified.push_str(&format!(" cwd={:?}", cwd));
+                    write!(stringified, " cwd={:?}", cwd).unwrap();
                 }
                 if !command_from_yaml.args.is_empty() {
                     stringified.push_str(" {\n");
-                    stringified.push_str(&format!(
-                        "{}    args {}\n",
+                    writeln!(stringified,
+                        "{}    args {}",
                         &indentation,
                         command_from_yaml
                             .args
@@ -228,12 +231,12 @@ fn stringify_template(
                             .map(|s| format!("{:?}", s))
                             .collect::<Vec<String>>()
                             .join(" ")
-                    ));
-                    stringified.push_str(&format!("{}}}", &indentation));
+                    ).unwrap();
+                    write!(stringified, "{}}}", &indentation).unwrap();
                 }
             },
             None => {
-                stringified.push_str(&format!(
+                write!(stringified,
                     "{}{}",
                     &indentation,
                     pane_line(
@@ -242,7 +245,7 @@ fn stringify_template(
                         template.focus,
                         template.borderless
                     )
-                ));
+                ).unwrap();
             },
         };
     }
@@ -254,7 +257,8 @@ fn stringify_tabs(tabs: Vec<OldTabLayout>) -> String {
     for tab in tabs {
         let child_indentation = String::from("    ");
         if !tab.parts.is_empty() {
-            stringified.push_str(&format!(
+            write!(
+                stringified,
                 "\n{}{} {{",
                 child_indentation,
                 tab_line_with_children(
@@ -264,7 +268,8 @@ fn stringify_tabs(tabs: Vec<OldTabLayout>) -> String {
                     tab.borderless,
                     tab.direction
                 )
-            ));
+            )
+            .unwrap();
             let tab_template = OldLayoutTemplate::from(tab);
             stringified.push_str(&stringify_template(
                 &tab_template,
@@ -272,9 +277,10 @@ fn stringify_tabs(tabs: Vec<OldTabLayout>) -> String {
                 true,
                 true,
             ));
-            stringified.push_str(&format!("\n{}}}", child_indentation));
+            write!(stringified, "\n{}}}", child_indentation).unwrap();
         } else {
-            stringified.push_str(&format!(
+            write!(
+                stringified,
                 "\n{}{}",
                 child_indentation,
                 tab_line(
@@ -283,7 +289,8 @@ fn stringify_tabs(tabs: Vec<OldTabLayout>) -> String {
                     tab.focus,
                     tab.borderless
                 )
-            ));
+            )
+            .unwrap();
         }
     }
     stringified
@@ -323,9 +330,9 @@ pub fn layout_yaml_to_layout_kdl(raw_yaml_layout: &str) -> Result<String, String
     let layout_config = config_yaml_to_config_kdl(raw_yaml_layout, true)?;
     if let Some(session_name) = layout_from_yaml.session.name {
         // we use debug print here so that quotes and backslashes will be escaped
-        kdl_layout.push_str(&format!("\nsession_name {:?}", session_name));
+        write!(kdl_layout, "\nsession_name {:?}", session_name).unwrap();
         if let Some(attach_to_session) = layout_from_yaml.session.attach {
-            kdl_layout.push_str(&format!("\nattach_to_session {}", attach_to_session));
+            write!(kdl_layout, "\nattach_to_session {}", attach_to_session).unwrap();
         }
     }
     if !layout_config.is_empty() {

--- a/zellij-client/src/stdin_ansi_parser.rs
+++ b/zellij-client/src/stdin_ansi_parser.rs
@@ -1,4 +1,7 @@
-use std::time::{Duration, Instant};
+use std::{
+    fmt::Write,
+    time::{Duration, Instant},
+};
 
 const STARTUP_PARSE_DEADLINE_MS: u64 = 500;
 const SIGWINCH_PARSE_DEADLINE_MS: u64 = 200;
@@ -31,13 +34,19 @@ impl StdinAnsiParser {
         // <ESC>[16t => get character cell size in pixels
         // <ESC>]11;?<ESC>\ => get background color
         // <ESC>]10;?<ESC>\ => get foreground color
-        let mut query_string =
-            String::from("\u{1b}[14t\u{1b}[16t\u{1b}]11;?\u{1b}\u{5c}\u{1b}]10;?\u{1b}\u{5c}");
+        //let mut query_string: Vec<u8> = Vec::with_capacity(11 * 256);
+        //write!(&mut query_string, "\u{1b}[14t\u{1b}[16t\u{1b}]11;?\u{1b}\u{5c}\u{1b}]10;?\u{1b}\u{5c}");
+        let mut query_string = String::with_capacity(11 * 256);
+        write!(
+            query_string,
+            "\u{1b}[14t\u{1b}[16t\u{1b}]11;?\u{1b}\u{5c}\u{1b}]10;?\u{1b}\u{5c}"
+        )
+        .unwrap();
 
         // query colors
         // eg. <ESC>]4;5;?<ESC>\ => query color register number 5
         for i in 0..256 {
-            query_string.push_str(&format!("\u{1b}]4;{};?\u{1b}\u{5c}", i));
+            write!(query_string, "\u{1b}]4;{};?\u{1b}\u{5c}", i).unwrap();
         }
         self.parse_deadline =
             Some(Instant::now() + Duration::from_millis(STARTUP_PARSE_DEADLINE_MS));

--- a/zellij-client/src/unit/stdin_tests.rs
+++ b/zellij-client/src/unit/stdin_tests.rs
@@ -19,6 +19,7 @@ use crate::{
 use ::insta::assert_snapshot;
 use std::path::Path;
 
+use std::fmt::Write;
 use std::io;
 use std::os::unix::io::RawFd;
 use std::sync::{Arc, Mutex};
@@ -348,7 +349,7 @@ pub fn terminal_info_queried_from_terminal_emulator() {
     let mut expected_query =
         String::from("\u{1b}[14t\u{1b}[16t\u{1b}]11;?\u{1b}\u{5c}\u{1b}]10;?\u{1b}\u{5c}");
     for i in 0..256 {
-        expected_query.push_str(&format!("\u{1b}]4;{};?\u{1b}\u{5c}", i));
+        write!(expected_query, "\u{1b}.unwrap()4;{};?\u{1b}\u{5c}", i).unwrap();
     }
     assert_eq!(
         String::from_utf8(extracted_stdout_buffer),

--- a/zellij-client/src/unit/stdin_tests.rs
+++ b/zellij-client/src/unit/stdin_tests.rs
@@ -349,7 +349,7 @@ pub fn terminal_info_queried_from_terminal_emulator() {
     let mut expected_query =
         String::from("\u{1b}[14t\u{1b}[16t\u{1b}]11;?\u{1b}\u{5c}\u{1b}]10;?\u{1b}\u{5c}");
     for i in 0..256 {
-        write!(expected_query, "\u{1b}.unwrap()4;{};?\u{1b}\u{5c}", i).unwrap();
+        write!(expected_query, "\u{1b}]4;{};?\u{1b}\u{5c}", i).unwrap();
     }
     assert_eq!(
         String::from_utf8(extracted_stdout_buffer),

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -146,7 +146,7 @@ fn handle_openpty(
     let err_context = |cmd: &RunCommand| {
         format!(
             "failed to open PTY for command '{}'",
-            cmd.command.to_string_lossy().to_string()
+            cmd.command.to_string_lossy()
         )
     };
 

--- a/zellij-server/src/output/mod.rs
+++ b/zellij-server/src/output/mod.rs
@@ -816,6 +816,14 @@ impl CharacterChunk {
     }
 }
 
+/// Custom data type for aggregating the output of `Pane::render`, for any suitable pane.
+#[derive(Debug, Clone, Default)]
+pub struct RenderOutput {
+    pub character_chunks: Vec<CharacterChunk>,
+    pub raw_vte_output: Option<String>,
+    pub sixel_image_chunks: Vec<SixelImageChunk>,
+}
+
 #[derive(Clone, Debug)]
 pub struct OutputBuffer {
     pub changed_lines: Vec<usize>, // line index

--- a/zellij-server/src/panes/active_panes.rs
+++ b/zellij-server/src/panes/active_panes.rs
@@ -55,12 +55,12 @@ impl ActivePanes {
         self.active_panes.remove(client_id)
     }
     pub fn unfocus_all_panes(&self, panes: &mut BTreeMap<PaneId, Box<dyn Pane>>) {
-        for (_client_id, pane_id) in &self.active_panes {
+        for pane_id in self.active_panes.values() {
             self.unfocus_pane(*pane_id, panes);
         }
     }
     pub fn focus_all_panes(&self, panes: &mut BTreeMap<PaneId, Box<dyn Pane>>) {
-        for (_client_id, pane_id) in &self.active_panes {
+        for pane_id in self.active_panes.values() {
             self.focus_pane(*pane_id, panes);
         }
     }

--- a/zellij-server/src/panes/active_panes.rs
+++ b/zellij-server/src/panes/active_panes.rs
@@ -49,7 +49,7 @@ impl ActivePanes {
         client_id: &ClientId,
         panes: &mut BTreeMap<PaneId, Box<dyn Pane>>,
     ) -> Option<PaneId> {
-        if let Some(pane_id_to_unfocus) = self.active_panes.get(&client_id) {
+        if let Some(pane_id_to_unfocus) = self.active_panes.get(client_id) {
             self.unfocus_pane(*pane_id_to_unfocus, panes);
         }
         self.active_panes.remove(client_id)

--- a/zellij-server/src/panes/active_panes.rs
+++ b/zellij-server/src/panes/active_panes.rs
@@ -9,6 +9,7 @@ pub struct ActivePanes {
 }
 
 impl ActivePanes {
+    #[allow(clippy::borrowed_box)]
     pub fn new(os_api: &Box<dyn ServerOsApi>) -> Self {
         let os_api = os_api.clone();
         ActivePanes {

--- a/zellij-server/src/panes/floating_panes/floating_pane_grid.rs
+++ b/zellij-server/src/panes/floating_panes/floating_pane_grid.rs
@@ -817,7 +817,7 @@ impl<'a> FloatingPaneGrid<'a> {
             &self.viewport,
             &pane_geoms
         );
-        return None;
+        None
     }
 }
 

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -162,8 +162,9 @@ impl FloatingPanes {
         is_first_run: bool,
         run_command: RunCommand,
     ) {
-        if let Some(p) = self.panes
-            .get_mut(&pane_id) { p.hold(exit_status, is_first_run, run_command) }
+        if let Some(p) = self.panes.get_mut(&pane_id) {
+            p.hold(exit_status, is_first_run, run_command)
+        }
     }
     pub fn get(&self, pane_id: &PaneId) -> Option<&Box<dyn Pane>> {
         self.panes.get(pane_id)

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -162,9 +162,8 @@ impl FloatingPanes {
         is_first_run: bool,
         run_command: RunCommand,
     ) {
-        self.panes
-            .get_mut(&pane_id)
-            .map(|p| p.hold(exit_status, is_first_run, run_command));
+        if let Some(p) = self.panes
+            .get_mut(&pane_id) { p.hold(exit_status, is_first_run, run_command) }
     }
     pub fn get(&self, pane_id: &PaneId) -> Option<&Box<dyn Pane>> {
         self.panes.get(pane_id)

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -273,7 +273,7 @@ fn calculate_row_display_height(row_width: usize, viewport_width: usize) -> usiz
 
 fn subtract_isize_from_usize(u: usize, i: isize) -> usize {
     if i.is_negative() {
-        u - i.abs() as usize
+        u - i.unsigned_abs()
     } else {
         u + i as usize
     }
@@ -1601,7 +1601,7 @@ impl Grid {
                 Row::from_columns(VecDeque::from(vec![EMPTY_TERMINAL_CHARACTER; self.width]));
 
             // get the row from lines_above, viewport, or lines below depending on index
-            let row = if l < 0 && self.lines_above.len() > l.abs() as usize {
+            let row = if l < 0 && self.lines_above.len() > l.unsigned_abs() {
                 let offset_from_end = l.abs();
                 &self.lines_above[self
                     .lines_above

--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -172,7 +172,7 @@ impl Pane for PluginPane {
                 .recv()
                 .with_context(err_context)
                 .to_log()
-                .unwrap_or("No output from plugin received. See logs".to_string());
+                .unwrap_or_else(|_| "No output from plugin received. See logs".to_string());
             for (index, line) in contents.lines().enumerate() {
                 let actual_len = ansi_len(line);
                 let line_to_print = if actual_len > self.get_content_columns() {

--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -807,7 +807,7 @@ pub fn render_first_run_banner(
             )
         },
         None => {
-            let bare_text = format!("Waiting to start...");
+            let bare_text = "Waiting to start...".to_string();
             let bare_text_width = bare_text.width();
             let column_start_postion = middle_column.saturating_sub(bare_text_width / 2);
             let bold_text = RESET_STYLES.bold(Some(AnsiCode::On));

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -1,4 +1,4 @@
-use crate::output::{CharacterChunk, SixelImageChunk};
+use crate::output::RenderOutput;
 use crate::panes::sixel::SixelImageStore;
 use crate::panes::{
     grid::Grid,
@@ -275,10 +275,7 @@ impl Pane for TerminalPane {
     fn set_selectable(&mut self, selectable: bool) {
         self.selectable = selectable;
     }
-    fn render(
-        &mut self,
-        _client_id: Option<ClientId>,
-    ) -> Result<Option<(Vec<CharacterChunk>, Option<String>, Vec<SixelImageChunk>)>> {
+    fn render(&mut self, _client_id: Option<ClientId>) -> Result<Option<RenderOutput>> {
         if self.should_render() {
             let mut raw_vte_output = String::new();
             let content_x = self.get_content_x();
@@ -338,11 +335,11 @@ impl Pane for TerminalPane {
                 self.grid.ring_bell = false;
             }
             self.set_should_render(false);
-            Ok(Some((
+            Ok(Some(RenderOutput {
                 character_chunks,
-                Some(raw_vte_output),
+                raw_vte_output: Some(raw_vte_output),
                 sixel_image_chunks,
-            )))
+            }))
         } else {
             Ok(None)
         }
@@ -352,7 +349,7 @@ impl Pane for TerminalPane {
         client_id: ClientId,
         frame_params: FrameParams,
         input_mode: InputMode,
-    ) -> Result<Option<(Vec<CharacterChunk>, Option<String>)>> {
+    ) -> Result<Option<RenderOutput>> {
         let err_context = || format!("failed to render frame for client {client_id}");
         // TODO: remove the cursor stuff from here
         let pane_title = if self.pane_name.is_empty()

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -233,7 +233,8 @@ impl TiledPanes {
             SplitDirection::Vertical => {
                 pane_grid.layout(direction, (*self.display_area.borrow()).rows)
             },
-        }.map_err(anyError::msg)
+        }
+        .map_err(anyError::msg)
         .with_context(|| format!("{:?} relayout of tab failed", direction))
         .non_fatal();
 
@@ -1036,8 +1037,9 @@ impl TiledPanes {
         is_first_run: bool,
         run_command: RunCommand,
     ) {
-        if let Some(p) = self.panes
-            .get_mut(&pane_id) { p.hold(exit_status, is_first_run, run_command) }
+        if let Some(p) = self.panes.get_mut(&pane_id) {
+            p.hold(exit_status, is_first_run, run_command)
+        }
     }
     pub fn panes_to_hide_contains(&self, pane_id: PaneId) -> bool {
         self.panes_to_hide.contains(&pane_id)

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -233,8 +233,7 @@ impl TiledPanes {
             SplitDirection::Vertical => {
                 pane_grid.layout(direction, (*self.display_area.borrow()).rows)
             },
-        }
-        .or_else(|e| Err(anyError::msg(e)))
+        }.map_err(anyError::msg)
         .with_context(|| format!("{:?} relayout of tab failed", direction))
         .non_fatal();
 
@@ -1037,9 +1036,8 @@ impl TiledPanes {
         is_first_run: bool,
         run_command: RunCommand,
     ) {
-        self.panes
-            .get_mut(&pane_id)
-            .map(|p| p.hold(exit_status, is_first_run, run_command));
+        if let Some(p) = self.panes
+            .get_mut(&pane_id) { p.hold(exit_status, is_first_run, run_command) }
     }
     pub fn panes_to_hide_contains(&self, pane_id: PaneId) -> bool {
         self.panes_to_hide.contains(&pane_id)

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -943,7 +943,7 @@ fn send_command_not_found_to_screen(
         .send_to_screen(ScreenInstruction::HoldPane(
             PaneId::Terminal(terminal_id),
             Some(2),
-            run_command.clone(),
+            run_command,
             None,
         ))
         .with_context(err_context)?;

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -19,7 +19,7 @@ use crate::ui::pane_boundaries_frame::FrameParams;
 use self::clipboard::ClipboardProvider;
 use crate::{
     os_input_output::ServerOsApi,
-    output::{CharacterChunk, Output, SixelImageChunk},
+    output::{Output, RenderOutput},
     panes::sixel::SixelImageStore,
     panes::{FloatingPanes, TiledPanes},
     panes::{LinkHandler, PaneId, PluginPane, TerminalPane},
@@ -143,16 +143,13 @@ pub trait Pane {
     fn set_should_render_boundaries(&mut self, _should_render: bool) {}
     fn selectable(&self) -> bool;
     fn set_selectable(&mut self, selectable: bool);
-    fn render(
-        &mut self,
-        client_id: Option<ClientId>,
-    ) -> Result<Option<(Vec<CharacterChunk>, Option<String>, Vec<SixelImageChunk>)>>; // TODO: better
+    fn render(&mut self, client_id: Option<ClientId>) -> Result<Option<RenderOutput>>;
     fn render_frame(
         &mut self,
         client_id: ClientId,
         frame_params: FrameParams,
         input_mode: InputMode,
-    ) -> Result<Option<(Vec<CharacterChunk>, Option<String>)>>; // TODO: better
+    ) -> Result<Option<RenderOutput>>;
     fn render_fake_cursor(
         &mut self,
         cursor_color: PaletteColor,

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -2554,12 +2554,9 @@ impl Tab {
                     .and_then(|serialized_output| {
                         self.senders
                             .send_to_server(ServerInstruction::Render(Some(serialized_output)))
-                    })
-                    .and_then(|_| {
-                        Ok(Event::CopyToClipboard(
+                    }).map(|_| Event::CopyToClipboard(
                             self.clipboard_provider.as_copy_destination(),
                         ))
-                    })
                     .with_context(err_context)?,
                 Err(err) => {
                     Err::<(), _>(err).with_context(err_context).non_fatal();

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -2554,9 +2554,8 @@ impl Tab {
                     .and_then(|serialized_output| {
                         self.senders
                             .send_to_server(ServerInstruction::Render(Some(serialized_output)))
-                    }).map(|_| Event::CopyToClipboard(
-                            self.clipboard_provider.as_copy_destination(),
-                        ))
+                    })
+                    .map(|_| Event::CopyToClipboard(self.clipboard_provider.as_copy_destination()))
                     .with_context(err_context)?,
                 Err(err) => {
                     Err::<(), _>(err).with_context(err_context).non_fatal();

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -63,7 +63,7 @@ impl ServerOsApi for FakeInputOutput {
             .lock()
             .unwrap()
             .entry(id)
-            .or_insert_with(|| vec![])
+            .or_insert_with(std::vec::Vec::new)
             .extend_from_slice(buf);
         Ok(buf.len())
     }

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -229,11 +229,7 @@ fn create_new_tab(size: Size, default_mode: ModeInfo) -> Tab {
     tab
 }
 
-fn create_new_tab_with_os_api(
-    size: Size,
-    default_mode: ModeInfo,
-    os_api: &Box<FakeInputOutput>,
-) -> Tab {
+fn create_new_tab_with_os_api(size: Size, default_mode: ModeInfo, os_api: &FakeInputOutput) -> Tab {
     set_session_name("test".into());
     let index = 0;
     let position = 0;
@@ -261,7 +257,7 @@ fn create_new_tab_with_os_api(
         size,
         character_cell_info,
         sixel_image_store,
-        os_api,
+        Box::new(os_api),
         senders,
         max_panes,
         style,

--- a/zellij-server/src/ui/pane_boundaries_frame.rs
+++ b/zellij-server/src/ui/pane_boundaries_frame.rs
@@ -652,23 +652,21 @@ impl PaneFrame {
             } else {
                 self.empty_undertitle(max_undertitle_length)
             }
-        } else {
-            if first_part_len <= max_undertitle_length {
-                // render first part
-                let full_text_len = first_part_len;
-                let mut padding = String::new();
-                for _ in full_text_len..max_undertitle_length {
-                    padding.push_str(boundary_type::HORIZONTAL);
-                }
-                let mut ret = vec![];
-                ret.append(&mut left_boundary);
-                ret.append(&mut first_part);
-                ret.append(&mut foreground_color(&padding, self.color));
-                ret.append(&mut right_boundary);
-                ret
-            } else {
-                self.empty_undertitle(max_undertitle_length)
+        } else if first_part_len <= max_undertitle_length {
+            // render first part
+            let full_text_len = first_part_len;
+            let mut padding = String::new();
+            for _ in full_text_len..max_undertitle_length {
+                padding.push_str(boundary_type::HORIZONTAL);
             }
+            let mut ret = vec![];
+            ret.append(&mut left_boundary);
+            ret.append(&mut first_part);
+            ret.append(&mut foreground_color(&padding, self.color));
+            ret.append(&mut right_boundary);
+            ret
+        } else {
+            self.empty_undertitle(max_undertitle_length)
         };
         Ok(res)
     }

--- a/zellij-server/src/ui/pane_boundaries_frame.rs
+++ b/zellij-server/src/ui/pane_boundaries_frame.rs
@@ -1,4 +1,4 @@
-use crate::output::CharacterChunk;
+use crate::output::{CharacterChunk, RenderOutput};
 use crate::panes::{AnsiCode, CharacterStyles, TerminalCharacter, EMPTY_TERMINAL_CHARACTER};
 use crate::ui::boundaries::boundary_type;
 use crate::ClientId;
@@ -670,7 +670,7 @@ impl PaneFrame {
         };
         Ok(res)
     }
-    pub fn render(&self) -> Result<(Vec<CharacterChunk>, Option<String>)> {
+    pub fn render(&self) -> Result<RenderOutput> {
         let err_context = || "failed to render pane frame";
         let mut character_chunks = vec![];
         for row in 0..self.geom.rows {
@@ -724,7 +724,10 @@ impl PaneFrame {
                 character_chunks.push(CharacterChunk::new(boundary_character_right, x, y));
             }
         }
-        Ok((character_chunks, None))
+        Ok(RenderOutput {
+            character_chunks,
+            ..Default::default()
+        })
     }
     fn first_exited_held_title_part_full(&self) -> (Vec<TerminalCharacter>, usize) {
         // (title part, length)

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -1292,12 +1292,7 @@ pub fn send_cli_scroll_up_action() {
         &mut mock_screen,
         client_id,
     );
-    send_cli_action_to_server(
-        &session_metadata,
-        cli_action,
-        &mut mock_screen,
-        client_id,
-    );
+    send_cli_action_to_server(&session_metadata, cli_action, &mut mock_screen, client_id);
     std::thread::sleep(std::time::Duration::from_millis(100));
     mock_screen.teardown(vec![server_instruction, screen_thread]);
     let snapshots = take_snapshots_and_cursor_coordinates_from_render_events(

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -20,6 +20,7 @@ use zellij_utils::pane_size::{Size, SizeInPixels};
 
 use crate::pty_writer::PtyWriteInstruction;
 use std::env::set_var;
+use std::fmt::Write;
 use std::os::unix::io::RawFd;
 use std::sync::{Arc, Mutex};
 
@@ -221,8 +222,10 @@ fn create_new_screen(size: Size) -> Screen {
         ..Default::default()
     };
     let max_panes = None;
-    let mut mode_info = ModeInfo::default();
-    mode_info.session_name = Some("zellij-test".into());
+    let mode_info = ModeInfo {
+        session_name: Some("zellij-test".into()),
+        ..Default::default()
+    };
     let draw_pane_frames = false;
     let session_is_mirrored = true;
     let copy_options = CopyOptions::default();
@@ -951,9 +954,11 @@ pub fn send_cli_write_action_to_screen() {
 pub fn send_cli_resize_action_to_screen() {
     let size = Size { cols: 80, rows: 20 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -989,9 +994,11 @@ pub fn send_cli_resize_action_to_screen() {
 pub fn send_cli_focus_next_pane_action() {
     let size = Size { cols: 80, rows: 20 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -1027,9 +1034,11 @@ pub fn send_cli_focus_next_pane_action() {
 pub fn send_cli_focus_previous_pane_action() {
     let size = Size { cols: 80, rows: 20 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -1065,9 +1074,11 @@ pub fn send_cli_focus_previous_pane_action() {
 pub fn send_cli_move_focus_pane_action() {
     let size = Size { cols: 80, rows: 20 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -1105,9 +1116,11 @@ pub fn send_cli_move_focus_pane_action() {
 pub fn send_cli_move_focus_or_tab_pane_action() {
     let size = Size { cols: 80, rows: 20 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -1145,9 +1158,11 @@ pub fn send_cli_move_focus_or_tab_pane_action() {
 pub fn send_cli_move_pane_action() {
     let size = Size { cols: 80, rows: 20 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -1179,9 +1194,11 @@ pub fn send_cli_move_pane_action() {
 pub fn send_cli_dump_screen_action() {
     let size = Size { cols: 80, rows: 20 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -1213,9 +1230,11 @@ pub fn send_cli_dump_screen_action() {
 pub fn send_cli_edit_scrollback_action() {
     let size = Size { cols: 80, rows: 20 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -1261,9 +1280,11 @@ pub fn send_cli_edit_scrollback_action() {
 pub fn send_cli_scroll_up_action() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -1277,7 +1298,7 @@ pub fn send_cli_scroll_up_action() {
     let cli_action = CliAction::ScrollUp;
     let mut pane_contents = String::new();
     for i in 0..20 {
-        pane_contents.push_str(&format!("fill pane up with something {}\n\r", i));
+        write!(pane_contents, "fill pane up with something {}\n\r", i).unwrap();
     }
     let _ = mock_screen.to_screen.send(ScreenInstruction::PtyBytes(
         0,
@@ -1310,9 +1331,11 @@ pub fn send_cli_scroll_up_action() {
 pub fn send_cli_scroll_down_action() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -1327,7 +1350,7 @@ pub fn send_cli_scroll_down_action() {
     let scroll_down_cli_action = CliAction::ScrollDown;
     let mut pane_contents = String::new();
     for i in 0..20 {
-        pane_contents.push_str(&format!("fill pane up with something {}\n\r", i));
+        write!(pane_contents, "fill pane up with something {}\n\r", i).unwrap();
     }
     let _ = mock_screen.to_screen.send(ScreenInstruction::PtyBytes(
         0,
@@ -1390,9 +1413,11 @@ pub fn send_cli_scroll_down_action() {
 pub fn send_cli_scroll_to_bottom_action() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -1407,7 +1432,7 @@ pub fn send_cli_scroll_to_bottom_action() {
     let scroll_to_bottom_action = CliAction::ScrollToBottom;
     let mut pane_contents = String::new();
     for i in 0..20 {
-        pane_contents.push_str(&format!("fill pane up with something {}\n\r", i));
+        write!(pane_contents, "fill pane up with something {}\n\r", i).unwrap();
     }
     let _ = mock_screen.to_screen.send(ScreenInstruction::PtyBytes(
         0,
@@ -1464,9 +1489,11 @@ pub fn send_cli_scroll_to_bottom_action() {
 pub fn send_cli_page_scroll_up_action() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -1480,7 +1507,7 @@ pub fn send_cli_page_scroll_up_action() {
     let page_scroll_up_action = CliAction::PageScrollUp;
     let mut pane_contents = String::new();
     for i in 0..20 {
-        pane_contents.push_str(&format!("fill pane up with something {}\n\r", i));
+        write!(pane_contents, "fill pane up with something {}\n\r", i).unwrap();
     }
     let _ = mock_screen.to_screen.send(ScreenInstruction::PtyBytes(
         0,
@@ -1510,9 +1537,11 @@ pub fn send_cli_page_scroll_up_action() {
 pub fn send_cli_page_scroll_down_action() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -1527,7 +1556,7 @@ pub fn send_cli_page_scroll_down_action() {
     let page_scroll_down_action = CliAction::PageScrollDown;
     let mut pane_contents = String::new();
     for i in 0..20 {
-        pane_contents.push_str(&format!("fill pane up with something {}\n\r", i));
+        write!(pane_contents, "fill pane up with something {}\n\r", i).unwrap();
     }
     let _ = mock_screen.to_screen.send(ScreenInstruction::PtyBytes(
         0,
@@ -1573,9 +1602,11 @@ pub fn send_cli_page_scroll_down_action() {
 pub fn send_cli_half_page_scroll_up_action() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -1589,7 +1620,7 @@ pub fn send_cli_half_page_scroll_up_action() {
     let half_page_scroll_up_action = CliAction::HalfPageScrollUp;
     let mut pane_contents = String::new();
     for i in 0..20 {
-        pane_contents.push_str(&format!("fill pane up with something {}\n\r", i));
+        write!(pane_contents, "fill pane up with something {}\n\r", i).unwrap();
     }
     let _ = mock_screen.to_screen.send(ScreenInstruction::PtyBytes(
         0,
@@ -1619,9 +1650,11 @@ pub fn send_cli_half_page_scroll_up_action() {
 pub fn send_cli_half_page_scroll_down_action() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -1636,7 +1669,7 @@ pub fn send_cli_half_page_scroll_down_action() {
     let half_page_scroll_down_action = CliAction::HalfPageScrollDown;
     let mut pane_contents = String::new();
     for i in 0..20 {
-        pane_contents.push_str(&format!("fill pane up with something {}\n\r", i));
+        write!(pane_contents, "fill pane up with something {}\n\r", i).unwrap();
     }
     let _ = mock_screen.to_screen.send(ScreenInstruction::PtyBytes(
         0,
@@ -1682,9 +1715,11 @@ pub fn send_cli_half_page_scroll_down_action() {
 pub fn send_cli_toggle_full_screen_action() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -1719,9 +1754,11 @@ pub fn send_cli_toggle_full_screen_action() {
 pub fn send_cli_toggle_pane_frames_action() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -1762,9 +1799,11 @@ pub fn send_cli_toggle_active_tab_sync_action() {
     let mut mock_screen = MockScreen::new(size);
     let pty_writer_receiver = mock_screen.pty_writer_receiver.take().unwrap();
     let session_metadata = mock_screen.clone_session_metadata();
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let screen_thread = mock_screen.run(Some(initial_layout));
     let received_pty_instructions = Arc::new(Mutex::new(vec![]));
     let pty_writer_thread = log_actions_in_thread!(
@@ -1803,9 +1842,11 @@ pub fn send_cli_new_pane_action_with_default_parameters() {
     let mut mock_screen = MockScreen::new(size);
     let pty_receiver = mock_screen.pty_receiver.take().unwrap();
     let session_metadata = mock_screen.clone_session_metadata();
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let screen_thread = mock_screen.run(Some(initial_layout));
     let received_pty_instructions = Arc::new(Mutex::new(vec![]));
     let pty_thread = log_actions_in_thread!(
@@ -1843,9 +1884,11 @@ pub fn send_cli_new_pane_action_with_split_direction() {
     let mut mock_screen = MockScreen::new(size);
     let pty_receiver = mock_screen.pty_receiver.take().unwrap();
     let session_metadata = mock_screen.clone_session_metadata();
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let screen_thread = mock_screen.run(Some(initial_layout));
     let received_pty_instructions = Arc::new(Mutex::new(vec![]));
     let pty_thread = log_actions_in_thread!(
@@ -1883,9 +1926,11 @@ pub fn send_cli_new_pane_action_with_command_and_cwd() {
     let mut mock_screen = MockScreen::new(size);
     let pty_receiver = mock_screen.pty_receiver.take().unwrap();
     let session_metadata = mock_screen.clone_session_metadata();
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let screen_thread = mock_screen.run(Some(initial_layout));
     let received_pty_instructions = Arc::new(Mutex::new(vec![]));
     let pty_thread = log_actions_in_thread!(
@@ -1923,9 +1968,11 @@ pub fn send_cli_edit_action_with_default_parameters() {
     let mut mock_screen = MockScreen::new(size);
     let pty_receiver = mock_screen.pty_receiver.take().unwrap();
     let session_metadata = mock_screen.clone_session_metadata();
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let screen_thread = mock_screen.run(Some(initial_layout));
     let received_pty_instructions = Arc::new(Mutex::new(vec![]));
     let pty_thread = log_actions_in_thread!(
@@ -1961,9 +2008,11 @@ pub fn send_cli_edit_action_with_line_number() {
     let mut mock_screen = MockScreen::new(size);
     let pty_receiver = mock_screen.pty_receiver.take().unwrap();
     let session_metadata = mock_screen.clone_session_metadata();
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let screen_thread = mock_screen.run(Some(initial_layout));
     let received_pty_instructions = Arc::new(Mutex::new(vec![]));
     let pty_thread = log_actions_in_thread!(
@@ -1999,9 +2048,11 @@ pub fn send_cli_edit_action_with_split_direction() {
     let mut mock_screen = MockScreen::new(size);
     let pty_receiver = mock_screen.pty_receiver.take().unwrap();
     let session_metadata = mock_screen.clone_session_metadata();
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let screen_thread = mock_screen.run(Some(initial_layout));
     let received_pty_instructions = Arc::new(Mutex::new(vec![]));
     let pty_thread = log_actions_in_thread!(
@@ -2036,9 +2087,11 @@ pub fn send_cli_switch_mode_action() {
     let client_id = 10; // fake client id should not appear in the screen's state
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let screen_thread = mock_screen.run(Some(initial_layout));
     let cli_switch_mode = CliAction::SwitchMode {
         input_mode: InputMode::Locked,
@@ -2065,9 +2118,11 @@ pub fn send_cli_switch_mode_action() {
 pub fn send_cli_toggle_pane_embed_or_float() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -2111,9 +2166,11 @@ pub fn send_cli_toggle_pane_embed_or_float() {
 pub fn send_cli_toggle_floating_panes() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -2166,9 +2223,11 @@ pub fn send_cli_toggle_floating_panes() {
 pub fn send_cli_close_pane_action() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -2203,9 +2262,11 @@ pub fn send_cli_close_pane_action() {
 pub fn send_cli_new_tab_action_default_params() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -2236,9 +2297,11 @@ pub fn send_cli_new_tab_action_default_params() {
 pub fn send_cli_new_tab_action_with_name_and_layout() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     let session_metadata = mock_screen.clone_session_metadata();
     let screen_thread = mock_screen.run(Some(initial_layout));
@@ -2269,13 +2332,7 @@ pub fn send_cli_new_tab_action_with_name_and_layout() {
         .lock()
         .unwrap()
         .iter()
-        .find(|i| {
-            if let PtyInstruction::NewTab(..) = i {
-                true
-            } else {
-                false
-            }
-        })
+        .find(|i| matches!(i, PtyInstruction::NewTab(..)))
         .unwrap()
         .clone();
     assert_snapshot!(format!("{:#?}", new_tab_instruction));
@@ -2285,12 +2342,16 @@ pub fn send_cli_new_tab_action_with_name_and_layout() {
 pub fn send_cli_next_tab_action() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
-    let mut second_tab_layout = PaneLayout::default();
-    second_tab_layout.children_split_direction = SplitDirection::Horizontal;
-    second_tab_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
+    let second_tab_layout = PaneLayout {
+        children_split_direction: SplitDirection::Horizontal,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     mock_screen.new_tab(second_tab_layout);
     let session_metadata = mock_screen.clone_session_metadata();
@@ -2326,12 +2387,16 @@ pub fn send_cli_next_tab_action() {
 pub fn send_cli_previous_tab_action() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
-    let mut second_tab_layout = PaneLayout::default();
-    second_tab_layout.children_split_direction = SplitDirection::Horizontal;
-    second_tab_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
+    let second_tab_layout = PaneLayout {
+        children_split_direction: SplitDirection::Horizontal,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     mock_screen.new_tab(second_tab_layout);
     let session_metadata = mock_screen.clone_session_metadata();
@@ -2367,12 +2432,16 @@ pub fn send_cli_previous_tab_action() {
 pub fn send_cli_goto_tab_action() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
-    let mut second_tab_layout = PaneLayout::default();
-    second_tab_layout.children_split_direction = SplitDirection::Horizontal;
-    second_tab_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
+    let second_tab_layout = PaneLayout {
+        children_split_direction: SplitDirection::Horizontal,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     mock_screen.new_tab(second_tab_layout);
     let session_metadata = mock_screen.clone_session_metadata();
@@ -2403,12 +2472,16 @@ pub fn send_cli_goto_tab_action() {
 pub fn send_cli_close_tab_action() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
-    let mut second_tab_layout = PaneLayout::default();
-    second_tab_layout.children_split_direction = SplitDirection::Horizontal;
-    second_tab_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
+    let second_tab_layout = PaneLayout {
+        children_split_direction: SplitDirection::Horizontal,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     mock_screen.new_tab(second_tab_layout);
     let session_metadata = mock_screen.clone_session_metadata();
@@ -2439,12 +2512,16 @@ pub fn send_cli_close_tab_action() {
 pub fn send_cli_rename_tab() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
-    let mut second_tab_layout = PaneLayout::default();
-    second_tab_layout.children_split_direction = SplitDirection::Horizontal;
-    second_tab_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
+    let second_tab_layout = PaneLayout {
+        children_split_direction: SplitDirection::Horizontal,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     mock_screen.new_tab(second_tab_layout);
     let session_metadata = mock_screen.clone_session_metadata();
@@ -2472,12 +2549,16 @@ pub fn send_cli_rename_tab() {
 pub fn send_cli_undo_rename_tab() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10; // fake client id should not appear in the screen's state
-    let mut initial_layout = PaneLayout::default();
-    initial_layout.children_split_direction = SplitDirection::Vertical;
-    initial_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
-    let mut second_tab_layout = PaneLayout::default();
-    second_tab_layout.children_split_direction = SplitDirection::Horizontal;
-    second_tab_layout.children = vec![PaneLayout::default(), PaneLayout::default()];
+    let initial_layout = PaneLayout {
+        children_split_direction: SplitDirection::Vertical,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
+    let second_tab_layout = PaneLayout {
+        children_split_direction: SplitDirection::Horizontal,
+        children: vec![PaneLayout::default(), PaneLayout::default()],
+        ..Default::default()
+    };
     let mut mock_screen = MockScreen::new(size);
     mock_screen.new_tab(second_tab_layout);
     let session_metadata = mock_screen.clone_session_metadata();

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -111,7 +111,7 @@ fn send_cli_action_to_server(
     for action in actions {
         route_action(
             action,
-            &session_metadata,
+            session_metadata,
             &*os_input,
             &to_server.clone(),
             client_id,
@@ -322,7 +322,7 @@ impl MockScreen {
         // hack that only clones the clonable parts of SessionMetaData
         SessionMetaData {
             senders: self.session_metadata.senders.clone(),
-            capabilities: self.session_metadata.capabilities.clone(),
+            capabilities: self.session_metadata.capabilities,
             client_attributes: self.session_metadata.client_attributes.clone(),
             default_shell: self.session_metadata.default_shell.clone(),
             screen_thread: None,
@@ -1294,7 +1294,7 @@ pub fn send_cli_scroll_up_action() {
     );
     send_cli_action_to_server(
         &session_metadata,
-        cli_action.clone(),
+        cli_action,
         &mut mock_screen,
         client_id,
     );
@@ -1360,7 +1360,7 @@ pub fn send_cli_scroll_down_action() {
     );
     send_cli_action_to_server(
         &session_metadata,
-        scroll_up_cli_action.clone(),
+        scroll_up_cli_action,
         &mut mock_screen,
         client_id,
     );
@@ -1374,7 +1374,7 @@ pub fn send_cli_scroll_down_action() {
     );
     send_cli_action_to_server(
         &session_metadata,
-        scroll_down_cli_action.clone(),
+        scroll_down_cli_action,
         &mut mock_screen,
         client_id,
     );
@@ -1440,7 +1440,7 @@ pub fn send_cli_scroll_to_bottom_action() {
     );
     send_cli_action_to_server(
         &session_metadata,
-        scroll_up_cli_action.clone(),
+        scroll_up_cli_action,
         &mut mock_screen,
         client_id,
     );
@@ -1448,7 +1448,7 @@ pub fn send_cli_scroll_to_bottom_action() {
     // scroll to bottom
     send_cli_action_to_server(
         &session_metadata,
-        scroll_to_bottom_action.clone(),
+        scroll_to_bottom_action,
         &mut mock_screen,
         client_id,
     );
@@ -1549,7 +1549,7 @@ pub fn send_cli_page_scroll_down_action() {
     );
     send_cli_action_to_server(
         &session_metadata,
-        page_scroll_up_action.clone(),
+        page_scroll_up_action,
         &mut mock_screen,
         client_id,
     );
@@ -1658,7 +1658,7 @@ pub fn send_cli_half_page_scroll_down_action() {
     );
     send_cli_action_to_server(
         &session_metadata,
-        half_page_scroll_up_action.clone(),
+        half_page_scroll_up_action,
         &mut mock_screen,
         client_id,
     );
@@ -2095,7 +2095,7 @@ pub fn send_cli_toggle_pane_embed_or_float() {
     // second time to embed
     send_cli_action_to_server(
         &session_metadata,
-        toggle_pane_embed_or_floating.clone(),
+        toggle_pane_embed_or_floating,
         &mut mock_screen,
         client_id,
     );
@@ -2150,7 +2150,7 @@ pub fn send_cli_toggle_floating_panes() {
     // toggle floating panes (will show the floated pane)
     send_cli_action_to_server(
         &session_metadata,
-        toggle_floating_panes.clone(),
+        toggle_floating_panes,
         &mut mock_screen,
         client_id,
     );
@@ -2276,9 +2276,9 @@ pub fn send_cli_new_tab_action_with_name_and_layout() {
         .iter()
         .find(|i| {
             if let PtyInstruction::NewTab(..) = i {
-                return true;
+                true
             } else {
-                return false;
+                false
             }
         })
         .unwrap()

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -52,7 +52,7 @@ pub fn exec_cmd(cmd: &[&str]) {
 }
 
 pub fn report_panic(info: &std::panic::PanicInfo) {
-    println!("");
+    println!();
     println!("A panic occured in a plugin");
     println!("{:#?}", info);
     unsafe { host_report_panic() };

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -122,24 +122,26 @@ impl FromStr for Key {
                 _ => {
                     let mut key_chars = main_key.chars();
                     let key_count = main_key.chars().count();
-                    if key_count == 1 {
-                        let key_char = key_chars.next().unwrap();
-                        Ok(Key::Char(key_char))
-                    } else if key_count > 1 {
-                        if let Some(first_char) = key_chars.next() {
-                            if first_char == 'F' {
-                                let f_index: String = key_chars.collect();
-                                let f_index: u8 = f_index
-                                    .parse()
-                                    .map_err(|e| format!("Failed to parse F index: {}", e))?;
-                                if (1..=12).contains(&f_index) {
-                                    return Ok(Key::F(f_index));
+                    match key_count {
+                        0 => Err(format!("Failed to parse key: {}", key_str).into()),
+                        1 => {
+                            let key_char = key_chars.next().unwrap();
+                            Ok(Key::Char(key_char))
+                        },
+                        _ => {
+                            if let Some(first_char) = key_chars.next() {
+                                if first_char == 'F' {
+                                    let f_index: String = key_chars.collect();
+                                    let f_index: u8 = f_index
+                                        .parse()
+                                        .map_err(|e| format!("Failed to parse F index: {}", e))?;
+                                    if (1..=12).contains(&f_index) {
+                                        return Ok(Key::F(f_index));
+                                    }
                                 }
                             }
-                        }
-                        Err(format!("Failed to parse key: {}", key_str).into())
-                    } else {
-                        Err(format!("Failed to parse key: {}", key_str).into())
+                            Err(format!("Failed to parse key: {}", key_str).into())
+                        },
                     }
                 },
             },

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -132,7 +132,7 @@ impl FromStr for Key {
                                 let f_index: u8 = f_index
                                     .parse()
                                     .map_err(|e| format!("Failed to parse F index: {}", e))?;
-                                if f_index >= 1 && f_index <= 12 {
+                                if (1..=12).contains(&f_index) {
                                     return Ok(Key::F(f_index));
                                 }
                             }

--- a/zellij-utils/src/input/config.rs
+++ b/zellij-utils/src/input/config.rs
@@ -63,7 +63,7 @@ impl Diagnostic for KdlError {
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         match &self.help_message {
             Some(help_message) => Some(Box::new(help_message)),
-            None => Some(Box::new(format!("For more information, please see our configuration guide: https://zellij.dev/documentation/configuration.html")))
+            None => Some(Box::new("For more information, please see our configuration guide: https://zellij.dev/documentation/configuration.html".to_string()))
         }
     }
     fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
@@ -117,7 +117,7 @@ impl ConfigError {
             src: None,
             offset: Some(offset),
             len: Some(len),
-            help_message: Some(format!("For more information, please see our layout guide: https://zellij.dev/documentation/creating-a-layout.html")),
+            help_message: Some("For more information, please see our layout guide: https://zellij.dev/documentation/creating-a-layout.html".to_string()),
         })
     }
 }

--- a/zellij-utils/src/input/keybinds.rs
+++ b/zellij-utils/src/input/keybinds.rs
@@ -59,7 +59,7 @@ impl Keybinds {
         for (mode, mode_binds) in &self.0 {
             let mut mode_binds_vec: Vec<(Key, Vec<Action>)> = vec![];
             for (key, actions) in mode_binds {
-                mode_binds_vec.push((key.clone(), actions.clone()));
+                mode_binds_vec.push((*key, actions.clone()));
             }
             ret.push((*mode, mode_binds_vec))
         }

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -136,7 +136,7 @@ impl Run {
         if let Some(args) = args {
             if let Run::Command(run_command) = self {
                 if !args.is_empty() {
-                    run_command.args = args.clone();
+                    run_command.args = args;
                 }
             }
         }
@@ -561,7 +561,7 @@ fn split_space(
         }
     }
     if pane_positions.is_empty() {
-        pane_positions.push((layout.clone(), space_to_split.clone()));
+        pane_positions.push((layout.clone(), *space_to_split));
     }
     pane_positions
 }
@@ -601,7 +601,7 @@ impl FromStr for SplitDirection {
 impl FromStr for SplitSize {
     type Err = Box<dyn std::error::Error>;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.chars().last() == Some('%') {
+        if s.ends_with('%') {
             let char_count = s.chars().count();
             let percent_size = usize::from_str_radix(&s[..char_count.saturating_sub(1)], 10)?;
             if percent_size > 0 && percent_size <= 100 {

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -310,7 +310,6 @@ impl From<CliOptions> for Options {
             scrollback_editor: opts.scrollback_editor,
             session_name: opts.session_name,
             attach_to_session: opts.attach_to_session,
-            ..Default::default()
         }
     }
 }

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -174,9 +174,7 @@ impl Options {
             .scrollback_editor
             .or_else(|| self.scrollback_editor.clone());
         let session_name = other.session_name.or_else(|| self.session_name.clone());
-        let attach_to_session = other
-            .attach_to_session
-            .or_else(|| self.attach_to_session.clone());
+        let attach_to_session = other.attach_to_session.or(self.attach_to_session);
 
         Options {
             simplified_ui,
@@ -235,9 +233,7 @@ impl Options {
             .scrollback_editor
             .or_else(|| self.scrollback_editor.clone());
         let session_name = other.session_name.or_else(|| self.session_name.clone());
-        let attach_to_session = other
-            .attach_to_session
-            .or_else(|| self.attach_to_session.clone());
+        let attach_to_session = other.attach_to_session.or(self.attach_to_session);
 
         Options {
             simplified_ui,

--- a/zellij-utils/src/input/plugins.rs
+++ b/zellij-utils/src/input/plugins.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 
 /// Used in the config struct for plugin metadata
-#[derive(Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Deserialize, Serialize, Default)]
 pub struct PluginsConfig(pub HashMap<PluginTag, PluginConfig>);
 
 impl fmt::Debug for PluginsConfig {
@@ -64,12 +64,6 @@ impl PluginsConfig {
         let mut plugin_config = self.0.clone();
         plugin_config.extend(other.0);
         Self(plugin_config)
-    }
-}
-
-impl Default for PluginsConfig {
-    fn default() -> Self {
-        PluginsConfig(HashMap::new())
     }
 }
 

--- a/zellij-utils/src/input/plugins.rs
+++ b/zellij-utils/src/input/plugins.rs
@@ -125,13 +125,13 @@ impl PluginConfig {
             match fs::read(&path) {
                 Ok(val) => return Ok(val),
                 Err(err) => {
-                    last_err = last_err.with_context(|| err_context(err, &path));
+                    last_err = last_err.with_context(|| err_context(err, path));
                 },
             }
         }
 
         // Not reached if a plugin is found!
-        return last_err;
+        last_err
     }
 
     /// Sets the tab index inside of the plugin type of the run field.

--- a/zellij-utils/src/input/theme.rs
+++ b/zellij-utils/src/input/theme.rs
@@ -16,7 +16,7 @@ pub struct UiConfig {
 
 impl UiConfig {
     pub fn merge(&self, other: UiConfig) -> Self {
-        let mut merged = self.clone();
+        let mut merged = *self;
         merged.pane_frames = merged.pane_frames.merge(other.pane_frames);
         merged
     }
@@ -29,7 +29,7 @@ pub struct FrameConfig {
 
 impl FrameConfig {
     pub fn merge(&self, other: FrameConfig) -> Self {
-        let mut merged = self.clone();
+        let mut merged = *self;
         merged.rounded_corners = other.rounded_corners;
         merged
     }

--- a/zellij-utils/src/input/unit/layout_test.rs
+++ b/zellij-utils/src/input/unit/layout_test.rs
@@ -917,113 +917,105 @@ fn cannot_define_pane_template_names_as_keywords() {
 
 #[test]
 fn error_on_multiple_layout_nodes_in_file() {
-    let kdl_layout = format!(
-        "
+    let kdl_layout = "
         layout
         layout
     "
-    );
+    .to_string();
     let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
 #[test]
 fn error_on_unknown_layout_node() {
-    let kdl_layout = format!(
-        "
-        layout {{
+    let kdl_layout = "
+        layout {
             pane
             i_am_not_a_proper_node
             pane
-        }}
+        }
     "
-    );
+    .to_string();
     let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
 #[test]
 fn error_on_unknown_layout_pane_property() {
-    let kdl_layout = format!(
-        "
-        layout {{
+    let kdl_layout = "
+        layout {
             pane spit_size=1
-        }}
+        }
     "
-    );
+    .to_string();
     let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
 #[test]
 fn error_on_unknown_layout_pane_template_property() {
-    let kdl_layout = format!(
-        "
-        layout {{
+    let kdl_layout = "
+        layout {
             pane_template name=\"my_cool_template\" spit_size=1
-        }}
+        }
     "
-    );
+    .to_string();
     let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
 #[test]
 fn error_on_unknown_layout_tab_property() {
-    let kdl_layout = format!(
-        "
-        layout {{
+    let kdl_layout = "
+        layout {
             tab spit_size=1
-        }}
+        }
     "
-    );
+    .to_string();
     let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
 #[test]
 fn error_on_unknown_layout_tab_template_property() {
-    let kdl_layout = format!(
-        "
-        layout {{
+    let kdl_layout = "
+        layout {
             tab_template name=\"my_cool_template\" spit_size=1
-        }}
+        }
     "
-    );
+    .to_string();
     let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
 #[test]
 fn error_on_pane_templates_without_a_name() {
-    let kdl_layout = format!(
-        "
-        layout {{
-            pane_template {{
+    let kdl_layout = "
+        layout {
+            pane_template {
                 pane
                 children
                 pane
-            }}
-        }}
+            }
+        }
     "
-    );
+    .to_string();
     let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
 #[test]
 fn error_on_tab_templates_without_a_name() {
-    let kdl_layout = format!(
-        "
-        layout {{
-            tab_template {{
+    let kdl_layout = "
+        layout {
+            tab_template {
                 pane
                 children
                 pane
-            }}
-        }}
+            }
+        }
     "
-    );
+    .to_string();
     let layout_error = Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }

--- a/zellij-utils/src/input/unit/layout_test.rs
+++ b/zellij-utils/src/input/unit/layout_test.rs
@@ -445,7 +445,6 @@ fn layout_with_focused_tab() {
         ],
         template: Some(PaneLayout::default()),
         focused_tab_index: Some(1),
-        ..Default::default()
     };
     assert_eq!(layout, expected_layout);
 }

--- a/zellij-utils/src/kdl/kdl_layout_parser.rs
+++ b/zellij-utils/src/kdl/kdl_layout_parser.rs
@@ -821,11 +821,13 @@ impl<'a> KdlLayoutParser<'a> {
     fn populate_one_tab_template(&mut self, kdl_node: &KdlNode) -> Result<(), ConfigError> {
         let template_name = kdl_get_string_property_or_child_value_with_error!(kdl_node, "name")
             .map(|s| s.to_string())
-            .ok_or(ConfigError::new_layout_kdl_error(
-                "Tab templates must have a name".into(),
-                kdl_node.span().offset(),
-                kdl_node.span().len(),
-            ))?;
+            .ok_or_else(|| {
+                ConfigError::new_layout_kdl_error(
+                    "Tab templates must have a name".into(),
+                    kdl_node.span().offset(),
+                    kdl_node.span().len(),
+                )
+            })?;
         self.assert_legal_node_name(&template_name, kdl_node)?;
         self.assert_legal_template_name(&template_name, kdl_node)?;
         if self.tab_templates.contains_key(&template_name) {
@@ -929,13 +931,14 @@ impl<'a> KdlLayoutParser<'a> {
         let mut dependency_tree = HashMap::new();
         for child in kdl_children {
             if kdl_name!(child) == "pane_template" {
-                let template_name = kdl_get_string_property_or_child_value!(child, "name").ok_or(
-                    ConfigError::new_layout_kdl_error(
-                        "Pane templates must have a name".into(),
-                        child.span().offset(),
-                        child.span().len(),
-                    ),
-                )?;
+                let template_name = kdl_get_string_property_or_child_value!(child, "name")
+                    .ok_or_else(|| {
+                        ConfigError::new_layout_kdl_error(
+                            "Pane templates must have a name".into(),
+                            child.span().offset(),
+                            child.span().len(),
+                        )
+                    })?;
                 let mut template_children = HashSet::new();
                 self.get_pane_template_dependencies(child, &mut template_children)?;
                 if dependency_tree.contains_key(template_name) {
@@ -1062,7 +1065,6 @@ impl<'a> KdlLayoutParser<'a> {
             tabs,
             template: Some(template),
             focused_tab_index,
-            ..Default::default()
         })
     }
     fn layout_with_one_tab(&self, panes: Vec<PaneLayout>) -> Result<Layout, ConfigError> {
@@ -1180,11 +1182,13 @@ impl<'a> KdlLayoutParser<'a> {
             .nodes()
             .iter()
             .find(|n| kdl_name!(n) == "layout")
-            .ok_or(ConfigError::new_layout_kdl_error(
-                "No layout found".into(),
-                kdl_layout.span().offset(),
-                kdl_layout.span().len(),
-            ))?;
+            .ok_or_else(|| {
+                ConfigError::new_layout_kdl_error(
+                    "No layout found".into(),
+                    kdl_layout.span().offset(),
+                    kdl_layout.span().len(),
+                )
+            })?;
         let has_multiple_layout_nodes = kdl_layout
             .nodes()
             .iter()

--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -515,113 +515,129 @@ mod setup_test {
     }
     #[test]
     fn cli_arguments_override_config_options() {
-        let mut cli_args = CliArgs::default();
-        cli_args.command = Some(Command::Options(CliOptions {
-            options: Options {
-                simplified_ui: Some(true),
+        let cli_args = CliArgs {
+            command: Some(Command::Options(CliOptions {
+                options: Options {
+                    simplified_ui: Some(true),
+                    ..Default::default()
+                },
                 ..Default::default()
-            },
+            })),
             ..Default::default()
-        }));
+        };
         let (_config, _layout, options) = Setup::from_cli_args(&cli_args).unwrap();
         assert_snapshot!(format!("{:#?}", options));
     }
     #[test]
     fn layout_options_override_config_options() {
-        let mut cli_args = CliArgs::default();
-        cli_args.layout = Some(PathBuf::from(format!(
-            "{}/src/test-fixtures/layout-with-options.kdl",
-            env!("CARGO_MANIFEST_DIR")
-        )));
+        let cli_args = CliArgs {
+            layout: Some(PathBuf::from(format!(
+                "{}/src/test-fixtures/layout-with-options.kdl",
+                env!("CARGO_MANIFEST_DIR")
+            ))),
+            ..Default::default()
+        };
         let (_config, layout, options) = Setup::from_cli_args(&cli_args).unwrap();
         assert_snapshot!(format!("{:#?}", options));
         assert_snapshot!(format!("{:#?}", layout));
     }
     #[test]
     fn cli_arguments_override_layout_options() {
-        let mut cli_args = CliArgs::default();
-        cli_args.layout = Some(PathBuf::from(format!(
-            "{}/src/test-fixtures/layout-with-options.kdl",
-            env!("CARGO_MANIFEST_DIR")
-        )));
-        cli_args.command = Some(Command::Options(CliOptions {
-            options: Options {
-                pane_frames: Some(true),
+        let cli_args = CliArgs {
+            layout: Some(PathBuf::from(format!(
+                "{}/src/test-fixtures/layout-with-options.kdl",
+                env!("CARGO_MANIFEST_DIR")
+            ))),
+            command: Some(Command::Options(CliOptions {
+                options: Options {
+                    pane_frames: Some(true),
+                    ..Default::default()
+                },
                 ..Default::default()
-            },
+            })),
             ..Default::default()
-        }));
+        };
         let (_config, layout, options) = Setup::from_cli_args(&cli_args).unwrap();
         assert_snapshot!(format!("{:#?}", options));
         assert_snapshot!(format!("{:#?}", layout));
     }
     #[test]
     fn layout_env_vars_override_config_env_vars() {
-        let mut cli_args = CliArgs::default();
-        cli_args.config = Some(PathBuf::from(format!(
-            "{}/src/test-fixtures/config-with-env-vars.kdl",
-            env!("CARGO_MANIFEST_DIR")
-        )));
-        cli_args.layout = Some(PathBuf::from(format!(
-            "{}/src/test-fixtures/layout-with-env-vars.kdl",
-            env!("CARGO_MANIFEST_DIR")
-        )));
+        let cli_args = CliArgs {
+            config: Some(PathBuf::from(format!(
+                "{}/src/test-fixtures/config-with-env-vars.kdl",
+                env!("CARGO_MANIFEST_DIR")
+            ))),
+            layout: Some(PathBuf::from(format!(
+                "{}/src/test-fixtures/layout-with-env-vars.kdl",
+                env!("CARGO_MANIFEST_DIR")
+            ))),
+            ..Default::default()
+        };
         let (config, _layout, _options) = Setup::from_cli_args(&cli_args).unwrap();
         assert_snapshot!(format!("{:#?}", config));
     }
     #[test]
     fn layout_ui_config_overrides_config_ui_config() {
-        let mut cli_args = CliArgs::default();
-        cli_args.config = Some(PathBuf::from(format!(
-            "{}/src/test-fixtures/config-with-ui-config.kdl",
-            env!("CARGO_MANIFEST_DIR")
-        )));
-        cli_args.layout = Some(PathBuf::from(format!(
-            "{}/src/test-fixtures/layout-with-ui-config.kdl",
-            env!("CARGO_MANIFEST_DIR")
-        )));
+        let cli_args = CliArgs {
+            config: Some(PathBuf::from(format!(
+                "{}/src/test-fixtures/config-with-ui-config.kdl",
+                env!("CARGO_MANIFEST_DIR")
+            ))),
+            layout: Some(PathBuf::from(format!(
+                "{}/src/test-fixtures/layout-with-ui-config.kdl",
+                env!("CARGO_MANIFEST_DIR")
+            ))),
+            ..Default::default()
+        };
         let (config, _layout, _options) = Setup::from_cli_args(&cli_args).unwrap();
         assert_snapshot!(format!("{:#?}", config));
     }
     #[test]
     fn layout_plugins_override_config_plugins() {
-        let mut cli_args = CliArgs::default();
-        cli_args.config = Some(PathBuf::from(format!(
-            "{}/src/test-fixtures/config-with-plugins-config.kdl",
-            env!("CARGO_MANIFEST_DIR")
-        )));
-        cli_args.layout = Some(PathBuf::from(format!(
-            "{}/src/test-fixtures/layout-with-plugins-config.kdl",
-            env!("CARGO_MANIFEST_DIR")
-        )));
+        let cli_args = CliArgs {
+            config: Some(PathBuf::from(format!(
+                "{}/src/test-fixtures/config-with-plugins-config.kdl",
+                env!("CARGO_MANIFEST_DIR")
+            ))),
+            layout: Some(PathBuf::from(format!(
+                "{}/src/test-fixtures/layout-with-plugins-config.kdl",
+                env!("CARGO_MANIFEST_DIR")
+            ))),
+            ..Default::default()
+        };
         let (config, _layout, _options) = Setup::from_cli_args(&cli_args).unwrap();
         assert_snapshot!(format!("{:#?}", config));
     }
     #[test]
     fn layout_themes_override_config_themes() {
-        let mut cli_args = CliArgs::default();
-        cli_args.config = Some(PathBuf::from(format!(
-            "{}/src/test-fixtures/config-with-themes-config.kdl",
-            env!("CARGO_MANIFEST_DIR")
-        )));
-        cli_args.layout = Some(PathBuf::from(format!(
-            "{}/src/test-fixtures/layout-with-themes-config.kdl",
-            env!("CARGO_MANIFEST_DIR")
-        )));
+        let cli_args = CliArgs {
+            config: Some(PathBuf::from(format!(
+                "{}/src/test-fixtures/config-with-themes-config.kdl",
+                env!("CARGO_MANIFEST_DIR")
+            ))),
+            layout: Some(PathBuf::from(format!(
+                "{}/src/test-fixtures/layout-with-themes-config.kdl",
+                env!("CARGO_MANIFEST_DIR")
+            ))),
+            ..Default::default()
+        };
         let (config, _layout, _options) = Setup::from_cli_args(&cli_args).unwrap();
         assert_snapshot!(format!("{:#?}", config));
     }
     #[test]
     fn layout_keybinds_override_config_keybinds() {
-        let mut cli_args = CliArgs::default();
-        cli_args.config = Some(PathBuf::from(format!(
-            "{}/src/test-fixtures/config-with-keybindings-config.kdl",
-            env!("CARGO_MANIFEST_DIR")
-        )));
-        cli_args.layout = Some(PathBuf::from(format!(
-            "{}/src/test-fixtures/layout-with-keybindings-config.kdl",
-            env!("CARGO_MANIFEST_DIR")
-        )));
+        let cli_args = CliArgs {
+            config: Some(PathBuf::from(format!(
+                "{}/src/test-fixtures/config-with-keybindings-config.kdl",
+                env!("CARGO_MANIFEST_DIR")
+            ))),
+            layout: Some(PathBuf::from(format!(
+                "{}/src/test-fixtures/layout-with-keybindings-config.kdl",
+                env!("CARGO_MANIFEST_DIR")
+            ))),
+            ..Default::default()
+        };
         let (config, _layout, _options) = Setup::from_cli_args(&cli_args).unwrap();
         assert_snapshot!(format!("{:#?}", config));
     }

--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -482,7 +482,7 @@ impl Setup {
             .or_else(|| config.options.default_layout.clone());
         // we merge-override the config here because the layout might contain configuration
         // that needs to take precedence
-        Layout::from_path_or_default(chosen_layout.as_ref(), layout_dir.clone(), config)
+        Layout::from_path_or_default(chosen_layout.as_ref(), layout_dir, config)
     }
     fn handle_setup_commands(cli_args: &CliArgs) {
         if let Some(Command::Setup(ref setup)) = &cli_args.command {

--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -360,7 +360,7 @@ impl Setup {
             .unwrap();
         }
         writeln!(&mut message, "[DATA DIR]: {:?}", data_dir).unwrap();
-        message.push_str(&format!("[PLUGIN DIR]: {:?}\n", plugin_dir));
+        writeln!(&mut message, "[PLUGIN DIR]: {:?}\n", plugin_dir).unwrap();
         if let Some(layout_dir) = layout_dir {
             writeln!(&mut message, "[LAYOUT DIR]: {:?}", layout_dir).unwrap();
         } else {


### PR DESCRIPTION
Fixes all clippy lints introduced in the KDL PR and afterwards. Reenables strict clippy lint checking.

@imsnif Did we already reach a consensus on this and if so, what was it again? I can disable the strict checking, too.