### PR TITLE
Apply correct color on 'more tabs' message

### DIFF
--- a/default-plugins/compact-bar/src/line.rs
+++ b/default-plugins/compact-bar/src/line.rs
@@ -122,13 +122,13 @@ fn left_more_message(
     // 238
     // chars length plus separator length on both sides
     let more_text_len = more_text.width() + 2 * separator.width();
-    let text_color = match palette.theme_hue {
-        ThemeHue::Dark => palette.white,
-        ThemeHue::Light => palette.black,
+    let (text_color, sep_color) = match palette.theme_hue {
+        ThemeHue::Dark => (palette.white, palette.black),
+        ThemeHue::Light => (palette.black, palette.white),
     };
-    let left_separator = style!(text_color, palette.orange).paint(separator);
+    let left_separator = style!(sep_color, palette.orange).paint(separator);
     let more_styled_text = style!(text_color, palette.orange).bold().paint(more_text);
-    let right_separator = style!(palette.orange, text_color).paint(separator);
+    let right_separator = style!(palette.orange, sep_color).paint(separator);
     let more_styled_text =
         ANSIStrings(&[left_separator, more_styled_text, right_separator]).to_string();
     LinePart {
@@ -154,13 +154,13 @@ fn right_more_message(
     };
     // chars length plus separator length on both sides
     let more_text_len = more_text.width() + 2 * separator.width();
-    let text_color = match palette.theme_hue {
-        ThemeHue::Dark => palette.white,
-        ThemeHue::Light => palette.black,
+    let (text_color, sep_color) = match palette.theme_hue {
+        ThemeHue::Dark => (palette.white, palette.black),
+        ThemeHue::Light => (palette.black, palette.white),
     };
-    let left_separator = style!(text_color, palette.orange).paint(separator);
+    let left_separator = style!(sep_color, palette.orange).paint(separator);
     let more_styled_text = style!(text_color, palette.orange).bold().paint(more_text);
-    let right_separator = style!(palette.orange, text_color).paint(separator);
+    let right_separator = style!(palette.orange, sep_color).paint(separator);
     let more_styled_text =
         ANSIStrings(&[left_separator, more_styled_text, right_separator]).to_string();
     LinePart {

--- a/default-plugins/tab-bar/src/line.rs
+++ b/default-plugins/tab-bar/src/line.rs
@@ -123,13 +123,13 @@ fn left_more_message(
     // 238
     // chars length plus separator length on both sides
     let more_text_len = more_text.width() + 2 * separator.width();
-    let text_color = match palette.theme_hue {
-        ThemeHue::Dark => palette.white,
-        ThemeHue::Light => palette.black,
+    let (text_color, sep_color) = match palette.theme_hue {
+        ThemeHue::Dark => (palette.white, palette.black),
+        ThemeHue::Light => (palette.black, palette.white),
     };
-    let left_separator = style!(text_color, palette.orange).paint(separator);
+    let left_separator = style!(sep_color, palette.orange).paint(separator);
     let more_styled_text = style!(text_color, palette.orange).bold().paint(more_text);
-    let right_separator = style!(palette.orange, text_color).paint(separator);
+    let right_separator = style!(palette.orange, sep_color).paint(separator);
     let more_styled_text =
         ANSIStrings(&[left_separator, more_styled_text, right_separator]).to_string();
     LinePart {
@@ -155,13 +155,13 @@ fn right_more_message(
     };
     // chars length plus separator length on both sides
     let more_text_len = more_text.width() + 2 * separator.width();
-    let text_color = match palette.theme_hue {
-        ThemeHue::Dark => palette.white,
-        ThemeHue::Light => palette.black,
+    let (text_color, sep_color) = match palette.theme_hue {
+        ThemeHue::Dark => (palette.white, palette.black),
+        ThemeHue::Light => (palette.black, palette.white),
     };
-    let left_separator = style!(text_color, palette.orange).paint(separator);
+    let left_separator = style!(sep_color, palette.orange).paint(separator);
     let more_styled_text = style!(text_color, palette.orange).bold().paint(more_text);
-    let right_separator = style!(palette.orange, text_color).paint(separator);
+    let right_separator = style!(palette.orange, sep_color).paint(separator);
     let more_styled_text =
         ANSIStrings(&[left_separator, more_styled_text, right_separator]).to_string();
     LinePart {


### PR DESCRIPTION
Fix the color of 'more tabs' message for tab-bar and compact-bar plugins.

Currently: 
![tab-pre-fix](https://user-images.githubusercontent.com/12203476/219175074-9cf2974d-0129-4dcc-b7b4-16e818139f06.png)

Fix:
![tab-post-fix](https://user-images.githubusercontent.com/12203476/219175166-f14dc721-3bb5-45b1-a6b2-a765900060c9.png)

Thank you.