### PR TITLE
fix(layouts): naming and gototabname

### DIFF
--- a/zellij-server/src/plugins/mod.rs
+++ b/zellij-server/src/plugins/mod.rs
@@ -30,7 +30,7 @@ pub enum PluginInstruction {
         Option<TerminalAction>,
         Option<TiledPaneLayout>,
         Vec<FloatingPaneLayout>,
-        usize,          // tab_index
+        usize, // tab_index
         ClientId,
     ),
     Exit,

--- a/zellij-server/src/plugins/mod.rs
+++ b/zellij-server/src/plugins/mod.rs
@@ -30,7 +30,6 @@ pub enum PluginInstruction {
         Option<TerminalAction>,
         Option<TiledPaneLayout>,
         Vec<FloatingPaneLayout>,
-        Option<String>, // tab name
         usize,          // tab_index
         ClientId,
     ),
@@ -92,7 +91,6 @@ pub(crate) fn plugin_thread_main(
                 terminal_action,
                 tab_layout,
                 floating_panes_layout,
-                tab_name,
                 tab_index,
                 client_id,
             ) => {
@@ -123,7 +121,6 @@ pub(crate) fn plugin_thread_main(
                     terminal_action,
                     tab_layout,
                     floating_panes_layout,
-                    tab_name,
                     tab_index,
                     plugin_ids,
                     client_id,

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -359,7 +359,6 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                     client_id,
                 )
                 .with_context(err_context)?;
-
             },
             PtyInstruction::ClosePane(id) => {
                 pty.close_pane(id)

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -51,7 +51,6 @@ pub enum PtyInstruction {
         Option<TerminalAction>,
         Option<TiledPaneLayout>,
         Vec<FloatingPaneLayout>,
-        Option<String>,
         usize,                                // tab_index
         HashMap<RunPluginLocation, Vec<u32>>, // plugin_ids
         ClientId,
@@ -340,7 +339,6 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                 terminal_action,
                 tab_layout,
                 floating_panes_layout,
-                tab_name,
                 tab_index,
                 plugin_ids,
                 client_id,
@@ -362,20 +360,6 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                 )
                 .with_context(err_context)?;
 
-                if let Some(tab_name) = tab_name {
-                    // clear current name at first
-                    pty.bus
-                        .senders
-                        .send_to_screen(ScreenInstruction::UpdateTabName(vec![0], client_id))
-                        .with_context(err_context)?;
-                    pty.bus
-                        .senders
-                        .send_to_screen(ScreenInstruction::UpdateTabName(
-                            tab_name.into_bytes(),
-                            client_id,
-                        ))
-                        .with_context(err_context)?;
-                }
             },
             PtyInstruction::ClosePane(id) => {
                 pty.close_pane(id)

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -498,6 +498,7 @@ pub(crate) fn route_action(
                 .with_context(err_context)?;
         },
         Action::GoToTabName(name, create) => {
+            let shell = session.default_shell.clone();
             let swap_tiled_layouts = session.layout.swap_tiled_layouts.clone();
             let swap_floating_layouts = session.layout.swap_floating_layouts.clone();
             session
@@ -505,6 +506,7 @@ pub(crate) fn route_action(
                 .send_to_screen(ScreenInstruction::GoToTabName(
                     name,
                     (swap_tiled_layouts, swap_floating_layouts),
+                    shell,
                     create,
                     Some(client_id),
                 ))

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -209,6 +209,7 @@ pub enum ScreenInstruction {
     GoToTabName(
         String,
         (Vec<SwapTiledLayout>, Vec<SwapFloatingLayout>), // swap layouts
+        Option<TerminalAction>, // default_shell
         bool,
         Option<ClientId>,
     ),
@@ -2084,7 +2085,7 @@ pub(crate) fn screen_thread_main(
                     },
                 }
             },
-            ScreenInstruction::GoToTabName(tab_name, swap_layouts, create, client_id) => {
+            ScreenInstruction::GoToTabName(tab_name, swap_layouts, default_shell, create, client_id) => {
                 let client_id = if client_id.is_none() {
                     None
                 } else if screen
@@ -2106,7 +2107,7 @@ pub(crate) fn screen_thread_main(
                                 .bus
                                 .senders
                                 .send_to_plugin(PluginInstruction::NewTab(
-                                    None,
+                                    default_shell,
                                     None,
                                     vec![],
                                     tab_index,

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -209,7 +209,7 @@ pub enum ScreenInstruction {
     GoToTabName(
         String,
         (Vec<SwapTiledLayout>, Vec<SwapFloatingLayout>), // swap layouts
-        Option<TerminalAction>, // default_shell
+        Option<TerminalAction>,                          // default_shell
         bool,
         Option<ClientId>,
     ),
@@ -2085,7 +2085,13 @@ pub(crate) fn screen_thread_main(
                     },
                 }
             },
-            ScreenInstruction::GoToTabName(tab_name, swap_layouts, default_shell, create, client_id) => {
+            ScreenInstruction::GoToTabName(
+                tab_name,
+                swap_layouts,
+                default_shell,
+                create,
+                client_id,
+            ) => {
                 let client_id = if client_id.is_none() {
                     None
                 } else if screen

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -932,6 +932,7 @@ impl Screen {
         &mut self,
         tab_index: usize,
         swap_layouts: (Vec<SwapTiledLayout>, Vec<SwapFloatingLayout>),
+        tab_name: Option<String>,
         client_id: ClientId,
     ) -> Result<()> {
         let err_context = || format!("failed to create new tab for client {client_id:?}",);
@@ -944,11 +945,13 @@ impl Screen {
             client_id
         };
 
+        let tab_name = tab_name.unwrap_or_else(|| String::new());
+
         let position = self.tabs.len();
         let tab = Tab::new(
             tab_index,
             position,
-            String::new(),
+            tab_name,
             self.size,
             self.character_cell_size.clone(),
             self.sixel_image_store.clone(),
@@ -2018,7 +2021,7 @@ pub(crate) fn screen_thread_main(
             ) => {
                 let tab_index = screen.get_new_tab_index();
                 pending_tab_ids.insert(tab_index);
-                screen.new_tab(tab_index, swap_layouts, client_id)?;
+                screen.new_tab(tab_index, swap_layouts, tab_name.clone(), client_id)?;
                 screen
                     .bus
                     .senders
@@ -2026,7 +2029,6 @@ pub(crate) fn screen_thread_main(
                         default_shell,
                         layout,
                         floating_panes_layout,
-                        tab_name,
                         tab_index,
                         client_id,
                     ))?;
@@ -2099,7 +2101,7 @@ pub(crate) fn screen_thread_main(
                         screen.render()?;
                         if create && !tab_exists {
                             let tab_index = screen.get_new_tab_index();
-                            screen.new_tab(tab_index, swap_layouts, client_id)?;
+                            screen.new_tab(tab_index, swap_layouts, Some(tab_name), client_id)?;
                             screen
                                 .bus
                                 .senders
@@ -2107,7 +2109,6 @@ pub(crate) fn screen_thread_main(
                                     None,
                                     None,
                                     vec![],
-                                    Some(tab_name),
                                     tab_index,
                                     client_id,
                                 ))?;

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -671,8 +671,6 @@ impl Tab {
                 client_id,
             )?;
         }
-        self.is_pending = false;
-        self.apply_buffered_instructions()?;
         self.set_force_render();
         Ok(())
     }
@@ -726,8 +724,6 @@ impl Tab {
             )?;
         }
         self.tiled_panes.reapply_pane_frames();
-        self.is_pending = false;
-        self.apply_buffered_instructions()?;
         let display_area = *self.display_area.borrow();
         // we do this so that the new swap layout has a chance to pass through the constraint system
         self.tiled_panes.resize(display_area);

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -485,7 +485,7 @@ fn new_tab(screen: &mut Screen, pid: u32, tab_index: usize) {
     let new_terminal_ids = vec![(pid, None)];
     let new_plugin_ids = HashMap::new();
     screen
-        .new_tab(tab_index, (vec![], vec![]), client_id)
+        .new_tab(tab_index, (vec![], vec![]), None, client_id)
         .expect("TEST");
     screen
         .apply_layout(

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_tab_action_default_params.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_tab_action_default_params.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 2304
+assertion_line: 2394
 expression: "format!(\"{:#?}\", new_tab_action)"
 ---
 Some(
@@ -43,7 +43,6 @@ Some(
             },
         ),
         [],
-        None,
         0,
         1,
     ),

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_tab_action_with_name_and_layout.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_tab_action_with_name_and_layout.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 2354
+assertion_line: 2445
 expression: "format!(\"{:#?}\", new_tab_instruction)"
 ---
 NewTab(
@@ -65,9 +65,6 @@ NewTab(
         },
     ),
     [],
-    Some(
-        "my-awesome-tab-name",
-    ),
     1,
     10,
 )

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_rename_tab.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_rename_tab.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 2538
+assertion_line: 2629
 expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
 ---
 [
@@ -65,7 +65,6 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
             },
         ),
         [],
-        None,
         0,
         1,
     ),
@@ -219,7 +218,6 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
             },
         ),
         [],
-        None,
         1,
         1,
     ),

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_undo_rename_tab.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_undo_rename_tab.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 2581
+assertion_line: 2672
 expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
 ---
 [
@@ -65,7 +65,6 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
             },
         ),
         [],
-        None,
         0,
         1,
     ),
@@ -219,7 +218,6 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
             },
         ),
         [],
-        None,
         1,
         1,
     ),


### PR DESCRIPTION
This fixes three bugs:
1. Tab names in layouts were sometimes being ignored - this was caused due to a race condition between the pty and screen threads. Fixed by simplifying some needless roundtrips for the tab_name string and just applying it initially in the screen thread
2. The `GoToTabName` action would crash when creating a tab, this was fixed by removing the `self.is_pending = false` statement in the various layout applying method and only leaving it in the main one (not really sure why they were there in the first place...)
3. The `GoToTabName` now uses the default shell when creating new tabs (with the `--create` flag)

Thanks @har7an for finding the first issue!