### PR TITLE
Add pencil theme

### DIFF
--- a/example/themes/pencil.kdl
+++ b/example/themes/pencil.kdl
@@ -1,0 +1,15 @@
+themes {
+    pencil-light {
+        fg "#005F87"
+        bg "#f1f1f1"
+        black "#f1f1f1"
+        red "#B6D6FD"
+        green "#10A778"
+        yellow "#A89C14"
+        blue "#008EC4"
+        magenta "#B6D6FD"
+        cyan "#20A5BA"
+        white "#424242"
+        orange "#D75F5F"
+    }
+}


### PR DESCRIPTION
This adds the pencil theme. 

Only a light variant (meant to be used alongside the pencil light theme in your terminal) is available at the moment.