### PR TITLE
Improve client disconnect handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * errors: Remove more `unwrwap`s from server code (https://github.com/zellij-org/zellij/pull/2069)
 * fix: support UTF-8 character in tab name and pane name (https://github.com/zellij-org/zellij/pull/2102)
 * fix: handle missing/inaccessible cache directory (https://github.com/zellij-org/zellij/pull/2093)
+* errors: Improve client disconnect handling (https://github.com/zellij-org/zellij/pull/2068)
 
 ## [0.34.4] - 2022-12-13
 

--- a/xtask/src/pipelines.rs
+++ b/xtask/src/pipelines.rs
@@ -104,6 +104,7 @@ pub fn run(sh: &Shell, flags: flags::Run) -> anyhow::Result<()> {
                     .arg("--no-default-features")
                     .args(["--features", "disable_automatic_asset_installation"])
                     .args(["--", "--data-dir", &format!("{}", data_dir.display())])
+                    .args(&flags.args)
                     .run()
                     .map_err(anyhow::Error::new)
             })

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -417,7 +417,7 @@ impl ClientSender {
                         TrySendError::Full(msg) => {
                             // Put the message back where we found it to maintain the order
                             self.client_retry_queue.borrow_mut().push_front(msg);
-                            return Ok(())
+                            return Ok(());
                         },
                         _ => return Err(err).with_context(err_context),
                     }

--- a/zellij-utils/src/channels.rs
+++ b/zellij-utils/src/channels.rs
@@ -4,7 +4,7 @@ use async_std::task_local;
 use std::cell::RefCell;
 
 use crate::errors::{get_current_ctx, ErrorContext};
-pub use crossbeam::channel::{bounded, unbounded, Receiver, RecvError, Select, SendError, Sender};
+pub use crossbeam::channel::{bounded, unbounded, Receiver, RecvError, Select, SendError, Sender, TrySendError};
 
 /// An [MPSC](mpsc) asynchronous channel with added error context.
 pub type ChannelWithContext<T> = (Sender<(T, ErrorContext)>, Receiver<(T, ErrorContext)>);

--- a/zellij-utils/src/channels.rs
+++ b/zellij-utils/src/channels.rs
@@ -4,7 +4,9 @@ use async_std::task_local;
 use std::cell::RefCell;
 
 use crate::errors::{get_current_ctx, ErrorContext};
-pub use crossbeam::channel::{bounded, unbounded, Receiver, RecvError, Select, SendError, Sender, TrySendError};
+pub use crossbeam::channel::{
+    bounded, unbounded, Receiver, RecvError, Select, SendError, Sender, TrySendError,
+};
 
 /// An [MPSC](mpsc) asynchronous channel with added error context.
 pub type ChannelWithContext<T> = (Sender<(T, ErrorContext)>, Receiver<(T, ErrorContext)>);

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -469,6 +469,9 @@ open an issue on GitHub:
 
     #[error("an error occured")]
     GenericError { source: anyhow::Error },
+
+    #[error("Client {client_id} is too slow to handle incoming messages")]
+    ClientTooSlow { client_id: u16 },
 }
 
 #[cfg(not(target_family = "wasm"))]

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -117,6 +117,7 @@ pub enum ExitReason {
     NormalDetached,
     ForceDetached,
     CannotAttach,
+    Disconnect,
     Error(String),
 }
 
@@ -132,6 +133,24 @@ impl Display for ExitReason {
             Self::CannotAttach => write!(
                 f,
                 "Session attached to another client. Use --force flag to force connect."
+            ),
+            Self::Disconnect => write!(
+                f,
+                "Your zellij client lost connection to the zellij server.
+
+As a safety measure, you have been disconnected from the current zellij session.
+However, the session should still exist and none of your data should be lost.
+
+This usually means that your terminal didn't process server messages quick
+enough. Maybe your system is currently under high load, or your terminal
+isn't performant enough.
+
+There are a few things you can try now:
+    - Reattach to your previous session and see if it works out better this
+      time (see `zellij ls` and `zellij attach`)
+    - Try using a faster terminal. GPU-accelerated terminals such as Kitty
+      or Alacritty are cross-platform and known to work well with zellij.
+"
             ),
             Self::Error(e) => write!(f, "Error occurred in server:\n{}", e),
         }

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -142,20 +142,20 @@ impl Display for ExitReason {
                 write!(
                     f,
                     "
-    Your zellij client lost connection to the zellij server.
+Your zellij client lost connection to the zellij server.
 
-    As a safety measure, you have been disconnected from the current zellij session.
-    However, the session should still exist and none of your data should be lost.
+As a safety measure, you have been disconnected from the current zellij session.
+However, the session should still exist and none of your data should be lost.
 
-    This usually means that your terminal didn't process server messages quick
-    enough. Maybe your system is currently under high load, or your terminal
-    isn't performant enough.
+This usually means that your terminal didn't process server messages quick
+enough. Maybe your system is currently under high load, or your terminal
+isn't performant enough.
 
-    There are a few things you can try now:
-        - Reattach to your previous session and see if it works out better this
-          time: {session_tip}
-        - Try using a faster terminal. GPU-accelerated terminals such as Kitty
-          or Alacritty are cross-platform and known to work well with zellij.
+There are a few things you can try now:
+    - Reattach to your previous session and see if it works out better this
+      time: {session_tip}
+    - Try using a faster terminal. GPU-accelerated terminals such as Kitty
+      or Alacritty are cross-platform and known to work well with zellij.
     "
                 )
             },

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -134,24 +134,31 @@ impl Display for ExitReason {
                 f,
                 "Session attached to another client. Use --force flag to force connect."
             ),
-            Self::Disconnect => write!(
-                f,
-                "Your zellij client lost connection to the zellij server.
+            Self::Disconnect => {
+                let session_tip = match crate::envs::get_session_name() {
+                    Ok(name) => format!("`zellij attach {}`", name),
+                    Err(_) => "see `zellij ls` and `zellij attach`".to_string(),
+                };
+                write!(
+                    f,
+                    "
+    Your zellij client lost connection to the zellij server.
 
-As a safety measure, you have been disconnected from the current zellij session.
-However, the session should still exist and none of your data should be lost.
+    As a safety measure, you have been disconnected from the current zellij session.
+    However, the session should still exist and none of your data should be lost.
 
-This usually means that your terminal didn't process server messages quick
-enough. Maybe your system is currently under high load, or your terminal
-isn't performant enough.
+    This usually means that your terminal didn't process server messages quick
+    enough. Maybe your system is currently under high load, or your terminal
+    isn't performant enough.
 
-There are a few things you can try now:
-    - Reattach to your previous session and see if it works out better this
-      time (see `zellij ls` and `zellij attach`)
-    - Try using a faster terminal. GPU-accelerated terminals such as Kitty
-      or Alacritty are cross-platform and known to work well with zellij.
-"
-            ),
+    There are a few things you can try now:
+        - Reattach to your previous session and see if it works out better this
+          time: {session_tip}
+        - Try using a faster terminal. GPU-accelerated terminals such as Kitty
+          or Alacritty are cross-platform and known to work well with zellij.
+    "
+                )
+            },
             Self::Error(e) => write!(f, "Error occurred in server:\n{}", e),
         }
     }


