### PR TITLE
fix(router): handle client buffer overflow

### DIFF
--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -13,13 +13,15 @@ use nix::{
 use signal_hook::consts::*;
 use sysinfo::{ProcessExt, ProcessRefreshKind, System, SystemExt};
 use zellij_utils::{
-    channels,
-    async_std,
+    async_std, channels,
     data::Palette,
     errors::prelude::*,
     input::command::{RunCommand, TerminalAction},
     interprocess,
-    ipc::{ClientToServerMsg, IpcReceiverWithContext, IpcSenderWithContext, ServerToClientMsg, ExitReason},
+    ipc::{
+        ClientToServerMsg, ExitReason, IpcReceiverWithContext, IpcSenderWithContext,
+        ServerToClientMsg,
+    },
     libc, nix,
     shared::default_palette,
     signal_hook,
@@ -347,16 +349,20 @@ impl ClientSender {
             for msg in client_buffer_receiver.iter() {
                 let _ = sender.send(msg).with_context(err_context);
             }
-            let _ = sender.send(ServerToClientMsg::Exit(ExitReason::Error("Buffer full".to_string())));
+            let _ = sender.send(ServerToClientMsg::Exit(ExitReason::Error(
+                "Buffer full".to_string(),
+            )));
         });
         ClientSender {
             client_id,
-            client_buffer_sender
+            client_buffer_sender,
         }
     }
     pub fn send_or_buffer(&self, msg: ServerToClientMsg) -> Result<()> {
         let err_context = || format!("Client {} send buffer full", self.client_id);
-        self.client_buffer_sender.try_send(msg).with_context(err_context)
+        self.client_buffer_sender
+            .try_send(msg)
+            .with_context(err_context)
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/1781

## What was happening
As per @raphCode 's excellent analysis in the issue comments, since the SSH session seems not to close the controlling terminal, after its buffer is filled, the client thread gets blocked printing to STDOUT, and then in turn the entire router thread *on the Zellij server* gets blocked when trying to send messages to the client.

## The fix
Instead of sending messages directly to the client from the server, we now employ a separate thread to send messages to each client. This thread has its own buffer (50 messages), and once that buffer is filled, we stop sending messages to this particular client (essentially "forget" about it). If the client ever picks up its end of the IPC socket again, we send it one last "Buffer full" message before telling it to disconnect, so it knows what happened.

## Other considerations
I initially wanted to fix this by making sending messages to the client non blocking with a buffer (to avoid the indirection of doing this in a separate thread), but the only way to do that would be to make the entire IPC channel non-blocking. And this would require quite some infrastructure change on our part (probably writing some event loop or using a shiny async framework to manage it).
