### PR TITLE
Refator and consolidate code around splitting panes

### DIFF
--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -314,24 +314,7 @@ impl TiledPanes {
             false
         }
     }
-    pub fn split_pane_horizontally(
-        &mut self,
-        pid: PaneId,
-        mut new_pane: Box<dyn Pane>,
-        client_id: ClientId,
-    ) {
-        let active_pane_id = &self.active_panes.get(&client_id).unwrap();
-        let active_pane = self.panes.get_mut(active_pane_id).unwrap();
-        let full_pane_size = active_pane.position_and_size();
-        if let Some((top_winsize, bottom_winsize)) =
-            split(SplitDirection::Horizontal, &full_pane_size)
-        {
-            active_pane.set_geom(top_winsize);
-            new_pane.set_geom(bottom_winsize);
-            self.panes.insert(pid, new_pane);
-            self.relayout(SplitDirection::Vertical);
-        }
-    }
+
     pub fn can_split_active_pane_vertically(&self, client_id: ClientId) -> bool {
         let active_pane_id = &self.active_panes.get(&client_id).unwrap();
         let active_pane = self.panes.get(active_pane_id).unwrap();
@@ -345,24 +328,29 @@ impl TiledPanes {
             false
         }
     }
-    pub fn split_pane_vertically(
+
+    pub fn split_pane(
         &mut self,
         pid: PaneId,
         mut new_pane: Box<dyn Pane>,
         client_id: ClientId,
+        direction: SplitDirection,
     ) {
         let active_pane_id = &self.active_panes.get(&client_id).unwrap();
         let active_pane = self.panes.get_mut(active_pane_id).unwrap();
         let full_pane_size = active_pane.position_and_size();
-        if let Some((left_winsize, right_winsize)) =
-            split(SplitDirection::Vertical, &full_pane_size)
-        {
-            active_pane.set_geom(left_winsize);
-            new_pane.set_geom(right_winsize);
+        if let Some((one_winsize, other_winsize)) = split(direction, &full_pane_size) {
+            active_pane.set_geom(one_winsize);
+            new_pane.set_geom(other_winsize);
             self.panes.insert(pid, new_pane);
-            self.relayout(SplitDirection::Horizontal);
+            let relayout_dir = match direction {
+                SplitDirection::Vertical => SplitDirection::Horizontal,
+                SplitDirection::Horizontal => SplitDirection::Vertical,
+            };
+            self.relayout(relayout_dir);
         }
     }
+
     pub fn focus_pane(&mut self, pane_id: PaneId, client_id: ClientId) {
         self.active_panes
             .insert(client_id, pane_id, &mut self.panes);

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -283,31 +283,24 @@ impl TiledPanes {
         }
         self.reset_boundaries();
     }
-    pub fn can_split_pane_horizontally(&mut self, client_id: ClientId) -> bool {
+
+    pub fn can_split_pane(&self, direction: SplitDirection, client_id: ClientId) -> bool {
         if let Some(active_pane_id) = &self.active_panes.get(&client_id) {
-            if let Some(active_pane) = self.panes.get_mut(active_pane_id) {
+            if let Some(active_pane) = self.panes.get(active_pane_id) {
                 let full_pane_size = active_pane.position_and_size();
-                if full_pane_size.rows.as_usize() < MIN_TERMINAL_HEIGHT * 2 {
-                    return false;
-                } else {
-                    return split(SplitDirection::Horizontal, &full_pane_size).is_some();
-                }
+                return match direction {
+                    SplitDirection::Horizontal => {
+                        full_pane_size.rows.as_usize() >= MIN_TERMINAL_HEIGHT * 2
+                    },
+                    SplitDirection::Vertical => {
+                        full_pane_size.cols.as_usize() >= MIN_TERMINAL_WIDTH * 2
+                    },
+                } && split(direction, &full_pane_size).is_some();
             }
         }
         false
     }
-    pub fn can_split_pane_vertically(&mut self, client_id: ClientId) -> bool {
-        if let Some(active_pane_id) = &self.active_panes.get(&client_id) {
-            if let Some(active_pane) = self.panes.get_mut(active_pane_id) {
-                let full_pane_size = active_pane.position_and_size();
-                if full_pane_size.cols.as_usize() < MIN_TERMINAL_WIDTH * 2 {
-                    return false;
-                }
-                return split(SplitDirection::Vertical, &full_pane_size).is_some();
-            }
-        }
-        false
-    }
+
     pub fn can_split_active_pane_horizontally(&self, client_id: ClientId) -> bool {
         let active_pane_id = &self.active_panes.get(&client_id).unwrap();
         let active_pane = self.panes.get(active_pane_id).unwrap();

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -224,27 +224,12 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                     ))
                                     .with_context(err_context)?;
                                 if let Some(run_command) = run_command {
-                                    pty.bus
-                                        .senders
-                                        .send_to_screen(ScreenInstruction::PtyBytes(
-                                            *terminal_id,
-                                            format!(
-                                                "Command not found: {}",
-                                                run_command.command.display()
-                                            )
-                                            .as_bytes()
-                                            .to_vec(),
-                                        ))
-                                        .with_context(err_context)?;
-                                    pty.bus
-                                        .senders
-                                        .send_to_screen(ScreenInstruction::HoldPane(
-                                            PaneId::Terminal(*terminal_id),
-                                            Some(2), // exit status
-                                            run_command,
-                                            None,
-                                        ))
-                                        .with_context(err_context)?;
+                                    send_command_not_found_to_screen(
+                                        pty.bus.senders.clone(),
+                                        *terminal_id,
+                                        run_command.clone(),
+                                    )
+                                    .with_context(err_context)?;
                                 }
                             }
                         },
@@ -294,27 +279,12 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                     ))
                                     .with_context(err_context)?;
                                 if let Some(run_command) = run_command {
-                                    pty.bus
-                                        .senders
-                                        .send_to_screen(ScreenInstruction::PtyBytes(
-                                            *terminal_id,
-                                            format!(
-                                                "Command not found: {}",
-                                                run_command.command.display()
-                                            )
-                                            .as_bytes()
-                                            .to_vec(),
-                                        ))
-                                        .with_context(err_context)?;
-                                    pty.bus
-                                        .senders
-                                        .send_to_screen(ScreenInstruction::HoldPane(
-                                            PaneId::Terminal(*terminal_id),
-                                            Some(2), // exit status
-                                            run_command,
-                                            None,
-                                        ))
-                                        .with_context(err_context)?;
+                                    send_command_not_found_to_screen(
+                                        pty.bus.senders.clone(),
+                                        *terminal_id,
+                                        run_command.clone(),
+                                    )
+                                    .with_context(err_context)?;
                                 }
                             }
                         },
