### PR TITLE
fix(pty): report no-cwd for empty path returned from sysinfo

### DIFF
--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -722,7 +722,11 @@ impl ServerOsApi for ServerOsInputOutput {
         system_info.refresh_processes_specifics(ProcessRefreshKind::default());
 
         if let Some(process) = system_info.process(pid.into()) {
-            return Some(process.cwd().to_path_buf());
+            let cwd = process.cwd();
+            let cwd_is_empty = cwd.iter().next().is_none();
+            if !cwd_is_empty {
+                return Some(process.cwd().to_path_buf());
+            }
         }
         None
     }


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/2116

This was due to the `sysinfo` crate reporting permission denied as an empty path. We now check for this before returning the path.