### PR TITLE
Pass Environmental Variables and Handle Correctly Cwd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,6 +809,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2548,6 +2557,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd1c7ddea665294d484c39fd0c0d2b7e35bbfe10035c5fe1854741a57f6880e1"
+dependencies = [
+ "dirs 4.0.0",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2898,7 +2916,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76971977e6121664ec1b960d1313aacfa75642adc93b9d4d53b247bd4cb1747e"
 dependencies = [
- "dirs",
+ "dirs 2.0.2",
  "fnv",
  "nom 5.1.2",
  "phf 0.8.0",
@@ -3937,6 +3955,7 @@ dependencies = [
  "log",
  "semver 0.11.0",
  "serde_json",
+ "shellexpand",
  "sixel-image",
  "sixel-tokenizer",
  "sysinfo",

--- a/default-plugins/status-bar/src/second_line.rs
+++ b/default-plugins/status-bar/src/second_line.rs
@@ -3,8 +3,8 @@ use ansi_term::{
     Color::{Fixed, RGB},
     Style,
 };
-use zellij_tile::prelude::actions::Action;
-use zellij_tile::prelude::*;
+use zellij_tile::prelude::{actions::Action, command::PaneOptions};
+use zellij_tile::prelude::{command::RunCommand, *};
 use zellij_tile_utils::palette_match;
 
 use crate::{
@@ -148,12 +148,12 @@ fn get_keys_and_hints(mi: &ModeInfo) -> Vec<(String, String, Vec<Key>)> {
         (s("Move focus"), s("Move"),
             action_key_group(&km, &[&[A::MoveFocus(Dir::Left)], &[A::MoveFocus(Dir::Down)],
                 &[A::MoveFocus(Dir::Up)], &[A::MoveFocus(Dir::Right)]])),
-        (s("New"), s("New"), action_key(&km, &[A::NewPane(None, None), TO_NORMAL])),
+        (s("New"), s("New"), action_key(&km, &[A::NewPane(RunCommand::new(), PaneOptions::new()), TO_NORMAL])),
         (s("Close"), s("Close"), action_key(&km, &[A::CloseFocus, TO_NORMAL])),
         (s("Rename"), s("Rename"),
             action_key(&km, &[A::SwitchToMode(IM::RenamePane), A::PaneNameInput(vec![0])])),
-        (s("Split down"), s("Down"), action_key(&km, &[A::NewPane(Some(Dir::Down), None), TO_NORMAL])),
-        (s("Split right"), s("Right"), action_key(&km, &[A::NewPane(Some(Dir::Right), None), TO_NORMAL])),
+        (s("Split down"), s("Down"), action_key(&km, &[A::NewPane(RunCommand::new(), PaneOptions{ direction: Some(Dir::Down), ..Default::default()}), TO_NORMAL])),
+        (s("Split right"), s("Right"), action_key(&km, &[A::NewPane(RunCommand::new(), PaneOptions{ direction: Some(Dir::Right), ..Default::default()}), TO_NORMAL])),
         (s("Fullscreen"), s("Fullscreen"), action_key(&km, &[A::ToggleFocusFullscreen, TO_NORMAL])),
         (s("Frames"), s("Frames"), action_key(&km, &[A::TogglePaneFrames, TO_NORMAL])),
         (s("Floating toggle"), s("Floating"),
@@ -239,8 +239,8 @@ fn get_keys_and_hints(mi: &ModeInfo) -> Vec<(String, String, Vec<Key>)> {
         (s("Move focus"), s("Move"), action_key_group(&km, &[
             &[A::MoveFocus(Dir::Left)], &[A::MoveFocus(Dir::Down)],
             &[A::MoveFocus(Dir::Up)], &[A::MoveFocus(Dir::Right)]])),
-        (s("Split down"), s("Down"), action_key(&km, &[A::NewPane(Some(Dir::Down), None), TO_NORMAL])),
-        (s("Split right"), s("Right"), action_key(&km, &[A::NewPane(Some(Dir::Right), None), TO_NORMAL])),
+        (s("Split down"), s("Down"), action_key(&km, &[A::NewPane(RunCommand::new(), PaneOptions{ direction: Some(Dir::Down), ..Default::default()}), TO_NORMAL])),
+        (s("Split right"), s("Right"), action_key(&km, &[A::NewPane(RunCommand::new(), PaneOptions{ direction: Some(Dir::Right), ..Default::default()}), TO_NORMAL])),
         (s("Fullscreen"), s("Fullscreen"), action_key(&km, &[A::ToggleFocusFullscreen, TO_NORMAL])),
         (s("New tab"), s("New"), action_key(&km, &[A::NewTab(None, None), TO_NORMAL])),
         (s("Rename tab"), s("Rename"),

--- a/default-plugins/status-bar/src/tip/data/quicknav.rs
+++ b/default-plugins/status-bar/src/tip/data/quicknav.rs
@@ -3,6 +3,7 @@ use ansi_term::{unstyled_len, ANSIString, ANSIStrings, Style};
 use crate::{action_key, action_key_group, style_key_with_modifier, LinePart};
 use zellij_tile::prelude::{
     actions::{Action, Direction, ResizeDirection},
+    command::{PaneOptions, RunCommand},
     *,
 };
 
@@ -65,7 +66,10 @@ struct Keygroups<'a> {
 
 fn add_keybinds(help: &ModeInfo) -> Keygroups {
     let normal_keymap = help.get_mode_keybinds();
-    let new_pane_keys = action_key(&normal_keymap, &[Action::NewPane(None, None)]);
+    let new_pane_keys = action_key(
+        &normal_keymap,
+        &[Action::NewPane(RunCommand::new(), PaneOptions::new())],
+    );
     let new_pane = if new_pane_keys.is_empty() {
         vec![Style::new().bold().paint("UNBOUND")]
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ fn main() {
             name,
             close_on_exit,
             start_suspended,
+            env,
         })) = opts.command
         {
             let command_cli_action = CliAction::NewPane {
@@ -36,6 +37,7 @@ fn main() {
                 name,
                 close_on_exit,
                 start_suspended,
+                env,
             };
             commands::send_action_to_session(command_cli_action, opts.session);
             std::process::exit(0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,21 +48,17 @@ fn main() {
             line_number,
             floating,
             cwd,
+            env,
         })) = opts.command
         {
-            let mut file = file;
             let cwd = cwd.or_else(|| std::env::current_dir().ok());
-            if file.is_relative() {
-                if let Some(cwd) = cwd.as_ref() {
-                    file = cwd.join(file);
-                }
-            }
             let command_cli_action = CliAction::Edit {
                 file,
                 direction,
                 line_number,
                 floating,
                 cwd,
+                env,
             };
             commands::send_action_to_session(command_cli_action, opts.session);
             std::process::exit(0);

--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -289,7 +289,7 @@ impl InputHandler {
             },
             Action::CloseFocus
             | Action::NewPane(..)
-            | Action::Run(_)
+            | Action::Run(..)
             | Action::ToggleFloatingPanes
             | Action::TogglePaneEmbedOrFloating
             | Action::NewTab(..)

--- a/zellij-server/Cargo.toml
+++ b/zellij-server/Cargo.toml
@@ -32,7 +32,7 @@ sixel-image = "0.1.0"
 arrayvec = "0.7.2"
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
 semver = "0.11.0"
+shellexpand = "3.0.0"
 
 [dev-dependencies]
 insta = "1.6.0"
-

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -320,7 +320,7 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
 
                 let default_shell = config_options.default_shell.map(|shell| {
                     TerminalAction::RunCommand(RunCommand {
-                        command: shell,
+                        command: Some(shell),
                         ..Default::default()
                     })
                 });
@@ -647,7 +647,7 @@ fn init_session(
 
     let default_shell = config_options.default_shell.clone().map(|command| {
         TerminalAction::RunCommand(RunCommand {
-            command,
+            command: Some(command),
             ..Default::default()
         })
     });

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use async_std::task::{self, JoinHandle};
 use std::{collections::HashMap, env, os::unix::io::RawFd, path::PathBuf};
+use zellij_utils::envs::EnvironmentVariables;
 use zellij_utils::nix::unistd::Pid;
 use zellij_utils::{
     async_std,
@@ -446,6 +447,7 @@ impl Pty {
             cwd, // note: this might also be filled by the calling function, eg. spawn_terminal
             hold_on_close: false,
             hold_on_start: false,
+            env: EnvironmentVariables::from_data(HashMap::new()),
         })
     }
     fn fill_cwd(&self, terminal_action: &mut TerminalAction, client_id: ClientId) {

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -277,10 +277,10 @@ pub(crate) fn route_action(
                 .send_to_pty(pty_instr)
                 .with_context(err_context)?;
         },
-        Action::EditFile(path_to_file, line_number, split_direction, should_float) => {
-            let title = format!("Editing: {}", path_to_file.display());
-            let open_file = TerminalAction::OpenFile(path_to_file, line_number);
-            let pty_instr = match (split_direction, should_float) {
+        Action::EditFile(open_file_action) => {
+            let title = format!("Editing: {}", open_file_action.file_name.display());
+            let open_file = TerminalAction::OpenFile(open_file_action.clone().into());
+            let pty_instr = match (open_file_action.direction, open_file_action.floating) {
                 (Some(Direction::Left), false) => {
                     PtyInstruction::SpawnTerminalVertically(Some(open_file), Some(title), client_id)
                 },
@@ -300,7 +300,7 @@ pub(crate) fn route_action(
                 // No direction specified or should float - defer placement to screen
                 (None, _) | (_, true) => PtyInstruction::SpawnTerminal(
                     Some(open_file),
-                    Some(should_float),
+                    Some(open_file_action.floating),
                     Some(title),
                     ClientOrTabIndex::ClientId(client_id),
                 ),

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -6,9 +6,11 @@ mod copy_command;
 
 use copy_command::CopyCommand;
 use std::env::temp_dir;
+use std::path::PathBuf;
 use uuid::Uuid;
+use zellij_utils::envs::EnvironmentVariables;
 use zellij_utils::errors::prelude::*;
-use zellij_utils::input::command::RunCommand;
+use zellij_utils::input::command::{OpenFile, RunCommand};
 use zellij_utils::position::{Column, Line};
 use zellij_utils::{position::Position, serde};
 
@@ -1954,10 +1956,10 @@ impl Tab {
     pub fn edit_scrollback(&mut self, client_id: ClientId) -> Result<()> {
         let err_context = || format!("failed to edit scrollback for client {client_id}");
 
-        let mut file = temp_dir();
-        file.push(format!("{}.dump", Uuid::new_v4()));
+        let cwd = temp_dir();
+        let file_name = PathBuf::from(format!("{}.dump", Uuid::new_v4()));
         self.dump_active_terminal_screen(
-            Some(String::from(file.to_string_lossy())),
+            Some(String::from(cwd.join(file_name.clone()).to_string_lossy())),
             client_id,
             true,
         )
@@ -1967,8 +1969,12 @@ impl Tab {
             .and_then(|a_t| a_t.get_line_number());
         self.senders
             .send_to_pty(PtyInstruction::OpenInPlaceEditor(
-                file,
-                line_number,
+                OpenFile {
+                    file_name,
+                    line_number,
+                    cwd: Some(cwd),
+                    env: EnvironmentVariables::new(),
+                },
                 client_id,
             ))
             .with_context(err_context)

--- a/zellij-server/src/wasm_vm.rs
+++ b/zellij-server/src/wasm_vm.rs
@@ -31,9 +31,10 @@ use crate::{
 use zellij_utils::{
     consts::{DEBUG_MODE, VERSION, ZELLIJ_CACHE_DIR, ZELLIJ_TMP_DIR},
     data::{Event, EventType, PluginIds},
+    envs::EnvironmentVariables,
     errors::{prelude::*, ContextType, PluginContext},
     input::{
-        command::TerminalAction,
+        command::{OpenFile, TerminalAction},
         layout::RunPlugin,
         plugins::{PluginConfig, PluginType, PluginsConfig},
     },
@@ -681,7 +682,12 @@ fn host_open_file(plugin_env: &PluginEnv) {
     plugin_env
         .senders
         .send_to_pty(PtyInstruction::SpawnTerminal(
-            Some(TerminalAction::OpenFile(path, None)),
+            Some(TerminalAction::OpenFile(OpenFile {
+                file_name: path,
+                line_number: None,
+                cwd: None,
+                env: EnvironmentVariables::new(),
+            })),
             None,
             None,
             ClientOrTabIndex::TabIndex(plugin_env.tab_index),

--- a/zellij-tile/src/prelude.rs
+++ b/zellij-tile/src/prelude.rs
@@ -3,4 +3,4 @@ pub use crate::*;
 pub use zellij_utils::consts::VERSION;
 pub use zellij_utils::data::*;
 pub use zellij_utils::errors::prelude::*;
-pub use zellij_utils::input::actions;
+pub use zellij_utils::input::{actions, command};

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -175,6 +175,14 @@ pub enum Sessions {
         /// Change the working directory of the editor
         #[clap(long, value_parser)]
         cwd: Option<PathBuf>,
+
+        #[clap(
+            short,
+            long,
+            value_parser = parse_key_val::<String, String>,
+            takes_value(true)
+        )]
+        env: Option<Vec<(String, String)>>,
     },
     ConvertConfig {
         old_config_file: PathBuf,
@@ -308,6 +316,14 @@ pub enum CliAction {
         /// Change the working directory of the editor
         #[clap(long, value_parser)]
         cwd: Option<PathBuf>,
+
+        #[clap(
+            short,
+            long,
+            value_parser = parse_key_val::<String, String>,
+            takes_value(true)
+        )]
+        env: Option<Vec<(String, String)>>,
     },
     /// Switch input mode of all connected clients [locked|pane|tab|resize|move|search|session]
     SwitchMode { input_mode: InputMode },

--- a/zellij-utils/src/envs.rs
+++ b/zellij-utils/src/envs.rs
@@ -32,9 +32,9 @@ pub fn get_socket_dir() -> Result<String> {
 }
 
 /// Manage ENVIRONMENT VARIABLES from the configuration and the layout files
-#[derive(Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Clone, PartialEq, Serialize, Deserialize, Eq)]
 pub struct EnvironmentVariables {
-    env: HashMap<String, String>,
+    pub env: HashMap<String, String>,
 }
 
 impl fmt::Debug for EnvironmentVariables {
@@ -48,6 +48,11 @@ impl fmt::Debug for EnvironmentVariables {
 }
 
 impl EnvironmentVariables {
+    pub fn new() -> Self {
+        EnvironmentVariables {
+            env: HashMap::new(),
+        }
+    }
     /// Merges two structs, keys from `other` supersede keys from `self`
     pub fn merge(&self, other: Self) -> Self {
         let mut env = self.clone();

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -4,11 +4,13 @@ use super::command::RunCommandAction;
 use super::layout::{Layout, PaneLayout};
 use crate::cli::CliAction;
 use crate::data::InputMode;
+use crate::envs::EnvironmentVariables;
 use crate::input::config::{ConfigError, KdlError};
 use crate::input::options::OnForceClose;
 use miette::{NamedSource, Report};
 use serde::{Deserialize, Serialize};
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -264,6 +266,7 @@ impl Action {
                 name,
                 close_on_exit,
                 start_suspended,
+                env,
             } => {
                 if !command.is_empty() {
                     let mut command = command.clone();
@@ -274,6 +277,9 @@ impl Action {
                         .or_else(|| Some(current_dir));
                     let hold_on_start = start_suspended;
                     let hold_on_close = !close_on_exit;
+                    let env_vars = env.map_or(EnvironmentVariables::new(), |e| {
+                        EnvironmentVariables::from_data(HashMap::from_iter(e))
+                    });
                     let run_command_action = RunCommandAction {
                         command,
                         args,
@@ -281,6 +287,7 @@ impl Action {
                         direction,
                         hold_on_close,
                         hold_on_start,
+                        env: env_vars,
                     };
                     if floating {
                         Ok(vec![Action::NewFloatingPane(

--- a/zellij-utils/src/input/command.rs
+++ b/zellij-utils/src/input/command.rs
@@ -3,11 +3,11 @@ use crate::envs::EnvironmentVariables;
 
 use super::actions::Direction;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
 #[derive(Debug, Clone)]
 pub enum TerminalAction {
-    OpenFile(PathBuf, Option<usize>), // path to file and optional line_number
+    OpenFile(OpenFile),
     RunCommand(RunCommand),
 }
 
@@ -20,11 +20,11 @@ pub struct RunCommand {
     #[serde(default)]
     pub cwd: Option<PathBuf>,
     #[serde(default)]
+    pub env: EnvironmentVariables,
+    #[serde(default)]
     pub hold_on_close: bool,
     #[serde(default)]
     pub hold_on_start: bool,
-    #[serde(default)]
-    pub env: EnvironmentVariables,
 }
 
 impl std::fmt::Display for RunCommand {
@@ -53,13 +53,15 @@ pub struct RunCommandAction {
     #[serde(default)]
     pub cwd: Option<PathBuf>,
     #[serde(default)]
-    pub direction: Option<Direction>,
+    pub env: EnvironmentVariables,
+
     #[serde(default)]
     pub hold_on_close: bool,
     #[serde(default)]
     pub hold_on_start: bool,
+
     #[serde(default)]
-    pub env: EnvironmentVariables,
+    pub direction: Option<Direction>,
 }
 
 impl From<RunCommandAction> for RunCommand {
@@ -68,9 +70,120 @@ impl From<RunCommandAction> for RunCommand {
             command: action.command,
             args: action.args,
             cwd: action.cwd,
+            env: action.env,
             hold_on_close: action.hold_on_close,
             hold_on_start: action.hold_on_start,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Default, Serialize, PartialEq, Eq)]
+pub struct OpenFile {
+    #[serde(default)]
+    pub file_name: PathBuf,
+    #[serde(default)]
+    pub line_number: Option<usize>,
+    #[serde(default)]
+    pub cwd: Option<PathBuf>,
+    #[serde(default)]
+    pub env: EnvironmentVariables,
+}
+
+/// Intermediate representation
+#[derive(Clone, Debug, Deserialize, Default, Serialize, PartialEq, Eq)]
+pub struct OpenFileAction {
+    #[serde(rename = "file")]
+    pub file_name: PathBuf,
+    #[serde(default)]
+    pub line_number: Option<usize>,
+    #[serde(default)]
+    pub cwd: Option<PathBuf>,
+    #[serde(default)]
+    pub env: EnvironmentVariables,
+
+    #[serde(default)]
+    pub direction: Option<Direction>,
+    #[serde(default)]
+    pub floating: bool,
+}
+
+impl From<OpenFileAction> for OpenFile {
+    fn from(action: OpenFileAction) -> Self {
+        OpenFile {
+            file_name: action.file_name,
+            line_number: action.line_number,
+            cwd: action.cwd,
             env: action.env,
+        }
+    }
+}
+
+impl OpenFile {
+    pub fn to_run_action(
+        self,
+        default_editor: Option<PathBuf>,
+    ) -> (RunCommand, Option<RunCommand>) {
+        let mut failover_cmd_args = None;
+        let mut command = default_editor.unwrap_or_else(|| {
+            PathBuf::from(
+                env::var("EDITOR")
+                    .unwrap_or_else(|_| env::var("VISUAL").unwrap_or_else(|_| "vi".into())),
+            )
+        });
+        let mut args = vec![];
+        if !command.is_dir() {
+            separate_command_arguments(&mut command, &mut args);
+        }
+        let file_to_open = self
+            .file_name
+            .into_os_string()
+            .into_string()
+            .expect("Not valid Utf8 Encoding");
+        if let Some(line_number) = self.line_number {
+            if command.ends_with("vim")
+                || command.ends_with("nvim")
+                || command.ends_with("emacs")
+                || command.ends_with("nano")
+                || command.ends_with("kak")
+            {
+                failover_cmd_args = Some(vec![file_to_open.clone()]);
+                args.push(format!("+{}", line_number));
+            }
+        }
+        args.push(file_to_open);
+        let cmd = RunCommand {
+            command,
+            args,
+            cwd: self.cwd,
+            hold_on_close: false,
+            hold_on_start: false,
+            env: self.env,
+        };
+        let failover_cmd = if let Some(failover_cmd_args) = failover_cmd_args {
+            let mut cmd = cmd.clone();
+            cmd.args = failover_cmd_args;
+            Some(cmd)
+        } else {
+            None
+        };
+        (cmd, failover_cmd)
+    }
+}
+
+// this is a utility method to separate the arguments from a pathbuf before we turn it into a
+// Command. eg. "/usr/bin/vim -e" ==> "/usr/bin/vim" + "-e" (the latter will be pushed to args)
+fn separate_command_arguments(command: &mut PathBuf, args: &mut Vec<String>) {
+    if let Some(file_name) = command
+        .file_name()
+        .and_then(|f_n| f_n.to_str())
+        .map(|f_n| f_n.to_string())
+    {
+        let mut file_name_parts = file_name.split_ascii_whitespace();
+        if let Some(first_part) = file_name_parts.next() {
+            command.set_file_name(first_part);
+            for part in file_name_parts {
+                args.push(String::from(part));
+            }
         }
     }
 }

--- a/zellij-utils/src/input/command.rs
+++ b/zellij-utils/src/input/command.rs
@@ -1,4 +1,6 @@
 //! Trigger a command
+use crate::envs::EnvironmentVariables;
+
 use super::actions::Direction;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -21,6 +23,8 @@ pub struct RunCommand {
     pub hold_on_close: bool,
     #[serde(default)]
     pub hold_on_start: bool,
+    #[serde(default)]
+    pub env: EnvironmentVariables,
 }
 
 impl std::fmt::Display for RunCommand {
@@ -54,6 +58,8 @@ pub struct RunCommandAction {
     pub hold_on_close: bool,
     #[serde(default)]
     pub hold_on_start: bool,
+    #[serde(default)]
+    pub env: EnvironmentVariables,
 }
 
 impl From<RunCommandAction> for RunCommand {
@@ -64,6 +70,7 @@ impl From<RunCommandAction> for RunCommand {
             cwd: action.cwd,
             hold_on_close: action.hold_on_close,
             hold_on_start: action.hold_on_start,
+            env: action.env,
         }
     }
 }

--- a/zellij-utils/src/kdl/kdl_layout_parser.rs
+++ b/zellij-utils/src/kdl/kdl_layout_parser.rs
@@ -1,7 +1,7 @@
 use crate::{
     envs::EnvironmentVariables,
     input::{
-        command::RunCommand,
+        command::{OpenFile, RunCommand},
         config::ConfigError,
         layout::{
             Layout, PaneLayout, Run, RunPlugin, RunPluginLocation, SplitDirection, SplitSize,
@@ -278,8 +278,12 @@ impl<'a> KdlLayoutParser<'a> {
                 hold_on_start,
                 env,
             }))),
-            (None, Some(edit), Some(cwd)) => Ok(Some(Run::EditFile(cwd.join(edit), None))),
-            (None, Some(edit), None) => Ok(Some(Run::EditFile(edit, None))),
+            (None, Some(edit), cwd) => Ok(Some(Run::EditFile(OpenFile {
+                file_name: edit,
+                line_number: None,
+                cwd,
+                env,
+            }))),
             (Some(_command), Some(_edit), _) => Err(ConfigError::new_layout_kdl_error(
                 "cannot have both a command and an edit instruction for the same pane".into(),
                 pane_node.span().offset(),

--- a/zellij-utils/src/kdl/kdl_layout_parser.rs
+++ b/zellij-utils/src/kdl/kdl_layout_parser.rs
@@ -271,7 +271,7 @@ impl<'a> KdlLayoutParser<'a> {
         match (command, edit, cwd) {
             (None, None, Some(cwd)) => Ok(Some(Run::Cwd(cwd))),
             (Some(command), None, cwd) => Ok(Some(Run::Command(RunCommand {
-                command,
+                command: Some(command),
                 args: args.unwrap_or_else(|| vec![]),
                 cwd,
                 hold_on_close,

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -757,6 +757,12 @@ impl TryFrom<&KdlNode> for Action {
                 let hold_on_start = command_metadata
                     .and_then(|c_m| kdl_child_bool_value_for_entry(c_m, "start_suspended"))
                     .unwrap_or(false);
+                let env = if let Some(env_node) = command_metadata.and_then(|c_m| c_m.get("env")) {
+                    EnvironmentVariables::from_kdl(env_node)?
+                } else {
+                    EnvironmentVariables::from_data(HashMap::new())
+                };
+
                 let run_command_action = RunCommandAction {
                     command: PathBuf::from(command),
                     args,
@@ -764,6 +770,7 @@ impl TryFrom<&KdlNode> for Action {
                     direction,
                     hold_on_close,
                     hold_on_start,
+                    env,
                 };
                 Ok(Action::Run(run_command_action))
             },


### PR DESCRIPTION
# Description

- Pass environmental variables as arguments for `run` `edit`, `new-tab` `new-pane` #1987
- Handle correctly and consistently `cwd` 
- Refactor the code to be simpler and to allow an easier implementation of #1988

# TODO:

- [ ] Consistent Tab behavior
- [ ] Write Functions and Struct Documentation
- [ ] Unit Test (`Help Wanted` for layout)