### PR TITLE
fix(cli): new-tab now also looks in layout_dir for layouts

### DIFF
--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -2370,6 +2370,7 @@ pub fn send_cli_new_tab_action_default_params() {
     let new_tab_action = CliAction::NewTab {
         name: None,
         layout: None,
+        layout_dir: None,
         cwd: None,
     };
     send_cli_action_to_server(
@@ -2414,6 +2415,7 @@ pub fn send_cli_new_tab_action_with_name_and_layout() {
             "{}/src/unit/fixtures/layout-with-three-panes.kdl",
             env!("CARGO_MANIFEST_DIR")
         ))),
+        layout_dir: None,
         cwd: None,
     };
     send_cli_action_to_server(

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -352,6 +352,10 @@ pub enum CliAction {
         #[clap(short, long, value_parser)]
         layout: Option<PathBuf>,
 
+        /// Default folder to look for layouts
+        #[clap(short, long, value_parser, requires("layout"))]
+        layout_dir: Option<PathBuf>,
+
         /// Name of the new tab
         #[clap(short, long, value_parser)]
         name: Option<String>,

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -9,6 +9,7 @@ use crate::data::InputMode;
 use crate::data::{Direction, Resize};
 use crate::input::config::{ConfigError, KdlError};
 use crate::input::options::OnForceClose;
+use crate::setup::{get_layout_dir, find_default_config_dir};
 use miette::{NamedSource, Report};
 use serde::{Deserialize, Serialize};
 
@@ -348,14 +349,15 @@ impl Action {
                 Action::TabNameInput(name.as_bytes().to_vec()),
             ]),
             CliAction::UndoRenameTab => Ok(vec![Action::UndoRenameTab]),
-            CliAction::NewTab { name, layout, cwd } => {
+            CliAction::NewTab { name, layout, layout_dir, cwd } => {
                 let current_dir = get_current_dir();
                 let cwd = cwd
                     .map(|cwd| current_dir.join(cwd))
                     .or_else(|| Some(current_dir));
                 if let Some(layout_path) = layout {
+                    let layout_dir = layout_dir.or_else(|| get_layout_dir(find_default_config_dir()));
                     let (path_to_raw_layout, raw_layout, swap_layouts) =
-                        Layout::stringified_from_path_or_default(Some(&layout_path), None)
+                        Layout::stringified_from_path_or_default(Some(&layout_path), layout_dir)
                             .map_err(|e| format!("Failed to load layout: {}", e))?;
                     let layout = Layout::from_str(&raw_layout, path_to_raw_layout, swap_layouts.as_ref().map(|(f, p)| (f.as_str(), p.as_str())), cwd).map_err(|e| {
                         let stringified_error = match e {

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -9,7 +9,7 @@ use crate::data::InputMode;
 use crate::data::{Direction, Resize};
 use crate::input::config::{ConfigError, KdlError};
 use crate::input::options::OnForceClose;
-use crate::setup::{get_layout_dir, find_default_config_dir};
+use crate::setup::{find_default_config_dir, get_layout_dir};
 use miette::{NamedSource, Report};
 use serde::{Deserialize, Serialize};
 
@@ -349,13 +349,19 @@ impl Action {
                 Action::TabNameInput(name.as_bytes().to_vec()),
             ]),
             CliAction::UndoRenameTab => Ok(vec![Action::UndoRenameTab]),
-            CliAction::NewTab { name, layout, layout_dir, cwd } => {
+            CliAction::NewTab {
+                name,
+                layout,
+                layout_dir,
+                cwd,
+            } => {
                 let current_dir = get_current_dir();
                 let cwd = cwd
                     .map(|cwd| current_dir.join(cwd))
                     .or_else(|| Some(current_dir));
                 if let Some(layout_path) = layout {
-                    let layout_dir = layout_dir.or_else(|| get_layout_dir(find_default_config_dir()));
+                    let layout_dir =
+                        layout_dir.or_else(|| get_layout_dir(find_default_config_dir()));
                     let (path_to_raw_layout, raw_layout, swap_layouts) =
                         Layout::stringified_from_path_or_default(Some(&layout_path), layout_dir)
                             .map_err(|e| format!("Failed to load layout: {}", e))?;

--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -291,8 +291,8 @@ impl Setup {
     /// file options, superceeding the config file options:
     /// 1. command line options (`zellij options`)
     /// 2. layout options
-    ///    (`layout.yaml` / `zellij --layout`)
-    /// 3. config options (`config.yaml`)
+    ///    (`layout.kdl` / `zellij --layout`)
+    /// 3. config options (`config.kdl`)
     pub fn from_cli_args(cli_args: &CliArgs) -> Result<(Config, Layout, Options), ConfigError> {
         // note that this can potentially exit the process
         Setup::handle_setup_commands(cli_args);


### PR DESCRIPTION
This fixes the CLI `new-tab` action to also look for layouts in the `layout_dir`, similar to how `--layout` does it.

So now: `zellij action new-tab --layout my-cool-layout` will look for the `my-cool-layout` file first in the `layouts` folder in the config directory and only then try to resolve it as a path.

EDIT: this is a fix for https://github.com/zellij-org/zellij/issues/1969 (and maybe others?)