### PR TITLE
fix(layout): tab focus

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -385,9 +385,9 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                             .as_ref()
                             .unwrap()
                             .senders
-                            .send_to_pty(PtyInstruction::GoToTab(
+                            .send_to_screen(ScreenInstruction::GoToTab(
                                 (focused_tab_index + 1) as u32,
-                                client_id,
+                                Some(client_id),
                             ))
                             .unwrap();
                     }

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1409,7 +1409,7 @@ pub(crate) fn screen_thread_main(
 
     let mut pending_tab_ids: HashSet<usize> = HashSet::new();
     let mut pending_tab_switches: HashSet<(usize, ClientId)> = HashSet::new(); // usize is the
-                                                                                       // tab_index
+                                                                               // tab_index
 
     loop {
         let (event, mut err_ctx) = screen
@@ -2064,7 +2064,7 @@ pub(crate) fn screen_thread_main(
                         if let Some(client_id) = client_id {
                             pending_tab_switches.insert((tab_index as usize, client_id));
                         }
-                    }
+                    },
                 }
             },
             ScreenInstruction::GoToTabName(tab_name, swap_layouts, create, client_id) => {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1407,6 +1407,10 @@ pub(crate) fn screen_thread_main(
         copy_options,
     );
 
+    let mut pending_tab_ids: HashSet<usize> = HashSet::new();
+    let mut pending_tab_switches: HashSet<(usize, ClientId)> = HashSet::new(); // usize is the
+                                                                                       // tab_index
+
     loop {
         let (event, mut err_ctx) = screen
             .bus
@@ -1998,6 +2002,7 @@ pub(crate) fn screen_thread_main(
                 client_id,
             ) => {
                 let tab_index = screen.get_new_tab_index();
+                pending_tab_ids.insert(tab_index);
                 screen.new_tab(tab_index, swap_layouts, client_id)?;
                 screen
                     .bus
@@ -2029,11 +2034,17 @@ pub(crate) fn screen_thread_main(
                     tab_index,
                     client_id,
                 )?;
+                pending_tab_ids.remove(&tab_index);
+                if pending_tab_ids.is_empty() {
+                    for (tab_index, client_id) in pending_tab_switches.drain() {
+                        screen.go_to_tab(tab_index as usize, client_id)?;
+                    }
+                }
                 screen.unblock_input()?;
                 screen.render()?;
             },
             ScreenInstruction::GoToTab(tab_index, client_id) => {
-                let client_id = if client_id.is_none() {
+                let client_id_to_switch = if client_id.is_none() {
                     None
                 } else if screen
                     .active_tab_indices
@@ -2043,10 +2054,17 @@ pub(crate) fn screen_thread_main(
                 } else {
                     screen.active_tab_indices.keys().next().copied()
                 };
-                if let Some(client_id) = client_id {
-                    screen.go_to_tab(tab_index as usize, client_id)?;
-                    screen.unblock_input()?;
-                    screen.render()?;
+                match client_id_to_switch {
+                    Some(client_id) => {
+                        screen.go_to_tab(tab_index as usize, client_id)?;
+                        screen.unblock_input()?;
+                        screen.render()?;
+                    },
+                    None => {
+                        if let Some(client_id) = client_id {
+                            pending_tab_switches.insert((tab_index as usize, client_id));
+                        }
+                    }
                 }
             },
             ScreenInstruction::GoToTabName(tab_name, swap_layouts, create, client_id) => {


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/2021

This is a regression caused by some performance fixes to starting layouts. These fixes caused a race which made the tab focus instruction get lost.

This fixes it by caching the instructions and reapplying them once there are no more pending tabs in the screen.