### PR TITLE
Use singlepass compiler in debug mode

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,8 @@
 parallel-compiler = true
 
+[build]
+target-dir = "target"
+
 [alias]
 xtask = "run --package xtask --"
 x = "xtask"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,14 @@ Note that the output is truncated at 100KB. This can be adjusted for the purpose
 
 When running Zellij with the `--debug` flag, Zellij will dump a copy of all bytes received over the pty for each pane in: `/$temp_dir/zellij-<UID>/zellij-log/zellij-<pane_id>.log`. These might be useful when troubleshooting terminal issues.
 
+## Testing plugins
+Zellij by default uses a fast, non-optimized, compiler for WASM when running in debug mode. This behavior can be overriden by using the `force_cranelit` feature flag, if you wish to reproduce the behavior in release mode.
+
+To enable the flag, run:
+```sh
+cargo xtask run --cranelift
+```
+
 ## How we treat clippy lints
 
 We currently use clippy in [GitHub Actions](https://github.com/zellij-org/zellij/blob/main/.github/workflows/rust.yml) with the default settings that report only [`clippy::correctness`](https://github.com/rust-lang/rust-clippy#readme) as errors and other lints as warnings because Zellij is still unstable. This means that all warnings can be ignored depending on the situation at that time, even though they are also helpful to keep the code quality.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,6 +837,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
+name = "dynasm"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add9a102807b524ec050363f09e06f1504214b0e1c7797f64261c891022dce8b"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dynasmrt"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fba5a42bd76a17cad4bfa00de168ee1cbfa06a5e8ce992ae880218c05641a9"
+dependencies = [
+ "byteorder",
+ "dynasm",
+ "memmap2",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3412,6 +3438,7 @@ dependencies = [
  "wasmer-artifact",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",
+ "wasmer-compiler-singlepass",
  "wasmer-derive",
  "wasmer-engine",
  "wasmer-engine-dylib",
@@ -3469,6 +3496,25 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "tracing",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-compiler-singlepass"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ca2a35204d8befa85062bc7aac259a8db8070b801b8a783770ba58231d729e"
+dependencies = [
+ "byteorder",
+ "dynasm",
+ "dynasmrt",
+ "gimli",
+ "lazy_static",
+ "loupe",
+ "more-asserts",
+ "rayon",
+ "smallvec",
  "wasmer-compiler",
  "wasmer-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,3 +73,4 @@ pkg-fmt = "tgz"
 default = [ "zellij-utils/plugins_from_target" ]
 disable_automatic_asset_installation = [ "zellij-utils/disable_automatic_asset_installation" ]
 unstable = [ "zellij-client/unstable", "zellij-utils/unstable" ]
+force_cranelift = [ "zellij-server/force_cranelift" ]

--- a/xtask/src/flags.rs
+++ b/xtask/src/flags.rs
@@ -63,6 +63,8 @@ xflags::xflags! {
         cmd run {
             /// Take plugins from here, skip building plugins. Passed to zellij verbatim
             optional --data-dir path: PathBuf
+            /// Force the use of Cranelift for compiling WASM modules
+            optional --cranelift
             /// Arguments to pass after `cargo run --`
             repeated args: OsString
         }
@@ -173,6 +175,8 @@ pub struct Run {
     pub args: Vec<OsString>,
 
     pub data_dir: Option<PathBuf>,
+
+    pub cranelift: bool,
 }
 
 #[derive(Debug)]

--- a/zellij-server/Cargo.toml
+++ b/zellij-server/Cargo.toml
@@ -18,7 +18,7 @@ daemonize = "0.4.1"
 serde_json = "1.0"
 unicode-width = "0.1.8"
 url = "2.2.2"
-wasmer = "2.3.0"
+wasmer = { version = "2.3.0", features = ["singlepass"]}
 wasmer-wasi = "2.3.0"
 cassowary = "0.3.0"
 zellij-utils = { path = "../zellij-utils/", version = "0.34.5" }
@@ -36,3 +36,5 @@ semver = "0.11.0"
 [dev-dependencies]
 insta = "1.6.0"
 
+[features]
+force_cranelift = []

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -749,7 +749,7 @@ fn init_session(
                 Some(&to_background_jobs),
                 None,
             );
-            let store = Store::default();
+            let store = get_store();
 
             move || {
                 plugin_thread_main(
@@ -817,4 +817,16 @@ fn init_session(
         pty_writer_thread: Some(pty_writer_thread),
         background_jobs_thread: Some(background_jobs_thread),
     }
+}
+
+#[cfg(any(feature = "force_cranelift", not(debug_assertions)))]
+fn get_store() -> Store {
+    log::debug!("Compiling using Cranelift");
+    Store::new(&wasmer::Universal::new(wasmer::Cranelift::default()).engine())
+}
+
+#[cfg(not(any(feature = "force_cranelift", not(debug_assertions))))]
+fn get_store() -> Store {
+    log::debug!("Compiling using Singlepass");
+    Store::new(&wasmer::Universal::new(wasmer::Singlepass::default()).engine())
 }

--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -4,6 +4,7 @@ use log::{debug, info, warn};
 use semver::Version;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
+    borrow::Cow,
     collections::{HashMap, HashSet},
     fmt, fs,
     path::PathBuf,
@@ -30,7 +31,7 @@ use crate::{
 };
 
 use zellij_utils::{
-    consts::{DEBUG_MODE, VERSION, ZELLIJ_CACHE_DIR, ZELLIJ_TMP_DIR},
+    consts::{VERSION, ZELLIJ_CACHE_DIR, ZELLIJ_TMP_DIR},
     data::{Event, EventType, PluginIds},
     errors::prelude::*,
     input::{
@@ -125,11 +126,7 @@ pub struct PluginEnv {
 impl PluginEnv {
     // Get the name (path) of the containing plugin
     pub fn name(&self) -> String {
-        format!(
-            "{} (ID {})",
-            self.plugin.path.display().to_string(),
-            self.plugin_id
-        )
+        format!("{} (ID {})", self.plugin.path.display(), self.plugin_id)
     }
 }
 
@@ -245,7 +242,6 @@ impl WasmBridge {
         let err_context = || format!("failed to start plugin {plugin:#?} for client {client_id}");
 
         let plugin_own_data_dir = ZELLIJ_CACHE_DIR.join(Url::from(&plugin.location).to_string());
-        let cache_hit = self.plugin_cache.contains_key(&plugin.path);
 
         // Create filesystem entries mounted into WASM.
         // We create them here to get expressive error messages in case they fail.
@@ -262,13 +258,13 @@ impl WasmBridge {
         // arm, because we create the Module from scratch there. Any reference passed outside would
         // outlive the Module we create there. Hence, we remove the plugin here and reinsert it
         // below...
-        let module = match self.plugin_cache.remove(&plugin.path) {
+        let module = match self.plugin_cache.get(&plugin.path) {
             Some(module) => {
                 log::debug!(
                     "Loaded plugin '{}' from plugin cache",
                     plugin.path.display()
                 );
-                module
+                Cow::Borrowed(module)
             },
             None => {
                 // Populate plugin module cache for this plugin!
@@ -293,32 +289,37 @@ impl WasmBridge {
                     .collect();
                 let cached_path = ZELLIJ_CACHE_DIR.join(&hash);
 
-                unsafe {
-                    match Module::deserialize_from_file(&self.store, &cached_path) {
-                        Ok(m) => {
-                            log::debug!(
-                                "Loaded plugin '{}' from cache folder at '{}'",
-                                plugin.path.display(),
-                                ZELLIJ_CACHE_DIR.display(),
-                            );
-                            m
-                        },
-                        Err(e) => {
-                            let inner_context = || format!("failed to recover from {e:?}");
+                let timer = std::time::Instant::now();
+                match unsafe { Module::deserialize_from_file(&self.store, &cached_path) } {
+                    Ok(m) => {
+                        log::debug!(
+                            "Loaded plugin '{}' from cache folder at '{}' in {:?}",
+                            plugin.path.display(),
+                            ZELLIJ_CACHE_DIR.display(),
+                            timer.elapsed(),
+                        );
+                        Cow::Owned(m)
+                    },
+                    Err(e) => {
+                        let inner_context = || format!("failed to recover from {e:?}");
 
-                            fs::create_dir_all(ZELLIJ_CACHE_DIR.to_owned())
-                                .map_err(anyError::new)
-                                .and_then(|_| {
-                                    Module::new(&self.store, &wasm_bytes).map_err(anyError::new)
-                                })
-                                .and_then(|m| {
-                                    m.serialize_to_file(&cached_path).map_err(anyError::new)?;
-                                    Ok(m)
-                                })
-                                .with_context(inner_context)
-                                .with_context(err_context)?
-                        },
-                    }
+                        fs::create_dir_all(ZELLIJ_CACHE_DIR.to_owned())
+                            .map_err(anyError::new)
+                            .and_then(|_| {
+                                Module::new(&self.store, &wasm_bytes).map_err(anyError::new)
+                            })
+                            .and_then(|m| {
+                                m.serialize_to_file(&cached_path).map_err(anyError::new)?;
+                                log::debug!(
+                                    "Compiled plugin '{}' in {:?}",
+                                    plugin.path.display(),
+                                    timer.elapsed()
+                                );
+                                Ok(Cow::Owned(m))
+                            })
+                            .with_context(inner_context)
+                            .with_context(err_context)?
+                    },
                 }
             },
         };
@@ -357,14 +358,11 @@ impl WasmBridge {
         let instance =
             Instance::new(&module, &zellij.chain_back(wasi)).with_context(err_context)?;
 
-        if !cache_hit {
-            // Check plugin version
-            assert_plugin_version(&instance, &plugin_env).with_context(err_context)?;
-        }
-
         // Only do an insert when everything went well!
-        let cloned_plugin = plugin.clone();
-        self.plugin_cache.insert(cloned_plugin.path, module);
+        if let Cow::Owned(module) = module {
+            assert_plugin_version(&instance, &plugin_env).with_context(err_context)?;
+            self.plugin_cache.insert(plugin.path.clone(), module);
+        }
 
         Ok((instance, plugin_env))
     }
@@ -442,13 +440,7 @@ impl WasmBridge {
         &mut self,
         mut updates: Vec<(Option<u32>, Option<ClientId>, Event)>,
     ) -> Result<()> {
-        let err_context = || {
-            if *DEBUG_MODE.get().unwrap_or(&true) {
-                format!("failed to update plugin state")
-            } else {
-                "failed to update plugin state".to_string()
-            }
-        };
+        let err_context = || "failed to update plugin state".to_string();
 
         let mut plugin_bytes = vec![];
         for (pid, cid, event) in updates.drain(..) {
@@ -743,7 +735,7 @@ fn host_set_timeout(plugin_env: &PluginEnv, secs: f64) {
         let elapsed_time = Instant::now().duration_since(start_time).as_secs_f64();
 
         send_plugin_instructions
-            .ok_or(anyhow!("found no sender to send plugin instruction to"))
+            .ok_or_else(|| anyhow!("found no sender to send plugin instruction to"))
             .and_then(|sender| {
                 sender
                     .send(PluginInstruction::Update(vec![(
@@ -817,12 +809,12 @@ pub fn wasi_read_string(wasi_env: &WasiEnv) -> Result<String> {
         .and_then(|stdout| {
             stdout
                 .as_mut()
-                .ok_or(anyhow!("failed to get mutable reference to stdout"))
+                .ok_or_else(|| anyhow!("failed to get mutable reference to stdout"))
         })
         .and_then(|wasi_file| wasi_file.read_to_string(&mut buf).map_err(anyError::new))
         .with_context(err_context)?;
     // https://stackoverflow.com/questions/66450942/in-rust-is-there-a-way-to-make-literal-newlines-in-r-using-windows-c
-    Ok(buf.replace("\n", "\n\r"))
+    Ok(buf.replace('\n', "\n\r"))
 }
 
 pub fn wasi_write_string(wasi_env: &WasiEnv, buf: &str) -> Result<()> {
@@ -834,7 +826,7 @@ pub fn wasi_write_string(wasi_env: &WasiEnv, buf: &str) -> Result<()> {
         .and_then(|stdin| {
             stdin
                 .as_mut()
-                .ok_or(anyhow!("failed to get mutable reference to stdin"))
+                .ok_or_else(|| anyhow!("failed to get mutable reference to stdin"))
         })
         .and_then(|stdin| writeln!(stdin, "{}\r", buf).map_err(anyError::new))
         .with_context(|| format!("failed to write string to WASI env '{wasi_env:?}'"))

--- a/zellij-utils/src/input/plugins.rs
+++ b/zellij-utils/src/input/plugins.rs
@@ -18,7 +18,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 
 /// Used in the config struct for plugin metadata
-#[derive(Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Default, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct PluginsConfig(pub HashMap<PluginTag, PluginConfig>);
 
 impl fmt::Debug for PluginsConfig {
@@ -66,12 +66,6 @@ impl PluginsConfig {
         let mut plugin_config = self.0.clone();
         plugin_config.extend(other.0);
         Self(plugin_config)
-    }
-}
-
-impl Default for PluginsConfig {
-    fn default() -> Self {
-        PluginsConfig(HashMap::new())
     }
 }
 
@@ -154,7 +148,7 @@ impl PluginConfig {
                     return Ok(val);
                 },
                 Err(err) => {
-                    last_err = last_err.with_context(|| err_context(err, &path));
+                    last_err = last_err.with_context(|| err_context(err, path));
                 },
             }
         }
@@ -183,7 +177,7 @@ impl PluginConfig {
             }
         }
 
-        return last_err;
+        last_err
     }
 
     /// Sets the tab index inside of the plugin type of the run field.
@@ -221,7 +215,7 @@ impl Default for PluginType {
     }
 }
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum PluginsConfigError {
     #[error("Duplication in plugin tag names is not allowed: '{}'", String::from(.0.clone()))]
     DuplicatePlugins(PluginTag),


### PR DESCRIPTION
By default, in debug mode, Zellij will use the Singlepass compiler for loading WASM.

The core change resides in zellij-server/src/lib.rs

Additional changes:
- Allow forcing cranelift in debug mode to reproduce release mode runtime (`cargo xtask run --cranelift`)
- Output the time taken to load the module to debug-level DEBUG
- Due to a requirement from **zellij-utils/src/consts.rs**, set the location of `CARGO_TARGET_DIR` to a known location (happy to revert if you think I stepped too far here)
- Clippy drive-by on files touched
  - From the CONTRIBUTING.md file, I know that clippy is not a high priority, but the changes suggested made a lot of sense like lazy evaluations and double-dereferencing
  - Again, happy to revert to reduce noise