### PR TITLE
fix(cli): make auto_layout work through the cli

### DIFF
--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -324,6 +324,7 @@ impl From<CliOptions> for Options {
             scrollback_editor: opts.scrollback_editor,
             session_name: opts.session_name,
             attach_to_session: opts.attach_to_session,
+            auto_layout: opts.auto_layout,
             ..Default::default()
         }
     }


### PR DESCRIPTION
Previously `auto_layout false` didn't work through the cli (eg. `zellij options --auto-layout false`). Now it does.