### PR TITLE
Fix fullscreen navigation

### DIFF
--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -1181,6 +1181,30 @@ impl TiledPanes {
         }
     }
 
+    pub fn focus_pane_left_fullscreen(&mut self, client_id: ClientId) {
+        self.unset_fullscreen();
+        self.move_focus_left(client_id);
+        self.toggle_active_pane_fullscreen(client_id);
+    }
+
+    pub fn focus_pane_right_fullscreen(&mut self, client_id: ClientId) {
+        self.unset_fullscreen();
+        self.move_focus_right(client_id);
+        self.toggle_active_pane_fullscreen(client_id);
+    }
+
+    pub fn focus_pane_up_fullscreen(&mut self, client_id: ClientId) {
+        self.unset_fullscreen();
+        self.move_focus_up(client_id);
+        self.toggle_active_pane_fullscreen(client_id);
+    }
+
+    pub fn focus_pane_down_fullscreen(&mut self, client_id: ClientId) {
+        self.unset_fullscreen();
+        self.move_focus_down(client_id);
+        self.toggle_active_pane_fullscreen(client_id);
+    }
+
     pub fn switch_next_pane_fullscreen(&mut self, client_id: ClientId) {
         self.unset_fullscreen();
         self.focus_next_pane(client_id);

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1339,6 +1339,34 @@ impl Tab {
     pub fn are_floating_panes_visible(&self) -> bool {
         self.floating_panes.panes_are_visible()
     }
+    pub fn focus_pane_left_fullscreen(&mut self, client_id: ClientId) {
+        if !self.is_fullscreen_active() {
+            return;
+        }
+
+        self.tiled_panes.focus_pane_left_fullscreen(client_id);
+    }
+    pub fn focus_pane_right_fullscreen(&mut self, client_id: ClientId) {
+        if !self.is_fullscreen_active() {
+            return;
+        }
+
+        self.tiled_panes.focus_pane_right_fullscreen(client_id);
+    }
+    pub fn focus_pane_up_fullscreen(&mut self, client_id: ClientId) {
+        if !self.is_fullscreen_active() {
+            return;
+        }
+
+        self.tiled_panes.focus_pane_up_fullscreen(client_id);
+    }
+    pub fn focus_pane_down_fullscreen(&mut self, client_id: ClientId) {
+        if !self.is_fullscreen_active() {
+            return;
+        }
+
+        self.tiled_panes.focus_pane_down_fullscreen(client_id);
+    }
     pub fn switch_next_pane_fullscreen(&mut self, client_id: ClientId) {
         if !self.is_fullscreen_active() {
             return;
@@ -1613,7 +1641,7 @@ impl Tab {
                 return Ok(false);
             }
             if self.tiled_panes.fullscreen_is_active() {
-                self.switch_next_pane_fullscreen(client_id);
+                self.focus_pane_left_fullscreen(client_id);
                 return Ok(true);
             }
             Ok(self.tiled_panes.move_focus_left(client_id))
@@ -1635,7 +1663,8 @@ impl Tab {
                 return Ok(false);
             }
             if self.tiled_panes.fullscreen_is_active() {
-                return Ok(false);
+                self.focus_pane_down_fullscreen(client_id);
+                return Ok(true);
             }
             Ok(self.tiled_panes.move_focus_down(client_id))
         }
@@ -1656,7 +1685,8 @@ impl Tab {
                 return Ok(false);
             }
             if self.tiled_panes.fullscreen_is_active() {
-                return Ok(false);
+                self.focus_pane_up_fullscreen(client_id);
+                return Ok(true);
             }
             Ok(self.tiled_panes.move_focus_up(client_id))
         }
@@ -1678,7 +1708,7 @@ impl Tab {
                 return Ok(false);
             }
             if self.tiled_panes.fullscreen_is_active() {
-                self.switch_next_pane_fullscreen(client_id);
+                self.focus_pane_right_fullscreen(client_id);
                 return Ok(true);
             }
             Ok(self.tiled_panes.move_focus_right(client_id))

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1377,7 +1377,7 @@ impl Tab {
         if !self.is_fullscreen_active() {
             return;
         }
-        self.tiled_panes.switch_next_pane_fullscreen(client_id);
+        self.tiled_panes.switch_prev_pane_fullscreen(client_id);
     }
     pub fn set_force_render(&mut self) {
         self.tiled_panes.set_force_render();


### PR DESCRIPTION
Closes #2106
Well it started to bother we as well, so I implemented a fix. Instead of focusing the next pane in fullscreen mode, now the corresponding direction is respected.

During the implementation I also saw a small error (the prev focus method used the next focus function instead of the prev focus function;) which I also fixed, but put into a separate commit.

I haven't bothered to add additional tests for these changes, do you want me to add tests as well?