### PR TITLE
fix(pty): do not crash when unable to set cwd

### DIFF
--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -174,12 +174,7 @@ fn handle_openpty(
                 if current_dir.exists() && current_dir.is_dir() {
                     command.current_dir(current_dir);
                 } else {
-                    // TODO: propagate this to the user
-                    return Err(anyhow!(
-                        "Failed to set CWD for new pane. '{}' does not exist or is not a folder",
-                        current_dir.display()
-                    ))
-                    .context("failed to open PTY");
+                    log::error!("Failed to set CWD for new pane. '{}' does not exist or is not a folder", current_dir.display());
                 }
             }
             command

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -174,7 +174,10 @@ fn handle_openpty(
                 if current_dir.exists() && current_dir.is_dir() {
                     command.current_dir(current_dir);
                 } else {
-                    log::error!("Failed to set CWD for new pane. '{}' does not exist or is not a folder", current_dir.display());
+                    log::error!(
+                        "Failed to set CWD for new pane. '{}' does not exist or is not a folder",
+                        current_dir.display()
+                    );
                 }
             }
             command


### PR DESCRIPTION
Better to log an error and open a pane in the current directory than to crash the entire app...