### PR TITLE
Make the singlepass compiler opt-in through flags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,11 +86,11 @@ Note that the output is truncated at 100KB. This can be adjusted for the purpose
 When running Zellij with the `--debug` flag, Zellij will dump a copy of all bytes received over the pty for each pane in: `/$temp_dir/zellij-<UID>/zellij-log/zellij-<pane_id>.log`. These might be useful when troubleshooting terminal issues.
 
 ## Testing plugins
-Zellij by default uses a fast, non-optimized, compiler for WASM when running in debug mode. This can be overriden by using the `force_cranelift` feature flag, if you wish to reproduce the behavior of release mode.
+Zellij allows the use of the [Singlepass](https://crates.io/crates/wasmer-compiler-singlepass) compiler for wasmer. This can enable great gains in compilation time of plugins in detriment of stability, notably on Arm64 architectures.
 
-To enable the flag, run:
+To enable the singlepass compiler, use the `singlepass` flag. E.g.:
 ```sh
-cargo xtask run --cranelift
+cargo xtask run --singlepass
 ```
 
 ## How we treat clippy lints

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,4 +73,4 @@ pkg-fmt = "tgz"
 default = [ "zellij-utils/plugins_from_target" ]
 disable_automatic_asset_installation = [ "zellij-utils/disable_automatic_asset_installation" ]
 unstable = [ "zellij-client/unstable", "zellij-utils/unstable" ]
-force_cranelift = [ "zellij-server/force_cranelift" ]
+singlepass = [ "zellij-server/singlepass" ]

--- a/xtask/src/flags.rs
+++ b/xtask/src/flags.rs
@@ -63,8 +63,8 @@ xflags::xflags! {
         cmd run {
             /// Take plugins from here, skip building plugins. Passed to zellij verbatim
             optional --data-dir path: PathBuf
-            /// Force the use of Cranelift for compiling WASM modules
-            optional --cranelift
+            /// Enable the singlepass compiler for WASM plugins
+            optional --singlepass
             /// Arguments to pass after `cargo run --`
             repeated args: OsString
         }
@@ -176,7 +176,7 @@ pub struct Run {
 
     pub data_dir: Option<PathBuf>,
 
-    pub cranelift: bool,
+    pub singlepass: bool,
 }
 
 #[derive(Debug)]

--- a/xtask/src/pipelines.rs
+++ b/xtask/src/pipelines.rs
@@ -94,7 +94,7 @@ pub fn install(sh: &Shell, flags: flags::Install) -> anyhow::Result<()> {
 pub fn run(sh: &Shell, flags: flags::Run) -> anyhow::Result<()> {
     let err_context = || format!("failed to run pipeline 'run' with args {flags:?}");
 
-    let cranelift = flags.cranelift.then_some(["--features", "force_cranelift"]);
+    let singlepass = flags.singlepass.then_some(["--features", "singlepass"]);
 
     if let Some(ref data_dir) = flags.data_dir {
         let data_dir = sh.current_dir().join(data_dir);
@@ -105,7 +105,7 @@ pub fn run(sh: &Shell, flags: flags::Run) -> anyhow::Result<()> {
                     .args(["--package", "zellij"])
                     .arg("--no-default-features")
                     .args(["--features", "disable_automatic_asset_installation"])
-                    .args(cranelift.iter().flatten())
+                    .args(singlepass.iter().flatten())
                     .args(["--", "--data-dir", &format!("{}", data_dir.display())])
                     .args(&flags.args)
                     .run()
@@ -124,7 +124,7 @@ pub fn run(sh: &Shell, flags: flags::Run) -> anyhow::Result<()> {
         .and_then(|_| crate::cargo())
         .and_then(|cargo| {
             cmd!(sh, "{cargo} run")
-                .args(cranelift.iter().flatten())
+                .args(singlepass.iter().flatten())
                 .args(["--"])
                 .args(&flags.args)
                 .run()

--- a/zellij-server/Cargo.toml
+++ b/zellij-server/Cargo.toml
@@ -18,7 +18,7 @@ daemonize = "0.4.1"
 serde_json = "1.0"
 unicode-width = "0.1.8"
 url = "2.2.2"
-wasmer = { version = "2.3.0", features = ["singlepass"]}
+wasmer = "2.3.0"
 wasmer-wasi = "2.3.0"
 cassowary = "0.3.0"
 zellij-utils = { path = "../zellij-utils/", version = "0.34.5" }
@@ -37,4 +37,4 @@ semver = "0.11.0"
 insta = "1.6.0"
 
 [features]
-force_cranelift = []
+singlepass = ["wasmer/singlepass"]

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -819,13 +819,13 @@ fn init_session(
     }
 }
 
-#[cfg(any(feature = "force_cranelift", not(debug_assertions)))]
+#[cfg(not(feature = "singlepass"))]
 fn get_store() -> Store {
     log::info!("Compiling plugins using Cranelift");
     Store::new(&wasmer::Universal::new(wasmer::Cranelift::default()).engine())
 }
 
-#[cfg(not(any(feature = "force_cranelift", not(debug_assertions))))]
+#[cfg(feature = "singlepass")]
 fn get_store() -> Store {
     log::info!("Compiling plugins using Singlepass");
     Store::new(&wasmer::Universal::new(wasmer::Singlepass::default()).engine())


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/2144

Makes the simplepass compiler opt-in instead of the default compiler for debug mode.
This may be desired due to consistent failure when running the default `cargo x run` command on arm64.