### PR TITLE
fix(new-tab): get config parameters from config file

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -18,7 +18,11 @@ use zellij_server::{os_input_output::get_server_os_input, start_server as start_
 use zellij_utils::{
     cli::{CliArgs, Command, SessionCommand, Sessions},
     envs,
-    input::{actions::Action, config::{Config, ConfigError}, options::Options},
+    input::{
+        actions::Action,
+        config::{Config, ConfigError},
+        options::Options,
+    },
     nix,
     setup::Setup,
 };
@@ -227,7 +231,11 @@ pub(crate) fn convert_old_theme_file(old_theme_file: PathBuf) {
     }
 }
 
-fn attach_with_cli_client(cli_action: zellij_utils::cli::CliAction, session_name: &str, config: Option<Config>) {
+fn attach_with_cli_client(
+    cli_action: zellij_utils::cli::CliAction,
+    session_name: &str,
+    config: Option<Config>,
+) {
     let os_input = get_os_input(zellij_client::os_input_output::get_cli_client_os_input);
     let get_current_dir = || std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     match Action::actions_from_cli(cli_action, Box::new(get_current_dir), config) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod tests;
 use zellij_utils::{
     clap::Parser,
     cli::{CliAction, CliArgs, Command, Sessions},
+    input::config::Config,
     logging::*,
 };
 
@@ -14,8 +15,9 @@ fn main() {
     let opts = CliArgs::parse();
 
     {
+        let config = Config::try_from(&opts).ok();
         if let Some(Command::Sessions(Sessions::Action(cli_action))) = opts.command {
-            commands::send_action_to_session(cli_action, opts.session);
+            commands::send_action_to_session(cli_action, opts.session, config);
             std::process::exit(0);
         }
         if let Some(Command::Sessions(Sessions::Run {
@@ -37,7 +39,7 @@ fn main() {
                 close_on_exit,
                 start_suspended,
             };
-            commands::send_action_to_session(command_cli_action, opts.session);
+            commands::send_action_to_session(command_cli_action, opts.session, config);
             std::process::exit(0);
         }
         if let Some(Command::Sessions(Sessions::Edit {
@@ -62,7 +64,7 @@ fn main() {
                 floating,
                 cwd,
             };
-            commands::send_action_to_session(command_cli_action, opts.session);
+            commands::send_action_to_session(command_cli_action, opts.session, config);
             std::process::exit(0);
         }
         if let Some(Command::Sessions(Sessions::ConvertConfig { old_config_file })) = opts.command {

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -455,7 +455,11 @@ impl Pty {
             default_editor,
         }
     }
-    pub fn get_default_terminal(&self, cwd: Option<PathBuf>, default_shell: Option<TerminalAction>) -> TerminalAction {
+    pub fn get_default_terminal(
+        &self,
+        cwd: Option<PathBuf>,
+        default_shell: Option<TerminalAction>,
+    ) -> TerminalAction {
         match default_shell {
             Some(mut default_shell) => {
                 if let Some(cwd) = cwd {
@@ -472,7 +476,7 @@ impl Pty {
                                     let _ = edit_cwd.insert(cwd.clone());
                                 },
                             };
-                        }
+                        },
                     }
                 }
                 default_shell
@@ -489,7 +493,7 @@ impl Pty {
                     hold_on_close: false,
                     hold_on_start: false,
                 })
-            }
+            },
         }
     }
     fn fill_cwd(&self, terminal_action: &mut TerminalAction, client_id: ClientId) {
@@ -613,7 +617,8 @@ impl Pty {
     ) -> Result<()> {
         let err_context = || format!("failed to spawn terminals for layout for client {client_id}");
 
-        let mut default_shell = default_shell.unwrap_or_else(|| self.get_default_terminal(None, None));
+        let mut default_shell =
+            default_shell.unwrap_or_else(|| self.get_default_terminal(None, None));
         self.fill_cwd(&mut default_shell, client_id);
         let extracted_run_instructions = layout.extract_run_instructions();
         let extracted_floating_run_instructions =

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -455,18 +455,42 @@ impl Pty {
             default_editor,
         }
     }
-    pub fn get_default_terminal(&self, cwd: Option<PathBuf>) -> TerminalAction {
-        let shell = PathBuf::from(env::var("SHELL").unwrap_or_else(|_| {
-            log::warn!("Cannot read SHELL env, falling back to use /bin/sh");
-            "/bin/sh".to_string()
-        }));
-        TerminalAction::RunCommand(RunCommand {
-            args: vec![],
-            command: shell,
-            cwd, // note: this might also be filled by the calling function, eg. spawn_terminal
-            hold_on_close: false,
-            hold_on_start: false,
-        })
+    pub fn get_default_terminal(&self, cwd: Option<PathBuf>, default_shell: Option<TerminalAction>) -> TerminalAction {
+        match default_shell {
+            Some(mut default_shell) => {
+                if let Some(cwd) = cwd {
+                    match default_shell {
+                        TerminalAction::RunCommand(ref mut command) => {
+                            command.cwd = Some(cwd);
+                        },
+                        TerminalAction::OpenFile(ref file, line_number, ref mut edit_cwd) => {
+                            match edit_cwd.as_mut() {
+                                Some(edit_cwd) => {
+                                    *edit_cwd = cwd.join(&edit_cwd);
+                                },
+                                None => {
+                                    let _ = edit_cwd.insert(cwd.clone());
+                                },
+                            };
+                        }
+                    }
+                }
+                default_shell
+            },
+            None => {
+                let shell = PathBuf::from(env::var("SHELL").unwrap_or_else(|_| {
+                    log::warn!("Cannot read SHELL env, falling back to use /bin/sh");
+                    "/bin/sh".to_string()
+                }));
+                TerminalAction::RunCommand(RunCommand {
+                    args: vec![],
+                    command: shell,
+                    cwd, // note: this might also be filled by the calling function, eg. spawn_terminal
+                    hold_on_close: false,
+                    hold_on_start: false,
+                })
+            }
+        }
     }
     fn fill_cwd(&self, terminal_action: &mut TerminalAction, client_id: ClientId) {
         if let TerminalAction::RunCommand(run_command) = terminal_action {
@@ -499,12 +523,12 @@ impl Pty {
         let terminal_action = match client_or_tab_index {
             ClientOrTabIndex::ClientId(client_id) => {
                 let mut terminal_action =
-                    terminal_action.unwrap_or_else(|| self.get_default_terminal(None));
+                    terminal_action.unwrap_or_else(|| self.get_default_terminal(None, None));
                 self.fill_cwd(&mut terminal_action, client_id);
                 terminal_action
             },
             ClientOrTabIndex::TabIndex(_) => {
-                terminal_action.unwrap_or_else(|| self.get_default_terminal(None))
+                terminal_action.unwrap_or_else(|| self.get_default_terminal(None, None))
             },
         };
         let (hold_on_start, hold_on_close) = match &terminal_action {
@@ -589,7 +613,7 @@ impl Pty {
     ) -> Result<()> {
         let err_context = || format!("failed to spawn terminals for layout for client {client_id}");
 
-        let mut default_shell = default_shell.unwrap_or_else(|| self.get_default_terminal(None));
+        let mut default_shell = default_shell.unwrap_or_else(|| self.get_default_terminal(None, None));
         self.fill_cwd(&mut default_shell, client_id);
         let extracted_run_instructions = layout.extract_run_instructions();
         let extracted_floating_run_instructions =
@@ -800,7 +824,7 @@ impl Pty {
             },
             Some(Run::Cwd(cwd)) => {
                 let starts_held = false; // we do not hold Cwd panes
-                let shell = self.get_default_terminal(Some(cwd));
+                let shell = self.get_default_terminal(Some(cwd), Some(default_shell.clone()));
                 match self
                     .bus
                     .os_input

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -103,7 +103,7 @@ fn send_cli_action_to_server(
     let os_input = Box::new(mock_screen.os_input.clone());
     let to_server = mock_screen.to_server.clone();
     let get_current_dir = || PathBuf::from(".");
-    let actions = Action::actions_from_cli(cli_action, Box::new(get_current_dir)).unwrap();
+    let actions = Action::actions_from_cli(cli_action, Box::new(get_current_dir), None).unwrap();
     for action in actions {
         route_action(
             action,

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -368,8 +368,7 @@ impl Action {
                     .map(|cwd| current_dir.join(cwd))
                     .or_else(|| Some(current_dir));
                 if let Some(layout_path) = layout {
-                    let layout_dir =
-                        layout_dir
+                    let layout_dir = layout_dir
                         .or_else(|| config.and_then(|c| c.options.layout_dir))
                         .or_else(|| get_layout_dir(find_default_config_dir()));
                     let (path_to_raw_layout, raw_layout, swap_layouts) =

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -7,7 +7,7 @@ use super::layout::{
 use crate::cli::CliAction;
 use crate::data::InputMode;
 use crate::data::{Direction, Resize};
-use crate::input::config::{ConfigError, KdlError};
+use crate::input::config::{Config, ConfigError, KdlError};
 use crate::input::options::OnForceClose;
 use crate::setup::{find_default_config_dir, get_layout_dir};
 use miette::{NamedSource, Report};
@@ -237,6 +237,7 @@ impl Action {
     pub fn actions_from_cli(
         cli_action: CliAction,
         get_current_dir: Box<dyn Fn() -> PathBuf>,
+        config: Option<Config>,
     ) -> Result<Vec<Action>, String> {
         match cli_action {
             CliAction::Write { bytes } => Ok(vec![Action::Write(bytes)]),
@@ -368,7 +369,9 @@ impl Action {
                     .or_else(|| Some(current_dir));
                 if let Some(layout_path) = layout {
                     let layout_dir =
-                        layout_dir.or_else(|| get_layout_dir(find_default_config_dir()));
+                        layout_dir
+                        .or_else(|| config.and_then(|c| c.options.layout_dir))
+                        .or_else(|| get_layout_dir(find_default_config_dir()));
                     let (path_to_raw_layout, raw_layout, swap_layouts) =
                         Layout::stringified_from_path_or_default(Some(&layout_path), layout_dir)
                             .map_err(|e| format!("Failed to load layout: {}", e))?;


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/2187

This PR does two things:
1. We now take the default shell from the default config when opening a new tab (if it's configured)
2. We now take the layout_dir from the default config when looking for new layouts while opening a new tab with the `zellij action new-tab` cli action.