### PR TITLE
Support UTF-8 character in tab name and pane name

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1110,7 +1110,7 @@ impl Screen {
                             },
                             c => {
                                 // It only allows printable unicode
-                                if buf.iter().all(|u| matches!(u, 0x20..=0xFF)) {
+                                if buf.iter().all(|u| matches!(u, 0x20..=0x7E | 0xA0..=0xFF)) {
                                     active_tab.name.push_str(c);
                                 }
                             },

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1110,7 +1110,7 @@ impl Screen {
                             },
                             c => {
                                 // It only allows printable unicode
-                                if buf.iter().all(|u| matches!(u, 0x20..=0x7E)) {
+                                if buf.iter().all(|u| matches!(u, 0x20..=0xFF)) {
                                     active_tab.name.push_str(c);
                                 }
                             },

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -2635,7 +2635,9 @@ impl Tab {
             .with_context(err_context)?;
 
             // It only allows printable unicode, delete and backspace keys.
-            let is_updatable = buf.iter().all(|u| matches!(u, 0x20..=0xFF | 0x08 | 0x7F));
+            let is_updatable = buf
+                .iter()
+                .all(|u| matches!(u, 0x20..=0x7E | 0xA0..=0xFF | 0x08 | 0x7F));
             if is_updatable {
                 let s = str::from_utf8(&buf).with_context(err_context)?;
                 active_terminal.update_name(s);

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -2635,7 +2635,7 @@ impl Tab {
             .with_context(err_context)?;
 
             // It only allows printable unicode, delete and backspace keys.
-            let is_updatable = buf.iter().all(|u| matches!(u, 0x20..=0x7E | 0x08 | 0x7F));
+            let is_updatable = buf.iter().all(|u| matches!(u, 0x20..=0xFF | 0x08 | 0x7F));
             if is_updatable {
                 let s = str::from_utf8(&buf).with_context(err_context)?;
                 active_terminal.update_name(s);


### PR DESCRIPTION
To fix #2065 , expand characters in tab name and pane name