### PR TITLE
fix 3 bugs

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -324,6 +324,10 @@ pub(crate) fn start_client(opts: CliArgs) {
     };
     let os_input = get_os_input(get_client_os_input);
 
+    let start_client_plan = |session_name: std::string::String| {
+        assert_session_ne(&session_name);
+    };
+
     if let Some(Command::Sessions(Sessions::Attach {
         session_name,
         create,
@@ -339,6 +343,9 @@ pub(crate) fn start_client(opts: CliArgs) {
         let client = if let Some(idx) = index {
             attach_with_session_index(config_options.clone(), idx, create)
         } else {
+            if create {
+                session_name.clone().map(start_client_plan);
+            }
             attach_with_session_name(session_name, config_options.clone(), create)
         };
 
@@ -363,10 +370,6 @@ pub(crate) fn start_client(opts: CliArgs) {
             attach_layout,
         );
     } else {
-        let start_client_plan = |session_name: std::string::String| {
-            assert_session_ne(&session_name);
-        };
-
         if let Some(session_name) = opts.session.clone() {
             start_client_plan(session_name.clone());
             start_client_impl(

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -202,6 +202,14 @@ pub(crate) fn assert_session_ne(name: &str) {
         eprintln!("Session name cannot be empty. Please provide a specific session name.");
         process::exit(1);
     }
+    if name == "." || name == ".." {
+        eprintln!("Invalid session name: \"{}\".", name);
+        process::exit(1);
+    }
+    if name.contains('/') {
+        eprintln!("Session name cannot contains '/'.");
+        process::exit(1);
+    }
 
     match session_exists(name) {
         Ok(result) if !result => return,

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -3218,6 +3218,8 @@ impl Row {
         let mut drained_part: VecDeque<TerminalCharacter> = VecDeque::new();
         let mut drained_part_len = 0;
         while let Some(next_character) = self.columns.remove(0) {
+            // drained_part_len == 0 here is so that if the grid is resized
+            // to a size of 1, we won't drop wide characters
             if drained_part_len + next_character.width <= x || drained_part_len == 0 {
                 drained_part.push_back(next_character);
                 drained_part_len += next_character.width;

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -3218,7 +3218,7 @@ impl Row {
         let mut drained_part: VecDeque<TerminalCharacter> = VecDeque::new();
         let mut drained_part_len = 0;
         while let Some(next_character) = self.columns.remove(0) {
-            if drained_part_len + next_character.width <= x {
+            if drained_part_len + next_character.width <= x || drained_part_len == 0 {
                 drained_part.push_back(next_character);
                 drained_part_len += next_character.width;
             } else {


### PR DESCRIPTION
1. https://github.com/zellij-org/zellij/blob/3da1cbf95c34283091186fd54926673fe2ec10f6/zellij-server/src/panes/tiled_panes/tiled_pane_grid.rs#L1168-L1178

   first_rect.cols.inner == 1.
   Between `split_vertically()` and `relayout()`, there is a `change_size()` call. New pane usually has a frame,so `get_content_columns()` returns 0, `change_size()` is skipped.
   However if you set `pane_frames false` and vertically split the right most pane, `get_content_columns()` returns 1.`change_size()` calls `drain_until(1)` for each row.
   Finally, `drain_until(1)` discard first widechar and all characters behind it.
2. `ZELLIJ_SOCK_DIR.join(name)` should be a valid filename in directory `ZELLIJ_SOCK_DIR`,so name cannot equals to "." or "..", as well as contains '/'. 
3. `zellij -s ''` Session name cannot be empty. Please provide a specific session name.
   `zellij attach --create ''` Panic occured: called `Result::unwrap()` on an `Err` value: Os { code: 98, kind: AddrInUse, message: "Address already in use" }