### PR TITLE
cleanups around "buffer full" error

### DIFF
--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -344,6 +344,15 @@ struct ClientSender {
 
 impl ClientSender {
     pub fn new(client_id: ClientId, mut sender: IpcSenderWithContext<ServerToClientMsg>) -> Self {
+        // FIXME(hartan): This queue is responsible for buffering messages between server and
+        // client. If it fills up, the client is disconnected with a "Buffer full" sort of error
+        // message. It was previously found to be too small (with depth 50), so it was increased to
+        // 5000 instead. This decision was made because it was found that a queue of depth 5000
+        // doesn't cause noticable increase in RAM usage, but there's no reason beyond that. If in
+        // the future this is found to fill up too quickly again, it may be worthwhile to increase
+        // the size even further. We, the zellij maintainers, have decided against an unbounded
+        // queue for the time being because we want to prevent e.g. the whole session being killed
+        // (by OOM-killers or some other mechanism) just because a single client doesn't respond.
         let (client_buffer_sender, client_buffer_receiver) = channels::bounded(5000);
         std::thread::spawn(move || {
             let err_context = || format!("failed to send message to client {client_id}");

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -350,7 +350,8 @@ impl ClientSender {
         // 5000 instead. This decision was made because it was found that a queue of depth 5000
         // doesn't cause noticable increase in RAM usage, but there's no reason beyond that. If in
         // the future this is found to fill up too quickly again, it may be worthwhile to increase
-        // the size even further. We, the zellij maintainers, have decided against an unbounded
+        // the size even further (or better yet, implement a redraw-on-backpressure mechanism).
+        // We, the zellij maintainers, have decided against an unbounded
         // queue for the time being because we want to prevent e.g. the whole session being killed
         // (by OOM-killers or some other mechanism) just because a single client doesn't respond.
         let (client_buffer_sender, client_buffer_receiver) = channels::bounded(5000);

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -154,8 +154,7 @@ isn't performant enough.
 There are a few things you can try now:
     - Reattach to your previous session and see if it works out better this
       time: {session_tip}
-    - Try using a faster terminal. GPU-accelerated terminals such as Kitty
-      or Alacritty are cross-platform and known to work well with zellij.
+    - Try using a faster (maybe GPU-accelerated) terminal emulator
     "
                 )
             },


### PR DESCRIPTION
As discussed in the last team meeting, this PR performs two minor cleanups:

1. Add a `FIXME` note to the bounded queue between server and client that explains why it has its' current size, and in order to make it easier to find and change if the need arises (again)
2. Don't recommend terminal emulator applications inside error messages. It's fine for users/maintainers to recommend their personal favorite applications and suchlike, but zellij itself remains neutral in this regard