### PR TITLE
fix(panes): focus change when closing and between tabs

### DIFF
--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__detach_and_attach_session.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__detach_and_attach_session.snap
@@ -1,11 +1,11 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 948
+assertion_line: 952
 expression: last_snapshot
 ---
  Zellij (e2e-test)  Tab #1                                                                                            
 ┌ Pane #1 ─────────────────────────────────────────────────┐┌ Pane #2 ─────────────────────────────────────────────────┐
-│$ █                                                       ││$ I am some text                                          │
+│$                                                         ││$ I am some text█                                         │
 │                                                          ││                                                          │
 │                                                          ││                                                          │
 │                                                          ││                                                          │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__mirrored_sessions-2.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__mirrored_sessions-2.snap
@@ -1,11 +1,11 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 1308
+assertion_line: 1312
 expression: second_runner_snapshot
 ---
  Zellij (mirrored_sessions)  Tab #1  Tab #2                                                                         
 ┌ Pane #1 ─────────────────────────────────────────────────┐┌ Pane #2 ─────────────────────────────────────────────────┐
-│$ █                                                       ││$                                                         │
+│$                                                         ││$ █                                                       │
 │                                                          ││                                                          │
 │                                                          ││                                                          │
 │                                                          ││                                                          │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__mirrored_sessions.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__mirrored_sessions.snap
@@ -1,11 +1,11 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 1342
+assertion_line: 1311
 expression: first_runner_snapshot
 ---
  Zellij (mirrored_sessions)  Tab #1  Tab #2                                                                         
 ┌ Pane #1 ─────────────────────────────────────────────────┐┌ Pane #2 ─────────────────────────────────────────────────┐
-│$ █                                                       ││$                                                         │
+│$                                                         ││$ █                                                       │
 │                                                          ││                                                          │
 │                                                          ││                                                          │
 │                                                          ││                                                          │

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -817,7 +817,9 @@ impl FloatingPanes {
         next_active_pane_candidates.sort_by(|(_pane_id_a, pane_a), (_pane_id_b, pane_b)| {
             pane_a.active_at().cmp(&pane_b.active_at())
         });
-        let next_active_pane_id = next_active_pane_candidates.last().map(|(pane_id, _pane)| **pane_id);
+        let next_active_pane_id = next_active_pane_candidates
+            .last()
+            .map(|(pane_id, _pane)| **pane_id);
 
         for (client_id, active_pane_id) in active_panes {
             if active_pane_id == pane_id {

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -807,14 +807,25 @@ impl FloatingPanes {
             .iter()
             .map(|(cid, pid)| (*cid, *pid))
             .collect();
-        let next_active_pane = self.panes.keys().next().copied();
+
+        // find the most recently active pane
+        let mut next_active_pane_candidates: Vec<(&PaneId, &Box<dyn Pane>)> = self
+            .panes
+            .iter()
+            .filter(|(_p_id, p)| p.selectable())
+            .collect();
+        next_active_pane_candidates.sort_by(|(_pane_id_a, pane_a), (_pane_id_b, pane_b)| {
+            pane_a.active_at().cmp(&pane_b.active_at())
+        });
+        let next_active_pane_id = next_active_pane_candidates.last().map(|(pane_id, _pane)| **pane_id);
+
         for (client_id, active_pane_id) in active_panes {
             if active_pane_id == pane_id {
-                match next_active_pane {
-                    Some(next_active_pane) => {
+                match next_active_pane_id {
+                    Some(next_active_pane_id) => {
                         self.active_panes
-                            .insert(client_id, next_active_pane, &mut self.panes);
-                        self.focus_pane(next_active_pane, client_id);
+                            .insert(client_id, next_active_pane_id, &mut self.panes);
+                        self.focus_pane(next_active_pane_id, client_id);
                     },
                     None => {
                         self.defocus_pane(pane_id, client_id);
@@ -839,6 +850,11 @@ impl FloatingPanes {
         self.active_panes
             .insert(client_id, pane_id, &mut self.panes);
         self.focus_pane_for_all_clients(pane_id);
+    }
+    pub fn focus_pane_if_client_not_focused(&mut self, pane_id: PaneId, client_id: ClientId) {
+        if self.active_panes.get(&client_id).is_none() {
+            self.focus_pane(pane_id, client_id)
+        }
     }
     pub fn defocus_pane(&mut self, pane_id: PaneId, client_id: ClientId) {
         self.z_indices.retain(|p_id| *p_id != pane_id);

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -1016,7 +1016,9 @@ impl TiledPanes {
         next_active_pane_candidates.sort_by(|(_pane_id_a, pane_a), (_pane_id_b, pane_b)| {
             pane_a.active_at().cmp(&pane_b.active_at())
         });
-        let next_active_pane_id = next_active_pane_candidates.last().map(|(pane_id, _pane)| **pane_id);
+        let next_active_pane_id = next_active_pane_candidates
+            .last()
+            .map(|(pane_id, _pane)| **pane_id);
 
         match next_active_pane_id {
             Some(next_active_pane) => {

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -707,7 +707,8 @@ impl Tab {
                     format!("failed to acquire id of focused pane while adding client {client_id}",)
                 })?)
             };
-            self.tiled_panes.focus_pane_if_client_not_focused(focus_pane_id, client_id);
+            self.tiled_panes
+                .focus_pane_if_client_not_focused(focus_pane_id, client_id);
             self.connected_clients.borrow_mut().insert(client_id);
             self.mode_info.borrow_mut().insert(
                 client_id,

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -681,11 +681,11 @@ impl Tab {
                 self.floating_panes.first_active_floating_pane_id()
             {
                 self.floating_panes
-                    .focus_pane(first_active_floating_pane_id, client_id);
+                    .focus_pane_if_client_not_focused(first_active_floating_pane_id, client_id);
             }
             if let Some(first_active_tiled_pane_id) = self.tiled_panes.first_active_pane_id() {
                 self.tiled_panes
-                    .focus_pane(first_active_tiled_pane_id, client_id);
+                    .focus_pane_if_client_not_focused(first_active_tiled_pane_id, client_id);
             }
             self.connected_clients.borrow_mut().insert(client_id);
             self.mode_info.borrow_mut().insert(
@@ -707,7 +707,7 @@ impl Tab {
                     format!("failed to acquire id of focused pane while adding client {client_id}",)
                 })?)
             };
-            self.tiled_panes.focus_pane(focus_pane_id, client_id);
+            self.tiled_panes.focus_pane_if_client_not_focused(focus_pane_id, client_id);
             self.connected_clients.borrow_mut().insert(client_id);
             self.mode_info.borrow_mut().insert(
                 client_id,


### PR DESCRIPTION
This fixes two bugs:
1. When closing a pane, now the most recently focused pane will be focused - rather than the first pane in the tab.
2. When switching tabs, the focused pane will be remembered