### PR TITLE
refactor(messaging): reduce extraneous cross-thread messaging

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -404,11 +404,11 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                     .unwrap();
                 session_data
                     .senders
-                    .send_to_plugin(PluginInstruction::Update(
+                    .send_to_plugin(PluginInstruction::Update(vec![(
                         None,
                         Some(client_id),
                         Event::ModeUpdate(mode_info),
-                    ))
+                    )]))
                     .unwrap();
                 send_to_client!(
                     client_id,

--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -378,20 +378,20 @@ impl Pane for PluginPane {
     }
     fn scroll_up(&mut self, count: usize, client_id: ClientId) {
         self.send_plugin_instructions
-            .send(PluginInstruction::Update(
+            .send(PluginInstruction::Update(vec![(
                 Some(self.pid),
                 Some(client_id),
                 Event::Mouse(Mouse::ScrollUp(count)),
-            ))
+            )]))
             .unwrap();
     }
     fn scroll_down(&mut self, count: usize, client_id: ClientId) {
         self.send_plugin_instructions
-            .send(PluginInstruction::Update(
+            .send(PluginInstruction::Update(vec![(
                 Some(self.pid),
                 Some(client_id),
                 Event::Mouse(Mouse::ScrollDown(count)),
-            ))
+            )]))
             .unwrap();
     }
     fn clear_scroll(&mut self) {
@@ -399,29 +399,29 @@ impl Pane for PluginPane {
     }
     fn start_selection(&mut self, start: &Position, client_id: ClientId) {
         self.send_plugin_instructions
-            .send(PluginInstruction::Update(
+            .send(PluginInstruction::Update(vec![(
                 Some(self.pid),
                 Some(client_id),
                 Event::Mouse(Mouse::LeftClick(start.line.0, start.column.0)),
-            ))
+            )]))
             .unwrap();
     }
     fn update_selection(&mut self, position: &Position, client_id: ClientId) {
         self.send_plugin_instructions
-            .send(PluginInstruction::Update(
+            .send(PluginInstruction::Update(vec![(
                 Some(self.pid),
                 Some(client_id),
                 Event::Mouse(Mouse::Hold(position.line.0, position.column.0)),
-            ))
+            )]))
             .unwrap();
     }
     fn end_selection(&mut self, end: &Position, client_id: ClientId) {
         self.send_plugin_instructions
-            .send(PluginInstruction::Update(
+            .send(PluginInstruction::Update(vec![(
                 Some(self.pid),
                 Some(client_id),
                 Event::Mouse(Mouse::Release(end.line(), end.column())),
-            ))
+            )]))
             .unwrap();
     }
     fn is_scrolled(&self) -> bool {
@@ -462,11 +462,11 @@ impl Pane for PluginPane {
     }
     fn handle_right_click(&mut self, to: &Position, client_id: ClientId) {
         self.send_plugin_instructions
-            .send(PluginInstruction::Update(
+            .send(PluginInstruction::Update(vec![(
                 Some(self.pid),
                 Some(client_id),
                 Event::Mouse(Mouse::RightClick(to.line.0, to.column.0)),
-            ))
+            )]))
             .unwrap();
     }
 }

--- a/zellij-server/src/plugins/mod.rs
+++ b/zellij-server/src/plugins/mod.rs
@@ -21,7 +21,7 @@ use zellij_utils::{
 #[derive(Clone, Debug)]
 pub enum PluginInstruction {
     Load(RunPlugin, usize, ClientId, Size), // plugin metadata, tab_index, client_ids
-    Update(Option<u32>, Option<ClientId>, Event), // Focused plugin / broadcast, client_id, event data
+    Update(Vec<(Option<u32>, Option<ClientId>, Event)>), // Focused plugin / broadcast, client_id, event data
     Unload(u32),                                  // plugin_id
     Resize(u32, usize, usize),                    // plugin_id, columns, rows
     AddClient(ClientId),
@@ -73,8 +73,8 @@ pub(crate) fn plugin_thread_main(
             PluginInstruction::Load(run, tab_index, client_id, size) => {
                 wasm_bridge.load_plugin(&run, tab_index, size, client_id)?;
             },
-            PluginInstruction::Update(pid, cid, event) => {
-                wasm_bridge.update_plugins(pid, cid, event)?;
+            PluginInstruction::Update(updates) => {
+                wasm_bridge.update_plugins(updates)?;
             },
             PluginInstruction::Unload(pid) => {
                 wasm_bridge.unload_plugin(pid)?;

--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -398,6 +398,7 @@ impl WasmBridge {
     }
     pub fn resize_plugin(&mut self, pid: u32, new_columns: usize, new_rows: usize) -> Result<()> {
         let err_context = || format!("failed to resize plugin {pid}");
+        let mut plugin_bytes = vec![];
         for ((plugin_id, client_id), (instance, plugin_env, (current_rows, current_columns))) in
             self.plugin_map.iter_mut()
         {
@@ -418,84 +419,84 @@ impl WasmBridge {
                     ])
                     .with_context(err_context)?;
                 let rendered_bytes = wasi_read_string(&plugin_env.wasi_env);
-                drop(self.senders.send_to_screen(ScreenInstruction::PluginBytes(
+                plugin_bytes.push((
                     *plugin_id,
                     *client_id,
                     rendered_bytes.as_bytes().to_vec(),
-                )));
+                ));
             }
         }
+        let _ = self.senders.send_to_screen(ScreenInstruction::PluginBytes(plugin_bytes));
         Ok(())
     }
-    pub fn update_plugins(
-        &mut self,
-        pid: Option<u32>,
-        cid: Option<ClientId>,
-        event: Event,
-    ) -> Result<()> {
+    pub fn update_plugins(&mut self, mut updates: Vec<(Option<u32>, Option<ClientId>, Event)>) -> Result<()> {
         let err_context = || {
             if *DEBUG_MODE.get().unwrap_or(&true) {
-                format!("failed to update plugin state with event: {event:#?}")
+                format!("failed to update plugin state")
             } else {
                 "failed to update plugin state".to_string()
             }
         };
 
-        for (&(plugin_id, client_id), (instance, plugin_env, (rows, columns))) in &self.plugin_map {
-            let subs = plugin_env
-                .subscriptions
-                .lock()
-                .to_anyhow()
-                .with_context(err_context)?;
-            // FIXME: This is very janky... Maybe I should write my own macro for Event -> EventType?
-            let event_type = EventType::from_str(&event.to_string()).with_context(err_context)?;
-            if subs.contains(&event_type)
-                && ((pid.is_none() && cid.is_none())
-                    || (pid.is_none() && cid == Some(client_id))
-                    || (cid.is_none() && pid == Some(plugin_id))
-                    || (cid == Some(client_id) && pid == Some(plugin_id)))
-            {
-                let update = instance
-                    .exports
-                    .get_function("update")
+        let mut plugin_bytes = vec![];
+        for (pid, cid, event) in updates.drain(..) {
+            for (&(plugin_id, client_id), (instance, plugin_env, (rows, columns))) in &self.plugin_map {
+                let subs = plugin_env
+                    .subscriptions
+                    .lock()
+                    .to_anyhow()
                     .with_context(err_context)?;
-                wasi_write_object(&plugin_env.wasi_env, &event);
-                let update_return = update.call(&[]).or_else::<anyError, _>(|e| {
-                    match e.downcast::<serde_json::Error>() {
-                        Ok(_) => panic!(
-                            "{}",
-                            anyError::new(VersionMismatchError::new(
-                                VERSION,
-                                "Unavailable",
-                                &plugin_env.plugin.path,
-                                plugin_env.plugin.is_builtin(),
-                            ))
-                        ),
-                        Err(e) => Err(e).with_context(err_context),
-                    }
-                })?;
-                let should_render = match update_return.get(0) {
-                    Some(Value::I32(n)) => *n == 1,
-                    _ => false,
-                };
-
-                if *rows > 0 && *columns > 0 && should_render {
-                    let render = instance
+                // FIXME: This is very janky... Maybe I should write my own macro for Event -> EventType?
+                let event_type = EventType::from_str(&event.to_string()).with_context(err_context)?;
+                if subs.contains(&event_type)
+                    && ((pid.is_none() && cid.is_none())
+                        || (pid.is_none() && cid == Some(client_id))
+                        || (cid.is_none() && pid == Some(plugin_id))
+                        || (cid == Some(client_id) && pid == Some(plugin_id)))
+                {
+                    let update = instance
                         .exports
-                        .get_function("render")
+                        .get_function("update")
                         .with_context(err_context)?;
-                    render
-                        .call(&[Value::I32(*rows as i32), Value::I32(*columns as i32)])
-                        .with_context(err_context)?;
-                    let rendered_bytes = wasi_read_string(&plugin_env.wasi_env);
-                    drop(self.senders.send_to_screen(ScreenInstruction::PluginBytes(
-                        plugin_id,
-                        client_id,
-                        rendered_bytes.as_bytes().to_vec(),
-                    )));
+                    wasi_write_object(&plugin_env.wasi_env, &event);
+                    let update_return = update.call(&[]).or_else::<anyError, _>(|e| {
+                        match e.downcast::<serde_json::Error>() {
+                            Ok(_) => panic!(
+                                "{}",
+                                anyError::new(VersionMismatchError::new(
+                                    VERSION,
+                                    "Unavailable",
+                                    &plugin_env.plugin.path,
+                                    plugin_env.plugin.is_builtin(),
+                                ))
+                            ),
+                            Err(e) => Err(e).with_context(err_context),
+                        }
+                    })?;
+                    let should_render = match update_return.get(0) {
+                        Some(Value::I32(n)) => *n == 1,
+                        _ => false,
+                    };
+
+                    if *rows > 0 && *columns > 0 && should_render {
+                        let render = instance
+                            .exports
+                            .get_function("render")
+                            .with_context(err_context)?;
+                        render
+                            .call(&[Value::I32(*rows as i32), Value::I32(*columns as i32)])
+                            .with_context(err_context)?;
+                        let rendered_bytes = wasi_read_string(&plugin_env.wasi_env);
+                        plugin_bytes.push((
+                            plugin_id,
+                            client_id,
+                            rendered_bytes.as_bytes().to_vec(),
+                        ));
+                    }
                 }
             }
         }
+        let _ = self.senders.send_to_screen(ScreenInstruction::PluginBytes(plugin_bytes));
         Ok(())
     }
     pub fn remove_client(&mut self, client_id: ClientId) {
@@ -673,11 +674,11 @@ fn host_set_timeout(plugin_env: &PluginEnv, secs: f64) {
 
         send_plugin_instructions
             .unwrap()
-            .send(PluginInstruction::Update(
+            .send(PluginInstruction::Update(vec![(
                 update_target,
                 Some(client_id),
                 Event::Timer(elapsed_time),
-            ))
+            )]))
             .unwrap();
     });
 }

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -39,11 +39,11 @@ pub(crate) fn route_action(
         _ => {
             session
                 .senders
-                .send_to_plugin(PluginInstruction::Update(
+                .send_to_plugin(PluginInstruction::Update(vec![(
                     None,
                     Some(client_id),
                     Event::InputReceived,
-                ))
+                )]))
                 .with_context(err_context)?;
         },
     }
@@ -84,11 +84,11 @@ pub(crate) fn route_action(
             // TODO: Need access to `ClientAttributes` here
             session
                 .senders
-                .send_to_plugin(PluginInstruction::Update(
+                .send_to_plugin(PluginInstruction::Update(vec![(
                     None,
                     Some(client_id),
                     Event::ModeUpdate(get_mode_info(mode, attrs, session.capabilities)),
-                ))
+                )]))
                 .with_context(err_context)?;
             session
                 .senders
@@ -314,11 +314,11 @@ pub(crate) fn route_action(
             let attrs = &session.client_attributes;
             session
                 .senders
-                .send_to_plugin(PluginInstruction::Update(
+                .send_to_plugin(PluginInstruction::Update(vec![(
                     None,
                     None,
                     Event::ModeUpdate(get_mode_info(input_mode, attrs, session.capabilities)),
-                ))
+                )]))
                 .with_context(err_context)?;
             session
                 .senders

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -683,21 +683,18 @@ impl Tab {
     pub fn update_input_modes(&mut self) -> Result<()> {
         // this updates all plugins with the client's input mode
         let mode_infos = self.mode_info.borrow();
+        let mut plugin_updates = vec![];
         for client_id in self.connected_clients.borrow().iter() {
             let mode_info = mode_infos.get(client_id).unwrap_or(&self.default_mode_info);
-            self.senders
-                .send_to_plugin(PluginInstruction::Update(
-                    None,
-                    Some(*client_id),
-                    Event::ModeUpdate(mode_info.clone()),
-                ))
-                .with_context(|| {
-                    format!(
-                        "failed to update plugins with mode info {:?}",
-                        mode_info.mode
-                    )
-                })?;
+            plugin_updates.push((
+                None,
+                Some(*client_id),
+                Event::ModeUpdate(mode_info.clone())
+            ));
         }
+        self.senders
+            .send_to_plugin(PluginInstruction::Update(plugin_updates))
+            .with_context(|| format!("failed to update plugins with mode info"))?;
         Ok(())
     }
     pub fn add_client(&mut self, client_id: ClientId, mode_info: Option<ModeInfo>) -> Result<()> {
@@ -742,8 +739,7 @@ impl Tab {
             );
         }
         self.set_force_render();
-        self.update_input_modes()
-            .with_context(|| format!("failed to add client {client_id} to tab"))
+        Ok(())
     }
 
     pub fn change_mode_info(&mut self, mode_info: ModeInfo, client_id: ClientId) {
@@ -1357,11 +1353,13 @@ impl Tab {
                 }
             },
             PaneId::Plugin(pid) => {
+                let mut plugin_updates = vec![];
                 for key in parse_keys(&input_bytes) {
-                    self.senders
-                        .send_to_plugin(PluginInstruction::Update(Some(pid), None, Event::Key(key)))
-                        .with_context(err_context)?;
+                    plugin_updates.push((Some(pid), None, Event::Key(key)));
                 }
+                self.senders
+                    .send_to_plugin(PluginInstruction::Update(plugin_updates))
+                    .with_context(err_context)?;
             },
         }
         Ok(should_update_ui)
@@ -2633,11 +2631,11 @@ impl Tab {
                     format!("failed to write selection to clipboard for client {client_id}")
                 })?;
             self.senders
-                .send_to_plugin(PluginInstruction::Update(
+                .send_to_plugin(PluginInstruction::Update(vec![(
                     None,
                     None,
                     Event::CopyToClipboard(self.clipboard_provider.as_copy_destination()),
-                ))
+                )]))
                 .with_context(|| {
                     format!("failed to inform plugins about copy selection for client {client_id}")
                 })
@@ -2677,7 +2675,7 @@ impl Tab {
                 },
             };
         self.senders
-            .send_to_plugin(PluginInstruction::Update(None, None, clipboard_event))
+            .send_to_plugin(PluginInstruction::Update(vec![(None, None, clipboard_event)]))
             .context("failed to notify plugins about new clipboard event")
             .non_fatal();
 
@@ -2712,15 +2710,17 @@ impl Tab {
             PaneId::Plugin(pid) => Some(pid),
             _ => None,
         });
+        let mut plugin_updates = vec![];
         for pid in pids_in_this_tab {
-            self.senders
-                .send_to_plugin(PluginInstruction::Update(
-                    Some(*pid),
-                    None,
-                    Event::Visible(visible),
-                ))
-                .with_context(|| format!("failed to set visibility of tab to {visible}"))?;
+            plugin_updates.push((
+                Some(*pid),
+                None,
+                Event::Visible(visible),
+            ));
         }
+        self.senders
+            .send_to_plugin(PluginInstruction::Update(plugin_updates))
+            .with_context(|| format!("failed to set visibility of tab to {visible}"))?;
         Ok(())
     }
 

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_next_tab_action-3.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_next_tab_action-3.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 2346
+assertion_line: 2366
 expression: "format!(\"{}\", snapshot)"
 ---
 00 (C): ┌ Pane #1 ─────────────────────────────────────────────────────────────────────┐

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_rename_tab.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_rename_tab.snap
@@ -1,22 +1,30 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 2506
+assertion_line: 2511
 expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
 ---
 [
     Update(
-        None,
-        Some(
-            10,
-        ),
-        InputReceived,
+        [
+            (
+                None,
+                Some(
+                    10,
+                ),
+                InputReceived,
+            ),
+        ],
     ),
     Update(
-        None,
-        Some(
-            10,
-        ),
-        InputReceived,
+        [
+            (
+                None,
+                Some(
+                    10,
+                ),
+                InputReceived,
+            ),
+        ],
     ),
     NewTab(
         None,
@@ -58,176 +66,111 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
         1,
     ),
     Update(
-        None,
-        Some(
-            1,
-        ),
-        ModeUpdate(
-            ModeInfo {
-                mode: Normal,
-                keybinds: [],
-                style: Style {
-                    colors: Palette {
-                        source: Default,
-                        theme_hue: Dark,
-                        fg: EightBit(
-                            0,
-                        ),
-                        bg: EightBit(
-                            0,
-                        ),
-                        black: EightBit(
-                            0,
-                        ),
-                        red: EightBit(
-                            0,
-                        ),
-                        green: EightBit(
-                            0,
-                        ),
-                        yellow: EightBit(
-                            0,
-                        ),
-                        blue: EightBit(
-                            0,
-                        ),
-                        magenta: EightBit(
-                            0,
-                        ),
-                        cyan: EightBit(
-                            0,
-                        ),
-                        white: EightBit(
-                            0,
-                        ),
-                        orange: EightBit(
-                            0,
-                        ),
-                        gray: EightBit(
-                            0,
-                        ),
-                        purple: EightBit(
-                            0,
-                        ),
-                        gold: EightBit(
-                            0,
-                        ),
-                        silver: EightBit(
-                            0,
-                        ),
-                        pink: EightBit(
-                            0,
-                        ),
-                        brown: EightBit(
-                            0,
+        [
+            (
+                None,
+                Some(
+                    1,
+                ),
+                ModeUpdate(
+                    ModeInfo {
+                        mode: Normal,
+                        keybinds: [],
+                        style: Style {
+                            colors: Palette {
+                                source: Default,
+                                theme_hue: Dark,
+                                fg: EightBit(
+                                    0,
+                                ),
+                                bg: EightBit(
+                                    0,
+                                ),
+                                black: EightBit(
+                                    0,
+                                ),
+                                red: EightBit(
+                                    0,
+                                ),
+                                green: EightBit(
+                                    0,
+                                ),
+                                yellow: EightBit(
+                                    0,
+                                ),
+                                blue: EightBit(
+                                    0,
+                                ),
+                                magenta: EightBit(
+                                    0,
+                                ),
+                                cyan: EightBit(
+                                    0,
+                                ),
+                                white: EightBit(
+                                    0,
+                                ),
+                                orange: EightBit(
+                                    0,
+                                ),
+                                gray: EightBit(
+                                    0,
+                                ),
+                                purple: EightBit(
+                                    0,
+                                ),
+                                gold: EightBit(
+                                    0,
+                                ),
+                                silver: EightBit(
+                                    0,
+                                ),
+                                pink: EightBit(
+                                    0,
+                                ),
+                                brown: EightBit(
+                                    0,
+                                ),
+                            },
+                            rounded_corners: false,
+                        },
+                        capabilities: PluginCapabilities {
+                            arrow_fonts: false,
+                        },
+                        session_name: Some(
+                            "zellij-test",
                         ),
                     },
-                    rounded_corners: false,
-                },
-                capabilities: PluginCapabilities {
-                    arrow_fonts: false,
-                },
-                session_name: Some(
-                    "zellij-test",
                 ),
-            },
-        ),
+            ),
+        ],
     ),
     Update(
-        None,
-        Some(
-            1,
-        ),
-        ModeUpdate(
-            ModeInfo {
-                mode: Normal,
-                keybinds: [],
-                style: Style {
-                    colors: Palette {
-                        source: Default,
-                        theme_hue: Dark,
-                        fg: EightBit(
-                            0,
-                        ),
-                        bg: EightBit(
-                            0,
-                        ),
-                        black: EightBit(
-                            0,
-                        ),
-                        red: EightBit(
-                            0,
-                        ),
-                        green: EightBit(
-                            0,
-                        ),
-                        yellow: EightBit(
-                            0,
-                        ),
-                        blue: EightBit(
-                            0,
-                        ),
-                        magenta: EightBit(
-                            0,
-                        ),
-                        cyan: EightBit(
-                            0,
-                        ),
-                        white: EightBit(
-                            0,
-                        ),
-                        orange: EightBit(
-                            0,
-                        ),
-                        gray: EightBit(
-                            0,
-                        ),
-                        purple: EightBit(
-                            0,
-                        ),
-                        gold: EightBit(
-                            0,
-                        ),
-                        silver: EightBit(
-                            0,
-                        ),
-                        pink: EightBit(
-                            0,
-                        ),
-                        brown: EightBit(
-                            0,
-                        ),
-                    },
-                    rounded_corners: false,
-                },
-                capabilities: PluginCapabilities {
-                    arrow_fonts: false,
-                },
-                session_name: Some(
-                    "zellij-test",
-                ),
-            },
-        ),
+        [],
     ),
     Update(
-        None,
-        Some(
-            1,
-        ),
-        TabUpdate(
-            [
-                TabInfo {
-                    position: 0,
-                    name: "Tab #1",
-                    active: true,
-                    panes_to_hide: 0,
-                    is_fullscreen_active: false,
-                    is_sync_panes_active: false,
-                    are_floating_panes_visible: false,
-                    other_focused_clients: [],
-                },
-            ],
-        ),
+        [
+            (
+                None,
+                Some(
+                    1,
+                ),
+                TabUpdate(
+                    [
+                        TabInfo {
+                            position: 0,
+                            name: "Tab #1",
+                            active: true,
+                            panes_to_hide: 0,
+                            is_fullscreen_active: false,
+                            is_sync_panes_active: false,
+                            are_floating_panes_visible: false,
+                            other_focused_clients: [],
+                        },
+                    ],
+                ),
+            ),
+        ],
     ),
     NewTab(
         None,
@@ -269,246 +212,192 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
         1,
     ),
     Update(
-        None,
-        Some(
-            1,
-        ),
-        ModeUpdate(
-            ModeInfo {
-                mode: Normal,
-                keybinds: [],
-                style: Style {
-                    colors: Palette {
-                        source: Default,
-                        theme_hue: Dark,
-                        fg: EightBit(
-                            0,
-                        ),
-                        bg: EightBit(
-                            0,
-                        ),
-                        black: EightBit(
-                            0,
-                        ),
-                        red: EightBit(
-                            0,
-                        ),
-                        green: EightBit(
-                            0,
-                        ),
-                        yellow: EightBit(
-                            0,
-                        ),
-                        blue: EightBit(
-                            0,
-                        ),
-                        magenta: EightBit(
-                            0,
-                        ),
-                        cyan: EightBit(
-                            0,
-                        ),
-                        white: EightBit(
-                            0,
-                        ),
-                        orange: EightBit(
-                            0,
-                        ),
-                        gray: EightBit(
-                            0,
-                        ),
-                        purple: EightBit(
-                            0,
-                        ),
-                        gold: EightBit(
-                            0,
-                        ),
-                        silver: EightBit(
-                            0,
-                        ),
-                        pink: EightBit(
-                            0,
-                        ),
-                        brown: EightBit(
-                            0,
+        [],
+    ),
+    Update(
+        [
+            (
+                None,
+                Some(
+                    1,
+                ),
+                ModeUpdate(
+                    ModeInfo {
+                        mode: Normal,
+                        keybinds: [],
+                        style: Style {
+                            colors: Palette {
+                                source: Default,
+                                theme_hue: Dark,
+                                fg: EightBit(
+                                    0,
+                                ),
+                                bg: EightBit(
+                                    0,
+                                ),
+                                black: EightBit(
+                                    0,
+                                ),
+                                red: EightBit(
+                                    0,
+                                ),
+                                green: EightBit(
+                                    0,
+                                ),
+                                yellow: EightBit(
+                                    0,
+                                ),
+                                blue: EightBit(
+                                    0,
+                                ),
+                                magenta: EightBit(
+                                    0,
+                                ),
+                                cyan: EightBit(
+                                    0,
+                                ),
+                                white: EightBit(
+                                    0,
+                                ),
+                                orange: EightBit(
+                                    0,
+                                ),
+                                gray: EightBit(
+                                    0,
+                                ),
+                                purple: EightBit(
+                                    0,
+                                ),
+                                gold: EightBit(
+                                    0,
+                                ),
+                                silver: EightBit(
+                                    0,
+                                ),
+                                pink: EightBit(
+                                    0,
+                                ),
+                                brown: EightBit(
+                                    0,
+                                ),
+                            },
+                            rounded_corners: false,
+                        },
+                        capabilities: PluginCapabilities {
+                            arrow_fonts: false,
+                        },
+                        session_name: Some(
+                            "zellij-test",
                         ),
                     },
-                    rounded_corners: false,
-                },
-                capabilities: PluginCapabilities {
-                    arrow_fonts: false,
-                },
-                session_name: Some(
-                    "zellij-test",
                 ),
-            },
-        ),
+            ),
+        ],
     ),
     Update(
-        None,
-        Some(
-            1,
-        ),
-        ModeUpdate(
-            ModeInfo {
-                mode: Normal,
-                keybinds: [],
-                style: Style {
-                    colors: Palette {
-                        source: Default,
-                        theme_hue: Dark,
-                        fg: EightBit(
-                            0,
-                        ),
-                        bg: EightBit(
-                            0,
-                        ),
-                        black: EightBit(
-                            0,
-                        ),
-                        red: EightBit(
-                            0,
-                        ),
-                        green: EightBit(
-                            0,
-                        ),
-                        yellow: EightBit(
-                            0,
-                        ),
-                        blue: EightBit(
-                            0,
-                        ),
-                        magenta: EightBit(
-                            0,
-                        ),
-                        cyan: EightBit(
-                            0,
-                        ),
-                        white: EightBit(
-                            0,
-                        ),
-                        orange: EightBit(
-                            0,
-                        ),
-                        gray: EightBit(
-                            0,
-                        ),
-                        purple: EightBit(
-                            0,
-                        ),
-                        gold: EightBit(
-                            0,
-                        ),
-                        silver: EightBit(
-                            0,
-                        ),
-                        pink: EightBit(
-                            0,
-                        ),
-                        brown: EightBit(
-                            0,
-                        ),
-                    },
-                    rounded_corners: false,
-                },
-                capabilities: PluginCapabilities {
-                    arrow_fonts: false,
-                },
-                session_name: Some(
-                    "zellij-test",
+        [],
+    ),
+    Update(
+        [
+            (
+                None,
+                Some(
+                    1,
                 ),
-            },
-        ),
+                TabUpdate(
+                    [
+                        TabInfo {
+                            position: 0,
+                            name: "Tab #1",
+                            active: false,
+                            panes_to_hide: 0,
+                            is_fullscreen_active: false,
+                            is_sync_panes_active: false,
+                            are_floating_panes_visible: false,
+                            other_focused_clients: [],
+                        },
+                        TabInfo {
+                            position: 1,
+                            name: "Tab #2",
+                            active: true,
+                            panes_to_hide: 0,
+                            is_fullscreen_active: false,
+                            is_sync_panes_active: false,
+                            are_floating_panes_visible: false,
+                            other_focused_clients: [],
+                        },
+                    ],
+                ),
+            ),
+        ],
     ),
     Update(
-        None,
-        Some(
-            1,
-        ),
-        TabUpdate(
-            [
-                TabInfo {
-                    position: 0,
-                    name: "Tab #1",
-                    active: false,
-                    panes_to_hide: 0,
-                    is_fullscreen_active: false,
-                    is_sync_panes_active: false,
-                    are_floating_panes_visible: false,
-                    other_focused_clients: [],
-                },
-                TabInfo {
-                    position: 1,
-                    name: "Tab #2",
-                    active: true,
-                    panes_to_hide: 0,
-                    is_fullscreen_active: false,
-                    is_sync_panes_active: false,
-                    are_floating_panes_visible: false,
-                    other_focused_clients: [],
-                },
-            ],
-        ),
+        [
+            (
+                None,
+                Some(
+                    1,
+                ),
+                TabUpdate(
+                    [
+                        TabInfo {
+                            position: 0,
+                            name: "Tab #1",
+                            active: false,
+                            panes_to_hide: 0,
+                            is_fullscreen_active: false,
+                            is_sync_panes_active: false,
+                            are_floating_panes_visible: false,
+                            other_focused_clients: [],
+                        },
+                        TabInfo {
+                            position: 1,
+                            name: "",
+                            active: true,
+                            panes_to_hide: 0,
+                            is_fullscreen_active: false,
+                            is_sync_panes_active: false,
+                            are_floating_panes_visible: false,
+                            other_focused_clients: [],
+                        },
+                    ],
+                ),
+            ),
+        ],
     ),
     Update(
-        None,
-        Some(
-            1,
-        ),
-        TabUpdate(
-            [
-                TabInfo {
-                    position: 0,
-                    name: "Tab #1",
-                    active: false,
-                    panes_to_hide: 0,
-                    is_fullscreen_active: false,
-                    is_sync_panes_active: false,
-                    are_floating_panes_visible: false,
-                    other_focused_clients: [],
-                },
-                TabInfo {
-                    position: 1,
-                    name: "",
-                    active: true,
-                    panes_to_hide: 0,
-                    is_fullscreen_active: false,
-                    is_sync_panes_active: false,
-                    are_floating_panes_visible: false,
-                    other_focused_clients: [],
-                },
-            ],
-        ),
-    ),
-    Update(
-        None,
-        Some(
-            1,
-        ),
-        TabUpdate(
-            [
-                TabInfo {
-                    position: 0,
-                    name: "Tab #1",
-                    active: false,
-                    panes_to_hide: 0,
-                    is_fullscreen_active: false,
-                    is_sync_panes_active: false,
-                    are_floating_panes_visible: false,
-                    other_focused_clients: [],
-                },
-                TabInfo {
-                    position: 1,
-                    name: "new-tab-name",
-                    active: true,
-                    panes_to_hide: 0,
-                    is_fullscreen_active: false,
-                    is_sync_panes_active: false,
-                    are_floating_panes_visible: false,
-                    other_focused_clients: [],
-                },
-            ],
-        ),
+        [
+            (
+                None,
+                Some(
+                    1,
+                ),
+                TabUpdate(
+                    [
+                        TabInfo {
+                            position: 0,
+                            name: "Tab #1",
+                            active: false,
+                            panes_to_hide: 0,
+                            is_fullscreen_active: false,
+                            is_sync_panes_active: false,
+                            are_floating_panes_visible: false,
+                            other_focused_clients: [],
+                        },
+                        TabInfo {
+                            position: 1,
+                            name: "new-tab-name",
+                            active: true,
+                            panes_to_hide: 0,
+                            is_fullscreen_active: false,
+                            is_sync_panes_active: false,
+                            are_floating_panes_visible: false,
+                            other_focused_clients: [],
+                        },
+                    ],
+                ),
+            ),
+        ],
     ),
     Exit,
 ]

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_undo_rename_tab.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_undo_rename_tab.snap
@@ -1,22 +1,30 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 2549
+assertion_line: 2554
 expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
 ---
 [
     Update(
-        None,
-        Some(
-            10,
-        ),
-        InputReceived,
+        [
+            (
+                None,
+                Some(
+                    10,
+                ),
+                InputReceived,
+            ),
+        ],
     ),
     Update(
-        None,
-        Some(
-            10,
-        ),
-        InputReceived,
+        [
+            (
+                None,
+                Some(
+                    10,
+                ),
+                InputReceived,
+            ),
+        ],
     ),
     NewTab(
         None,
@@ -58,176 +66,111 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
         1,
     ),
     Update(
-        None,
-        Some(
-            1,
-        ),
-        ModeUpdate(
-            ModeInfo {
-                mode: Normal,
-                keybinds: [],
-                style: Style {
-                    colors: Palette {
-                        source: Default,
-                        theme_hue: Dark,
-                        fg: EightBit(
-                            0,
-                        ),
-                        bg: EightBit(
-                            0,
-                        ),
-                        black: EightBit(
-                            0,
-                        ),
-                        red: EightBit(
-                            0,
-                        ),
-                        green: EightBit(
-                            0,
-                        ),
-                        yellow: EightBit(
-                            0,
-                        ),
-                        blue: EightBit(
-                            0,
-                        ),
-                        magenta: EightBit(
-                            0,
-                        ),
-                        cyan: EightBit(
-                            0,
-                        ),
-                        white: EightBit(
-                            0,
-                        ),
-                        orange: EightBit(
-                            0,
-                        ),
-                        gray: EightBit(
-                            0,
-                        ),
-                        purple: EightBit(
-                            0,
-                        ),
-                        gold: EightBit(
-                            0,
-                        ),
-                        silver: EightBit(
-                            0,
-                        ),
-                        pink: EightBit(
-                            0,
-                        ),
-                        brown: EightBit(
-                            0,
+        [
+            (
+                None,
+                Some(
+                    1,
+                ),
+                ModeUpdate(
+                    ModeInfo {
+                        mode: Normal,
+                        keybinds: [],
+                        style: Style {
+                            colors: Palette {
+                                source: Default,
+                                theme_hue: Dark,
+                                fg: EightBit(
+                                    0,
+                                ),
+                                bg: EightBit(
+                                    0,
+                                ),
+                                black: EightBit(
+                                    0,
+                                ),
+                                red: EightBit(
+                                    0,
+                                ),
+                                green: EightBit(
+                                    0,
+                                ),
+                                yellow: EightBit(
+                                    0,
+                                ),
+                                blue: EightBit(
+                                    0,
+                                ),
+                                magenta: EightBit(
+                                    0,
+                                ),
+                                cyan: EightBit(
+                                    0,
+                                ),
+                                white: EightBit(
+                                    0,
+                                ),
+                                orange: EightBit(
+                                    0,
+                                ),
+                                gray: EightBit(
+                                    0,
+                                ),
+                                purple: EightBit(
+                                    0,
+                                ),
+                                gold: EightBit(
+                                    0,
+                                ),
+                                silver: EightBit(
+                                    0,
+                                ),
+                                pink: EightBit(
+                                    0,
+                                ),
+                                brown: EightBit(
+                                    0,
+                                ),
+                            },
+                            rounded_corners: false,
+                        },
+                        capabilities: PluginCapabilities {
+                            arrow_fonts: false,
+                        },
+                        session_name: Some(
+                            "zellij-test",
                         ),
                     },
-                    rounded_corners: false,
-                },
-                capabilities: PluginCapabilities {
-                    arrow_fonts: false,
-                },
-                session_name: Some(
-                    "zellij-test",
                 ),
-            },
-        ),
+            ),
+        ],
     ),
     Update(
-        None,
-        Some(
-            1,
-        ),
-        ModeUpdate(
-            ModeInfo {
-                mode: Normal,
-                keybinds: [],
-                style: Style {
-                    colors: Palette {
-                        source: Default,
-                        theme_hue: Dark,
-                        fg: EightBit(
-                            0,
-                        ),
-                        bg: EightBit(
-                            0,
-                        ),
-                        black: EightBit(
-                            0,
-                        ),
-                        red: EightBit(
-                            0,
-                        ),
-                        green: EightBit(
-                            0,
-                        ),
-                        yellow: EightBit(
-                            0,
-                        ),
-                        blue: EightBit(
-                            0,
-                        ),
-                        magenta: EightBit(
-                            0,
-                        ),
-                        cyan: EightBit(
-                            0,
-                        ),
-                        white: EightBit(
-                            0,
-                        ),
-                        orange: EightBit(
-                            0,
-                        ),
-                        gray: EightBit(
-                            0,
-                        ),
-                        purple: EightBit(
-                            0,
-                        ),
-                        gold: EightBit(
-                            0,
-                        ),
-                        silver: EightBit(
-                            0,
-                        ),
-                        pink: EightBit(
-                            0,
-                        ),
-                        brown: EightBit(
-                            0,
-                        ),
-                    },
-                    rounded_corners: false,
-                },
-                capabilities: PluginCapabilities {
-                    arrow_fonts: false,
-                },
-                session_name: Some(
-                    "zellij-test",
-                ),
-            },
-        ),
+        [],
     ),
     Update(
-        None,
-        Some(
-            1,
-        ),
-        TabUpdate(
-            [
-                TabInfo {
-                    position: 0,
-                    name: "Tab #1",
-                    active: true,
-                    panes_to_hide: 0,
-                    is_fullscreen_active: false,
-                    is_sync_panes_active: false,
-                    are_floating_panes_visible: false,
-                    other_focused_clients: [],
-                },
-            ],
-        ),
+        [
+            (
+                None,
+                Some(
+                    1,
+                ),
+                TabUpdate(
+                    [
+                        TabInfo {
+                            position: 0,
+                            name: "Tab #1",
+                            active: true,
+                            panes_to_hide: 0,
+                            is_fullscreen_active: false,
+                            is_sync_panes_active: false,
+                            are_floating_panes_visible: false,
+                            other_focused_clients: [],
+                        },
+                    ],
+                ),
+            ),
+        ],
     ),
     NewTab(
         None,
@@ -269,283 +212,237 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
         1,
     ),
     Update(
-        None,
-        Some(
-            1,
-        ),
-        ModeUpdate(
-            ModeInfo {
-                mode: Normal,
-                keybinds: [],
-                style: Style {
-                    colors: Palette {
-                        source: Default,
-                        theme_hue: Dark,
-                        fg: EightBit(
-                            0,
-                        ),
-                        bg: EightBit(
-                            0,
-                        ),
-                        black: EightBit(
-                            0,
-                        ),
-                        red: EightBit(
-                            0,
-                        ),
-                        green: EightBit(
-                            0,
-                        ),
-                        yellow: EightBit(
-                            0,
-                        ),
-                        blue: EightBit(
-                            0,
-                        ),
-                        magenta: EightBit(
-                            0,
-                        ),
-                        cyan: EightBit(
-                            0,
-                        ),
-                        white: EightBit(
-                            0,
-                        ),
-                        orange: EightBit(
-                            0,
-                        ),
-                        gray: EightBit(
-                            0,
-                        ),
-                        purple: EightBit(
-                            0,
-                        ),
-                        gold: EightBit(
-                            0,
-                        ),
-                        silver: EightBit(
-                            0,
-                        ),
-                        pink: EightBit(
-                            0,
-                        ),
-                        brown: EightBit(
-                            0,
+        [],
+    ),
+    Update(
+        [
+            (
+                None,
+                Some(
+                    1,
+                ),
+                ModeUpdate(
+                    ModeInfo {
+                        mode: Normal,
+                        keybinds: [],
+                        style: Style {
+                            colors: Palette {
+                                source: Default,
+                                theme_hue: Dark,
+                                fg: EightBit(
+                                    0,
+                                ),
+                                bg: EightBit(
+                                    0,
+                                ),
+                                black: EightBit(
+                                    0,
+                                ),
+                                red: EightBit(
+                                    0,
+                                ),
+                                green: EightBit(
+                                    0,
+                                ),
+                                yellow: EightBit(
+                                    0,
+                                ),
+                                blue: EightBit(
+                                    0,
+                                ),
+                                magenta: EightBit(
+                                    0,
+                                ),
+                                cyan: EightBit(
+                                    0,
+                                ),
+                                white: EightBit(
+                                    0,
+                                ),
+                                orange: EightBit(
+                                    0,
+                                ),
+                                gray: EightBit(
+                                    0,
+                                ),
+                                purple: EightBit(
+                                    0,
+                                ),
+                                gold: EightBit(
+                                    0,
+                                ),
+                                silver: EightBit(
+                                    0,
+                                ),
+                                pink: EightBit(
+                                    0,
+                                ),
+                                brown: EightBit(
+                                    0,
+                                ),
+                            },
+                            rounded_corners: false,
+                        },
+                        capabilities: PluginCapabilities {
+                            arrow_fonts: false,
+                        },
+                        session_name: Some(
+                            "zellij-test",
                         ),
                     },
-                    rounded_corners: false,
-                },
-                capabilities: PluginCapabilities {
-                    arrow_fonts: false,
-                },
-                session_name: Some(
-                    "zellij-test",
                 ),
-            },
-        ),
+            ),
+        ],
     ),
     Update(
-        None,
-        Some(
-            1,
-        ),
-        ModeUpdate(
-            ModeInfo {
-                mode: Normal,
-                keybinds: [],
-                style: Style {
-                    colors: Palette {
-                        source: Default,
-                        theme_hue: Dark,
-                        fg: EightBit(
-                            0,
-                        ),
-                        bg: EightBit(
-                            0,
-                        ),
-                        black: EightBit(
-                            0,
-                        ),
-                        red: EightBit(
-                            0,
-                        ),
-                        green: EightBit(
-                            0,
-                        ),
-                        yellow: EightBit(
-                            0,
-                        ),
-                        blue: EightBit(
-                            0,
-                        ),
-                        magenta: EightBit(
-                            0,
-                        ),
-                        cyan: EightBit(
-                            0,
-                        ),
-                        white: EightBit(
-                            0,
-                        ),
-                        orange: EightBit(
-                            0,
-                        ),
-                        gray: EightBit(
-                            0,
-                        ),
-                        purple: EightBit(
-                            0,
-                        ),
-                        gold: EightBit(
-                            0,
-                        ),
-                        silver: EightBit(
-                            0,
-                        ),
-                        pink: EightBit(
-                            0,
-                        ),
-                        brown: EightBit(
-                            0,
-                        ),
-                    },
-                    rounded_corners: false,
-                },
-                capabilities: PluginCapabilities {
-                    arrow_fonts: false,
-                },
-                session_name: Some(
-                    "zellij-test",
+        [],
+    ),
+    Update(
+        [
+            (
+                None,
+                Some(
+                    1,
                 ),
-            },
-        ),
+                TabUpdate(
+                    [
+                        TabInfo {
+                            position: 0,
+                            name: "Tab #1",
+                            active: false,
+                            panes_to_hide: 0,
+                            is_fullscreen_active: false,
+                            is_sync_panes_active: false,
+                            are_floating_panes_visible: false,
+                            other_focused_clients: [],
+                        },
+                        TabInfo {
+                            position: 1,
+                            name: "Tab #2",
+                            active: true,
+                            panes_to_hide: 0,
+                            is_fullscreen_active: false,
+                            is_sync_panes_active: false,
+                            are_floating_panes_visible: false,
+                            other_focused_clients: [],
+                        },
+                    ],
+                ),
+            ),
+        ],
     ),
     Update(
-        None,
-        Some(
-            1,
-        ),
-        TabUpdate(
-            [
-                TabInfo {
-                    position: 0,
-                    name: "Tab #1",
-                    active: false,
-                    panes_to_hide: 0,
-                    is_fullscreen_active: false,
-                    is_sync_panes_active: false,
-                    are_floating_panes_visible: false,
-                    other_focused_clients: [],
-                },
-                TabInfo {
-                    position: 1,
-                    name: "Tab #2",
-                    active: true,
-                    panes_to_hide: 0,
-                    is_fullscreen_active: false,
-                    is_sync_panes_active: false,
-                    are_floating_panes_visible: false,
-                    other_focused_clients: [],
-                },
-            ],
-        ),
+        [
+            (
+                None,
+                Some(
+                    1,
+                ),
+                TabUpdate(
+                    [
+                        TabInfo {
+                            position: 0,
+                            name: "Tab #1",
+                            active: false,
+                            panes_to_hide: 0,
+                            is_fullscreen_active: false,
+                            is_sync_panes_active: false,
+                            are_floating_panes_visible: false,
+                            other_focused_clients: [],
+                        },
+                        TabInfo {
+                            position: 1,
+                            name: "",
+                            active: true,
+                            panes_to_hide: 0,
+                            is_fullscreen_active: false,
+                            is_sync_panes_active: false,
+                            are_floating_panes_visible: false,
+                            other_focused_clients: [],
+                        },
+                    ],
+                ),
+            ),
+        ],
     ),
     Update(
-        None,
-        Some(
-            1,
-        ),
-        TabUpdate(
-            [
-                TabInfo {
-                    position: 0,
-                    name: "Tab #1",
-                    active: false,
-                    panes_to_hide: 0,
-                    is_fullscreen_active: false,
-                    is_sync_panes_active: false,
-                    are_floating_panes_visible: false,
-                    other_focused_clients: [],
-                },
-                TabInfo {
-                    position: 1,
-                    name: "",
-                    active: true,
-                    panes_to_hide: 0,
-                    is_fullscreen_active: false,
-                    is_sync_panes_active: false,
-                    are_floating_panes_visible: false,
-                    other_focused_clients: [],
-                },
-            ],
-        ),
+        [
+            (
+                None,
+                Some(
+                    1,
+                ),
+                TabUpdate(
+                    [
+                        TabInfo {
+                            position: 0,
+                            name: "Tab #1",
+                            active: false,
+                            panes_to_hide: 0,
+                            is_fullscreen_active: false,
+                            is_sync_panes_active: false,
+                            are_floating_panes_visible: false,
+                            other_focused_clients: [],
+                        },
+                        TabInfo {
+                            position: 1,
+                            name: "new-tab-name",
+                            active: true,
+                            panes_to_hide: 0,
+                            is_fullscreen_active: false,
+                            is_sync_panes_active: false,
+                            are_floating_panes_visible: false,
+                            other_focused_clients: [],
+                        },
+                    ],
+                ),
+            ),
+        ],
     ),
     Update(
-        None,
-        Some(
-            1,
-        ),
-        TabUpdate(
-            [
-                TabInfo {
-                    position: 0,
-                    name: "Tab #1",
-                    active: false,
-                    panes_to_hide: 0,
-                    is_fullscreen_active: false,
-                    is_sync_panes_active: false,
-                    are_floating_panes_visible: false,
-                    other_focused_clients: [],
-                },
-                TabInfo {
-                    position: 1,
-                    name: "new-tab-name",
-                    active: true,
-                    panes_to_hide: 0,
-                    is_fullscreen_active: false,
-                    is_sync_panes_active: false,
-                    are_floating_panes_visible: false,
-                    other_focused_clients: [],
-                },
-            ],
-        ),
+        [
+            (
+                None,
+                Some(
+                    10,
+                ),
+                InputReceived,
+            ),
+        ],
     ),
     Update(
-        None,
-        Some(
-            10,
-        ),
-        InputReceived,
-    ),
-    Update(
-        None,
-        Some(
-            1,
-        ),
-        TabUpdate(
-            [
-                TabInfo {
-                    position: 0,
-                    name: "Tab #1",
-                    active: false,
-                    panes_to_hide: 0,
-                    is_fullscreen_active: false,
-                    is_sync_panes_active: false,
-                    are_floating_panes_visible: false,
-                    other_focused_clients: [],
-                },
-                TabInfo {
-                    position: 1,
-                    name: "Tab #2",
-                    active: true,
-                    panes_to_hide: 0,
-                    is_fullscreen_active: false,
-                    is_sync_panes_active: false,
-                    are_floating_panes_visible: false,
-                    other_focused_clients: [],
-                },
-            ],
-        ),
+        [
+            (
+                None,
+                Some(
+                    1,
+                ),
+                TabUpdate(
+                    [
+                        TabInfo {
+                            position: 0,
+                            name: "Tab #1",
+                            active: false,
+                            panes_to_hide: 0,
+                            is_fullscreen_active: false,
+                            is_sync_panes_active: false,
+                            are_floating_panes_visible: false,
+                            other_focused_clients: [],
+                        },
+                        TabInfo {
+                            position: 1,
+                            name: "Tab #2",
+                            active: true,
+                            panes_to_hide: 0,
+                            is_fullscreen_active: false,
+                            is_sync_panes_active: false,
+                            are_floating_panes_visible: false,
+                            other_focused_clients: [],
+                        },
+                    ],
+                ),
+            ),
+        ],
     ),
     Exit,
 ]


### PR DESCRIPTION
This PR includes two changes:

1. `PluginInstruction::Update` now transfers multiple plugin update events (instead of sending one event per message and triggering the whole render pipeline every time).
2. `ScreenInstruction::PluginBytes` similarly now transfers multiple messages at once, preventing the same sort of roundtrip.