### PR TITLE
fix(themes/catppuccin): black and white inverted

### DIFF
--- a/example/themes/catppuccin.kdl
+++ b/example/themes/catppuccin.kdl
@@ -12,8 +12,8 @@ themes {
     magenta "#ea76cb" // Pink
     orange "#fe640b" // Peach
     cyan "#04a5e5" // Sky
-    black "#4c4f69" // Text
-    white "#dce0e8" // Crust
+    black "#dce0e8" // Crust
+    white "#4c4f69" // Text
   }
 
   catppuccin-frappe {


### PR DESCRIPTION
Fixed an issue where the white and black palettes were inverted.