### PR TITLE
Errors: less unwrap in server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix: copy_on_select = false sticky selection (https://github.com/zellij-org/zellij/pull/2086)
 * fix: do not drop wide chars when resizing to width of 1 column (https://github.com/zellij-org/zellij/pull/2082)
 * fix: disallow path-like names for sessions (https://github.com/zellij-org/zellij/pull/2082)
+* errors: Remove more `unwrwap`s from server code (https://github.com/zellij-org/zellij/pull/2069)
 
 ## [0.34.4] - 2022-12-13
 

--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -800,7 +800,9 @@ fn host_exec_cmd(plugin_env: &PluginEnv) {
 // code trying to deserialize an `Event` upon a plugin state update, we read some panic message,
 // formatted as string from the plugin.
 fn host_report_panic(plugin_env: &PluginEnv) {
-    let msg = wasi_read_string(&plugin_env.wasi_env).fatal();
+    let msg = wasi_read_string(&plugin_env.wasi_env)
+        .with_context(|| format!("failed to report panic for plugin '{}'", plugin_env.name()))
+        .fatal();
     panic!("{}", msg);
 }
 

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -513,7 +513,13 @@ impl Pty {
         if hold_on_start {
             // we don't actually open a terminal in this case, just wait for the user to run it
             let starts_held = hold_on_start;
-            let terminal_id = self.bus.os_input.as_mut().unwrap().reserve_terminal_id()?;
+            let terminal_id = self
+                .bus
+                .os_input
+                .as_mut()
+                .context("couldn't get mutable reference to OS interface")
+                .and_then(|os_input| os_input.reserve_terminal_id())
+                .with_context(err_context)?;
             return Ok((terminal_id, starts_held));
         }
 

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -618,9 +618,7 @@ pub(crate) fn route_action(
 macro_rules! send_to_screen_or_retry_queue {
     ($rlocked_sessions:expr, $message:expr, $instruction: expr, $retry_queue:expr) => {{
         match $rlocked_sessions.as_ref() {
-            Some(session_metadata) => {
-                session_metadata.senders.send_to_screen($message)
-            },
+            Some(session_metadata) => session_metadata.senders.send_to_screen($message),
             None => {
                 log::warn!("Server not ready, trying to place instruction in retry queue...");
                 if let Some(retry_queue) = $retry_queue.as_mut() {
@@ -706,7 +704,8 @@ pub(crate) fn route_thread_main(
                                 ScreenInstruction::TerminalPixelDimensions(pixel_dimensions),
                                 instruction,
                                 retry_queue
-                            ).with_context(err_context)?;
+                            )
+                            .with_context(err_context)?;
                         },
                         ClientToServerMsg::BackgroundColor(ref background_color_instruction) => {
                             send_to_screen_or_retry_queue!(
@@ -716,7 +715,8 @@ pub(crate) fn route_thread_main(
                                 ),
                                 instruction,
                                 retry_queue
-                            ).with_context(err_context)?;
+                            )
+                            .with_context(err_context)?;
                         },
                         ClientToServerMsg::ForegroundColor(ref foreground_color_instruction) => {
                             send_to_screen_or_retry_queue!(
@@ -726,7 +726,8 @@ pub(crate) fn route_thread_main(
                                 ),
                                 instruction,
                                 retry_queue
-                            ).with_context(err_context)?;
+                            )
+                            .with_context(err_context)?;
                         },
                         ClientToServerMsg::ColorRegisters(ref color_registers) => {
                             send_to_screen_or_retry_queue!(
@@ -734,7 +735,8 @@ pub(crate) fn route_thread_main(
                                 ScreenInstruction::TerminalColorRegisters(color_registers.clone()),
                                 instruction,
                                 retry_queue
-                            ).with_context(err_context)?;
+                            )
+                            .with_context(err_context)?;
                         },
                         ClientToServerMsg::NewClient(
                             client_attributes,

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -995,7 +995,10 @@ impl Screen {
             // this means this is a new client and we need to add it to our state properly
             self.add_client(client_id).with_context(err_context)?;
         }
-        self.render().with_context(err_context)
+
+        self.update_tabs()
+            .and_then(|_| self.render())
+            .with_context(err_context)
     }
 
     pub fn add_client(&mut self, client_id: ClientId) -> Result<()> {

--- a/zellij-server/src/tab/layout_applier.rs
+++ b/zellij-server/src/tab/layout_applier.rs
@@ -198,7 +198,7 @@ impl<'a> LayoutApplier<'a> {
                         .send_to_pty(PtyInstruction::ClosePane(PaneId::Terminal(*unused_pid)))
                         .with_context(err_context)?;
                 }
-                self.adjust_viewport();
+                self.adjust_viewport().with_context(err_context)?;
                 self.set_focused_tiled_pane(focus_pane_id, client_id);
             },
             Err(e) => {
@@ -309,12 +309,21 @@ impl<'a> LayoutApplier<'a> {
             Ok(false)
         }
     }
-    fn resize_whole_tab(&mut self, new_screen_size: Size) {
+    fn resize_whole_tab(&mut self, new_screen_size: Size) -> Result<()> {
+        let err_context = || {
+            format!(
+                "failed to resize whole tab to new screen size {:?}",
+                new_screen_size
+            )
+        };
+
         self.floating_panes.resize(new_screen_size);
+        // we need to do this explicitly because floating_panes.resize does not do this
         self.floating_panes
             .resize_pty_all_panes(&mut self.os_api)
-            .unwrap(); // we need to do this explicitly because floating_panes.resize does not do this
+            .with_context(err_context)?;
         self.tiled_panes.resize(new_screen_size);
+        Ok(())
     }
     fn offset_viewport(&mut self, position_and_size: &Viewport) {
         let mut viewport = self.viewport.borrow_mut();
@@ -339,23 +348,26 @@ impl<'a> LayoutApplier<'a> {
             }
         }
     }
-    fn adjust_viewport(&mut self) {
+    fn adjust_viewport(&mut self) -> Result<()> {
         // here we offset the viewport after applying a tiled panes layout
         // from borderless panes that are on the edges of the
         // screen, this is so that when we don't have pane boundaries (eg. when they were
         // disabled by the user) boundaries won't be drawn around these panes
         // geometrically, we can only do this with panes that are on the edges of the
         // screen - so it's mostly a best-effort thing
+        let err_context = "failed to adjust viewport";
+
         let display_area = {
             let display_area = self.display_area.borrow();
             *display_area
         };
-        self.resize_whole_tab(display_area);
+        self.resize_whole_tab(display_area).context(err_context)?;
         let boundary_geoms = self.tiled_panes.borderless_pane_geoms();
         for geom in boundary_geoms {
             self.offset_viewport(&geom)
         }
         self.tiled_panes.set_pane_frames(self.draw_pane_frames);
+        Ok(())
     }
     fn set_focused_tiled_pane(&mut self, focus_pane_id: Option<PaneId>, client_id: ClientId) {
         if let Some(pane_id) = focus_pane_id {

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1230,7 +1230,10 @@ impl Tab {
         let err_context = || format!("failed to write to terminal at position {position:?}");
 
         if self.floating_panes.panes_are_visible() {
-            let pane_id = self.floating_panes.get_pane_id_at(position, false).unwrap();
+            let pane_id = self
+                .floating_panes
+                .get_pane_id_at(position, false)
+                .with_context(err_context)?;
             if let Some(pane_id) = pane_id {
                 self.write_to_pane_id(input_bytes, pane_id)
                     .with_context(err_context)?;
@@ -1518,13 +1521,17 @@ impl Tab {
         let selectable_tiled_panes = self.tiled_panes.get_panes().filter(|(_, p)| p.selectable());
         selectable_tiled_panes.count() > 0
     }
-    pub fn resize_whole_tab(&mut self, new_screen_size: Size) {
+    pub fn resize_whole_tab(&mut self, new_screen_size: Size) -> Result<()> {
+        let err_context = || format!("failed to resize whole tab (index {})", self.index);
+
         self.floating_panes.resize(new_screen_size);
+        // we need to do this explicitly because floating_panes.resize does not do this
         self.floating_panes
             .resize_pty_all_panes(&mut self.os_api)
-            .unwrap(); // we need to do this explicitly because floating_panes.resize does not do this
+            .with_context(err_context)?;
         self.tiled_panes.resize(new_screen_size);
         self.should_clear_display_before_rendering = true;
+        Ok(())
     }
     pub fn resize(&mut self, client_id: ClientId, strategy: ResizeStrategy) -> Result<()> {
         let err_context = || format!("unable to resize pane");
@@ -1532,7 +1539,7 @@ impl Tab {
             let successfully_resized = self
                 .floating_panes
                 .resize_active_pane(client_id, &mut self.os_api, &strategy)
-                .unwrap();
+                .with_context(err_context)?;
             if successfully_resized {
                 self.set_force_render(); // we force render here to make sure the panes under the floating pane render and don't leave "garbage" in case of a decrease
             }
@@ -1590,7 +1597,9 @@ impl Tab {
         self.tiled_panes.focus_previous_pane(client_id);
     }
     // returns a boolean that indicates whether the focus moved
-    pub fn move_focus_left(&mut self, client_id: ClientId) -> bool {
+    pub fn move_focus_left(&mut self, client_id: ClientId) -> Result<bool> {
+        let err_context = || format!("failed to move focus left for client {}", client_id);
+
         if self.floating_panes.panes_are_visible() {
             self.floating_panes
                 .move_focus(
@@ -1598,19 +1607,21 @@ impl Tab {
                     &self.connected_clients.borrow().iter().copied().collect(),
                     &Direction::Left,
                 )
-                .unwrap()
+                .with_context(err_context)
         } else {
             if !self.has_selectable_panes() {
-                return false;
+                return Ok(false);
             }
             if self.tiled_panes.fullscreen_is_active() {
                 self.switch_next_pane_fullscreen(client_id);
-                return true;
+                return Ok(true);
             }
-            self.tiled_panes.move_focus_left(client_id)
+            Ok(self.tiled_panes.move_focus_left(client_id))
         }
     }
-    pub fn move_focus_down(&mut self, client_id: ClientId) -> bool {
+    pub fn move_focus_down(&mut self, client_id: ClientId) -> Result<bool> {
+        let err_context = || format!("failed to move focus down for client {}", client_id);
+
         if self.floating_panes.panes_are_visible() {
             self.floating_panes
                 .move_focus(
@@ -1618,18 +1629,20 @@ impl Tab {
                     &self.connected_clients.borrow().iter().copied().collect(),
                     &Direction::Down,
                 )
-                .unwrap()
+                .with_context(err_context)
         } else {
             if !self.has_selectable_panes() {
-                return false;
+                return Ok(false);
             }
             if self.tiled_panes.fullscreen_is_active() {
-                return false;
+                return Ok(false);
             }
-            self.tiled_panes.move_focus_down(client_id)
+            Ok(self.tiled_panes.move_focus_down(client_id))
         }
     }
-    pub fn move_focus_up(&mut self, client_id: ClientId) -> bool {
+    pub fn move_focus_up(&mut self, client_id: ClientId) -> Result<bool> {
+        let err_context = || format!("failed to move focus up for client {}", client_id);
+
         if self.floating_panes.panes_are_visible() {
             self.floating_panes
                 .move_focus(
@@ -1637,19 +1650,21 @@ impl Tab {
                     &self.connected_clients.borrow().iter().copied().collect(),
                     &Direction::Up,
                 )
-                .unwrap()
+                .with_context(err_context)
         } else {
             if !self.has_selectable_panes() {
-                return false;
+                return Ok(false);
             }
             if self.tiled_panes.fullscreen_is_active() {
-                return false;
+                return Ok(false);
             }
-            self.tiled_panes.move_focus_up(client_id)
+            Ok(self.tiled_panes.move_focus_up(client_id))
         }
     }
     // returns a boolean that indicates whether the focus moved
-    pub fn move_focus_right(&mut self, client_id: ClientId) -> bool {
+    pub fn move_focus_right(&mut self, client_id: ClientId) -> Result<bool> {
+        let err_context = || format!("failed to move focus right for client {}", client_id);
+
         if self.floating_panes.panes_are_visible() {
             self.floating_panes
                 .move_focus(
@@ -1657,16 +1672,16 @@ impl Tab {
                     &self.connected_clients.borrow().iter().copied().collect(),
                     &Direction::Right,
                 )
-                .unwrap()
+                .with_context(err_context)
         } else {
             if !self.has_selectable_panes() {
-                return false;
+                return Ok(false);
             }
             if self.tiled_panes.fullscreen_is_active() {
                 self.switch_next_pane_fullscreen(client_id);
-                return true;
+                return Ok(true);
             }
-            self.tiled_panes.move_focus_right(client_id)
+            Ok(self.tiled_panes.move_focus_right(client_id))
         }
     }
     pub fn move_active_pane(&mut self, client_id: ClientId) {
@@ -1796,7 +1811,15 @@ impl Tab {
         // TODO: separate the "close_pane" logic and the "move_pane_somewhere_else" logic, they're
         // overloaded here and that's not great
         if !ignore_suppressed_panes && self.suppressed_panes.contains_key(&id) {
-            return self.replace_pane_with_suppressed_pane(id);
+            return match self.replace_pane_with_suppressed_pane(id) {
+                Ok(pane) => pane,
+                Err(e) => {
+                    Err::<(), _>(e)
+                        .with_context(|| format!("failed to close pane {:?}", id))
+                        .non_fatal();
+                    None
+                },
+            };
         }
         if self.floating_panes.panes_contain(&id) {
             let closed_pane = self.floating_panes.remove_pane(id);
@@ -1832,15 +1855,22 @@ impl Tab {
                 .hold_pane(id, exit_status, is_first_run, run_command);
         }
     }
-    pub fn replace_pane_with_suppressed_pane(&mut self, pane_id: PaneId) -> Option<Box<dyn Pane>> {
+    pub fn replace_pane_with_suppressed_pane(
+        &mut self,
+        pane_id: PaneId,
+    ) -> Result<Option<Box<dyn Pane>>> {
         self.suppressed_panes
             .remove(&pane_id)
+            .with_context(|| {
+                format!(
+                    "couldn't find pane with id {:?} in suppressed panes",
+                    pane_id
+                )
+            })
             .and_then(|suppressed_pane| {
                 let suppressed_pane_id = suppressed_pane.pid();
                 let replaced_pane = if self.are_floating_panes_visible() {
-                    Some(self.floating_panes.replace_pane(pane_id, suppressed_pane))
-                        .transpose()
-                        .unwrap()
+                    Some(self.floating_panes.replace_pane(pane_id, suppressed_pane)).transpose()?
                 } else {
                     self.tiled_panes.replace_pane(pane_id, suppressed_pane)
                 };
@@ -1857,9 +1887,15 @@ impl Tab {
                     // the pane there we replaced. Now, we need to update its pty about its new size.
                     // We couldn't do that before, and we can't use the original moved item now - so we
                     // need to refetch it
-                    resize_pty!(suppressed_pane, self.os_api, self.senders).unwrap();
+                    resize_pty!(suppressed_pane, self.os_api, self.senders)?;
                 }
-                replaced_pane
+                Ok(replaced_pane)
+            })
+            .with_context(|| {
+                format!(
+                    "failed to replace active pane with suppressed pane {:?}",
+                    pane_id
+                )
             })
     }
     pub fn close_focused_pane(&mut self, client_id: ClientId) -> Result<()> {
@@ -2098,18 +2134,20 @@ impl Tab {
         point: &Position,
         search_selectable: bool,
     ) -> Result<Option<&mut Box<dyn Pane>>> {
+        let err_context = || format!("failed to get pane at position {point:?}");
+
         if self.floating_panes.panes_are_visible() {
             if let Some(pane_id) = self
                 .floating_panes
                 .get_pane_id_at(point, search_selectable)
-                .unwrap()
+                .with_context(err_context)?
             {
                 return Ok(self.floating_panes.get_pane_mut(pane_id));
             }
         }
         if let Some(pane_id) = self
             .get_pane_id_at(point, search_selectable)
-            .with_context(|| format!("failed to get pane at position {point:?}"))?
+            .with_context(err_context)?
         {
             Ok(self.tiled_panes.get_pane_mut(pane_id))
         } else {
@@ -2245,7 +2283,11 @@ impl Tab {
             || format!("failed to focus pane at position {point:?} for client {client_id}");
 
         if self.floating_panes.panes_are_visible() {
-            if let Some(clicked_pane) = self.floating_panes.get_pane_id_at(point, true).unwrap() {
+            if let Some(clicked_pane) = self
+                .floating_panes
+                .get_pane_id_at(point, true)
+                .with_context(err_context)?
+            {
                 self.floating_panes.focus_pane(clicked_pane, client_id);
                 self.set_pane_active_at(clicked_pane);
                 return Ok(());

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -996,7 +996,7 @@ fn move_floating_pane_focus_left() {
         .unwrap();
     tab.handle_pty_bytes(6, Vec::from("\u{1b}#8".as_bytes()))
         .unwrap();
-    tab.move_focus_left(client_id);
+    tab.move_focus_left(client_id).unwrap();
     tab.render(&mut output, None).unwrap();
     let (snapshot, cursor_coordinates) = take_snapshot_and_cursor_position(
         output.serialize().unwrap().get(&client_id).unwrap(),
@@ -1051,8 +1051,8 @@ fn move_floating_pane_focus_right() {
         .unwrap();
     tab.handle_pty_bytes(6, Vec::from("\u{1b}#8".as_bytes()))
         .unwrap();
-    tab.move_focus_left(client_id);
-    tab.move_focus_right(client_id);
+    tab.move_focus_left(client_id).unwrap();
+    tab.move_focus_right(client_id).unwrap();
     tab.render(&mut output, None).unwrap();
     let (snapshot, cursor_coordinates) = take_snapshot_and_cursor_position(
         output.serialize().unwrap().get(&client_id).unwrap(),
@@ -1107,7 +1107,7 @@ fn move_floating_pane_focus_up() {
         .unwrap();
     tab.handle_pty_bytes(6, Vec::from("\u{1b}#8".as_bytes()))
         .unwrap();
-    tab.move_focus_up(client_id);
+    tab.move_focus_up(client_id).unwrap();
     tab.render(&mut output, None).unwrap();
     let (snapshot, cursor_coordinates) = take_snapshot_and_cursor_position(
         output.serialize().unwrap().get(&client_id).unwrap(),
@@ -1162,8 +1162,8 @@ fn move_floating_pane_focus_down() {
         .unwrap();
     tab.handle_pty_bytes(6, Vec::from("\u{1b}#8".as_bytes()))
         .unwrap();
-    tab.move_focus_up(client_id);
-    tab.move_focus_down(client_id);
+    tab.move_focus_up(client_id).unwrap();
+    tab.move_focus_down(client_id).unwrap();
     tab.render(&mut output, None).unwrap();
     let (snapshot, cursor_coordinates) = take_snapshot_and_cursor_position(
         output.serialize().unwrap().get(&client_id).unwrap(),
@@ -1461,7 +1461,8 @@ fn resize_tab_with_floating_panes() {
     tab.resize_whole_tab(Size {
         cols: 100,
         rows: 10,
-    });
+    })
+    .unwrap();
     tab.render(&mut output, None).unwrap();
     let (snapshot, _cursor_coordinates) = take_snapshot_and_cursor_position(
         output.serialize().unwrap().get(&client_id).unwrap(),
@@ -1511,7 +1512,7 @@ fn shrink_whole_tab_with_floating_panes_horizontally_and_vertically() {
         .unwrap();
     tab.handle_pty_bytes(6, Vec::from("\u{1b}#8".as_bytes()))
         .unwrap();
-    tab.resize_whole_tab(Size { cols: 50, rows: 10 });
+    tab.resize_whole_tab(Size { cols: 50, rows: 10 }).unwrap();
     tab.render(&mut output, None).unwrap();
     let (snapshot, _cursor_coordinates) = take_snapshot_and_cursor_position(
         output.serialize().unwrap().get(&client_id).unwrap(),
@@ -1561,11 +1562,12 @@ fn shrink_whole_tab_with_floating_panes_horizontally_and_vertically_and_expand_b
         .unwrap();
     tab.handle_pty_bytes(6, Vec::from("\u{1b}#8".as_bytes()))
         .unwrap();
-    tab.resize_whole_tab(Size { cols: 50, rows: 10 });
+    tab.resize_whole_tab(Size { cols: 50, rows: 10 }).unwrap();
     tab.resize_whole_tab(Size {
         cols: 121,
         rows: 20,
-    });
+    })
+    .unwrap();
     tab.render(&mut output, None).unwrap();
     let (snapshot, _cursor_coordinates) = take_snapshot_and_cursor_position(
         output.serialize().unwrap().get(&client_id).unwrap(),
@@ -1833,7 +1835,7 @@ fn save_cursor_position_across_resizes() {
         1,
         Vec::from("\n\nI am some text\nI am another line of text\nLet's save the cursor position here \u{1b}[sI should be ovewritten".as_bytes()),
     ).unwrap();
-    tab.resize_whole_tab(Size { cols: 100, rows: 3 });
+    tab.resize_whole_tab(Size { cols: 100, rows: 3 }).unwrap();
     tab.handle_pty_bytes(1, Vec::from("\u{1b}[uthis overwrote me!".as_bytes()))
         .unwrap();
 
@@ -2106,7 +2108,8 @@ fn resize_whole_tab_while_tiled_pane_is_suppressed() {
     tab.resize_whole_tab(Size {
         cols: 100,
         rows: 10,
-    });
+    })
+    .unwrap();
     tab.render(&mut output, None).unwrap();
     let snapshot = take_snapshot(
         output.serialize().unwrap().get(&client_id).unwrap(),
@@ -2138,7 +2141,8 @@ fn resize_whole_tab_while_floting_pane_is_suppressed() {
     tab.resize_whole_tab(Size {
         cols: 100,
         rows: 10,
-    });
+    })
+    .unwrap();
     tab.render(&mut output, None).unwrap();
     let snapshot = take_snapshot(
         output.serialize().unwrap().get(&client_id).unwrap(),
@@ -2749,7 +2753,7 @@ fn move_pane_focus_sends_tty_csi_event() {
         Vec::from("\u{1b}[?1004h".as_bytes()),
     )
     .unwrap();
-    tab.move_focus_left(client_id);
+    tab.move_focus_left(client_id).unwrap();
     assert_snapshot!(format!("{:?}", *tty_stdin_bytes.lock().unwrap()));
 }
 
@@ -2792,7 +2796,7 @@ fn move_floating_pane_focus_sends_tty_csi_event() {
         Vec::from("\u{1b}[?1004h".as_bytes()),
     )
     .unwrap();
-    tab.move_focus_left(client_id);
+    tab.move_focus_left(client_id).unwrap();
     assert_snapshot!(format!("{:?}", *tty_stdin_bytes.lock().unwrap()));
 }
 

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -995,7 +995,7 @@ pub fn close_pane_with_another_pane_below_it() {
     let mut tab = create_new_tab(size);
     let new_pane_id = PaneId::Terminal(2);
     tab.horizontal_split(new_pane_id, None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.close_focused_pane(1).unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 1, "One pane left in tab");
 
@@ -1120,7 +1120,7 @@ pub fn close_pane_with_another_pane_to_the_right() {
     let mut tab = create_new_tab(size);
     let new_pane_id = PaneId::Terminal(2);
     tab.vertical_split(new_pane_id, None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab.close_focused_pane(1).unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 1, "One pane left in tab");
 
@@ -1186,9 +1186,9 @@ pub fn close_pane_with_multiple_panes_above_it() {
     let new_pane_id_1 = PaneId::Terminal(2);
     let new_pane_id_2 = PaneId::Terminal(3);
     tab.horizontal_split(new_pane_id_1, None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(new_pane_id_2, None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab.close_focused_pane(1).unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 2, "Two panes left in tab");
 
@@ -1298,7 +1298,7 @@ pub fn close_pane_with_multiple_panes_below_it() {
     let new_pane_id_2 = PaneId::Terminal(3);
     tab.horizontal_split(new_pane_id_1, None, 1).unwrap();
     tab.vertical_split(new_pane_id_2, None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.close_focused_pane(1).unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 2, "Two panes left in tab");
 
@@ -1407,9 +1407,9 @@ pub fn close_pane_with_multiple_panes_to_the_left() {
     let new_pane_id_1 = PaneId::Terminal(2);
     let new_pane_id_2 = PaneId::Terminal(3);
     tab.vertical_split(new_pane_id_1, None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
-    tab.move_focus_right(1);
+    tab.move_focus_right(1).unwrap();
     tab.close_focused_pane(1).unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 2, "Two panes left in tab");
 
@@ -1519,7 +1519,7 @@ pub fn close_pane_with_multiple_panes_to_the_right() {
     let new_pane_id_2 = PaneId::Terminal(3);
     tab.vertical_split(new_pane_id_1, None, 1).unwrap();
     tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab.close_focused_pane(1).unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 2, "Two panes left in tab");
 
@@ -1634,18 +1634,18 @@ pub fn close_pane_with_multiple_panes_above_it_away_from_screen_edges() {
 
     tab.vertical_split(new_pane_id_1, None, 1).unwrap();
     tab.vertical_split(new_pane_id_2, None, 1).unwrap();
-    tab.move_focus_left(1);
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1).unwrap();
     tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_right(1);
+    tab.move_focus_right(1).unwrap();
     tab.horizontal_split(new_pane_id_4, None, 1).unwrap();
-    tab.move_focus_right(1);
+    tab.move_focus_right(1).unwrap();
     tab.horizontal_split(new_pane_id_5, None, 1).unwrap();
-    tab.move_focus_left(1);
-    tab.move_focus_up(1);
+    tab.move_focus_left(1).unwrap();
+    tab.move_focus_up(1).unwrap();
     tab_resize_down(&mut tab, 1);
     tab.vertical_split(new_pane_id_6, None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab.close_focused_pane(1).unwrap();
 
     assert_eq!(tab.tiled_panes.panes.len(), 6, "Six panes left in tab");
@@ -1934,17 +1934,17 @@ pub fn close_pane_with_multiple_panes_below_it_away_from_screen_edges() {
 
     tab.vertical_split(new_pane_id_1, None, 1).unwrap();
     tab.vertical_split(new_pane_id_2, None, 1).unwrap();
-    tab.move_focus_left(1);
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1).unwrap();
     tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_right(1);
+    tab.move_focus_right(1).unwrap();
     tab.horizontal_split(new_pane_id_4, None, 1).unwrap();
-    tab.move_focus_right(1);
+    tab.move_focus_right(1).unwrap();
     tab.horizontal_split(new_pane_id_5, None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab_resize_up(&mut tab, 1);
     tab.vertical_split(new_pane_id_6, None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.close_focused_pane(1).unwrap();
 
     assert_eq!(tab.tiled_panes.panes.len(), 6, "Six panes left in tab");
@@ -2235,20 +2235,20 @@ pub fn close_pane_with_multiple_panes_to_the_left_away_from_screen_edges() {
 
     tab.horizontal_split(new_pane_id_1, None, 1).unwrap();
     tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
-    tab.move_focus_up(1);
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab.vertical_split(new_pane_id_4, None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab.vertical_split(new_pane_id_5, None, 1).unwrap();
-    tab.move_focus_up(1);
-    tab.move_focus_left(1);
+    tab.move_focus_up(1).unwrap();
+    tab.move_focus_left(1).unwrap();
     tab_resize_right(&mut tab, 1);
     tab_resize_up(&mut tab, 1);
     tab_resize_up(&mut tab, 1);
     tab.horizontal_split(new_pane_id_6, None, 1).unwrap();
-    tab.move_focus_right(1);
+    tab.move_focus_right(1).unwrap();
     tab.close_focused_pane(1).unwrap();
 
     assert_eq!(tab.tiled_panes.panes.len(), 6, "Six panes left in tab");
@@ -2539,19 +2539,19 @@ pub fn close_pane_with_multiple_panes_to_the_right_away_from_screen_edges() {
 
     tab.horizontal_split(new_pane_id_1, None, 1).unwrap();
     tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
-    tab.move_focus_up(1);
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab.vertical_split(new_pane_id_4, None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab.vertical_split(new_pane_id_5, None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab_resize_left(&mut tab, 1);
     tab_resize_up(&mut tab, 1);
     tab_resize_up(&mut tab, 1);
     tab.horizontal_split(new_pane_id_6, None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab.close_focused_pane(1).unwrap();
 
     assert_eq!(tab.tiled_panes.panes.len(), 6, "Six panes left in tab");
@@ -2825,8 +2825,8 @@ pub fn move_focus_down() {
     let new_pane_id = PaneId::Terminal(2);
 
     tab.horizontal_split(new_pane_id, None, 1).unwrap();
-    tab.move_focus_up(1);
-    tab.move_focus_down(1);
+    tab.move_focus_up(1).unwrap();
+    tab.move_focus_down(1).unwrap();
 
     assert_eq!(
         tab.get_active_pane(1).unwrap().y(),
@@ -2849,8 +2849,8 @@ pub fn move_focus_down_to_the_most_recently_used_pane() {
     tab.horizontal_split(new_pane_id_1, None, 1).unwrap();
     tab.vertical_split(new_pane_id_2, None, 1).unwrap();
     tab.vertical_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_up(1);
-    tab.move_focus_down(1);
+    tab.move_focus_up(1).unwrap();
+    tab.move_focus_down(1).unwrap();
 
     assert_eq!(
         tab.get_active_pane(1).unwrap().y(),
@@ -2874,7 +2874,7 @@ pub fn move_focus_up() {
     let new_pane_id = PaneId::Terminal(2);
 
     tab.horizontal_split(new_pane_id, None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
 
     assert_eq!(
         tab.get_active_pane(1).unwrap().y(),
@@ -2895,11 +2895,11 @@ pub fn move_focus_up_to_the_most_recently_used_pane() {
     let new_pane_id_3 = PaneId::Terminal(4);
 
     tab.horizontal_split(new_pane_id_1, None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(new_pane_id_2, None, 1).unwrap();
     tab.vertical_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_down(1);
-    tab.move_focus_up(1);
+    tab.move_focus_down(1).unwrap();
+    tab.move_focus_up(1).unwrap();
 
     assert_eq!(
         tab.get_active_pane(1).unwrap().y(),
@@ -2923,7 +2923,7 @@ pub fn move_focus_left() {
     let new_pane_id = PaneId::Terminal(2);
 
     tab.vertical_split(new_pane_id, None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
 
     assert_eq!(
         tab.get_active_pane(1).unwrap().x(),
@@ -2944,11 +2944,11 @@ pub fn move_focus_left_to_the_most_recently_used_pane() {
     let new_pane_id_3 = PaneId::Terminal(4);
 
     tab.vertical_split(new_pane_id_1, None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
     tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_right(1);
-    tab.move_focus_left(1);
+    tab.move_focus_right(1).unwrap();
+    tab.move_focus_left(1).unwrap();
 
     assert_eq!(
         tab.get_active_pane(1).unwrap().y(),
@@ -2972,8 +2972,8 @@ pub fn move_focus_right() {
     let new_pane_id = PaneId::Terminal(2);
 
     tab.vertical_split(new_pane_id, None, 1).unwrap();
-    tab.move_focus_left(1);
-    tab.move_focus_right(1);
+    tab.move_focus_left(1).unwrap();
+    tab.move_focus_right(1).unwrap();
 
     assert_eq!(
         tab.get_active_pane(1).unwrap().x(),
@@ -2996,8 +2996,8 @@ pub fn move_focus_right_to_the_most_recently_used_pane() {
     tab.vertical_split(new_pane_id_1, None, 1).unwrap();
     tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
     tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_left(1);
-    tab.move_focus_right(1);
+    tab.move_focus_left(1).unwrap();
+    tab.move_focus_right(1).unwrap();
 
     assert_eq!(
         tab.get_active_pane(1).unwrap().y(),
@@ -3021,7 +3021,7 @@ pub fn move_active_pane_down() {
     let new_pane_id = PaneId::Terminal(2);
 
     tab.horizontal_split(new_pane_id, None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.move_active_pane_down(1);
 
     assert_eq!(
@@ -3050,7 +3050,7 @@ pub fn move_active_pane_down_to_the_most_recently_used_position() {
     tab.horizontal_split(new_pane_id_1, None, 1).unwrap();
     tab.vertical_split(new_pane_id_2, None, 1).unwrap();
     tab.vertical_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.move_active_pane_down(1);
 
     assert_eq!(
@@ -3106,10 +3106,10 @@ pub fn move_active_pane_up_to_the_most_recently_used_position() {
     let new_pane_id_3 = PaneId::Terminal(4);
 
     tab.horizontal_split(new_pane_id_1, None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(new_pane_id_2, None, 1).unwrap();
     tab.vertical_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab.move_active_pane_up(1);
 
     assert_eq!(
@@ -3166,10 +3166,10 @@ pub fn move_active_pane_left_to_the_most_recently_used_position() {
     let new_pane_id_3 = PaneId::Terminal(4);
 
     tab.vertical_split(new_pane_id_1, None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
     tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_right(1);
+    tab.move_focus_right(1).unwrap();
     tab.move_active_pane_left(1);
 
     assert_eq!(
@@ -3200,7 +3200,7 @@ pub fn move_active_pane_right() {
     let new_pane_id = PaneId::Terminal(2);
 
     tab.vertical_split(new_pane_id, None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab.move_active_pane_right(1);
 
     assert_eq!(
@@ -3229,7 +3229,7 @@ pub fn move_active_pane_right_to_the_most_recently_used_position() {
     tab.vertical_split(new_pane_id_1, None, 1).unwrap();
     tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
     tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab.move_active_pane_right(1);
 
     assert_eq!(
@@ -3373,7 +3373,7 @@ pub fn resize_down_with_pane_below() {
     let mut tab = create_new_tab(size);
     let new_pane_id = PaneId::Terminal(2);
     tab.horizontal_split(new_pane_id, None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab_resize_down(&mut tab, 1);
 
     assert_eq!(
@@ -3487,7 +3487,7 @@ pub fn resize_down_with_panes_above_and_below() {
     let new_pane_id_2 = PaneId::Terminal(3);
     tab.horizontal_split(new_pane_id_1, None, 1).unwrap();
     tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab_resize_down(&mut tab, 1);
 
     assert_eq!(
@@ -3639,9 +3639,9 @@ pub fn resize_down_with_multiple_panes_above() {
     let new_pane_id_1 = PaneId::Terminal(2);
     let new_pane_id_2 = PaneId::Terminal(3);
     tab.horizontal_split(new_pane_id_1, None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(new_pane_id_2, None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab_resize_down(&mut tab, 1);
 
     assert_eq!(
@@ -3795,9 +3795,9 @@ pub fn resize_down_with_panes_above_aligned_left_with_current_pane() {
     let pane_above = PaneId::Terminal(4);
     tab.horizontal_split(pane_to_the_left, None, 1).unwrap();
     tab.vertical_split(focused_pane, None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(pane_above, None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab_resize_down(&mut tab, 1);
 
     assert_eq!(
@@ -3995,7 +3995,7 @@ pub fn resize_down_with_panes_below_aligned_left_with_current_pane() {
     let focused_pane = PaneId::Terminal(4);
     tab.horizontal_split(pane_below_and_left, None, 1).unwrap();
     tab.vertical_split(pane_below, None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(focused_pane, None, 1).unwrap();
     tab_resize_down(&mut tab, 1);
 
@@ -4194,10 +4194,10 @@ pub fn resize_down_with_panes_above_aligned_right_with_current_pane() {
     let pane_above_and_right = PaneId::Terminal(4);
     tab.horizontal_split(focused_pane, None, 1).unwrap();
     tab.vertical_split(pane_to_the_right, None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(pane_above_and_right, None, 1).unwrap();
-    tab.move_focus_down(1);
-    tab.move_focus_left(1);
+    tab.move_focus_down(1).unwrap();
+    tab.move_focus_left(1).unwrap();
     tab_resize_down(&mut tab, 1);
 
     assert_eq!(
@@ -4395,9 +4395,9 @@ pub fn resize_down_with_panes_below_aligned_right_with_current_pane() {
     let pane_to_the_right = PaneId::Terminal(4);
     tab.horizontal_split(pane_below, None, 1).unwrap();
     tab.vertical_split(pane_below_and_right, None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(pane_to_the_right, None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab_resize_down(&mut tab, 1);
 
     assert_eq!(
@@ -4592,11 +4592,11 @@ pub fn resize_down_with_panes_above_aligned_left_and_right_with_current_pane() {
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_left(1);
-    tab.move_focus_down(1);
+    tab.move_focus_left(1).unwrap();
+    tab.move_focus_down(1).unwrap();
     tab_resize_down(&mut tab, 1);
 
     assert_eq!(
@@ -4877,10 +4877,10 @@ pub fn resize_down_with_panes_below_aligned_left_and_right_with_current_pane() {
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab_resize_down(&mut tab, 1);
 
     assert_eq!(
@@ -5159,16 +5159,16 @@ pub fn resize_down_with_panes_above_aligned_left_and_right_with_panes_to_the_lef
     };
     let mut tab = create_new_tab(size);
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab.vertical_split(PaneId::Terminal(7), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(8), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab_resize_down(&mut tab, 1);
 
     assert_eq!(
@@ -5533,18 +5533,18 @@ pub fn resize_down_with_panes_below_aligned_left_and_right_with_to_the_left_and_
     };
     let mut tab = create_new_tab(size);
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab.vertical_split(PaneId::Terminal(7), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(8), None, 1).unwrap();
-    tab.move_focus_left(1);
-    tab.move_focus_up(1);
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
+    tab.move_focus_up(1).unwrap();
+    tab.move_focus_left(1).unwrap();
     tab_resize_down(&mut tab, 1);
 
     assert_eq!(
@@ -5907,7 +5907,7 @@ pub fn cannot_resize_down_when_pane_below_is_at_minimum_height() {
     };
     let mut tab = create_new_tab(size);
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab_resize_down(&mut tab, 1);
 
     assert_eq!(
@@ -6190,7 +6190,7 @@ pub fn resize_left_with_pane_to_the_right() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab_resize_left(&mut tab, 1);
 
     assert_eq!(
@@ -6296,7 +6296,7 @@ pub fn resize_left_with_panes_to_the_left_and_right() {
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab_resize_left(&mut tab, 1);
 
     assert_eq!(
@@ -6443,9 +6443,9 @@ pub fn resize_left_with_multiple_panes_to_the_left() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_right(1);
+    tab.move_focus_right(1).unwrap();
     tab_resize_left(&mut tab, 1);
 
     assert_eq!(
@@ -6594,9 +6594,9 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_with_current_pane() {
     let mut tab = create_new_tab(size);
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab_resize_left(&mut tab, 1);
 
     assert_eq!(
@@ -6788,10 +6788,10 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_with_current_pane() {
     let mut tab = create_new_tab(size);
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_down(1);
-    tab.move_focus_left(1);
+    tab.move_focus_down(1).unwrap();
+    tab.move_focus_left(1).unwrap();
     tab_resize_left(&mut tab, 1);
 
     assert_eq!(
@@ -6983,7 +6983,7 @@ pub fn resize_left_with_panes_to_the_left_aligned_bottom_with_current_pane() {
     let mut tab = create_new_tab(size);
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
     tab_resize_left(&mut tab, 1);
 
@@ -7176,9 +7176,9 @@ pub fn resize_left_with_panes_to_the_right_aligned_bottom_with_current_pane() {
     let mut tab = create_new_tab(size);
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab_resize_left(&mut tab, 1);
 
     assert_eq!(
@@ -7373,11 +7373,11 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_and_bottom_with_current_pa
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab_resize_left(&mut tab, 1);
 
     assert_eq!(
@@ -7658,12 +7658,12 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_and_bottom_with_current_p
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_down(1);
-    tab.move_focus_left(1);
+    tab.move_focus_down(1).unwrap();
+    tab.move_focus_left(1).unwrap();
     tab_resize_left(&mut tab, 1);
 
     assert_eq!(
@@ -7944,15 +7944,15 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_and_bottom_with_panes_abov
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_up(1);
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab_resize_down(&mut tab, 1);
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
     tab.horizontal_split(PaneId::Terminal(7), None, 1).unwrap();
     tab.horizontal_split(PaneId::Terminal(8), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab_resize_left(&mut tab, 1);
 
     assert_eq!(
@@ -8319,16 +8319,16 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_and_bottom_with_panes_abo
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_up(1);
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab_resize_down(&mut tab, 1);
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab.horizontal_split(PaneId::Terminal(7), None, 1).unwrap();
     tab.horizontal_split(PaneId::Terminal(8), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab_resize_left(&mut tab, 1);
 
     assert_eq!(
@@ -8833,7 +8833,7 @@ pub fn resize_right_with_pane_to_the_right() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab_resize_right(&mut tab, 1);
 
     assert_eq!(
@@ -8939,7 +8939,7 @@ pub fn resize_right_with_panes_to_the_left_and_right() {
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab_resize_right(&mut tab, 1);
 
     assert_eq!(
@@ -9087,9 +9087,9 @@ pub fn resize_right_with_multiple_panes_to_the_left() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_right(1);
+    tab.move_focus_right(1).unwrap();
     tab_resize_right(&mut tab, 1);
 
     assert_eq!(
@@ -9237,9 +9237,9 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_with_current_pane() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_right(1);
+    tab.move_focus_right(1).unwrap();
     tab.horizontal_split(PaneId::Terminal(4), None, 1).unwrap();
     tab_resize_right(&mut tab, 1);
 
@@ -9430,11 +9430,11 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_with_current_pane() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_right(1);
+    tab.move_focus_right(1).unwrap();
     tab.horizontal_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab_resize_right(&mut tab, 1);
 
     assert_eq!(
@@ -9625,11 +9625,11 @@ pub fn resize_right_with_panes_to_the_left_aligned_bottom_with_current_pane() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_right(1);
+    tab.move_focus_right(1).unwrap();
     tab.horizontal_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab_resize_right(&mut tab, 1);
 
     assert_eq!(
@@ -9820,12 +9820,12 @@ pub fn resize_right_with_panes_to_the_right_aligned_bottom_with_current_pane() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_right(1);
+    tab.move_focus_right(1).unwrap();
     tab.horizontal_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_up(1);
-    tab.move_focus_left(1);
+    tab.move_focus_up(1).unwrap();
+    tab.move_focus_left(1).unwrap();
     tab_resize_right(&mut tab, 1);
 
     assert_eq!(
@@ -10020,11 +10020,11 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_and_bottom_with_current_p
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab_resize_right(&mut tab, 1);
 
     assert_eq!(
@@ -10304,12 +10304,12 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_and_bottom_with_current_
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_down(1);
-    tab.move_focus_left(1);
+    tab.move_focus_down(1).unwrap();
+    tab.move_focus_left(1).unwrap();
     tab_resize_right(&mut tab, 1);
 
     assert_eq!(
@@ -10589,15 +10589,15 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_and_bottom_with_panes_abo
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_up(1);
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab_resize_up(&mut tab, 1);
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
     tab.horizontal_split(PaneId::Terminal(7), None, 1).unwrap();
     tab.horizontal_split(PaneId::Terminal(8), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab_resize_right(&mut tab, 1);
 
     assert_eq!(
@@ -10963,16 +10963,16 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_and_bottom_with_panes_ab
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_up(1);
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab_resize_up(&mut tab, 1);
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab.horizontal_split(PaneId::Terminal(7), None, 1).unwrap();
     tab.horizontal_split(PaneId::Terminal(8), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab_resize_right(&mut tab, 1);
 
     assert_eq!(
@@ -11524,7 +11524,7 @@ pub fn resize_up_with_pane_below() {
     };
     let mut tab = create_new_tab(size);
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab_resize_up(&mut tab, 1);
 
     assert_eq!(
@@ -11634,7 +11634,7 @@ pub fn resize_up_with_panes_above_and_below() {
     let mut tab = create_new_tab(size);
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab_resize_up(&mut tab, 1);
 
     assert_eq!(
@@ -11782,9 +11782,9 @@ pub fn resize_up_with_multiple_panes_above() {
     };
     let mut tab = create_new_tab(size);
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab_resize_up(&mut tab, 1);
 
     assert_eq!(
@@ -11931,9 +11931,9 @@ pub fn resize_up_with_panes_above_aligned_left_with_current_pane() {
     };
     let mut tab = create_new_tab(size);
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
     tab_resize_up(&mut tab, 1);
 
@@ -12126,11 +12126,11 @@ pub fn resize_up_with_panes_below_aligned_left_with_current_pane() {
     };
     let mut tab = create_new_tab(size);
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab_resize_up(&mut tab, 1);
 
     assert_eq!(
@@ -12322,11 +12322,11 @@ pub fn resize_up_with_panes_above_aligned_right_with_current_pane() {
     };
     let mut tab = create_new_tab(size);
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab_resize_up(&mut tab, 1);
 
     assert_eq!(
@@ -12518,12 +12518,12 @@ pub fn resize_up_with_panes_below_aligned_right_with_current_pane() {
     };
     let mut tab = create_new_tab(size);
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_left(1);
-    tab.move_focus_up(1);
+    tab.move_focus_left(1).unwrap();
+    tab.move_focus_up(1).unwrap();
     tab_resize_up(&mut tab, 1);
 
     assert_eq!(
@@ -12717,10 +12717,10 @@ pub fn resize_up_with_panes_above_aligned_left_and_right_with_current_pane() {
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab_resize_up(&mut tab, 1);
 
     assert_eq!(
@@ -13000,11 +13000,11 @@ pub fn resize_up_with_panes_below_aligned_left_and_right_with_current_pane() {
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_left(1);
-    tab.move_focus_up(1);
+    tab.move_focus_left(1).unwrap();
+    tab.move_focus_up(1).unwrap();
     tab_resize_up(&mut tab, 1);
 
     assert_eq!(
@@ -13282,16 +13282,16 @@ pub fn resize_up_with_panes_above_aligned_left_and_right_with_panes_to_the_left_
     };
     let mut tab = create_new_tab(size);
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab.vertical_split(PaneId::Terminal(7), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(8), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab_resize_up(&mut tab, 1);
 
     assert_eq!(
@@ -13655,17 +13655,17 @@ pub fn resize_up_with_panes_below_aligned_left_and_right_with_to_the_left_and_ri
     };
     let mut tab = create_new_tab(size);
     tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_up(1);
+    tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_down(1);
+    tab.move_focus_down(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_up(1);
-    tab.move_focus_left(1);
+    tab.move_focus_up(1).unwrap();
+    tab.move_focus_left(1).unwrap();
     tab.vertical_split(PaneId::Terminal(7), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(8), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab_resize_up(&mut tab, 1);
 
     assert_eq!(
@@ -14118,9 +14118,9 @@ pub fn nondirectional_resize_increase_with_2_panes_to_left() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_right(1);
+    tab.move_focus_right(1).unwrap();
     tab_resize_increase(&mut tab, 1);
 
     // should behave like `resize_left_with_multiple_panes_to_the_left`
@@ -14176,7 +14176,7 @@ pub fn nondirectional_resize_increase_with_1_pane_to_right_1_pane_above() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
     tab_resize_increase(&mut tab, 1);
 
@@ -14233,7 +14233,7 @@ pub fn nondirectional_resize_increase_with_1_pane_to_right_1_pane_to_left() {
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab_resize_increase(&mut tab, 1);
 
     assert_eq!(
@@ -14289,7 +14289,7 @@ pub fn nondirectional_resize_increase_with_pane_above_aligned_right_with_current
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_left(1);
+    tab.move_focus_left(1).unwrap();
     tab_resize_increase(&mut tab, 1);
 
     assert_eq!(


### PR DESCRIPTION
Removes a bunch of `unwrap` statements in different parts of the `zellij-server` code and replaces them with `Result`-based error propagation instead.