### PR TITLE
fix(messaging): cache hold pane messages by their tab_id if the tab is not ready

### DIFF
--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -147,6 +147,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                         pty.bus.senders.clone(),
                                         *terminal_id,
                                         run_command.clone(),
+                                        None,
                                     )
                                     .with_context(err_context)?;
                                 }
@@ -243,6 +244,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                             Some(2), // exit status
                                             run_command,
                                             None,
+                                            None,
                                         ))
                                         .with_context(err_context)?;
                                 }
@@ -312,6 +314,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                             PaneId::Terminal(*terminal_id),
                                             Some(2), // exit status
                                             run_command,
+                                            None,
                                             None,
                                         ))
                                         .with_context(err_context)?;
@@ -421,6 +424,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                         PaneId::Terminal(*terminal_id),
                                         Some(2), // exit status
                                         run_command,
+                                        None,
                                         None,
                                     ))
                                     .with_context(err_context)?;
@@ -532,6 +536,7 @@ impl Pty {
                         exit_status,
                         command,
                         None,
+                        None,
                     ));
                 } else {
                     let _ = senders.send_to_screen(ScreenInstruction::ClosePane(pane_id, None));
@@ -599,14 +604,14 @@ impl Pty {
                     // new_pane_pids
         for run_instruction in extracted_run_instructions {
             if let Some(new_pane_data) =
-                self.apply_run_instruction(run_instruction, default_shell.clone())?
+                self.apply_run_instruction(run_instruction, default_shell.clone(), tab_index)?
             {
                 new_pane_pids.push(new_pane_data);
             }
         }
         for run_instruction in extracted_floating_run_instructions {
             if let Some(new_pane_data) =
-                self.apply_run_instruction(run_instruction, default_shell.clone())?
+                self.apply_run_instruction(run_instruction, default_shell.clone(), tab_index)?
             {
                 new_floating_panes_pids.push(new_pane_data);
             }
@@ -686,6 +691,7 @@ impl Pty {
                                 self.bus.senders.clone(),
                                 terminal_id,
                                 run_command.clone(),
+                                Some(tab_index),
                             )
                             .with_context(err_context)?;
                         } else {
@@ -706,6 +712,7 @@ impl Pty {
         &mut self,
         run_instruction: Option<Run>,
         default_shell: TerminalAction,
+        tab_index: usize,
     ) -> Result<Option<(u32, bool, Option<RunCommand>, Result<i32>)>> {
         // terminal_id,
         // starts_held,
@@ -730,6 +737,7 @@ impl Pty {
                                 pane_id,
                                 exit_status,
                                 command,
+                                Some(tab_index),
                                 None,
                             ));
                         } else {
@@ -935,6 +943,7 @@ impl Pty {
                                 exit_status,
                                 command,
                                 None,
+                                None,
                             ));
                         } else {
                             let _ =
@@ -996,6 +1005,7 @@ fn send_command_not_found_to_screen(
     senders: ThreadSenders,
     terminal_id: u32,
     run_command: RunCommand,
+    tab_index: Option<usize>,
 ) -> Result<()> {
     let err_context = || format!("failed to send command_not_fount for terminal {terminal_id}");
     senders
@@ -1011,6 +1021,7 @@ fn send_command_not_found_to_screen(
             PaneId::Terminal(terminal_id),
             Some(2),
             run_command.clone(),
+            tab_index,
             None,
         ))
         .with_context(err_context)?;

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -175,7 +175,13 @@ pub enum ScreenInstruction {
     TogglePaneFrames,
     SetSelectable(PaneId, bool, usize),
     ClosePane(PaneId, Option<ClientId>),
-    HoldPane(PaneId, Option<i32>, RunCommand, Option<usize>, Option<ClientId>), // Option<i32> is the exit status, Option<usize> is the tab_index
+    HoldPane(
+        PaneId,
+        Option<i32>,
+        RunCommand,
+        Option<usize>,
+        Option<ClientId>,
+    ), // Option<i32> is the exit status, Option<usize> is the tab_index
     UpdatePaneName(Vec<u8>, ClientId),
     UndoRenamePane(ClientId),
     NewTab(
@@ -1925,8 +1931,9 @@ pub(crate) fn screen_thread_main(
                             run_command
                         ));
                     },
-                    (_,  Some(tab_index))=> {
-                        let tab = screen.tabs
+                    (_, Some(tab_index)) => {
+                        let tab = screen
+                            .tabs
                             .get_mut(&tab_index)
                             .context("couldn't find tab with index {tab_index}")?;
                         tab.hold_pane(id, exit_status, is_first_run, run_command);

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -738,7 +738,12 @@ impl Tab {
                 BufferedTabInstruction::HandlePtyBytes(terminal_id, bytes) => {
                     self.handle_pty_bytes(terminal_id, bytes)?;
                 },
-                BufferedTabInstruction::HoldPane(terminal_id, exit_status, is_first_run, run_command) => {
+                BufferedTabInstruction::HoldPane(
+                    terminal_id,
+                    exit_status,
+                    is_first_run,
+                    run_command,
+                ) => {
                     self.hold_pane(terminal_id, exit_status, is_first_run, run_command);
                 },
             }
@@ -2151,7 +2156,12 @@ impl Tab {
     ) {
         if self.is_pending {
             self.pending_instructions
-                .push(BufferedTabInstruction::HoldPane(id, exit_status, is_first_run, run_command));
+                .push(BufferedTabInstruction::HoldPane(
+                    id,
+                    exit_status,
+                    is_first_run,
+                    run_command,
+                ));
             return;
         }
         if self.floating_panes.panes_contain(&id) {


### PR DESCRIPTION
Before this fix, especially fast-running command started on startup through a layout would sometimes exit before the layout was applied to a tab. This would result in a command pane that has exited but not "held" - meaning we would be unable to re-run the command or see its exit status.

This fixes it by caching those messages for pending tabs using their tab_ids.

Great find, @har7an !!