### PR TITLE
fix(cli): edit cwd

### DIFF
--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -277,7 +277,12 @@ fn spawn_terminal(
     // secondary fd
     let mut failover_cmd_args = None;
     let cmd = match terminal_action {
-        TerminalAction::OpenFile(file_to_open, line_number) => {
+        TerminalAction::OpenFile(mut file_to_open, line_number, cwd) => {
+            if file_to_open.is_relative() {
+                if let Some(cwd) = cwd.as_ref() {
+                    file_to_open = cwd.join(file_to_open);
+                }
+            }
             let mut command = default_editor.unwrap_or_else(|| {
                 PathBuf::from(
                     env::var("EDITOR")
@@ -318,7 +323,7 @@ fn spawn_terminal(
             RunCommand {
                 command,
                 args,
-                cwd: None,
+                cwd,
                 hold_on_close: false,
                 hold_on_start: false,
             }

--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -691,7 +691,7 @@ fn host_open_file(plugin_env: &PluginEnv) {
             plugin_env
                 .senders
                 .send_to_pty(PtyInstruction::SpawnTerminal(
-                    Some(TerminalAction::OpenFile(path, None)),
+                    Some(TerminalAction::OpenFile(path, None, None)),
                     None,
                     None,
                     ClientOrTabIndex::TabIndex(plugin_env.tab_index),

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -822,7 +822,7 @@ impl Pty {
                     },
                 }
             },
-            Some(Run::EditFile(path_to_file, line_number)) => {
+            Some(Run::EditFile(path_to_file, line_number, cwd)) => {
                 let starts_held = false; // we do not hold edit panes (for now?)
                 match self
                     .bus
@@ -831,7 +831,7 @@ impl Pty {
                     .context("no OS I/O interface found")
                     .with_context(err_context)?
                     .spawn_terminal(
-                        TerminalAction::OpenFile(path_to_file, line_number, None),
+                        TerminalAction::OpenFile(path_to_file, line_number, cwd),
                         quit_cb,
                         self.default_editor.clone(),
                     )

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -166,7 +166,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                     || format!("failed to open in-place editor for client {}", client_id);
 
                 match pty.spawn_terminal(
-                    Some(TerminalAction::OpenFile(temp_file, line_number)),
+                    Some(TerminalAction::OpenFile(temp_file, line_number, None)),
                     ClientOrTabIndex::ClientId(client_id),
                 ) {
                     Ok((pid, _starts_held)) => {
@@ -831,7 +831,7 @@ impl Pty {
                     .context("no OS I/O interface found")
                     .with_context(err_context)?
                     .spawn_terminal(
-                        TerminalAction::OpenFile(path_to_file, line_number),
+                        TerminalAction::OpenFile(path_to_file, line_number, None),
                         quit_cb,
                         self.default_editor.clone(),
                     )

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -284,9 +284,9 @@ pub(crate) fn route_action(
                 .send_to_pty(pty_instr)
                 .with_context(err_context)?;
         },
-        Action::EditFile(path_to_file, line_number, split_direction, should_float) => {
+        Action::EditFile(path_to_file, line_number, cwd, split_direction, should_float) => {
             let title = format!("Editing: {}", path_to_file.display());
-            let open_file = TerminalAction::OpenFile(path_to_file, line_number);
+            let open_file = TerminalAction::OpenFile(path_to_file, line_number, cwd);
             let pty_instr = match (split_direction, should_float) {
                 (Some(Direction::Left), false) => {
                     PtyInstruction::SpawnTerminalVertically(Some(open_file), Some(title), client_id)

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_edit_action_with_default_parameters.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_edit_action_with_default_parameters.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 1944
+assertion_line: 2102
 expression: "format!(\"{:?}\", * received_pty_instructions.lock().unwrap())"
 ---
-[SpawnTerminal(Some(OpenFile("/file/to/edit", None)), Some(false), Some("Editing: /file/to/edit"), ClientId(10)), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]
+[SpawnTerminal(Some(OpenFile("/file/to/edit", None, Some("."))), Some(false), Some("Editing: /file/to/edit"), ClientId(10)), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_edit_action_with_line_number.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_edit_action_with_line_number.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 1989
+assertion_line: 2140
 expression: "format!(\"{:?}\", * received_pty_instructions.lock().unwrap())"
 ---
-[SpawnTerminal(Some(OpenFile("/file/to/edit", Some(100))), Some(false), Some("Editing: /file/to/edit"), ClientId(10)), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]
+[SpawnTerminal(Some(OpenFile("/file/to/edit", Some(100), Some("."))), Some(false), Some("Editing: /file/to/edit"), ClientId(10)), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_edit_action_with_split_direction.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_edit_action_with_split_direction.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 2018
+assertion_line: 2178
 expression: "format!(\"{:?}\", * received_pty_instructions.lock().unwrap())"
 ---
-[SpawnTerminalHorizontally(Some(OpenFile("/file/to/edit", None)), Some("Editing: /file/to/edit"), 10), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]
+[SpawnTerminalHorizontally(Some(OpenFile("/file/to/edit", None, Some("."))), Some("Editing: /file/to/edit"), 10), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -353,7 +353,7 @@ pub enum CliAction {
         layout: Option<PathBuf>,
 
         /// Default folder to look for layouts
-        #[clap(short, long, value_parser, requires("layout"))]
+        #[clap(long, value_parser, requires("layout"))]
         layout_dir: Option<PathBuf>,
 
         /// Name of the new tab

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -152,7 +152,7 @@ pub enum Action {
     /// If no direction is specified, will try to use the biggest available space.
     NewPane(Option<Direction>, Option<String>), // String is an optional pane name
     /// Open the file in a new pane using the default editor
-    EditFile(PathBuf, Option<usize>, Option<Direction>, bool), // usize is an optional line number, bool is floating true/false
+    EditFile(PathBuf, Option<usize>, Option<PathBuf>, Option<Direction>, bool), // usize is an optional line number, Option<PathBuf> is an optional cwd, bool is floating true/false
     /// Open a new floating pane
     NewFloatingPane(Option<RunCommandAction>, Option<String>), // String is an optional pane name
     /// Open a new tiled (embedded, non-floating) pane
@@ -317,13 +317,14 @@ impl Action {
                     .map(|cwd| current_dir.join(cwd))
                     .or_else(|| Some(current_dir));
                 if file.is_relative() {
-                    if let Some(cwd) = cwd {
+                    if let Some(cwd) = cwd.as_ref() {
                         file = cwd.join(file);
                     }
                 }
                 Ok(vec![Action::EditFile(
                     file,
                     line_number,
+                    cwd,
                     direction,
                     floating,
                 )])

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -152,7 +152,13 @@ pub enum Action {
     /// If no direction is specified, will try to use the biggest available space.
     NewPane(Option<Direction>, Option<String>), // String is an optional pane name
     /// Open the file in a new pane using the default editor
-    EditFile(PathBuf, Option<usize>, Option<PathBuf>, Option<Direction>, bool), // usize is an optional line number, Option<PathBuf> is an optional cwd, bool is floating true/false
+    EditFile(
+        PathBuf,
+        Option<usize>,
+        Option<PathBuf>,
+        Option<Direction>,
+        bool,
+    ), // usize is an optional line number, Option<PathBuf> is an optional cwd, bool is floating true/false
     /// Open a new floating pane
     NewFloatingPane(Option<RunCommandAction>, Option<String>), // String is an optional pane name
     /// Open a new tiled (embedded, non-floating) pane

--- a/zellij-utils/src/input/command.rs
+++ b/zellij-utils/src/input/command.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 #[derive(Debug, Clone)]
 pub enum TerminalAction {
     OpenFile(PathBuf, Option<usize>, Option<PathBuf>), // path to file (should be absolute), optional line_number and an
-                                                       // optional cwd
+    // optional cwd
     RunCommand(RunCommand),
 }
 

--- a/zellij-utils/src/input/command.rs
+++ b/zellij-utils/src/input/command.rs
@@ -5,7 +5,8 @@ use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 pub enum TerminalAction {
-    OpenFile(PathBuf, Option<usize>), // path to file and optional line_number
+    OpenFile(PathBuf, Option<usize>, Option<PathBuf>), // path to file (should be absolute), optional line_number and an
+                                                       // optional cwd
     RunCommand(RunCommand),
 }
 

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -110,12 +110,24 @@ impl Run {
                 Some(Run::Command(base_run_command)),
                 Some(Run::EditFile(file_to_edit, line_number, edit_cwd)),
             ) => match &base_run_command.cwd {
-                Some(cwd) => Some(Run::EditFile(cwd.join(&file_to_edit), *line_number, Some(cwd.join(edit_cwd.clone().unwrap_or_default())))),
-                None => Some(Run::EditFile(file_to_edit.clone(), *line_number, edit_cwd.clone())),
+                Some(cwd) => Some(Run::EditFile(
+                    cwd.join(&file_to_edit),
+                    *line_number,
+                    Some(cwd.join(edit_cwd.clone().unwrap_or_default())),
+                )),
+                None => Some(Run::EditFile(
+                    file_to_edit.clone(),
+                    *line_number,
+                    edit_cwd.clone(),
+                )),
             },
             (Some(Run::Cwd(cwd)), Some(Run::EditFile(file_to_edit, line_number, edit_cwd))) => {
                 let cwd = edit_cwd.clone().unwrap_or(cwd.clone());
-                Some(Run::EditFile(cwd.join(&file_to_edit), *line_number, Some(cwd)))
+                Some(Run::EditFile(
+                    cwd.join(&file_to_edit),
+                    *line_number,
+                    Some(cwd),
+                ))
             },
             (Some(_base), Some(other)) => Some(other.clone()),
             (Some(base), _) => Some(base.clone()),
@@ -140,7 +152,7 @@ impl Run {
                     },
                     None => {
                         let _ = edit_cwd.insert(cwd.clone());
-                    }
+                    },
                 };
                 *path_to_file = cwd.join(&path_to_file);
             },

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_bare_propagated_to_its_consumer_edit.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_bare_propagated_to_its_consumer_edit.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1558
+assertion_line: 1614
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -21,6 +21,9 @@ Layout {
                             EditFile(
                                 "/tmp/foo/bar",
                                 None,
+                                Some(
+                                    "/tmp/foo",
+                                ),
                             ),
                         ),
                         borderless: false,

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_command_propagated_to_its_consumer_edit.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_command_propagated_to_its_consumer_edit.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1574
+assertion_line: 1630
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -21,6 +21,9 @@ Layout {
                             EditFile(
                                 "/tmp/foo/bar",
                                 None,
+                                Some(
+                                    "/tmp/foo/",
+                                ),
                             ),
                         ),
                         borderless: false,

--- a/zellij-utils/src/kdl/kdl_layout_parser.rs
+++ b/zellij-utils/src/kdl/kdl_layout_parser.rs
@@ -962,7 +962,6 @@ impl<'a> KdlLayoutParser<'a> {
                     .unwrap_or(false);
             let split_size = self.parse_split_size(kdl_node)?;
             let children_split_direction = self.parse_split_direction(kdl_node)?;
-            let is_part_of_stack = false;
             let (external_children_index, pane_parts) = match kdl_children_nodes!(kdl_node) {
                 Some(children) => {
                     self.parse_child_pane_nodes_for_pane(&children, children_are_stacked)?

--- a/zellij-utils/src/kdl/kdl_layout_parser.rs
+++ b/zellij-utils/src/kdl/kdl_layout_parser.rs
@@ -374,8 +374,8 @@ impl<'a> KdlLayoutParser<'a> {
                 hold_on_close,
                 hold_on_start,
             }))),
-            (None, Some(edit), Some(cwd)) => Ok(Some(Run::EditFile(cwd.join(edit), None))),
-            (None, Some(edit), None) => Ok(Some(Run::EditFile(edit, None))),
+            (None, Some(edit), Some(cwd)) => Ok(Some(Run::EditFile(cwd.join(edit), None, Some(cwd)))),
+            (None, Some(edit), None) => Ok(Some(Run::EditFile(edit, None, None))),
             (Some(_command), Some(_edit), _) => Err(ConfigError::new_layout_kdl_error(
                 "cannot have both a command and an edit instruction for the same pane".into(),
                 pane_node.span().offset(),

--- a/zellij-utils/src/kdl/kdl_layout_parser.rs
+++ b/zellij-utils/src/kdl/kdl_layout_parser.rs
@@ -374,7 +374,9 @@ impl<'a> KdlLayoutParser<'a> {
                 hold_on_close,
                 hold_on_start,
             }))),
-            (None, Some(edit), Some(cwd)) => Ok(Some(Run::EditFile(cwd.join(edit), None, Some(cwd)))),
+            (None, Some(edit), Some(cwd)) => {
+                Ok(Some(Run::EditFile(cwd.join(edit), None, Some(cwd))))
+            },
             (None, Some(edit), None) => Ok(Some(Run::EditFile(edit, None, None))),
             (Some(_command), Some(_edit), _) => Err(ConfigError::new_layout_kdl_error(
                 "cannot have both a command and an edit instruction for the same pane".into(),


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/2016 and https://github.com/zellij-org/zellij/issues/2044

This sets the cwd when editing a file to the current folder (if opened through a pane or through a new-tab action) instead of to the session cwd as was up until now.