### PR TITLE
Fix plugin location path decoding from Url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4095,6 +4095,7 @@ dependencies = [
  "miette 3.3.0",
  "nix 0.23.1",
  "once_cell",
+ "percent-encoding",
  "regex",
  "rmp-serde",
  "serde",

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -23,6 +23,7 @@ lazy_static = "1.4.0"
 libc = "0.2"
 nix = "0.23.1"
 once_cell = "1.8.0"
+percent-encoding = "2.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 strip-ansi-escapes = "0.1.0"

--- a/zellij-utils/src/input/plugins.rs
+++ b/zellij-utils/src/input/plugins.rs
@@ -225,8 +225,10 @@ impl Default for PluginType {
 pub enum PluginsConfigError {
     #[error("Duplication in plugin tag names is not allowed: '{}'", String::from(.0.clone()))]
     DuplicatePlugins(PluginTag),
+    #[error("Failed to parse url: {0:?}")]
+    InvalidUrl(#[from] url::ParseError),
     #[error("Only 'file:' and 'zellij:' url schemes are supported for plugin lookup. '{0}' does not match either.")]
-    InvalidUrl(Url),
+    InvalidUrlScheme(Url),
     #[error("Could not find plugin at the path: '{0:?}'")]
     InvalidPluginLocation(PathBuf),
 }

--- a/zellij-utils/src/input/unit/layout_test.rs
+++ b/zellij-utils/src/input/unit/layout_test.rs
@@ -1942,3 +1942,55 @@ fn cannot_define_stacked_panes_with_grandchildren_in_pane_template() {
     let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None);
     assert!(layout.is_err(), "error provided for tab name with space");
 }
+
+fn run_plugin_location_parsing() {
+    let kdl_layout = r#"
+        layout {
+            pane {
+                plugin location="zellij:tab-bar"
+            }
+            pane {
+                plugin location="file:/path/to/my/plugin.wasm"
+            }
+            pane {
+                plugin location="file:plugin.wasm"
+            }
+        }
+    "#;
+    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let expected_layout = Layout {
+        template: Some((
+            TiledPaneLayout {
+                children: vec![
+                    TiledPaneLayout {
+                        run: Some(Run::Plugin(RunPlugin {
+                            _allow_exec_host_cmd: false,
+                            location: RunPluginLocation::Zellij(PluginTag::new("tab-bar")),
+                        })),
+                        ..Default::default()
+                    },
+                    TiledPaneLayout {
+                        run: Some(Run::Plugin(RunPlugin {
+                            _allow_exec_host_cmd: false,
+                            location: RunPluginLocation::File(PathBuf::from(
+                                "/path/to/my/plugin.wasm",
+                            )),
+                        })),
+                        ..Default::default()
+                    },
+                    TiledPaneLayout {
+                        run: Some(Run::Plugin(RunPlugin {
+                            _allow_exec_host_cmd: false,
+                            location: RunPluginLocation::File(PathBuf::from("plugin.wasm")),
+                        })),
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            },
+            vec![],
+        )),
+        ..Default::default()
+    };
+    assert_eq!(layout, expected_layout);
+}

--- a/zellij-utils/src/input/unit/layout_test.rs
+++ b/zellij-utils/src/input/unit/layout_test.rs
@@ -1955,6 +1955,9 @@ fn run_plugin_location_parsing() {
             pane {
                 plugin location="file:plugin.wasm"
             }
+            pane {
+                plugin location="file:/path/with space/plugin.wasm"
+            }
         }
     "#;
     let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
@@ -1982,6 +1985,15 @@ fn run_plugin_location_parsing() {
                         run: Some(Run::Plugin(RunPlugin {
                             _allow_exec_host_cmd: false,
                             location: RunPluginLocation::File(PathBuf::from("plugin.wasm")),
+                        })),
+                        ..Default::default()
+                    },
+                    TiledPaneLayout {
+                        run: Some(Run::Plugin(RunPlugin {
+                            _allow_exec_host_cmd: false,
+                            location: RunPluginLocation::File(PathBuf::from(
+                                "/path/with space/plugin.wasm",
+                            )),
                         })),
                         ..Default::default()
                     },

--- a/zellij-utils/src/input/unit/layout_test.rs
+++ b/zellij-utils/src/input/unit/layout_test.rs
@@ -1956,7 +1956,13 @@ fn run_plugin_location_parsing() {
                 plugin location="file:plugin.wasm"
             }
             pane {
-                plugin location="file:/path/with space/plugin.wasm"
+                plugin location="file:relative/with space/plugin.wasm"
+            }
+            pane {
+                plugin location="file:///absolute/with space/plugin.wasm"
+            }
+            pane {
+                plugin location="file:c:/absolute/windows/plugin.wasm"
             }
         }
     "#;
@@ -1992,7 +1998,25 @@ fn run_plugin_location_parsing() {
                         run: Some(Run::Plugin(RunPlugin {
                             _allow_exec_host_cmd: false,
                             location: RunPluginLocation::File(PathBuf::from(
-                                "/path/with space/plugin.wasm",
+                                "relative/with space/plugin.wasm",
+                            )),
+                        })),
+                        ..Default::default()
+                    },
+                    TiledPaneLayout {
+                        run: Some(Run::Plugin(RunPlugin {
+                            _allow_exec_host_cmd: false,
+                            location: RunPluginLocation::File(PathBuf::from(
+                                "/absolute/with space/plugin.wasm",
+                            )),
+                        })),
+                        ..Default::default()
+                    },
+                    TiledPaneLayout {
+                        run: Some(Run::Plugin(RunPlugin {
+                            _allow_exec_host_cmd: false,
+                            location: RunPluginLocation::File(PathBuf::from(
+                                "c:/absolute/windows/plugin.wasm",
                             )),
                         })),
                         ..Default::default()

--- a/zellij-utils/src/kdl/kdl_layout_parser.rs
+++ b/zellij-utils/src/kdl/kdl_layout_parser.rs
@@ -22,10 +22,8 @@ use crate::{
     kdl_string_arguments,
 };
 
-use std::convert::TryFrom;
 use std::path::PathBuf;
 use std::vec::Vec;
-use url::Url;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PaneOrFloatingPane {
@@ -296,14 +294,13 @@ impl<'a> KdlLayoutParser<'a> {
                 plugin_block.span().len(),
             ),
         )?;
-        let url = Url::parse(string_url).map_err(|e| {
+        let location = RunPluginLocation::parse(&string_url).map_err(|e| {
             ConfigError::new_layout_kdl_error(
-                format!("Failed to parse url: {:?}", e),
+                e.to_string(),
                 url_node.span().offset(),
                 url_node.span().len(),
             )
         })?;
-        let location = RunPluginLocation::try_from(url)?;
         Ok(Some(Run::Plugin(RunPlugin {
             _allow_exec_host_cmd,
             location,

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -12,7 +12,6 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 use strum::IntoEnumIterator;
-use url::Url;
 
 use miette::NamedSource;
 
@@ -1382,14 +1381,13 @@ impl RunPlugin {
                 kdl_node.span().len(),
             ),
         )?;
-        let url = Url::parse(string_url).map_err(|e| {
-            ConfigError::new_kdl_error(
-                format!("Failed to parse url: {:?}", e),
+        let location = RunPluginLocation::parse(string_url).map_err(|e| {
+            ConfigError::new_layout_kdl_error(
+                e.to_string(),
                 kdl_node.span().offset(),
                 kdl_node.span().len(),
             )
         })?;
-        let location = RunPluginLocation::try_from(url)?;
         Ok(RunPlugin {
             _allow_exec_host_cmd,
             location,


### PR DESCRIPTION
Using URL file schema for plugin location is currently broken in a couple different ways:

- Naively converting URL path to a `PathBuf` doesn't decode the percent encoded URL. This makes any path with "spaces" or percent encoded characters break.
- Using `path` or now w/ `to_file_path` always returns an "absolute" `PathBuf`. The root prefix is now stripped when adding it to the config directory for relative lookup.

I've tested both relative lookup `file:plugin.wasm` as well as absolute path w/ spaces and both now work.