### PR TITLE
server/pty: Crash if shell doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 * hotfix: fix panics when resizing with flexible plugin panes in layout (https://github.com/zellij-org/zellij/pull/2019)
 * hotfix: allow non-absolute `SHELL` variables (https://github.com/zellij-org/zellij/pull/2013)
+* fix: Crash application if shell is non-existent (https://github.com/zellij-org/zellij/pull/2020)
 
 ## [0.34.3] - 2022-12-09
 

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -221,7 +221,9 @@ fn handle_terminal(
     // Create a pipe to allow the child the communicate the shell's pid to its
     // parent.
     match openpty(None, Some(&orig_termios)) {
-        Ok(open_pty_res) => handle_openpty(open_pty_res, cmd, quit_cb, terminal_id),
+        Ok(open_pty_res) => {
+            handle_openpty(open_pty_res, cmd, quit_cb, terminal_id).with_context(err_context)
+        },
         Err(e) => match failover_cmd {
             Some(failover_cmd) => {
                 handle_terminal(failover_cmd, None, orig_termios, quit_cb, terminal_id)

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -732,7 +732,13 @@ impl Pty {
                         },
                         Err(err) => match err.downcast_ref::<ZellijError>() {
                             Some(ZellijError::CommandNotFound { terminal_id, .. }) => {
-                                new_pane_pids.push((*terminal_id, starts_held, None, Err(err)));
+                                if self.task_handles.is_empty() {
+                                    // This instance of zellij is being spawned. If we find no
+                                    // terminal here, just bail out
+                                    Err::<(), _>(err).fatal();
+                                } else {
+                                    new_pane_pids.push((*terminal_id, starts_held, None, Err(err)));
+                                }
                             },
                             _ => {
                                 Err::<(), _>(err).non_fatal();


### PR DESCRIPTION
Supplement to #2013, this makes sure that when zellij is being spawned but there is not valid shell found, the application crashes with an error message.