### PR TITLE
errors: Maintain caller location in `to_log`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix(themes): missing tokyo-night-dark theme (https://github.com/zellij-org/zellij/pull/1972)
 * refactor(plugins): fix plugin loading data flow (https://github.com/zellij-org/zellij/pull/1995)
 * refactor(messaging): reduce extraneous cross-thread messaging (https://github.com/zellij-org/zellij/pull/1996)
+* errors: preserve caller location in `to_log` (https://github.com/zellij-org/zellij/pull/1994)
 
 ## [0.33.0] - 2022-11-10
 


### PR DESCRIPTION
The `errors::LoggableError` trait provides the `to_log` method as convenience function to log error messages easily. It is increasingly used throughout the zellij codebase, either directly or indirectly from the `non_fatal` function.

Previously, the log messages generated by `to_log` would look something like this:

```
ERROR  |zellij_utils::errors::not| 2022-12-05 21:22:07.662 [stdin_handler] [zellij-utils/src/errors.rs:130]:  a non-fatal error occured

Caused by:
[ ... ]
```

The log output tells us that the error occured at `zellij-utils/src/errors.rs:130`, which is in fact wrong: This is only the location where `to_log` calls `log::error!` to log the actual message content. It loses information about where the error originated.

This PR changes the way the messages are logged, and provides log entries like the following instead:

```
ERROR  |???                      | 2022-12-06 10:04:57.527 [screen    ] [zellij-server/src/screen.rs:1931]: a non-fatal error occured

Caused by:
[ ... ]
```

Most notably, now the file and line number of the real caller are preserved. Unfortunately, this leaves the module empty ("???"), but this is unavoidable (and wasn't correct previously, either). That is because `log` by default resolves the module name with the `std::module_path!()` macro, which is replaced at compile time in the location it is written. In our case, this would still be the `to_log` function. Hence, we leave the module empty.