### PR TITLE
Project Governance Change

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -5,7 +5,7 @@ As such, we feel it's important to codify some rules that seem obvious and strai
 ## Organization members
 Members of the Zellij organization are in effect those empowered to make decisions for the project. Individual members are trusted to make decisions on their own and to bring larger and more controversial decisions to be decided by the full quorum of members in a real-time meeting or by correspondence.
 
-## BDFL
+## BDFL (Benevolent Dictator for Life)
 Aram Drevekenin (@imsnif) is in charge of steering the project and making large decisions regarding finances and collaboration. He will bring such decisions to the group when possible in order to hear all dissenting opinions, but the ultimate decision is his.
 
 He also has veto power over decisions made by the group. Since we strive to make decisions by consensus, this power is to be used only as a last resort.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -5,34 +5,13 @@ As such, we feel it's important to codify some rules that seem obvious and strai
 ## Organization members
 Members of the Zellij organization are in effect those empowered to make decisions for the project. Individual members are trusted to make decisions on their own and to bring larger and more controversial decisions to be decided by the full quorum of members in a real-time meeting or by correspondence.
 
-## How decisions are made regarding the project
-When larger decisions are brought to the full quorum of members, we would like to hear all the voices and dissenting  opinions on the decision at hand. Ideally, we would then decide on a course of action by consensus. Only if one cannot be reached, will each member of the organization get a vote. The decision in the majority will be taken.
+## BDFL
+Aram Drevekenin (@imsnif) is in charge of steering the project and making large decisions regarding finances and collaboration. He will bring such decisions to the group when possible in order to hear all dissenting opinions, but the ultimate decision is his.
 
-In case of ties, one member designated as Arbiter can break the tie. For reasons of focus and expediency, the Arbiter also has veto privileges which are to be used as scarecely as possible.
-
-Some decisions that should always be brought to the quorum of members:
-* Adding new members to the organization
-* Removing existing members from the organization
-* Any decision involving money or finances
-* Collaborations with outside organizations
-
-## Role of the Arbiter
-The Arbiter is a member of the quorum who serves as a tie breaker in votes and also has veto privileges for the votes themselves. Both of these should be used as seldom as possible and preferably not at all.
-
-### Arbiter no-confidence vote
-It is preferable that any conflict with the Arbiter, no matter how severe, be resolved amicably. However, it is acknowledged that this is not always possible. For those cases, and for the health of Zellij and its community, this is the process in order to remove a sitting Arbiter against their will:
-
-1. Find another willing candidate from the existing organization members
-2. Email all the organization members to the addresses specified in this document, letting them know about the vote and the replacement candidate
-3. All the maintainers have 2 weeks to reply (privately) with a yes (remove the Arbiter) or no (do not remove the Arbiter) vote - the sitting Arbiter does not get a vote
-4. The votes should be tallied and verified by the vote initiator as well as another organization member who is not the sitting Arbiter
-5. If at least two thirds (rounded up) of the respondents vote to remove - the vote succeeds and the new Arbiter is instated in place of the sitting one
-6. The sitting Arbiter remains an organization member unless explicitly removed by a normal majority vote
-
-For the removal of doubt: changing this rule itself requires a two thirds majority of maintainers as well.
+He also has veto power over decisions made by the group. Since we strive to make decisions by consensus, this power is to be used only as a last resort.
 
 ## Current Organization Members
-* Aram Drevekenin <aram@poor.dev> (Arbiter)
+* Aram Drevekenin <aram@poor.dev>
 * Doron Tsur <qballer@gmail.com>
 * Brooks Rady <b.j.rady@gmail.com>
 * Denis Maximov <denis_maxim0v@protonmail.com>


### PR DESCRIPTION
This change is a result of an email vote as dictated in the current governance document.

All organization members received an email regarding this change and were asked to vote `yes` (make this change) or `no` (do not make this change). @tlinford was CCed to the email and all responses - I would kindly ask him to confirm this by merging this PR.

We received 8 `yes` votes and zero `no` votes. And so this change is carried.

## My personal notes about this change
When I started Zellij, I hoped for it to be a project steered by a small and dedicated group of people. I recruited friends and acquaintances from previous projects. But while many of them contributed significantly to the project (some still do), it has come to pass that running this project and driving it forward has mostly fallen to me.

Right now, I have no income and am living on my savings. I have devoted myself to Zellij completely, because I passionately believe we have something special here - and I don't want it to die and wither away in the darkness as only my personal development environment.

For this reason, I want to make official that which has been unofficial until now. Allow myself the freedom to run this project and try to find a way to make it sustainable for me. Because if it's not, at some point I'll have to devote my time to projects that are.

### Things that will not change
Zellij will always be open-source. 
Zellij will never collect your telemetry. 
Zellij will never run ads. 
The Zellij software will always be free.

I don't have a specific sustainability avenue in mind yet, but I am sure something will come up!

**If you are interested in supporting my efforts, please consider sponsoring me: https://github.com/sponsors/imsnif**