### PR TITLE
Fix: Make sure to get full path from SHELL env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3752,13 +3752,13 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.2.5"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
 dependencies = [
  "either",
- "lazy_static",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -3946,6 +3946,7 @@ dependencies = [
  "uuid",
  "wasmer",
  "wasmer-wasi",
+ "which",
  "zellij-utils",
 ]
 

--- a/zellij-server/Cargo.toml
+++ b/zellij-server/Cargo.toml
@@ -32,6 +32,7 @@ sixel-image = "0.1.0"
 arrayvec = "0.7.2"
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
 semver = "0.11.0"
+which = "4.3.0"
 
 [dev-dependencies]
 insta = "1.6.0"

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -444,10 +444,18 @@ impl Pty {
         }
     }
     pub fn get_default_terminal(&self, cwd: Option<PathBuf>) -> TerminalAction {
-        let shell = PathBuf::from(env::var("SHELL").unwrap_or_else(|_| {
+        let mut shell_path = env::var("SHELL").unwrap_or_else(|_| {
             log::warn!("Cannot read SHELL env, falling back to use /bin/sh");
             "/bin/sh".to_string()
-        }));
+        });
+        if shell_path.chars().next().unwrap_or('/') != '/' {
+            shell_path = which::which(shell_path)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string();
+        }
+        let shell = PathBuf::from(shell_path);
         if !shell.exists() {
             panic!("Cannot find shell {}", shell.display());
         }


### PR DESCRIPTION
Fixes #2006 by using my proposed solution https://github.com/zellij-org/zellij/issues/2006#issuecomment-1345299570

> Upon inspecting https://github.com/zellij-org/zellij/blame/main/zellij-server/src/pty.rs#L451 I noticed that the reason why this is happening is because it would need to take the absolute path of the shell. My `$SHELL` equals `zsh`, when checking if a path from that exists it will return false. Now, we could just check it and set it to the fallback `/bin/sh` instead.. But it's not only my system that does this, a far better solution would be to perhaps use the `which` command to get the full path of the `$SHELL` output and return that instead.