### PR TITLE
Fix status bar not displaying w/ size=1 and show shortcuts

### DIFF
--- a/default-plugins/status-bar/src/main.rs
+++ b/default-plugins/status-bar/src/main.rs
@@ -238,7 +238,7 @@ impl ZellijPlugin for State {
 
         let first_line = first_line(&self.mode_info, cols, separator);
         let second_line = self.second_line(cols);
-        
+
         let background = match self.mode_info.style.colors.theme_hue {
             ThemeHue::Dark => self.mode_info.style.colors.black,
             ThemeHue::Light => self.mode_info.style.colors.white,
@@ -249,24 +249,24 @@ impl ZellijPlugin for State {
         match background {
             PaletteColor::Rgb((r, g, b)) => {
                 if rows > 1 {
-                  println!("{}\u{1b}[48;2;{};{};{}m\u{1b}[0K", first_line, r, g, b);
+                    println!("{}\u{1b}[48;2;{};{};{}m\u{1b}[0K", first_line, r, g, b);
                 } else {
-                  if self.mode_info.mode == InputMode::Normal {
-                    print!("{}\u{1b}[48;2;{};{};{}m\u{1b}[0K", first_line, r, g, b);
-                  } else {
-                    print!("\u{1b}[m{}\u{1b}[0K", second_line);
-                  }
+                    if self.mode_info.mode == InputMode::Normal {
+                        print!("{}\u{1b}[48;2;{};{};{}m\u{1b}[0K", first_line, r, g, b);
+                    } else {
+                        print!("\u{1b}[m{}\u{1b}[0K", second_line);
+                    }
                 }
             },
             PaletteColor::EightBit(color) => {
                 if rows > 1 {
-                  println!("{}\u{1b}[48;5;{}m\u{1b}[0K", first_line, color);
+                    println!("{}\u{1b}[48;5;{}m\u{1b}[0K", first_line, color);
                 } else {
-                  if self.mode_info.mode == InputMode::Normal {
-                    print!("{}\u{1b}[48;5;{}m\u{1b}[0K", first_line, color);
-                  } else {
-                    print!("\u{1b}[m{}\u{1b}[0K", second_line);
-                  }
+                    if self.mode_info.mode == InputMode::Normal {
+                        print!("{}\u{1b}[48;5;{}m\u{1b}[0K", first_line, color);
+                    } else {
+                        print!("\u{1b}[m{}\u{1b}[0K", second_line);
+                    }
                 }
             },
         }

--- a/default-plugins/status-bar/src/main.rs
+++ b/default-plugins/status-bar/src/main.rs
@@ -238,7 +238,7 @@ impl ZellijPlugin for State {
 
         let first_line = first_line(&self.mode_info, cols, separator);
         let second_line = self.second_line(cols);
-
+        
         let background = match self.mode_info.style.colors.theme_hue {
             ThemeHue::Dark => self.mode_info.style.colors.black,
             ThemeHue::Light => self.mode_info.style.colors.white,
@@ -248,10 +248,26 @@ impl ZellijPlugin for State {
         // [m is background reset, [0K is so that it clears the rest of the line
         match background {
             PaletteColor::Rgb((r, g, b)) => {
-                println!("{}\u{1b}[48;2;{};{};{}m\u{1b}[0K", first_line, r, g, b);
+                if rows > 1 {
+                  println!("{}\u{1b}[48;2;{};{};{}m\u{1b}[0K", first_line, r, g, b);
+                } else {
+                  if self.mode_info.mode == InputMode::Normal {
+                    print!("{}\u{1b}[48;2;{};{};{}m\u{1b}[0K", first_line, r, g, b);
+                  } else {
+                    print!("\u{1b}[m{}\u{1b}[0K", second_line);
+                  }
+                }
             },
             PaletteColor::EightBit(color) => {
-                println!("{}\u{1b}[48;5;{}m\u{1b}[0K", first_line, color);
+                if rows > 1 {
+                  println!("{}\u{1b}[48;5;{}m\u{1b}[0K", first_line, color);
+                } else {
+                  if self.mode_info.mode == InputMode::Normal {
+                    print!("{}\u{1b}[48;5;{}m\u{1b}[0K", first_line, color);
+                  } else {
+                    print!("\u{1b}[m{}\u{1b}[0K", second_line);
+                  }
+                }
             },
         }
 


### PR DESCRIPTION
Closes #2077 
This changes behaviour if `status-bar` is used with `size=1`.

The issue of the status bar not showing with `size=1` arises from using `println!` when reaching the last line.
In this case, `print!` will be used instead.

This will also show the "second layer" of hints when not in normal mode, changing the first line.

Be careful reviewing, it's my first Rust PR 🚀