### PR TITLE
feat(ux): show loading screen

### DIFF
--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -147,6 +147,20 @@ impl InputHandler {
                         self.handle_stdin_ansi_instruction(ansi_instruction);
                     }
                 },
+                Ok((InputInstruction::StartedParsing, _error_context)) => {
+                    log::info!("sending done loading");
+                    self.send_client_instructions
+                        .send(ClientInstruction::StartedParsingStdinQuery)
+                        .unwrap();
+                    log::info!("done sent done loading");
+                }
+                Ok((InputInstruction::DoneParsing, _error_context)) => {
+                    log::info!("sending done loading");
+                    self.send_client_instructions
+                        .send(ClientInstruction::DoneParsingStdinQuery)
+                        .unwrap();
+                    log::info!("done sent done loading");
+                }
                 Err(err) => panic!("Encountered read error: {:?}", err),
             }
         }

--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -153,14 +153,14 @@ impl InputHandler {
                         .send(ClientInstruction::StartedParsingStdinQuery)
                         .unwrap();
                     log::info!("done sent done loading");
-                }
+                },
                 Ok((InputInstruction::DoneParsing, _error_context)) => {
                     log::info!("sending done loading");
                     self.send_client_instructions
                         .send(ClientInstruction::DoneParsingStdinQuery)
                         .unwrap();
                     log::info!("done sent done loading");
-                }
+                },
                 Err(err) => panic!("Encountered read error: {:?}", err),
             }
         }

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -73,7 +73,7 @@ impl From<&ClientInstruction> for ClientContext {
             ClientInstruction::Connected => ClientContext::Connected,
             ClientInstruction::ActiveClients(_) => ClientContext::ActiveClients,
             ClientInstruction::StartedParsingStdinQuery => ClientContext::StartedParsingStdinQuery,
-            ClientInstruction::DoneParsingStdinQuery=> ClientContext::DoneParsingStdinQuery,
+            ClientInstruction::DoneParsingStdinQuery => ClientContext::DoneParsingStdinQuery,
         }
     }
 }
@@ -371,7 +371,7 @@ pub fn start_client(
                         .write_all("\n\rQuerying terminal emulator for \u{1b}[32;1mdefault colors\u{1b}[m and \u{1b}[32;1mpixel/cell\u{1b}[m ratio...".as_bytes())
                         .expect("cannot write to stdout");
                     stdout.flush().expect("could not flush");
-                }
+                },
                 ClientInstruction::DoneParsingStdinQuery => {
                     stdout
                         .write_all("done".as_bytes())
@@ -381,7 +381,7 @@ pub fn start_client(
                 },
                 instruction => {
                     pending_instructions.push((instruction, err_ctx));
-                }
+                },
             }
             continue;
         }

--- a/zellij-client/src/stdin_ansi_parser.rs
+++ b/zellij-client/src/stdin_ansi_parser.rs
@@ -73,6 +73,9 @@ impl StdinAnsiParser {
         }
         false
     }
+    pub fn startup_query_duration(&self) -> u64 {
+        STARTUP_PARSE_DEADLINE_MS
+    }
     pub fn parse(&mut self, mut raw_bytes: Vec<u8>) -> Vec<AnsiStdinInstruction> {
         for byte in raw_bytes.drain(..) {
             self.parse_byte(byte);

--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -5,6 +5,17 @@ use std::sync::{Arc, Mutex};
 use zellij_utils::channels::SenderWithContext;
 use zellij_utils::termwiz::input::{InputEvent, InputParser, MouseButtons};
 
+fn send_done_parsing_after_query_timeout(send_input_instructions: SenderWithContext<InputInstruction>, query_duration: u64) {
+    std::thread::spawn({
+        move || {
+            std::thread::sleep(std::time::Duration::from_millis(query_duration));
+            send_input_instructions
+                .send(InputInstruction::DoneParsing)
+                .unwrap();
+        }
+    });
+}
+
 pub(crate) fn stdin_loop(
     mut os_input: Box<dyn ClientOsApi>,
     send_input_instructions: SenderWithContext<InputInstruction>,
@@ -15,6 +26,9 @@ pub(crate) fn stdin_loop(
     let mut current_buffer = vec![];
     // on startup we send a query to the terminal emulator for stuff like the pixel size and colors
     // we get a response through STDIN, so it makes sense to do this here
+    send_input_instructions
+        .send(InputInstruction::StartedParsing)
+        .unwrap();
     let terminal_emulator_query_string = stdin_ansi_parser
         .lock()
         .unwrap()
@@ -23,6 +37,8 @@ pub(crate) fn stdin_loop(
         .get_stdout_writer()
         .write(terminal_emulator_query_string.as_bytes())
         .unwrap();
+    let query_duration = stdin_ansi_parser.lock().unwrap().startup_query_duration();
+    send_done_parsing_after_query_timeout(send_input_instructions.clone(), query_duration);
     loop {
         let buf = os_input.read_from_stdin();
         {

--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -5,7 +5,10 @@ use std::sync::{Arc, Mutex};
 use zellij_utils::channels::SenderWithContext;
 use zellij_utils::termwiz::input::{InputEvent, InputParser, MouseButtons};
 
-fn send_done_parsing_after_query_timeout(send_input_instructions: SenderWithContext<InputInstruction>, query_duration: u64) {
+fn send_done_parsing_after_query_timeout(
+    send_input_instructions: SenderWithContext<InputInstruction>,
+    query_duration: u64,
+) {
     std::thread::spawn({
         move || {
             std::thread::sleep(std::time::Duration::from_millis(query_duration));

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -366,6 +366,8 @@ pub enum ClientContext {
     Connected,
     ActiveClients,
     OwnClientId,
+    StartedParsingStdinQuery,
+    DoneParsingStdinQuery,
 }
 
 /// Stack call representations corresponding to the different types of [`ServerInstruction`]s.


### PR DESCRIPTION
When Zellij loads, it queries the terminal emulator for its default colors and its pixel to cell ratio. Since it gets the responses over STDIN, we must drop all user input in the time that this query happens - otherwise it will get mixed up. For that reason the first 0.5 seconds after Zellij loads, input gets lots.

We can't do anything about that, but this PR communicates this to the user, showing a brief loading prompt while this happens so they know not to start typing.

![img-2022-12-07-141118](https://user-images.githubusercontent.com/795598/206189282-8d7d3fbe-ed21-408a-b283-0564fca88c7c.png)