### PR DESCRIPTION
This PR includes a few changes to the behavior when the session server disconnects a client as reaction to the client not handling messages quick enough. This happens for example when the system is under high load or the terminal application is blocked by some sort of user interaction (hence, keeping it from handling server messages). The server will continue sending `ServerToClientMsg` messages to all connected clients via an IPC channel. Currently, if the channel fills up the client is disconnected and a "Buffer full" error message is displayed to the user.

Now, we have a dynamically sized retry queue that stores messages that do not fit into the IPC channel. At the moment the queue is limited to 1000 messages, with the IPC channel itself holding at most 50 messages. This should drastically decrease disconnections caused by temporary flooding of STDOUT or high system load.

The retry queue is implemented as vector and allocated dynamically. Hence, on clients that are quick enough and never saw a "Buffer full" error before, it will not take any extra space. Slower clients will allocate the retry queue as needed.

In addition, when the IPC channel is full and messages are stored in the retry queue for the first time, a warning is now logged:

```
WARN   |zellij_server::os_input_o| 2023-01-08 08:33:48.696 [main      ] [zellij-server/src/os_input_output.rs:382]: client 1 is processing server messages too slow
```

If the client manages to catch up, a corresponding message is logged, too:

```
INFO   |zellij_server::os_input_o| 2023-01-08 08:43:23.394 [main      ] [zellij-server/src/os_input_output.rs:407]: client 1 caught up processing server messages
```

If the retry queue fills up the client is still forcefully disconnected, but logging on the server has now been improved:

```
ERROR  |???                      | 2023-01-08 08:34:04.220 [main      ] [zellij-server/src/lib.rs:572]: a non-fatal error occured

Caused by:
    0: client 1 is processing server messages too slow
    1: failed to send message to client 1
    2: failed to send or buffer message for client 1
    3: Client 1 is too slow to handle incoming messages
```

And instead of "Buffer full", the client will now see the following message on their terminal:

```
Your zellij client lost connection to the zellij server.

As a safety measure, you have been disconnected from the current zellij session.
However, the session should still exist and none of your data should be lost.

This usually means that your terminal didn't process server messages quick
enough. Maybe your system is currently under high load, or your terminal
isn't performant enough.

There are a few things you can try now:
    - Reattach to your previous session and see if it works out better this
      time: `zellij attach unarmed-snails`
    - Try using a faster terminal. GPU-accelerated terminals such as Kitty
      or Alacritty are cross-platform and known to work well with zellij.

```

This improves the UX on #2023, #2041, #2048 and #2063, and may help to mitigate client crashes in some of these cases. It does not, however, explain why sometimes the server bevomes unresponsive and locks up. I couldn't find an explanation for this.