@@ -403,27 +373,12 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                     Err(err) => match err.downcast_ref::<ZellijError>() {
                         Some(ZellijError::CommandNotFound { terminal_id, .. }) => {
                             if run_command.hold_on_close {
-                                pty.bus
-                                    .senders
-                                    .send_to_screen(ScreenInstruction::PtyBytes(
-                                        *terminal_id,
-                                        format!(
-                                            "Command not found: {}",
-                                            run_command.command.display()
-                                        )
-                                        .as_bytes()
-                                        .to_vec(),
-                                    ))
-                                    .with_context(err_context)?;
-                                pty.bus
-                                    .senders
-                                    .send_to_screen(ScreenInstruction::HoldPane(
-                                        PaneId::Terminal(*terminal_id),
-                                        Some(2), // exit status
-                                        run_command,
-                                        None,
-                                    ))
-                                    .with_context(err_context)?;
+                                send_command_not_found_to_screen(
+                                    pty.bus.senders.clone(),
+                                    *terminal_id,
+                                    run_command.clone(),
+                                )
+                                .with_context(err_context)?;
                             }
                         },
                         _ => Err::<(), _>(err).non_fatal(),

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use async_std::task::{self, JoinHandle};
 use std::{collections::HashMap, env, os::unix::io::RawFd, path::PathBuf};
+use zellij_utils::input::layout::SplitDirection;
 use zellij_utils::nix::unistd::Pid;
 use zellij_utils::{
     async_std,
@@ -202,11 +203,12 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                         let hold_for_command = if starts_held { run_command } else { None };
                         pty.bus
                             .senders
-                            .send_to_screen(ScreenInstruction::VerticalSplit(
+                            .send_to_screen(ScreenInstruction::Split(
                                 PaneId::Terminal(pid),
                                 pane_title,
                                 hold_for_command,
                                 client_id,
+                                SplitDirection::Vertical,
                             ))
                             .with_context(err_context)?;
                     },
@@ -216,11 +218,12 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                             if hold_on_close {
                                 pty.bus
                                     .senders
-                                    .send_to_screen(ScreenInstruction::VerticalSplit(
+                                    .send_to_screen(ScreenInstruction::Split(
                                         PaneId::Terminal(*terminal_id),
                                         pane_title,
                                         hold_for_command,
                                         client_id,
+                                        SplitDirection::Vertical,
                                     ))
                                     .with_context(err_context)?;
                                 if let Some(run_command) = run_command {
@@ -257,11 +260,12 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                         let hold_for_command = if starts_held { run_command } else { None };
                         pty.bus
                             .senders
-                            .send_to_screen(ScreenInstruction::HorizontalSplit(
+                            .send_to_screen(ScreenInstruction::Split(
                                 PaneId::Terminal(pid),
                                 pane_title,
                                 hold_for_command,
                                 client_id,
+                                SplitDirection::Horizontal,
                             ))
                             .with_context(err_context)?;
                     },
@@ -271,11 +275,12 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                 let hold_for_command = None; // we do not hold an "error" pane
                                 pty.bus
                                     .senders
-                                    .send_to_screen(ScreenInstruction::HorizontalSplit(
+                                    .send_to_screen(ScreenInstruction::Split(
                                         PaneId::Terminal(*terminal_id),
                                         pane_title,
                                         hold_for_command,
                                         client_id,
+                                        SplitDirection::Horizontal,
                                     ))
                                     .with_context(err_context)?;
                                 if let Some(run_command) = run_command {

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -15,6 +15,7 @@ use zellij_utils::{
         actions::{Action, SearchDirection, SearchOption},
         command::TerminalAction,
         get_mode_info,
+        layout::SplitDirection,
     },
     ipc::{ClientToServerMsg, ExitReason, IpcReceiverWithContext, ServerToClientMsg},
 };
@@ -252,18 +253,30 @@ pub(crate) fn route_action(
         Action::NewPane(direction, name) => {
             let shell = session.default_shell.clone();
             let pty_instr = match direction {
-                Some(Direction::Left) => {
-                    PtyInstruction::SpawnTerminalVertically(shell, name, client_id)
-                },
-                Some(Direction::Right) => {
-                    PtyInstruction::SpawnTerminalVertically(shell, name, client_id)
-                },
-                Some(Direction::Up) => {
-                    PtyInstruction::SpawnTerminalHorizontally(shell, name, client_id)
-                },
-                Some(Direction::Down) => {
-                    PtyInstruction::SpawnTerminalHorizontally(shell, name, client_id)
-                },
+                Some(Direction::Left) => PtyInstruction::SpawnSplitTerminal(
+                    shell,
+                    name,
+                    client_id,
+                    SplitDirection::Vertical,
+                ),
+                Some(Direction::Right) => PtyInstruction::SpawnSplitTerminal(
+                    shell,
+                    name,
+                    client_id,
+                    SplitDirection::Vertical,
+                ),
+                Some(Direction::Up) => PtyInstruction::SpawnSplitTerminal(
+                    shell,
+                    name,
+                    client_id,
+                    SplitDirection::Horizontal,
+                ),
+                Some(Direction::Down) => PtyInstruction::SpawnSplitTerminal(
+                    shell,
+                    name,
+                    client_id,
+                    SplitDirection::Horizontal,
+                ),
                 // No direction specified - try to put it in the biggest available spot
                 None => PtyInstruction::SpawnTerminal(
                     shell,
@@ -281,21 +294,29 @@ pub(crate) fn route_action(
             let title = format!("Editing: {}", path_to_file.display());
             let open_file = TerminalAction::OpenFile(path_to_file, line_number);
             let pty_instr = match (split_direction, should_float) {
-                (Some(Direction::Left), false) => {
-                    PtyInstruction::SpawnTerminalVertically(Some(open_file), Some(title), client_id)
-                },
-                (Some(Direction::Right), false) => {
-                    PtyInstruction::SpawnTerminalVertically(Some(open_file), Some(title), client_id)
-                },
-                (Some(Direction::Up), false) => PtyInstruction::SpawnTerminalHorizontally(
+                (Some(Direction::Left), false) => PtyInstruction::SpawnSplitTerminal(
                     Some(open_file),
                     Some(title),
                     client_id,
+                    SplitDirection::Vertical,
                 ),
-                (Some(Direction::Down), false) => PtyInstruction::SpawnTerminalHorizontally(
+                (Some(Direction::Right), false) => PtyInstruction::SpawnSplitTerminal(
                     Some(open_file),
                     Some(title),
                     client_id,
+                    SplitDirection::Vertical,
+                ),
+                (Some(Direction::Up), false) => PtyInstruction::SpawnSplitTerminal(
+                    Some(open_file),
+                    Some(title),
+                    client_id,
+                    SplitDirection::Horizontal,
+                ),
+                (Some(Direction::Down), false) => PtyInstruction::SpawnSplitTerminal(
+                    Some(open_file),
+                    Some(title),
+                    client_id,
+                    SplitDirection::Horizontal,
                 ),
                 // No direction specified or should float - defer placement to screen
                 (None, _) | (_, true) => PtyInstruction::SpawnTerminal(
@@ -350,18 +371,30 @@ pub(crate) fn route_action(
                 .map(|cmd| TerminalAction::RunCommand(cmd.into()))
                 .or_else(|| session.default_shell.clone());
             let pty_instr = match direction {
-                Some(Direction::Left) => {
-                    PtyInstruction::SpawnTerminalVertically(run_cmd, name, client_id)
-                },
-                Some(Direction::Right) => {
-                    PtyInstruction::SpawnTerminalVertically(run_cmd, name, client_id)
-                },
-                Some(Direction::Up) => {
-                    PtyInstruction::SpawnTerminalHorizontally(run_cmd, name, client_id)
-                },
-                Some(Direction::Down) => {
-                    PtyInstruction::SpawnTerminalHorizontally(run_cmd, name, client_id)
-                },
+                Some(Direction::Left) => PtyInstruction::SpawnSplitTerminal(
+                    run_cmd,
+                    name,
+                    client_id,
+                    SplitDirection::Vertical,
+                ),
+                Some(Direction::Right) => PtyInstruction::SpawnSplitTerminal(
+                    run_cmd,
+                    name,
+                    client_id,
+                    SplitDirection::Vertical,
+                ),
+                Some(Direction::Up) => PtyInstruction::SpawnSplitTerminal(
+                    run_cmd,
+                    name,
+                    client_id,
+                    SplitDirection::Horizontal,
+                ),
+                Some(Direction::Down) => PtyInstruction::SpawnSplitTerminal(
+                    run_cmd,
+                    name,
+                    client_id,
+                    SplitDirection::Horizontal,
+                ),
                 // No direction specified - try to put it in the biggest available spot
                 None => PtyInstruction::SpawnTerminal(
                     run_cmd,
@@ -405,18 +438,30 @@ pub(crate) fn route_action(
         Action::Run(command) => {
             let run_cmd = Some(TerminalAction::RunCommand(command.clone().into()));
             let pty_instr = match command.direction {
-                Some(Direction::Left) => {
-                    PtyInstruction::SpawnTerminalVertically(run_cmd, None, client_id)
-                },
-                Some(Direction::Right) => {
-                    PtyInstruction::SpawnTerminalVertically(run_cmd, None, client_id)
-                },
-                Some(Direction::Up) => {
-                    PtyInstruction::SpawnTerminalHorizontally(run_cmd, None, client_id)
-                },
-                Some(Direction::Down) => {
-                    PtyInstruction::SpawnTerminalHorizontally(run_cmd, None, client_id)
-                },
+                Some(Direction::Left) => PtyInstruction::SpawnSplitTerminal(
+                    run_cmd,
+                    None,
+                    client_id,
+                    SplitDirection::Vertical,
+                ),
+                Some(Direction::Right) => PtyInstruction::SpawnSplitTerminal(
+                    run_cmd,
+                    None,
+                    client_id,
+                    SplitDirection::Vertical,
+                ),
+                Some(Direction::Up) => PtyInstruction::SpawnSplitTerminal(
+                    run_cmd,
+                    None,
+                    client_id,
+                    SplitDirection::Horizontal,
+                ),
+                Some(Direction::Down) => PtyInstruction::SpawnSplitTerminal(
+                    run_cmd,
+                    None,
+                    client_id,
+                    SplitDirection::Horizontal,
+                ),
                 // No direction specified - try to put it in the biggest available spot
                 None => PtyInstruction::SpawnTerminal(
                     run_cmd,

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -12,7 +12,7 @@ use zellij_utils::input::options::Clipboard;
 use zellij_utils::pane_size::{Size, SizeInPixels};
 use zellij_utils::{
     input::command::TerminalAction,
-    input::layout::{FloatingPanesLayout, PaneLayout, RunPluginLocation},
+    input::layout::{FloatingPanesLayout, PaneLayout, RunPluginLocation, SplitDirection},
     position::Position,
 };
 
@@ -1491,7 +1491,7 @@ pub(crate) fn screen_thread_main(
                 active_tab_and_connected_client_id!(
                     screen,
                     client_id,
-                    |tab: &mut Tab, client_id: ClientId| tab.horizontal_split(pid, initial_pane_title, client_id),
+                    |tab: &mut Tab, client_id: ClientId| tab.split(pid, initial_pane_title, client_id, SplitDirection::Horizontal),
                     ?
                 );
                 if let Some(hold_for_command) = hold_for_command {
@@ -1520,7 +1520,7 @@ pub(crate) fn screen_thread_main(
                 active_tab_and_connected_client_id!(
                     screen,
                     client_id,
-                    |tab: &mut Tab, client_id: ClientId| tab.vertical_split(pid, initial_pane_title, client_id),
+                    |tab: &mut Tab, client_id: ClientId| tab.split(pid, initial_pane_title, client_id, SplitDirection::Vertical),
                     ?
                 );
                 if let Some(hold_for_command) = hold_for_command {

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -938,8 +938,12 @@ impl Tab {
                     self.terminal_emulator_color_codes.clone(),
                     initial_pane_title,
                 );
-                self.tiled_panes
-                    .split_pane_horizontally(pid, Box::new(new_terminal), client_id);
+                self.tiled_panes.split_pane(
+                    pid,
+                    Box::new(new_terminal),
+                    client_id,
+                    SplitDirection::Horizontal,
+                );
                 self.should_clear_display_before_rendering = true;
                 self.tiled_panes.focus_pane(pid, client_id);
             }
@@ -995,8 +999,12 @@ impl Tab {
                     self.terminal_emulator_color_codes.clone(),
                     initial_pane_title,
                 );
-                self.tiled_panes
-                    .split_pane_vertically(pid, Box::new(new_terminal), client_id);
+                self.tiled_panes.split_pane(
+                    pid,
+                    Box::new(new_terminal),
+                    client_id,
+                    SplitDirection::Vertical,
+                );
                 self.should_clear_display_before_rendering = true;
                 self.tiled_panes.focus_pane(pid, client_id);
             }

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -10,7 +10,7 @@ use std::env::temp_dir;
 use uuid::Uuid;
 use zellij_utils::data::{Direction, ResizeStrategy};
 use zellij_utils::errors::prelude::*;
-use zellij_utils::input::command::RunCommand;
+use zellij_utils::input::{command::RunCommand, layout::SplitDirection};
 use zellij_utils::position::{Column, Line};
 use zellij_utils::{position::Position, serde};
 
@@ -919,7 +919,10 @@ impl Tab {
         if self.tiled_panes.fullscreen_is_active() {
             self.toggle_active_pane_fullscreen(client_id);
         }
-        if self.tiled_panes.can_split_pane_horizontally(client_id) {
+        if self
+            .tiled_panes
+            .can_split_pane(SplitDirection::Horizontal, client_id)
+        {
             if let PaneId::Terminal(term_pid) = pid {
                 let next_terminal_position = self.get_next_terminal_position();
                 let new_terminal = TerminalPane::new(
@@ -973,7 +976,10 @@ impl Tab {
         if self.tiled_panes.fullscreen_is_active() {
             self.toggle_active_pane_fullscreen(client_id);
         }
-        if self.tiled_panes.can_split_pane_vertically(client_id) {
+        if self
+            .tiled_panes
+            .can_split_pane(SplitDirection::Vertical, client_id)
+        {
             if let PaneId::Terminal(term_pid) = pid {
                 let next_terminal_position = self.get_next_terminal_position();
                 let new_terminal = TerminalPane::new(

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -305,7 +305,8 @@ fn write_to_suppressed_pane() {
         rows: 20,
     };
     let mut tab = create_new_tab(size);
-    tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Vertical)
+        .unwrap();
 
     // Suppress pane 2 and remove it from active panes
     tab.suppress_active_pane(PaneId::Terminal(2), 1).unwrap();
@@ -326,7 +327,8 @@ fn split_panes_vertically() {
     };
     let mut tab = create_new_tab(size);
     let new_pane_id = PaneId::Terminal(2);
-    tab.vertical_split(new_pane_id, None, 1).unwrap();
+    tab.split(new_pane_id, None, 1, SplitDirection::Vertical)
+        .unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 2, "The tab has two panes");
     assert_eq!(
         tab.tiled_panes
@@ -422,7 +424,8 @@ fn split_panes_horizontally() {
     };
     let mut tab = create_new_tab(size);
     let new_pane_id = PaneId::Terminal(2);
-    tab.horizontal_split(new_pane_id, None, 1).unwrap();
+    tab.split(new_pane_id, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 2, "The tab has two panes");
 
     assert_eq!(
@@ -702,7 +705,8 @@ fn split_largest_pane() {
 pub fn cannot_split_panes_vertically_when_active_pane_is_too_small() {
     let size = Size { cols: 8, rows: 20 };
     let mut tab = create_new_tab(size);
-    tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Vertical)
+        .unwrap();
     assert_eq!(
         tab.tiled_panes.panes.len(),
         1,
@@ -714,7 +718,8 @@ pub fn cannot_split_panes_vertically_when_active_pane_is_too_small() {
 pub fn cannot_split_panes_horizontally_when_active_pane_is_too_small() {
     let size = Size { cols: 121, rows: 4 };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     assert_eq!(
         tab.tiled_panes.panes.len(),
         1,
@@ -744,7 +749,8 @@ pub fn cannot_split_panes_vertically_when_active_pane_has_fixed_columns() {
     fixed_child.split_size = Some(SplitSize::Fixed(30));
     initial_layout.children = vec![fixed_child, PaneLayout::default()];
     let mut tab = create_new_tab_with_layout(size, initial_layout);
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 2, "Tab still has two panes");
 }
 
@@ -757,7 +763,8 @@ pub fn cannot_split_panes_horizontally_when_active_pane_has_fixed_rows() {
     fixed_child.split_size = Some(SplitSize::Fixed(12));
     initial_layout.children = vec![fixed_child, PaneLayout::default()];
     let mut tab = create_new_tab_with_layout(size, initial_layout);
-    tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 2, "Tab still has two panes");
 }
 
@@ -929,7 +936,8 @@ pub fn close_pane_with_another_pane_above_it() {
     };
     let mut tab = create_new_tab(size);
     let new_pane_id = PaneId::Terminal(2);
-    tab.horizontal_split(new_pane_id, None, 1).unwrap();
+    tab.split(new_pane_id, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.close_focused_pane(1).unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 1, "One pane left in tab");
 
@@ -994,7 +1002,8 @@ pub fn close_pane_with_another_pane_below_it() {
     };
     let mut tab = create_new_tab(size);
     let new_pane_id = PaneId::Terminal(2);
-    tab.horizontal_split(new_pane_id, None, 1).unwrap();
+    tab.split(new_pane_id, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab.close_focused_pane(1).unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 1, "One pane left in tab");
@@ -1057,7 +1066,8 @@ pub fn close_pane_with_another_pane_to_the_left() {
     };
     let mut tab = create_new_tab(size);
     let new_pane_id = PaneId::Terminal(2);
-    tab.vertical_split(new_pane_id, None, 1).unwrap();
+    tab.split(new_pane_id, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.close_focused_pane(1).unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 1, "One pane left in tab");
 
@@ -1119,7 +1129,8 @@ pub fn close_pane_with_another_pane_to_the_right() {
     };
     let mut tab = create_new_tab(size);
     let new_pane_id = PaneId::Terminal(2);
-    tab.vertical_split(new_pane_id, None, 1).unwrap();
+    tab.split(new_pane_id, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab.close_focused_pane(1).unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 1, "One pane left in tab");
@@ -1185,9 +1196,11 @@ pub fn close_pane_with_multiple_panes_above_it() {
     let mut tab = create_new_tab(size);
     let new_pane_id_1 = PaneId::Terminal(2);
     let new_pane_id_2 = PaneId::Terminal(3);
-    tab.horizontal_split(new_pane_id_1, None, 1).unwrap();
+    tab.split(new_pane_id_1, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(new_pane_id_2, None, 1).unwrap();
+    tab.split(new_pane_id_2, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
     tab.close_focused_pane(1).unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 2, "Two panes left in tab");
@@ -1296,8 +1309,10 @@ pub fn close_pane_with_multiple_panes_below_it() {
     let mut tab = create_new_tab(size);
     let new_pane_id_1 = PaneId::Terminal(2);
     let new_pane_id_2 = PaneId::Terminal(3);
-    tab.horizontal_split(new_pane_id_1, None, 1).unwrap();
-    tab.vertical_split(new_pane_id_2, None, 1).unwrap();
+    tab.split(new_pane_id_1, None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(new_pane_id_2, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab.close_focused_pane(1).unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 2, "Two panes left in tab");
@@ -1406,9 +1421,11 @@ pub fn close_pane_with_multiple_panes_to_the_left() {
     let mut tab = create_new_tab(size);
     let new_pane_id_1 = PaneId::Terminal(2);
     let new_pane_id_2 = PaneId::Terminal(3);
-    tab.vertical_split(new_pane_id_1, None, 1).unwrap();
+    tab.split(new_pane_id_1, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
-    tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
+    tab.split(new_pane_id_2, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_right(1).unwrap();
     tab.close_focused_pane(1).unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 2, "Two panes left in tab");
@@ -1517,8 +1534,10 @@ pub fn close_pane_with_multiple_panes_to_the_right() {
     let mut tab = create_new_tab(size);
     let new_pane_id_1 = PaneId::Terminal(2);
     let new_pane_id_2 = PaneId::Terminal(3);
-    tab.vertical_split(new_pane_id_1, None, 1).unwrap();
-    tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
+    tab.split(new_pane_id_1, None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(new_pane_id_2, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab.close_focused_pane(1).unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 2, "Two panes left in tab");
@@ -1632,19 +1651,25 @@ pub fn close_pane_with_multiple_panes_above_it_away_from_screen_edges() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let new_pane_id_6 = PaneId::Terminal(7);
 
-    tab.vertical_split(new_pane_id_1, None, 1).unwrap();
-    tab.vertical_split(new_pane_id_2, None, 1).unwrap();
+    tab.split(new_pane_id_1, None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(new_pane_id_2, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab.move_focus_left(1).unwrap();
-    tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
+    tab.split(new_pane_id_3, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_right(1).unwrap();
-    tab.horizontal_split(new_pane_id_4, None, 1).unwrap();
+    tab.split(new_pane_id_4, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_right(1).unwrap();
-    tab.horizontal_split(new_pane_id_5, None, 1).unwrap();
+    tab.split(new_pane_id_5, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab.move_focus_up(1).unwrap();
     tab_resize_down(&mut tab, 1);
-    tab.vertical_split(new_pane_id_6, None, 1).unwrap();
+    tab.split(new_pane_id_6, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
     tab.close_focused_pane(1).unwrap();
 
@@ -1932,18 +1957,24 @@ pub fn close_pane_with_multiple_panes_below_it_away_from_screen_edges() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let new_pane_id_6 = PaneId::Terminal(7);
 
-    tab.vertical_split(new_pane_id_1, None, 1).unwrap();
-    tab.vertical_split(new_pane_id_2, None, 1).unwrap();
+    tab.split(new_pane_id_1, None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(new_pane_id_2, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab.move_focus_left(1).unwrap();
-    tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
+    tab.split(new_pane_id_3, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_right(1).unwrap();
-    tab.horizontal_split(new_pane_id_4, None, 1).unwrap();
+    tab.split(new_pane_id_4, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_right(1).unwrap();
-    tab.horizontal_split(new_pane_id_5, None, 1).unwrap();
+    tab.split(new_pane_id_5, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_up(&mut tab, 1);
-    tab.vertical_split(new_pane_id_6, None, 1).unwrap();
+    tab.split(new_pane_id_6, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab.close_focused_pane(1).unwrap();
 
@@ -2233,21 +2264,27 @@ pub fn close_pane_with_multiple_panes_to_the_left_away_from_screen_edges() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let new_pane_id_6 = PaneId::Terminal(7);
 
-    tab.horizontal_split(new_pane_id_1, None, 1).unwrap();
-    tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
+    tab.split(new_pane_id_1, None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(new_pane_id_2, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(new_pane_id_3, None, 1).unwrap();
+    tab.split(new_pane_id_3, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
-    tab.vertical_split(new_pane_id_4, None, 1).unwrap();
+    tab.split(new_pane_id_4, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
-    tab.vertical_split(new_pane_id_5, None, 1).unwrap();
+    tab.split(new_pane_id_5, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_right(&mut tab, 1);
     tab_resize_up(&mut tab, 1);
     tab_resize_up(&mut tab, 1);
-    tab.horizontal_split(new_pane_id_6, None, 1).unwrap();
+    tab.split(new_pane_id_6, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_right(1).unwrap();
     tab.close_focused_pane(1).unwrap();
 
@@ -2537,20 +2574,26 @@ pub fn close_pane_with_multiple_panes_to_the_right_away_from_screen_edges() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let new_pane_id_6 = PaneId::Terminal(7);
 
-    tab.horizontal_split(new_pane_id_1, None, 1).unwrap();
-    tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
+    tab.split(new_pane_id_1, None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(new_pane_id_2, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(new_pane_id_3, None, 1).unwrap();
+    tab.split(new_pane_id_3, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
-    tab.vertical_split(new_pane_id_4, None, 1).unwrap();
+    tab.split(new_pane_id_4, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
-    tab.vertical_split(new_pane_id_5, None, 1).unwrap();
+    tab.split(new_pane_id_5, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab_resize_left(&mut tab, 1);
     tab_resize_up(&mut tab, 1);
     tab_resize_up(&mut tab, 1);
-    tab.horizontal_split(new_pane_id_6, None, 1).unwrap();
+    tab.split(new_pane_id_6, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab.close_focused_pane(1).unwrap();
 
@@ -2824,7 +2867,8 @@ pub fn move_focus_down() {
     let mut tab = create_new_tab(size);
     let new_pane_id = PaneId::Terminal(2);
 
-    tab.horizontal_split(new_pane_id, None, 1).unwrap();
+    tab.split(new_pane_id, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab.move_focus_down(1).unwrap();
 
@@ -2846,9 +2890,12 @@ pub fn move_focus_down_to_the_most_recently_used_pane() {
     let new_pane_id_2 = PaneId::Terminal(3);
     let new_pane_id_3 = PaneId::Terminal(4);
 
-    tab.horizontal_split(new_pane_id_1, None, 1).unwrap();
-    tab.vertical_split(new_pane_id_2, None, 1).unwrap();
-    tab.vertical_split(new_pane_id_3, None, 1).unwrap();
+    tab.split(new_pane_id_1, None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(new_pane_id_2, None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(new_pane_id_3, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab.move_focus_down(1).unwrap();
 
@@ -2873,7 +2920,8 @@ pub fn move_focus_up() {
     let mut tab = create_new_tab(size);
     let new_pane_id = PaneId::Terminal(2);
 
-    tab.horizontal_split(new_pane_id, None, 1).unwrap();
+    tab.split(new_pane_id, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
 
     assert_eq!(
@@ -2894,10 +2942,13 @@ pub fn move_focus_up_to_the_most_recently_used_pane() {
     let new_pane_id_2 = PaneId::Terminal(3);
     let new_pane_id_3 = PaneId::Terminal(4);
 
-    tab.horizontal_split(new_pane_id_1, None, 1).unwrap();
+    tab.split(new_pane_id_1, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(new_pane_id_2, None, 1).unwrap();
-    tab.vertical_split(new_pane_id_3, None, 1).unwrap();
+    tab.split(new_pane_id_2, None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(new_pane_id_3, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
     tab.move_focus_up(1).unwrap();
 
@@ -2922,7 +2973,8 @@ pub fn move_focus_left() {
     let mut tab = create_new_tab(size);
     let new_pane_id = PaneId::Terminal(2);
 
-    tab.vertical_split(new_pane_id, None, 1).unwrap();
+    tab.split(new_pane_id, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
 
     assert_eq!(
@@ -2943,10 +2995,13 @@ pub fn move_focus_left_to_the_most_recently_used_pane() {
     let new_pane_id_2 = PaneId::Terminal(3);
     let new_pane_id_3 = PaneId::Terminal(4);
 
-    tab.vertical_split(new_pane_id_1, None, 1).unwrap();
+    tab.split(new_pane_id_1, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
-    tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
-    tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
+    tab.split(new_pane_id_2, None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(new_pane_id_3, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_right(1).unwrap();
     tab.move_focus_left(1).unwrap();
 
@@ -2971,7 +3026,8 @@ pub fn move_focus_right() {
     let mut tab = create_new_tab(size);
     let new_pane_id = PaneId::Terminal(2);
 
-    tab.vertical_split(new_pane_id, None, 1).unwrap();
+    tab.split(new_pane_id, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab.move_focus_right(1).unwrap();
 
@@ -2993,9 +3049,12 @@ pub fn move_focus_right_to_the_most_recently_used_pane() {
     let new_pane_id_2 = PaneId::Terminal(3);
     let new_pane_id_3 = PaneId::Terminal(4);
 
-    tab.vertical_split(new_pane_id_1, None, 1).unwrap();
-    tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
-    tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
+    tab.split(new_pane_id_1, None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(new_pane_id_2, None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(new_pane_id_3, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab.move_focus_right(1).unwrap();
 
@@ -3020,7 +3079,8 @@ pub fn move_active_pane_down() {
     let mut tab = create_new_tab(size);
     let new_pane_id = PaneId::Terminal(2);
 
-    tab.horizontal_split(new_pane_id, None, 1).unwrap();
+    tab.split(new_pane_id, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab.move_active_pane_down(1);
 
@@ -3047,9 +3107,12 @@ pub fn move_active_pane_down_to_the_most_recently_used_position() {
     let new_pane_id_2 = PaneId::Terminal(3);
     let new_pane_id_3 = PaneId::Terminal(4);
 
-    tab.horizontal_split(new_pane_id_1, None, 1).unwrap();
-    tab.vertical_split(new_pane_id_2, None, 1).unwrap();
-    tab.vertical_split(new_pane_id_3, None, 1).unwrap();
+    tab.split(new_pane_id_1, None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(new_pane_id_2, None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(new_pane_id_3, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab.move_active_pane_down(1);
 
@@ -3079,7 +3142,8 @@ pub fn move_active_pane_up() {
     let mut tab = create_new_tab(size);
     let new_pane_id = PaneId::Terminal(2);
 
-    tab.horizontal_split(new_pane_id, None, 1).unwrap();
+    tab.split(new_pane_id, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_active_pane_up(1);
 
     assert_eq!(
@@ -3105,10 +3169,13 @@ pub fn move_active_pane_up_to_the_most_recently_used_position() {
     let new_pane_id_2 = PaneId::Terminal(3);
     let new_pane_id_3 = PaneId::Terminal(4);
 
-    tab.horizontal_split(new_pane_id_1, None, 1).unwrap();
+    tab.split(new_pane_id_1, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(new_pane_id_2, None, 1).unwrap();
-    tab.vertical_split(new_pane_id_3, None, 1).unwrap();
+    tab.split(new_pane_id_2, None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(new_pane_id_3, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
     tab.move_active_pane_up(1);
 
@@ -3139,7 +3206,8 @@ pub fn move_active_pane_left() {
     let mut tab = create_new_tab(size);
     let new_pane_id = PaneId::Terminal(2);
 
-    tab.vertical_split(new_pane_id, None, 1).unwrap();
+    tab.split(new_pane_id, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_active_pane_left(1);
 
     assert_eq!(
@@ -3165,10 +3233,13 @@ pub fn move_active_pane_left_to_the_most_recently_used_position() {
     let new_pane_id_2 = PaneId::Terminal(3);
     let new_pane_id_3 = PaneId::Terminal(4);
 
-    tab.vertical_split(new_pane_id_1, None, 1).unwrap();
+    tab.split(new_pane_id_1, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
-    tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
-    tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
+    tab.split(new_pane_id_2, None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(new_pane_id_3, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_right(1).unwrap();
     tab.move_active_pane_left(1);
 
@@ -3199,7 +3270,8 @@ pub fn move_active_pane_right() {
     let mut tab = create_new_tab(size);
     let new_pane_id = PaneId::Terminal(2);
 
-    tab.vertical_split(new_pane_id, None, 1).unwrap();
+    tab.split(new_pane_id, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab.move_active_pane_right(1);
 
@@ -3226,9 +3298,12 @@ pub fn move_active_pane_right_to_the_most_recently_used_position() {
     let new_pane_id_2 = PaneId::Terminal(3);
     let new_pane_id_3 = PaneId::Terminal(4);
 
-    tab.vertical_split(new_pane_id_1, None, 1).unwrap();
-    tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
-    tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
+    tab.split(new_pane_id_1, None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(new_pane_id_2, None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(new_pane_id_3, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab.move_active_pane_right(1);
 
@@ -3266,7 +3341,8 @@ pub fn resize_down_with_pane_above() {
     };
     let mut tab = create_new_tab(size);
     let new_pane_id = PaneId::Terminal(2);
-    tab.horizontal_split(new_pane_id, None, 1).unwrap();
+    tab.split(new_pane_id, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab_resize_down(&mut tab, 1);
 
     assert_eq!(
@@ -3372,7 +3448,8 @@ pub fn resize_down_with_pane_below() {
     };
     let mut tab = create_new_tab(size);
     let new_pane_id = PaneId::Terminal(2);
-    tab.horizontal_split(new_pane_id, None, 1).unwrap();
+    tab.split(new_pane_id, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab_resize_down(&mut tab, 1);
 
@@ -3485,8 +3562,10 @@ pub fn resize_down_with_panes_above_and_below() {
     let first_pane_id = PaneId::Terminal(1);
     let new_pane_id_1 = PaneId::Terminal(2);
     let new_pane_id_2 = PaneId::Terminal(3);
-    tab.horizontal_split(new_pane_id_1, None, 1).unwrap();
-    tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
+    tab.split(new_pane_id_1, None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(new_pane_id_2, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab_resize_down(&mut tab, 1);
 
@@ -3638,9 +3717,11 @@ pub fn resize_down_with_multiple_panes_above() {
     let first_pane_id = PaneId::Terminal(1);
     let new_pane_id_1 = PaneId::Terminal(2);
     let new_pane_id_2 = PaneId::Terminal(3);
-    tab.horizontal_split(new_pane_id_1, None, 1).unwrap();
+    tab.split(new_pane_id_1, None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(new_pane_id_2, None, 1).unwrap();
+    tab.split(new_pane_id_2, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
     tab_resize_down(&mut tab, 1);
 
@@ -3793,10 +3874,13 @@ pub fn resize_down_with_panes_above_aligned_left_with_current_pane() {
     let pane_to_the_left = PaneId::Terminal(2);
     let focused_pane = PaneId::Terminal(3);
     let pane_above = PaneId::Terminal(4);
-    tab.horizontal_split(pane_to_the_left, None, 1).unwrap();
-    tab.vertical_split(focused_pane, None, 1).unwrap();
+    tab.split(pane_to_the_left, None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(focused_pane, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(pane_above, None, 1).unwrap();
+    tab.split(pane_above, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
     tab_resize_down(&mut tab, 1);
 
@@ -3993,10 +4077,13 @@ pub fn resize_down_with_panes_below_aligned_left_with_current_pane() {
     let pane_below_and_left = PaneId::Terminal(2);
     let pane_below = PaneId::Terminal(3);
     let focused_pane = PaneId::Terminal(4);
-    tab.horizontal_split(pane_below_and_left, None, 1).unwrap();
-    tab.vertical_split(pane_below, None, 1).unwrap();
+    tab.split(pane_below_and_left, None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(pane_below, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(focused_pane, None, 1).unwrap();
+    tab.split(focused_pane, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab_resize_down(&mut tab, 1);
 
     assert_eq!(
@@ -4192,10 +4279,13 @@ pub fn resize_down_with_panes_above_aligned_right_with_current_pane() {
     let focused_pane = PaneId::Terminal(2);
     let pane_to_the_right = PaneId::Terminal(3);
     let pane_above_and_right = PaneId::Terminal(4);
-    tab.horizontal_split(focused_pane, None, 1).unwrap();
-    tab.vertical_split(pane_to_the_right, None, 1).unwrap();
+    tab.split(focused_pane, None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(pane_to_the_right, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(pane_above_and_right, None, 1).unwrap();
+    tab.split(pane_above_and_right, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_down(&mut tab, 1);
@@ -4393,10 +4483,13 @@ pub fn resize_down_with_panes_below_aligned_right_with_current_pane() {
     let pane_below = PaneId::Terminal(2);
     let pane_below_and_right = PaneId::Terminal(3);
     let pane_to_the_right = PaneId::Terminal(4);
-    tab.horizontal_split(pane_below, None, 1).unwrap();
-    tab.vertical_split(pane_below_and_right, None, 1).unwrap();
+    tab.split(pane_below, None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(pane_below_and_right, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(pane_to_the_right, None, 1).unwrap();
+    tab.split(pane_to_the_right, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_down(&mut tab, 1);
 
@@ -4589,12 +4682,17 @@ pub fn resize_down_with_panes_above_aligned_left_and_right_with_current_pane() {
         rows: 30,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
+    tab.split(PaneId::Terminal(5), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(6), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab.move_focus_down(1).unwrap();
     tab_resize_down(&mut tab, 1);
@@ -4874,12 +4972,17 @@ pub fn resize_down_with_panes_below_aligned_left_and_right_with_current_pane() {
         rows: 30,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
+    tab.split(PaneId::Terminal(5), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(6), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_down(&mut tab, 1);
 
@@ -5158,16 +5261,23 @@ pub fn resize_down_with_panes_above_aligned_left_and_right_with_panes_to_the_lef
         rows: 30,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
+    tab.split(PaneId::Terminal(5), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(6), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(7), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(8), None, 1).unwrap();
+    tab.split(PaneId::Terminal(7), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(8), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_down(&mut tab, 1);
 
@@ -5532,16 +5642,23 @@ pub fn resize_down_with_panes_below_aligned_left_and_right_with_to_the_left_and_
         rows: 30,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
+    tab.split(PaneId::Terminal(5), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(6), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(7), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(8), None, 1).unwrap();
+    tab.split(PaneId::Terminal(7), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(8), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab.move_focus_up(1).unwrap();
     tab.move_focus_left(1).unwrap();
@@ -5906,7 +6023,8 @@ pub fn cannot_resize_down_when_pane_below_is_at_minimum_height() {
         rows: 10,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab_resize_down(&mut tab, 1);
 
@@ -6086,7 +6204,8 @@ pub fn resize_left_with_pane_to_the_left() {
         rows: 20,
     };
     let mut tab = create_new_tab(size);
-    tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab_resize_left(&mut tab, 1);
 
     assert_eq!(
@@ -6189,7 +6308,8 @@ pub fn resize_left_with_pane_to_the_right() {
         rows: 20,
     };
     let mut tab = create_new_tab(size);
-    tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_left(&mut tab, 1);
 
@@ -6294,8 +6414,10 @@ pub fn resize_left_with_panes_to_the_left_and_right() {
         rows: 20,
     };
     let mut tab = create_new_tab(size);
-    tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_left(&mut tab, 1);
 
@@ -6442,9 +6564,11 @@ pub fn resize_left_with_multiple_panes_to_the_left() {
         rows: 20,
     };
     let mut tab = create_new_tab(size);
-    tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_right(1).unwrap();
     tab_resize_left(&mut tab, 1);
 
@@ -6592,10 +6716,13 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_with_current_pane() {
         rows: 30,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
     tab_resize_left(&mut tab, 1);
 
@@ -6786,10 +6913,13 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_with_current_pane() {
         rows: 30,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_left(&mut tab, 1);
@@ -6981,10 +7111,13 @@ pub fn resize_left_with_panes_to_the_left_aligned_bottom_with_current_pane() {
         rows: 30,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab_resize_left(&mut tab, 1);
 
     assert_eq!(
@@ -7174,10 +7307,13 @@ pub fn resize_left_with_panes_to_the_right_aligned_bottom_with_current_pane() {
         rows: 30,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_left(&mut tab, 1);
 
@@ -7370,13 +7506,18 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_and_bottom_with_current_pa
         rows: 30,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
+    tab.split(PaneId::Terminal(5), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
+    tab.split(PaneId::Terminal(6), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
     tab_resize_left(&mut tab, 1);
 
@@ -7655,13 +7796,18 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_and_bottom_with_current_p
         rows: 30,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
+    tab.split(PaneId::Terminal(5), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
+    tab.split(PaneId::Terminal(6), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_left(&mut tab, 1);
@@ -7941,17 +8087,24 @@ pub fn resize_left_with_panes_to_the_left_aligned_top_and_bottom_with_panes_abov
         rows: 70,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
+    tab.split(PaneId::Terminal(5), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
     tab_resize_down(&mut tab, 1);
-    tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(7), None, 1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(8), None, 1).unwrap();
+    tab.split(PaneId::Terminal(6), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(7), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(8), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab_resize_left(&mut tab, 1);
 
@@ -8316,18 +8469,25 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_and_bottom_with_panes_abo
         rows: 70,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
+    tab.split(PaneId::Terminal(5), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
     tab_resize_down(&mut tab, 1);
-    tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
+    tab.split(PaneId::Terminal(6), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(7), None, 1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(8), None, 1).unwrap();
+    tab.split(PaneId::Terminal(7), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(8), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab_resize_left(&mut tab, 1);
 
@@ -8687,7 +8847,8 @@ pub fn cannot_resize_left_when_pane_to_the_left_is_at_minimum_width() {
 
     let size = Size { cols: 10, rows: 20 };
     let mut tab = create_new_tab(size);
-    tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab_resize_left(&mut tab, 1);
 
     assert_eq!(
@@ -8728,7 +8889,8 @@ pub fn resize_right_with_pane_to_the_left() {
         rows: 20,
     };
     let mut tab = create_new_tab(size);
-    tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab_resize_right(&mut tab, 1);
 
     assert_eq!(
@@ -8832,7 +8994,8 @@ pub fn resize_right_with_pane_to_the_right() {
         rows: 20,
     };
     let mut tab = create_new_tab(size);
-    tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_right(&mut tab, 1);
 
@@ -8937,8 +9100,10 @@ pub fn resize_right_with_panes_to_the_left_and_right() {
         rows: 20,
     };
     let mut tab = create_new_tab(size);
-    tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_right(&mut tab, 1);
 
@@ -9086,9 +9251,11 @@ pub fn resize_right_with_multiple_panes_to_the_left() {
         rows: 20,
     };
     let mut tab = create_new_tab(size);
-    tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_right(1).unwrap();
     tab_resize_right(&mut tab, 1);
 
@@ -9236,11 +9403,14 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_with_current_pane() {
         rows: 20,
     };
     let mut tab = create_new_tab(size);
-    tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_right(1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab_resize_right(&mut tab, 1);
 
     assert_eq!(
@@ -9429,11 +9599,14 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_with_current_pane() {
         rows: 20,
     };
     let mut tab = create_new_tab(size);
-    tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_right(1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_right(&mut tab, 1);
 
@@ -9624,11 +9797,14 @@ pub fn resize_right_with_panes_to_the_left_aligned_bottom_with_current_pane() {
         rows: 20,
     };
     let mut tab = create_new_tab(size);
-    tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_right(1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab_resize_right(&mut tab, 1);
 
@@ -9819,11 +9995,14 @@ pub fn resize_right_with_panes_to_the_right_aligned_bottom_with_current_pane() {
         rows: 20,
     };
     let mut tab = create_new_tab(size);
-    tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_right(1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_right(&mut tab, 1);
@@ -10017,13 +10196,18 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_and_bottom_with_current_p
         rows: 20,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
+    tab.split(PaneId::Terminal(5), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
+    tab.split(PaneId::Terminal(6), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
     tab_resize_right(&mut tab, 1);
 
@@ -10301,13 +10485,18 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_and_bottom_with_current_
         rows: 20,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
+    tab.split(PaneId::Terminal(5), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
+    tab.split(PaneId::Terminal(6), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_right(&mut tab, 1);
@@ -10586,17 +10775,24 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_and_bottom_with_panes_abo
         rows: 70,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
+    tab.split(PaneId::Terminal(5), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
     tab_resize_up(&mut tab, 1);
-    tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(7), None, 1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(8), None, 1).unwrap();
+    tab.split(PaneId::Terminal(6), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(7), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(8), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab_resize_right(&mut tab, 1);
 
@@ -10960,18 +11156,25 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_and_bottom_with_panes_ab
         rows: 70,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
+    tab.split(PaneId::Terminal(5), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
     tab_resize_up(&mut tab, 1);
-    tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
+    tab.split(PaneId::Terminal(6), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(7), None, 1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(8), None, 1).unwrap();
+    tab.split(PaneId::Terminal(7), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(8), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab_resize_right(&mut tab, 1);
 
@@ -11330,7 +11533,8 @@ pub fn cannot_resize_right_when_pane_to_the_left_is_at_minimum_width() {
     // █ == focused pane
     let size = Size { cols: 10, rows: 20 };
     let mut tab = create_new_tab(size);
-    tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab_resize_right(&mut tab, 1);
 
     assert_eq!(
@@ -11418,7 +11622,8 @@ pub fn resize_up_with_pane_above() {
         rows: 20,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab_resize_up(&mut tab, 1);
 
     assert_eq!(
@@ -11523,7 +11728,8 @@ pub fn resize_up_with_pane_below() {
         rows: 20,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab_resize_up(&mut tab, 1);
 
@@ -11632,8 +11838,10 @@ pub fn resize_up_with_panes_above_and_below() {
         rows: 30,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab_resize_up(&mut tab, 1);
 
@@ -11781,9 +11989,11 @@ pub fn resize_up_with_multiple_panes_above() {
         rows: 30,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
     tab_resize_up(&mut tab, 1);
 
@@ -11930,11 +12140,14 @@ pub fn resize_up_with_panes_above_aligned_left_with_current_pane() {
         rows: 30,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab_resize_up(&mut tab, 1);
 
     assert_eq!(
@@ -12125,11 +12338,14 @@ pub fn resize_up_with_panes_below_aligned_left_with_current_pane() {
         rows: 30,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab_resize_up(&mut tab, 1);
 
@@ -12321,11 +12537,14 @@ pub fn resize_up_with_panes_above_aligned_right_with_current_pane() {
         rows: 30,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_up(&mut tab, 1);
 
@@ -12517,11 +12736,14 @@ pub fn resize_up_with_panes_below_aligned_right_with_current_pane() {
         rows: 30,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab.move_focus_up(1).unwrap();
     tab_resize_up(&mut tab, 1);
@@ -12714,12 +12936,17 @@ pub fn resize_up_with_panes_above_aligned_left_and_right_with_current_pane() {
         rows: 30,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
+    tab.split(PaneId::Terminal(5), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(6), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_up(&mut tab, 1);
 
@@ -12997,12 +13224,17 @@ pub fn resize_up_with_panes_below_aligned_left_and_right_with_current_pane() {
         rows: 30,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
+    tab.split(PaneId::Terminal(5), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(6), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab.move_focus_up(1).unwrap();
     tab_resize_up(&mut tab, 1);
@@ -13281,16 +13513,23 @@ pub fn resize_up_with_panes_above_aligned_left_and_right_with_panes_to_the_left_
         rows: 30,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
+    tab.split(PaneId::Terminal(5), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(6), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(7), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(8), None, 1).unwrap();
+    tab.split(PaneId::Terminal(7), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(8), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_up(&mut tab, 1);
 
@@ -13654,17 +13893,24 @@ pub fn resize_up_with_panes_below_aligned_left_and_right_with_to_the_left_and_ri
         rows: 30,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(4), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_down(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
+    tab.split(PaneId::Terminal(5), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(6), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_up(1).unwrap();
     tab.move_focus_left(1).unwrap();
-    tab.vertical_split(PaneId::Terminal(7), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(8), None, 1).unwrap();
+    tab.split(PaneId::Terminal(7), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(8), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_up(&mut tab, 1);
 
@@ -14027,7 +14273,8 @@ pub fn cannot_resize_up_when_pane_above_is_at_minimum_height() {
         rows: 10,
     };
     let mut tab = create_new_tab(size);
-    tab.horizontal_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab_resize_down(&mut tab, 1);
 
     assert_eq!(
@@ -14084,7 +14331,8 @@ pub fn nondirectional_resize_increase_with_1_pane_to_left() {
     };
     let mut tab = create_new_tab(size);
     let new_pane_id_1 = PaneId::Terminal(2);
-    tab.vertical_split(new_pane_id_1, None, 1).unwrap();
+    tab.split(new_pane_id_1, None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab_resize_increase(&mut tab, 1);
 
     // should behave like `resize_left_with_pane_to_the_left`
@@ -14117,9 +14365,11 @@ pub fn nondirectional_resize_increase_with_2_panes_to_left() {
         rows: 20,
     };
     let mut tab = create_new_tab(size);
-    tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab.move_focus_right(1).unwrap();
     tab_resize_increase(&mut tab, 1);
 
@@ -14175,9 +14425,11 @@ pub fn nondirectional_resize_increase_with_1_pane_to_right_1_pane_above() {
         rows: 20,
     };
     let mut tab = create_new_tab(size);
-    tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
-    tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Horizontal)
+        .unwrap();
     tab_resize_increase(&mut tab, 1);
 
     assert_eq!(
@@ -14231,8 +14483,10 @@ pub fn nondirectional_resize_increase_with_1_pane_to_right_1_pane_to_left() {
         rows: 20,
     };
     let mut tab = create_new_tab(size);
-    tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_increase(&mut tab, 1);
 
@@ -14287,8 +14541,10 @@ pub fn nondirectional_resize_increase_with_pane_above_aligned_right_with_current
         rows: 20,
     };
     let mut tab = create_new_tab(size);
-    tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
+    tab.split(PaneId::Terminal(2), None, 1, SplitDirection::Vertical)
+        .unwrap();
+    tab.split(PaneId::Terminal(3), None, 1, SplitDirection::Vertical)
+        .unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_increase(&mut tab, 1);
 

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_edit_action_with_split_direction.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_edit_action_with_split_direction.snap
@@ -3,4 +3,4 @@ source: zellij-server/src/./unit/screen_tests.rs
 assertion_line: 2018
 expression: "format!(\"{:?}\", * received_pty_instructions.lock().unwrap())"
 ---
-[SpawnTerminalHorizontally(Some(OpenFile("/file/to/edit", None)), Some("Editing: /file/to/edit"), 10), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]
+[SpawnSplitTerminal(Some(OpenFile("/file/to/edit", None)), Some("Editing: /file/to/edit"), 10, Horizontal), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_pane_action_with_command_and_cwd.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_pane_action_with_command_and_cwd.snap
@@ -3,4 +3,4 @@ source: zellij-server/src/./unit/screen_tests.rs
 assertion_line: 1915
 expression: "format!(\"{:?}\", * received_pty_instructions.lock().unwrap())"
 ---
-[SpawnTerminalVertically(Some(RunCommand(RunCommand { command: "htop", args: [], cwd: Some("/some/folder"), hold_on_close: true, hold_on_start: false })), None, 10), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]
+[SpawnSplitTerminal(Some(RunCommand(RunCommand { command: "htop", args: [], cwd: Some("/some/folder"), hold_on_close: true, hold_on_start: false })), None, 10, Vertical), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_pane_action_with_split_direction.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_pane_action_with_split_direction.snap
@@ -3,4 +3,4 @@ source: zellij-server/src/./unit/screen_tests.rs
 assertion_line: 1869
 expression: "format!(\"{:?}\", * received_pty_instructions.lock().unwrap())"
 ---
-[SpawnTerminalVertically(None, None, 10), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]
+[SpawnSplitTerminal(None, None, 10, Vertical), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -49,6 +49,15 @@ impl Not for SplitDirection {
     }
 }
 
+impl fmt::Display for SplitDirection {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            SplitDirection::Vertical => write!(formatter, "Vertical"),
+            SplitDirection::Horizontal => write!(formatter, "Horizontal"),
+        }
+    }
+}
+
 impl From<Direction> for SplitDirection {
     fn from(direction: Direction) -> Self {
         match direction {


### PR DESCRIPTION
My goal is to add commands to split panes left, right, up and down rather than just left and down. I think that would involve less cut-and-paste if the code and commands for splitting is consolidated. This PR does just the refactoring.
