### PR TITLE
Fix crashes in status-bar plugin 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,6 +2682,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "zellij-tile",
  "zellij-tile-utils",

--- a/default-plugins/status-bar/Cargo.toml
+++ b/default-plugins/status-bar/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = "1.0"
 thiserror = "1.0.30"
 zellij-tile = { path = "../../zellij-tile" }
 zellij-tile-utils = { path = "../../zellij-tile-utils" }
+tempfile = "3.3.0"
 
 [dev-dependencies]
 regex = "1"

--- a/default-plugins/status-bar/src/tip/cache.rs
+++ b/default-plugins/status-bar/src/tip/cache.rs
@@ -1,9 +1,10 @@
 use std::collections::{HashMap, HashSet};
-use std::fs::{File, OpenOptions};
+use std::fs::OpenOptions;
 use std::io::{self, Read, Write};
-use std::path::PathBuf;
+use std::path::{self, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use tempfile::{NamedTempFile, PersistError};
 use thiserror::Error;
 
 use zellij_tile::prelude::get_zellij_version;
@@ -33,6 +34,8 @@ pub enum LocalCacheError {
     // Deserialization error
     #[error("Deserialization error: {0}")]
     Serde(#[from] serde_json::Error),
+    #[error("PersistError: {0}")]
+    Persist(#[from] PersistError),
 }
 
 impl LocalCache {
@@ -51,7 +54,7 @@ impl LocalCache {
         }
     }
 
-    pub fn new(path: PathBuf) -> LocalCacheResult {
+    fn from_file(path: PathBuf) -> LocalCacheResult {
         match OpenOptions::new()
             .read(true)
             .create(true)
@@ -62,29 +65,79 @@ impl LocalCache {
                 file.read_to_string(&mut json_cache)
                     .map_err(LocalCacheError::Io)?;
 
-                let metadata = LocalCache::from_json(&json_cache)?;
-                Ok(LocalCache { path, metadata })
+                let res = LocalCache::from_json(&json_cache);
+                match res {
+                    Ok(metadata) => Ok(LocalCache { path, metadata }),
+                    Err(e) => {
+                        // JSON cache file is corrupted, or using a bad schema. Try to remove it
+                        std::fs::remove_file(&path)?;
+                        Err(e)
+                    },
+                }
             },
             Err(e) => Err(LocalCacheError::IoPath(e, path)),
         }
     }
 
-    pub fn flush(&mut self) -> Result<(), LocalCacheError> {
+    pub fn new(path: PathBuf) -> LocalCache {
+        let res = LocalCache::from_file(path.clone());
+        match res {
+            Ok(cache) => cache,
+            Err(e) => {
+                eprintln!(
+                    "Error loading status-bar cache from {:?}, error: {:?}",
+                    path, e
+                );
+                LocalCache {
+                    path,
+                    metadata: Metadata {
+                        zellij_version: get_zellij_version(),
+                        cached_data: HashMap::new(),
+                    },
+                }
+            },
+        }
+    }
+
+    fn safe_parent(p: &path::Path) -> Option<&path::Path> {
+        match p.parent() {
+            None => None,
+            Some(x) if x.as_os_str().is_empty() => Some(path::Path::new(".")),
+            x => x,
+        }
+    }
+
+    fn flush(&mut self) -> Result<(), LocalCacheError> {
         match serde_json::to_string(&self.metadata) {
             Ok(json_cache) => {
-                let mut file = File::create(self.path.as_path())
-                    .map_err(|e| LocalCacheError::IoPath(e, self.path.clone()))?;
+                let mut file = NamedTempFile::new_in(
+                    LocalCache::safe_parent(self.path.as_path()).ok_or_else(|| {
+                        LocalCacheError::IoPath(
+                            io::Error::new(
+                                io::ErrorKind::Other,
+                                "Could not get a parent path for tips cache",
+                            ),
+                            self.path.clone(),
+                        )
+                    })?,
+                )
+                .map_err(LocalCacheError::Io)?;
                 file.write_all(json_cache.as_bytes())
                     .map_err(LocalCacheError::Io)?;
+                file.persist(self.path.as_path())
+                    .map_err(LocalCacheError::Persist)?;
                 Ok(())
             },
             Err(e) => Err(LocalCacheError::Serde(e)),
         }
     }
 
-    pub fn clear(&mut self) -> Result<(), LocalCacheError> {
+    pub fn clear(&mut self) {
         self.metadata.cached_data.clear();
-        self.flush()
+        match self.flush() {
+            Ok(_) => (),
+            Err(e) => eprintln!("Error flushing local cache to disk: {:?}", e),
+        }
     }
 
     pub fn get_version(&self) -> &String {
@@ -107,13 +160,16 @@ impl LocalCache {
         self.get_cached_data().keys().cloned().collect()
     }
 
-    pub fn caching<S: Into<String>>(&mut self, key: S) -> Result<(), LocalCacheError> {
+    pub fn caching<S: Into<String>>(&mut self, key: S) {
         let key = key.into();
         if let Some(item) = self.metadata.cached_data.get_mut(&key) {
             *item += 1;
         } else {
             self.metadata.cached_data.insert(key, 1);
         }
-        self.flush()
+        match self.flush() {
+            Ok(_) => (),
+            Err(e) => eprintln!("Error flushing local cache to disk: {:?}", e),
+        }
     }
 }

--- a/default-plugins/status-bar/src/tip/utils.rs
+++ b/default-plugins/status-bar/src/tip/utils.rs
@@ -11,12 +11,12 @@ use super::data::TIPS;
 macro_rules! get_name_and_caching {
     ($cache:expr) => {{
         let name = get_random_tip_name();
-        $cache.caching(name.clone()).unwrap();
+        $cache.caching(name.clone());
         return name;
     }};
     ($cache:expr, $from:expr) => {{
         let name = $from.choose(&mut rand::thread_rng()).unwrap().to_string();
-        $cache.caching(name.clone()).unwrap();
+        $cache.caching(name.clone());
         return name;
     }};
 }
@@ -24,7 +24,7 @@ macro_rules! get_name_and_caching {
 macro_rules! populate_cache {
     ($cache:expr) => {{
         for tip_name in TIPS.keys() {
-            $cache.caching(tip_name.clone()).unwrap();
+            $cache.caching(tip_name.clone());
         }
     }};
 }
@@ -37,12 +37,12 @@ pub fn get_random_tip_name() -> String {
 }
 
 pub fn get_cached_tip_name() -> String {
-    let mut local_cache = LocalCache::new(PathBuf::from(DEFAULT_CACHE_FILE_PATH)).unwrap();
+    let mut local_cache = LocalCache::new(PathBuf::from(DEFAULT_CACHE_FILE_PATH));
 
     let zellij_version = get_zellij_version();
     if zellij_version.ne(local_cache.get_version()) {
         local_cache.set_version(zellij_version);
-        local_cache.clear().unwrap();
+        local_cache.clear();
     }
 
     if local_cache.is_empty() {
@@ -51,7 +51,7 @@ pub fn get_cached_tip_name() -> String {
 
     let quicknav_show_count = local_cache.get_cached_data().get("quicknav").unwrap_or(&0);
     if quicknav_show_count <= &MAX_CACHE_HITS {
-        let _ = local_cache.caching("quicknav");
+        local_cache.caching("quicknav");
         return String::from("quicknav");
     }
 
@@ -72,7 +72,7 @@ pub fn get_cached_tip_name() -> String {
         if !diff.is_empty() {
             get_name_and_caching!(local_cache, diff);
         } else {
-            local_cache.clear().unwrap();
+            local_cache.clear();
             get_name_and_caching!(local_cache);
         }
     } else {


### PR DESCRIPTION
Turned a number of panics into logged errors that otherwise continue when interacting with the status-bar plugin's tips cache, and made writes to the cache atomic to avoid clobbering seen when running multiple zellij instances.

Fixes #1944