### PR TITLE
[DO NOT REVIEW YET - DRAFT]wrap around focus

### DIFF
--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -3,6 +3,7 @@ mod stacked_panes;
 mod tiled_pane_grid;
 
 use crate::resize_pty;
+use log::info;
 use tiled_pane_grid::{split, TiledPaneGrid, RESIZE_PERCENT};
 
 use crate::{
@@ -1011,7 +1012,7 @@ impl TiledPanes {
             None => false,
         }
     }
-    pub fn move_focus_right(&mut self, client_id: ClientId) -> bool {
+    pub fn move_focus_right(&mut self, client_id: ClientId, single_tab_wraparoud: bool) -> bool {
         match self.get_active_pane_id(client_id) {
             Some(active_pane_id) => {
                 let pane_grid = TiledPaneGrid::new(
@@ -1020,7 +1021,14 @@ impl TiledPanes {
                     *self.display_area.borrow(),
                     *self.viewport.borrow(),
                 );
-                let next_index = pane_grid.next_selectable_pane_id_to_the_right(&active_pane_id);
+                info!("active_pane_id: {:?}", active_pane_id);
+                let mut next_index =
+                    pane_grid.next_selectable_pane_id_to_the_right(&active_pane_id);
+
+                if next_index.is_none() && single_tab_wraparoud {
+                    next_index = Some(PaneId::Terminal(0));
+                }
+                info!("next_index: {:?}", next_index);
                 match next_index {
                     Some(p) => {
                         // render previously active pane so that its frame does not remain actively
@@ -1540,9 +1548,9 @@ impl TiledPanes {
         self.toggle_active_pane_fullscreen(client_id);
     }
 
-    pub fn focus_pane_right_fullscreen(&mut self, client_id: ClientId) {
+    pub fn focus_pane_right_fullscreen(&mut self, client_id: ClientId, single_tab_wraparoud: bool) {
         self.unset_fullscreen();
-        self.move_focus_right(client_id);
+        self.move_focus_right(client_id, single_tab_wraparoud);
         self.toggle_active_pane_fullscreen(client_id);
     }
 

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1322,11 +1322,12 @@ impl Screen {
         } else {
             self.get_first_client_id()
         };
+        let wrap_around_flag = if self.tabs.len() == 1 { true } else { false };
         if let Some(client_id) = client_id {
             match self.get_active_tab_mut(client_id) {
                 Ok(active_tab) => {
                     active_tab
-                        .move_focus_left(client_id)
+                        .move_focus_left(client_id, wrap_around_flag)
                         .and_then(|success| {
                             if !success {
                                 self.switch_tab_prev(client_id)
@@ -1356,14 +1357,13 @@ impl Screen {
             self.get_first_client_id()
         };
 
-        info!("active tabs: {:?}", self.active_tab_indices);
-        let single_tab_wraparound = if self.tabs.len() == 1 { true } else { false };
+        let wrap_around_flag = if self.tabs.len() == 1 { true } else { false };
 
         if let Some(client_id) = client_id {
             match self.get_active_tab_mut(client_id) {
                 Ok(active_tab) => {
                     active_tab
-                        .move_focus_right(client_id, single_tab_wraparound)
+                        .move_focus_right(client_id, wrap_around_flag)
                         .and_then(|success| {
                             if !success {
                                 self.switch_tab_next(client_id)
@@ -1666,7 +1666,7 @@ pub(crate) fn screen_thread_main(
                 active_tab_and_connected_client_id!(
                     screen,
                     client_id,
-                    |tab: &mut Tab, client_id: ClientId| tab.move_focus_left(client_id),
+                    |tab: &mut Tab, client_id: ClientId| tab.move_focus_left(client_id,false),
                     ?
                 );
                 screen.render()?;

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1615,24 +1615,21 @@ impl Tab {
     pub fn are_floating_panes_visible(&self) -> bool {
         self.floating_panes.panes_are_visible()
     }
-    pub fn focus_pane_left_fullscreen(&mut self, client_id: ClientId) {
-        if !self.is_fullscreen_active() {
-            return;
-        }
-
-        self.tiled_panes.focus_pane_left_fullscreen(client_id);
-    }
-    pub fn focus_pane_right_fullscreen(
-        &mut self,
-        client_id: ClientId,
-        single_tab_wraparound: bool,
-    ) {
+    pub fn focus_pane_left_fullscreen(&mut self, client_id: ClientId, wrap_around: bool) {
         if !self.is_fullscreen_active() {
             return;
         }
 
         self.tiled_panes
-            .focus_pane_right_fullscreen(client_id, single_tab_wraparound);
+            .focus_pane_left_fullscreen(client_id, wrap_around);
+    }
+    pub fn focus_pane_right_fullscreen(&mut self, client_id: ClientId, wrap_around: bool) {
+        if !self.is_fullscreen_active() {
+            return;
+        }
+
+        self.tiled_panes
+            .focus_pane_right_fullscreen(client_id, wrap_around);
     }
     pub fn focus_pane_up_fullscreen(&mut self, client_id: ClientId) {
         if !self.is_fullscreen_active() {
@@ -1922,7 +1919,7 @@ impl Tab {
         self.tiled_panes.focus_previous_pane(client_id);
     }
     // returns a boolean that indicates whether the focus moved
-    pub fn move_focus_left(&mut self, client_id: ClientId) -> Result<bool> {
+    pub fn move_focus_left(&mut self, client_id: ClientId, wrap_around: bool) -> Result<bool> {
         let err_context = || format!("failed to move focus left for client {}", client_id);
 
         if self.floating_panes.panes_are_visible() {
@@ -1938,10 +1935,10 @@ impl Tab {
                 return Ok(false);
             }
             if self.tiled_panes.fullscreen_is_active() {
-                self.focus_pane_left_fullscreen(client_id);
+                self.focus_pane_left_fullscreen(client_id, wrap_around);
                 return Ok(true);
             }
-            Ok(self.tiled_panes.move_focus_left(client_id))
+            Ok(self.tiled_panes.move_focus_left(client_id, wrap_around))
         }
     }
     pub fn move_focus_down(&mut self, client_id: ClientId) -> Result<bool> {
@@ -1989,11 +1986,7 @@ impl Tab {
         }
     }
     // returns a boolean that indicates whether the focus moved
-    pub fn move_focus_right(
-        &mut self,
-        client_id: ClientId,
-        single_tab_wraparound: bool,
-    ) -> Result<bool> {
+    pub fn move_focus_right(&mut self, client_id: ClientId, wrap_around: bool) -> Result<bool> {
         let err_context = || format!("failed to move focus right for client {}", client_id);
 
         if self.floating_panes.panes_are_visible() {
@@ -2007,17 +2000,13 @@ impl Tab {
                 .with_context(err_context)
         } else {
             if !self.has_selectable_panes() {
-                info!("no selectable panes");
                 return Ok(false);
             }
             if self.tiled_panes.fullscreen_is_active() {
-                info!("fullscreen is active");
-                self.focus_pane_right_fullscreen(client_id, single_tab_wraparound);
+                self.focus_pane_right_fullscreen(client_id, wrap_around);
                 return Ok(true);
             }
-            Ok(self
-                .tiled_panes
-                .move_focus_right(client_id, single_tab_wraparound))
+            Ok(self.tiled_panes.move_focus_right(client_id, wrap_around))
         }
     }
     pub fn move_active_pane(&mut self, client_id: ClientId) {

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -1105,7 +1105,7 @@ fn move_floating_pane_focus_left() {
         .unwrap();
     tab.handle_pty_bytes(6, Vec::from("\u{1b}#8".as_bytes()))
         .unwrap();
-    tab.move_focus_left(client_id).unwrap();
+    tab.move_focus_left(client_id, false).unwrap();
     tab.render(&mut output, None).unwrap();
     let (snapshot, cursor_coordinates) = take_snapshot_and_cursor_position(
         output.serialize().unwrap().get(&client_id).unwrap(),
@@ -1160,7 +1160,7 @@ fn move_floating_pane_focus_right() {
         .unwrap();
     tab.handle_pty_bytes(6, Vec::from("\u{1b}#8".as_bytes()))
         .unwrap();
-    tab.move_focus_left(client_id).unwrap();
+    tab.move_focus_left(client_id, false).unwrap();
     tab.move_focus_right(client_id, false).unwrap();
     tab.render(&mut output, None).unwrap();
     let (snapshot, cursor_coordinates) = take_snapshot_and_cursor_position(
@@ -2862,7 +2862,7 @@ fn move_pane_focus_sends_tty_csi_event() {
         Vec::from("\u{1b}[?1004h".as_bytes()),
     )
     .unwrap();
-    tab.move_focus_left(client_id).unwrap();
+    tab.move_focus_left(client_id, false).unwrap();
     assert_snapshot!(format!("{:?}", *tty_stdin_bytes.lock().unwrap()));
 }
 
@@ -2905,7 +2905,7 @@ fn move_floating_pane_focus_sends_tty_csi_event() {
         Vec::from("\u{1b}[?1004h".as_bytes()),
     )
     .unwrap();
-    tab.move_focus_left(client_id).unwrap();
+    tab.move_focus_left(client_id, false).unwrap();
     assert_snapshot!(format!("{:?}", *tty_stdin_bytes.lock().unwrap()));
 }
 
@@ -3399,7 +3399,7 @@ fn move_focus_right_into_stacked_panes() {
         tab.new_pane(PaneId::Terminal(new_pane_id), None, None, Some(client_id))
             .unwrap();
     }
-    tab.move_focus_left(client_id);
+    tab.move_focus_left(client_id, false);
     tab.horizontal_split(PaneId::Terminal(16), None, client_id)
         .unwrap();
 
@@ -3465,7 +3465,7 @@ fn move_focus_left_into_stacked_panes() {
         .unwrap();
 
     tab.move_focus_up(client_id);
-    tab.move_focus_left(client_id);
+    tab.move_focus_left(client_id, false);
     tab.render(&mut output, None).unwrap();
 
     let (snapshot, cursor_coordinates) = take_snapshot_and_cursor_position(
@@ -3525,7 +3525,7 @@ fn move_focus_up_into_stacked_panes() {
     }
     tab.move_focus_right(client_id, false);
     tab.move_focus_up(client_id);
-    tab.move_focus_left(client_id);
+    tab.move_focus_left(client_id, false);
     tab.move_focus_down(client_id);
     tab.vertical_split(PaneId::Terminal(7), None, client_id)
         .unwrap();
@@ -3587,7 +3587,7 @@ fn move_focus_down_into_stacked_panes() {
         tab.new_pane(PaneId::Terminal(new_pane_id), None, None, Some(client_id))
             .unwrap();
     }
-    tab.move_focus_left(client_id);
+    tab.move_focus_left(client_id, false);
     tab.move_focus_up(client_id);
     tab.vertical_split(PaneId::Terminal(7), None, client_id)
         .unwrap();
@@ -3767,7 +3767,7 @@ fn close_one_liner_stacked_pane_below_main_pane() {
         .unwrap();
     tab.new_pane(new_pane_id_5, None, None, Some(client_id))
         .unwrap();
-    tab.move_focus_left(client_id);
+    tab.move_focus_left(client_id, false);
     tab.move_focus_right(client_id, false);
     tab.move_focus_up(client_id);
     tab.move_focus_up(client_id);
@@ -4704,7 +4704,7 @@ fn focus_next_pane_expands_stacked_panes() {
         .unwrap();
     tab.new_pane(new_pane_id_5, None, None, Some(client_id))
         .unwrap();
-    tab.move_focus_left(client_id);
+    tab.move_focus_left(client_id, false);
     tab.focus_next_pane(client_id);
     tab.render(&mut output, None).unwrap();
     let snapshot = take_snapshot(

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -1161,7 +1161,7 @@ fn move_floating_pane_focus_right() {
     tab.handle_pty_bytes(6, Vec::from("\u{1b}#8".as_bytes()))
         .unwrap();
     tab.move_focus_left(client_id).unwrap();
-    tab.move_focus_right(client_id).unwrap();
+    tab.move_focus_right(client_id, false).unwrap();
     tab.render(&mut output, None).unwrap();
     let (snapshot, cursor_coordinates) = take_snapshot_and_cursor_position(
         output.serialize().unwrap().get(&client_id).unwrap(),
@@ -3296,7 +3296,7 @@ fn move_focus_up_with_stacked_panes() {
         .unwrap();
     tab.new_pane(new_pane_id_3, None, None, Some(client_id))
         .unwrap();
-    tab.move_focus_right(client_id);
+    tab.move_focus_right(client_id, false);
     tab.move_focus_up(client_id);
     tab.render(&mut output, None).unwrap();
     let snapshot = take_snapshot(
@@ -3348,7 +3348,7 @@ fn move_focus_down_with_stacked_panes() {
         .unwrap();
     tab.new_pane(new_pane_id_3, None, None, Some(client_id))
         .unwrap();
-    tab.move_focus_right(client_id);
+    tab.move_focus_right(client_id, false);
     tab.move_focus_up(client_id);
     tab.move_focus_down(client_id);
     tab.render(&mut output, None).unwrap();
@@ -3404,7 +3404,7 @@ fn move_focus_right_into_stacked_panes() {
         .unwrap();
 
     tab.move_focus_up(client_id);
-    tab.move_focus_right(client_id);
+    tab.move_focus_right(client_id, false);
     tab.render(&mut output, None).unwrap();
 
     let (snapshot, cursor_coordinates) = take_snapshot_and_cursor_position(
@@ -3460,7 +3460,7 @@ fn move_focus_left_into_stacked_panes() {
         tab.new_pane(PaneId::Terminal(new_pane_id), None, None, Some(client_id))
             .unwrap();
     }
-    tab.move_focus_right(client_id);
+    tab.move_focus_right(client_id, false);
     tab.horizontal_split(PaneId::Terminal(1), None, client_id)
         .unwrap();
 
@@ -3523,7 +3523,7 @@ fn move_focus_up_into_stacked_panes() {
         tab.new_pane(PaneId::Terminal(new_pane_id), None, None, Some(client_id))
             .unwrap();
     }
-    tab.move_focus_right(client_id);
+    tab.move_focus_right(client_id, false);
     tab.move_focus_up(client_id);
     tab.move_focus_left(client_id);
     tab.move_focus_down(client_id);
@@ -3707,7 +3707,7 @@ fn close_main_stacked_pane_in_mid_stack() {
         .unwrap();
     tab.new_pane(new_pane_id_5, None, None, Some(client_id))
         .unwrap();
-    tab.move_focus_right(client_id);
+    tab.move_focus_right(client_id, false);
     tab.move_focus_up(client_id);
     tab.move_focus_up(client_id);
     tab.close_pane(new_pane_id_3, false, None);
@@ -3768,7 +3768,7 @@ fn close_one_liner_stacked_pane_below_main_pane() {
     tab.new_pane(new_pane_id_5, None, None, Some(client_id))
         .unwrap();
     tab.move_focus_left(client_id);
-    tab.move_focus_right(client_id);
+    tab.move_focus_right(client_id, false);
     tab.move_focus_up(client_id);
     tab.move_focus_up(client_id);
     tab.close_pane(new_pane_id_2, false, None);
@@ -3828,7 +3828,7 @@ fn close_one_liner_stacked_pane_above_main_pane() {
         .unwrap();
     tab.new_pane(new_pane_id_5, None, None, Some(client_id))
         .unwrap();
-    tab.move_focus_right(client_id);
+    tab.move_focus_right(client_id, false);
     tab.move_focus_up(client_id);
     tab.move_focus_up(client_id);
     tab.close_pane(new_pane_id_1, false, None);
@@ -3888,7 +3888,7 @@ fn can_increase_size_of_main_pane_in_stack_horizontally() {
         .unwrap();
     tab.new_pane(new_pane_id_5, None, None, Some(client_id))
         .unwrap();
-    tab.move_focus_right(client_id);
+    tab.move_focus_right(client_id, false);
     tab.resize(
         client_id,
         ResizeStrategy::new(Resize::Increase, Some(Direction::Left)),
@@ -3952,7 +3952,7 @@ fn can_increase_size_of_main_pane_in_stack_vertically() {
         .unwrap();
     tab.new_pane(new_pane_id_5, None, None, Some(client_id))
         .unwrap();
-    tab.move_focus_right(client_id);
+    tab.move_focus_right(client_id, false);
     tab.resize(
         client_id,
         ResizeStrategy::new(Resize::Increase, Some(Direction::Down)),
@@ -4017,7 +4017,7 @@ fn can_increase_size_of_main_pane_in_stack_non_directionally() {
     tab.new_pane(new_pane_id_5, None, None, Some(client_id))
         .unwrap();
     let _ = tab.move_focus_up(client_id);
-    let _ = tab.move_focus_right(client_id);
+    let _ = tab.move_focus_right(client_id, false);
     tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None))
         .unwrap();
     tab.render(&mut output, None).unwrap();
@@ -4139,7 +4139,7 @@ fn can_increase_size_into_pane_stack_vertically() {
         .unwrap();
     tab.new_pane(new_pane_id_5, None, None, Some(client_id))
         .unwrap();
-    tab.move_focus_right(client_id);
+    tab.move_focus_right(client_id, false);
     tab.move_focus_down(client_id);
     tab.resize(
         client_id,

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -1136,7 +1136,7 @@ pub fn close_pane_with_another_pane_to_the_right() {
     let mut tab = create_new_tab(size);
     let new_pane_id = PaneId::Terminal(2);
     tab.vertical_split(new_pane_id, None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.close_focused_pane(1).unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 1, "One pane left in tab");
 
@@ -1423,9 +1423,9 @@ pub fn close_pane_with_multiple_panes_to_the_left() {
     let new_pane_id_1 = PaneId::Terminal(2);
     let new_pane_id_2 = PaneId::Terminal(3);
     tab.vertical_split(new_pane_id_1, None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
-    tab.move_focus_right(1, false).unwrap();
+    tab.move_focus_right(1, true).unwrap();
     tab.close_focused_pane(1).unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 2, "Two panes left in tab");
 
@@ -1535,7 +1535,7 @@ pub fn close_pane_with_multiple_panes_to_the_right() {
     let new_pane_id_2 = PaneId::Terminal(3);
     tab.vertical_split(new_pane_id_1, None, 1).unwrap();
     tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.close_focused_pane(1).unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 2, "Two panes left in tab");
 
@@ -1650,14 +1650,14 @@ pub fn close_pane_with_multiple_panes_above_it_away_from_screen_edges() {
 
     tab.vertical_split(new_pane_id_1, None, 1).unwrap();
     tab.vertical_split(new_pane_id_2, None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_right(1, false).unwrap();
+    tab.move_focus_right(1, true).unwrap();
     tab.horizontal_split(new_pane_id_4, None, 1).unwrap();
-    tab.move_focus_right(1, false).unwrap();
+    tab.move_focus_right(1, true).unwrap();
     tab.horizontal_split(new_pane_id_5, None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.move_focus_up(1).unwrap();
     tab_resize_down(&mut tab, 1);
     tab.vertical_split(new_pane_id_6, None, 1).unwrap();
@@ -1950,14 +1950,14 @@ pub fn close_pane_with_multiple_panes_below_it_away_from_screen_edges() {
 
     tab.vertical_split(new_pane_id_1, None, 1).unwrap();
     tab.vertical_split(new_pane_id_2, None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_right(1, false).unwrap();
+    tab.move_focus_right(1, true).unwrap();
     tab.horizontal_split(new_pane_id_4, None, 1).unwrap();
-    tab.move_focus_right(1, false).unwrap();
+    tab.move_focus_right(1, true).unwrap();
     tab.horizontal_split(new_pane_id_5, None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_up(&mut tab, 1);
     tab.vertical_split(new_pane_id_6, None, 1).unwrap();
     tab.move_focus_up(1).unwrap();
@@ -2259,12 +2259,12 @@ pub fn close_pane_with_multiple_panes_to_the_left_away_from_screen_edges() {
     tab.move_focus_down(1).unwrap();
     tab.vertical_split(new_pane_id_5, None, 1).unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_right(&mut tab, 1);
     tab_resize_up(&mut tab, 1);
     tab_resize_up(&mut tab, 1);
     tab.horizontal_split(new_pane_id_6, None, 1).unwrap();
-    tab.move_focus_right(1, false).unwrap();
+    tab.move_focus_right(1, true).unwrap();
     tab.close_focused_pane(1).unwrap();
 
     assert_eq!(tab.tiled_panes.panes.len(), 6, "Six panes left in tab");
@@ -2567,7 +2567,7 @@ pub fn close_pane_with_multiple_panes_to_the_right_away_from_screen_edges() {
     tab_resize_up(&mut tab, 1);
     tab_resize_up(&mut tab, 1);
     tab.horizontal_split(new_pane_id_6, None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.close_focused_pane(1).unwrap();
 
     assert_eq!(tab.tiled_panes.panes.len(), 6, "Six panes left in tab");
@@ -2939,7 +2939,7 @@ pub fn move_focus_left() {
     let new_pane_id = PaneId::Terminal(2);
 
     tab.vertical_split(new_pane_id, None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
 
     assert_eq!(
         tab.get_active_pane(1).unwrap().x(),
@@ -2960,11 +2960,11 @@ pub fn move_focus_left_to_the_most_recently_used_pane() {
     let new_pane_id_3 = PaneId::Terminal(4);
 
     tab.vertical_split(new_pane_id_1, None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
     tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_right(1, false).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_right(1, true).unwrap();
+    tab.move_focus_left(1, true).unwrap();
 
     assert_eq!(
         tab.get_active_pane(1).unwrap().y(),
@@ -2988,8 +2988,8 @@ pub fn move_focus_right() {
     let new_pane_id = PaneId::Terminal(2);
 
     tab.vertical_split(new_pane_id, None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
-    tab.move_focus_right(1, false).unwrap();
+    tab.move_focus_left(1, true).unwrap();
+    tab.move_focus_right(1, true).unwrap();
 
     assert_eq!(
         tab.get_active_pane(1).unwrap().x(),
@@ -3012,8 +3012,8 @@ pub fn move_focus_right_to_the_most_recently_used_pane() {
     tab.vertical_split(new_pane_id_1, None, 1).unwrap();
     tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
     tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
-    tab.move_focus_right(1, false).unwrap();
+    tab.move_focus_left(1, true).unwrap();
+    tab.move_focus_right(1, true).unwrap();
 
     assert_eq!(
         tab.get_active_pane(1).unwrap().y(),
@@ -3182,10 +3182,10 @@ pub fn move_active_pane_left_to_the_most_recently_used_position() {
     let new_pane_id_3 = PaneId::Terminal(4);
 
     tab.vertical_split(new_pane_id_1, None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
     tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_right(1, false).unwrap();
+    tab.move_focus_right(1, true).unwrap();
     tab.move_active_pane_left(1);
 
     assert_eq!(
@@ -3216,7 +3216,7 @@ pub fn move_active_pane_right() {
     let new_pane_id = PaneId::Terminal(2);
 
     tab.vertical_split(new_pane_id, None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.move_active_pane_right(1);
 
     assert_eq!(
@@ -3245,7 +3245,7 @@ pub fn move_active_pane_right_to_the_most_recently_used_position() {
     tab.vertical_split(new_pane_id_1, None, 1).unwrap();
     tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
     tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.move_active_pane_right(1);
 
     assert_eq!(
@@ -4213,7 +4213,7 @@ pub fn resize_down_with_panes_above_aligned_right_with_current_pane() {
     tab.move_focus_up(1).unwrap();
     tab.vertical_split(pane_above_and_right, None, 1).unwrap();
     tab.move_focus_down(1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_down(&mut tab, 1);
 
     assert_eq!(
@@ -4413,7 +4413,7 @@ pub fn resize_down_with_panes_below_aligned_right_with_current_pane() {
     tab.vertical_split(pane_below_and_right, None, 1).unwrap();
     tab.move_focus_up(1).unwrap();
     tab.vertical_split(pane_to_the_right, None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_down(&mut tab, 1);
 
     assert_eq!(
@@ -4611,7 +4611,7 @@ pub fn resize_down_with_panes_above_aligned_left_and_right_with_current_pane() {
     tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.move_focus_down(1).unwrap();
     tab_resize_down(&mut tab, 1);
 
@@ -4896,7 +4896,7 @@ pub fn resize_down_with_panes_below_aligned_left_and_right_with_current_pane() {
     tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_down(&mut tab, 1);
 
     assert_eq!(
@@ -5181,10 +5181,10 @@ pub fn resize_down_with_panes_above_aligned_left_and_right_with_panes_to_the_lef
     tab.move_focus_down(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.vertical_split(PaneId::Terminal(7), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(8), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_down(&mut tab, 1);
 
     assert_eq!(
@@ -5552,15 +5552,15 @@ pub fn resize_down_with_panes_below_aligned_left_and_right_with_to_the_left_and_
     tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
     tab.move_focus_down(1).unwrap();
     tab.vertical_split(PaneId::Terminal(7), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(8), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_down(&mut tab, 1);
 
     assert_eq!(
@@ -6206,7 +6206,7 @@ pub fn resize_left_with_pane_to_the_right() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_left(&mut tab, 1);
 
     assert_eq!(
@@ -6312,7 +6312,7 @@ pub fn resize_left_with_panes_to_the_left_and_right() {
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_left(&mut tab, 1);
 
     assert_eq!(
@@ -6459,9 +6459,9 @@ pub fn resize_left_with_multiple_panes_to_the_left() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_right(1, false).unwrap();
+    tab.move_focus_right(1, true).unwrap();
     tab_resize_left(&mut tab, 1);
 
     assert_eq!(
@@ -6807,7 +6807,7 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_with_current_pane() {
     tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
     tab.move_focus_down(1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_left(&mut tab, 1);
 
     assert_eq!(
@@ -7194,7 +7194,7 @@ pub fn resize_left_with_panes_to_the_right_aligned_bottom_with_current_pane() {
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_left(&mut tab, 1);
 
     assert_eq!(
@@ -7679,7 +7679,7 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_and_bottom_with_current_p
     tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
     tab.move_focus_down(1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_left(&mut tab, 1);
 
     assert_eq!(
@@ -8341,7 +8341,7 @@ pub fn resize_left_with_panes_to_the_right_aligned_top_and_bottom_with_panes_abo
     tab.move_focus_down(1).unwrap();
     tab_resize_down(&mut tab, 1);
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.horizontal_split(PaneId::Terminal(7), None, 1).unwrap();
     tab.horizontal_split(PaneId::Terminal(8), None, 1).unwrap();
     tab.move_focus_up(1).unwrap();
@@ -8849,7 +8849,7 @@ pub fn resize_right_with_pane_to_the_right() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_right(&mut tab, 1);
 
     assert_eq!(
@@ -8955,7 +8955,7 @@ pub fn resize_right_with_panes_to_the_left_and_right() {
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_right(&mut tab, 1);
 
     assert_eq!(
@@ -9103,7 +9103,7 @@ pub fn resize_right_with_multiple_panes_to_the_left() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.move_focus_right(1, false).unwrap();
     tab_resize_right(&mut tab, 1);
@@ -9253,9 +9253,9 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_with_current_pane() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_right(1, false).unwrap();
+    tab.move_focus_right(1, true).unwrap();
     tab.horizontal_split(PaneId::Terminal(4), None, 1).unwrap();
     tab_resize_right(&mut tab, 1);
 
@@ -9446,11 +9446,11 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_with_current_pane() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_right(1, false).unwrap();
+    tab.move_focus_right(1, true).unwrap();
     tab.horizontal_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_right(&mut tab, 1);
 
     assert_eq!(
@@ -9641,9 +9641,9 @@ pub fn resize_right_with_panes_to_the_left_aligned_bottom_with_current_pane() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_right(1, false).unwrap();
+    tab.move_focus_right(1, true).unwrap();
     tab.horizontal_split(PaneId::Terminal(4), None, 1).unwrap();
     tab.move_focus_up(1).unwrap();
     tab_resize_right(&mut tab, 1);
@@ -9836,12 +9836,12 @@ pub fn resize_right_with_panes_to_the_right_aligned_bottom_with_current_pane() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_right(1, false).unwrap();
+    tab.move_focus_right(1, true).unwrap();
     tab.horizontal_split(PaneId::Terminal(4), None, 1).unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_right(&mut tab, 1);
 
     assert_eq!(
@@ -10325,7 +10325,7 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_and_bottom_with_current_
     tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
     tab.move_focus_down(1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_right(&mut tab, 1);
 
     assert_eq!(
@@ -10985,7 +10985,7 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_and_bottom_with_panes_ab
     tab.move_focus_down(1).unwrap();
     tab_resize_up(&mut tab, 1);
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.horizontal_split(PaneId::Terminal(7), None, 1).unwrap();
     tab.horizontal_split(PaneId::Terminal(8), None, 1).unwrap();
     tab.move_focus_up(1).unwrap();
@@ -12342,7 +12342,7 @@ pub fn resize_up_with_panes_above_aligned_right_with_current_pane() {
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.move_focus_down(1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_up(&mut tab, 1);
 
     assert_eq!(
@@ -12538,7 +12538,7 @@ pub fn resize_up_with_panes_below_aligned_right_with_current_pane() {
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.move_focus_down(1).unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.move_focus_up(1).unwrap();
     tab_resize_up(&mut tab, 1);
 
@@ -12736,7 +12736,7 @@ pub fn resize_up_with_panes_above_aligned_left_and_right_with_current_pane() {
     tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_up(&mut tab, 1);
 
     assert_eq!(
@@ -13019,7 +13019,7 @@ pub fn resize_up_with_panes_below_aligned_left_and_right_with_current_pane() {
     tab.move_focus_up(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.move_focus_up(1).unwrap();
     tab_resize_up(&mut tab, 1);
 
@@ -13304,10 +13304,10 @@ pub fn resize_up_with_panes_above_aligned_left_and_right_with_panes_to_the_left_
     tab.move_focus_down(1).unwrap();
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.vertical_split(PaneId::Terminal(7), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(8), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_up(&mut tab, 1);
 
     assert_eq!(
@@ -13678,10 +13678,10 @@ pub fn resize_up_with_panes_below_aligned_left_and_right_with_to_the_left_and_ri
     tab.vertical_split(PaneId::Terminal(5), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(6), None, 1).unwrap();
     tab.move_focus_up(1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.vertical_split(PaneId::Terminal(7), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(8), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_up(&mut tab, 1);
 
     assert_eq!(
@@ -14134,7 +14134,7 @@ pub fn nondirectional_resize_increase_with_2_panes_to_left() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
     tab.move_focus_right(1, false).unwrap();
     tab_resize_increase(&mut tab, 1);
@@ -14192,7 +14192,7 @@ pub fn nondirectional_resize_increase_with_1_pane_to_right_1_pane_above() {
     };
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
     tab_resize_increase(&mut tab, 1);
 
@@ -14249,7 +14249,7 @@ pub fn nondirectional_resize_increase_with_1_pane_to_right_1_pane_to_left() {
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_increase(&mut tab, 1);
 
     assert_eq!(
@@ -14305,7 +14305,7 @@ pub fn nondirectional_resize_increase_with_pane_above_aligned_right_with_current
     let mut tab = create_new_tab(size);
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.vertical_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_left(1).unwrap();
+    tab.move_focus_left(1, true).unwrap();
     tab_resize_increase(&mut tab, 1);
 
     assert_eq!(

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -1425,7 +1425,7 @@ pub fn close_pane_with_multiple_panes_to_the_left() {
     tab.vertical_split(new_pane_id_1, None, 1).unwrap();
     tab.move_focus_left(1).unwrap();
     tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
-    tab.move_focus_right(1).unwrap();
+    tab.move_focus_right(1, false).unwrap();
     tab.close_focused_pane(1).unwrap();
     assert_eq!(tab.tiled_panes.panes.len(), 2, "Two panes left in tab");
 
@@ -1653,9 +1653,9 @@ pub fn close_pane_with_multiple_panes_above_it_away_from_screen_edges() {
     tab.move_focus_left(1).unwrap();
     tab.move_focus_left(1).unwrap();
     tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_right(1).unwrap();
+    tab.move_focus_right(1, false).unwrap();
     tab.horizontal_split(new_pane_id_4, None, 1).unwrap();
-    tab.move_focus_right(1).unwrap();
+    tab.move_focus_right(1, false).unwrap();
     tab.horizontal_split(new_pane_id_5, None, 1).unwrap();
     tab.move_focus_left(1).unwrap();
     tab.move_focus_up(1).unwrap();
@@ -1953,9 +1953,9 @@ pub fn close_pane_with_multiple_panes_below_it_away_from_screen_edges() {
     tab.move_focus_left(1).unwrap();
     tab.move_focus_left(1).unwrap();
     tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_right(1).unwrap();
+    tab.move_focus_right(1, false).unwrap();
     tab.horizontal_split(new_pane_id_4, None, 1).unwrap();
-    tab.move_focus_right(1).unwrap();
+    tab.move_focus_right(1, false).unwrap();
     tab.horizontal_split(new_pane_id_5, None, 1).unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_up(&mut tab, 1);
@@ -2264,7 +2264,7 @@ pub fn close_pane_with_multiple_panes_to_the_left_away_from_screen_edges() {
     tab_resize_up(&mut tab, 1);
     tab_resize_up(&mut tab, 1);
     tab.horizontal_split(new_pane_id_6, None, 1).unwrap();
-    tab.move_focus_right(1).unwrap();
+    tab.move_focus_right(1, false).unwrap();
     tab.close_focused_pane(1).unwrap();
 
     assert_eq!(tab.tiled_panes.panes.len(), 6, "Six panes left in tab");
@@ -2963,7 +2963,7 @@ pub fn move_focus_left_to_the_most_recently_used_pane() {
     tab.move_focus_left(1).unwrap();
     tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
     tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_right(1).unwrap();
+    tab.move_focus_right(1, false).unwrap();
     tab.move_focus_left(1).unwrap();
 
     assert_eq!(
@@ -2989,7 +2989,7 @@ pub fn move_focus_right() {
 
     tab.vertical_split(new_pane_id, None, 1).unwrap();
     tab.move_focus_left(1).unwrap();
-    tab.move_focus_right(1).unwrap();
+    tab.move_focus_right(1, false).unwrap();
 
     assert_eq!(
         tab.get_active_pane(1).unwrap().x(),
@@ -3013,7 +3013,7 @@ pub fn move_focus_right_to_the_most_recently_used_pane() {
     tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
     tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
     tab.move_focus_left(1).unwrap();
-    tab.move_focus_right(1).unwrap();
+    tab.move_focus_right(1, false).unwrap();
 
     assert_eq!(
         tab.get_active_pane(1).unwrap().y(),
@@ -3185,7 +3185,7 @@ pub fn move_active_pane_left_to_the_most_recently_used_position() {
     tab.move_focus_left(1).unwrap();
     tab.horizontal_split(new_pane_id_2, None, 1).unwrap();
     tab.horizontal_split(new_pane_id_3, None, 1).unwrap();
-    tab.move_focus_right(1).unwrap();
+    tab.move_focus_right(1, false).unwrap();
     tab.move_active_pane_left(1);
 
     assert_eq!(
@@ -6461,7 +6461,7 @@ pub fn resize_left_with_multiple_panes_to_the_left() {
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.move_focus_left(1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_right(1).unwrap();
+    tab.move_focus_right(1, false).unwrap();
     tab_resize_left(&mut tab, 1);
 
     assert_eq!(
@@ -9105,7 +9105,7 @@ pub fn resize_right_with_multiple_panes_to_the_left() {
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.move_focus_left(1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_right(1).unwrap();
+    tab.move_focus_right(1, false).unwrap();
     tab_resize_right(&mut tab, 1);
 
     assert_eq!(
@@ -9255,7 +9255,7 @@ pub fn resize_right_with_panes_to_the_left_aligned_top_with_current_pane() {
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.move_focus_left(1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_right(1).unwrap();
+    tab.move_focus_right(1, false).unwrap();
     tab.horizontal_split(PaneId::Terminal(4), None, 1).unwrap();
     tab_resize_right(&mut tab, 1);
 
@@ -9448,7 +9448,7 @@ pub fn resize_right_with_panes_to_the_right_aligned_top_with_current_pane() {
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.move_focus_left(1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_right(1).unwrap();
+    tab.move_focus_right(1, false).unwrap();
     tab.horizontal_split(PaneId::Terminal(4), None, 1).unwrap();
     tab.move_focus_left(1).unwrap();
     tab_resize_right(&mut tab, 1);
@@ -9643,7 +9643,7 @@ pub fn resize_right_with_panes_to_the_left_aligned_bottom_with_current_pane() {
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.move_focus_left(1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_right(1).unwrap();
+    tab.move_focus_right(1, false).unwrap();
     tab.horizontal_split(PaneId::Terminal(4), None, 1).unwrap();
     tab.move_focus_up(1).unwrap();
     tab_resize_right(&mut tab, 1);
@@ -9838,7 +9838,7 @@ pub fn resize_right_with_panes_to_the_right_aligned_bottom_with_current_pane() {
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.move_focus_left(1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_right(1).unwrap();
+    tab.move_focus_right(1, false).unwrap();
     tab.horizontal_split(PaneId::Terminal(4), None, 1).unwrap();
     tab.move_focus_up(1).unwrap();
     tab.move_focus_left(1).unwrap();
@@ -14136,7 +14136,7 @@ pub fn nondirectional_resize_increase_with_2_panes_to_left() {
     tab.vertical_split(PaneId::Terminal(2), None, 1).unwrap();
     tab.move_focus_left(1).unwrap();
     tab.horizontal_split(PaneId::Terminal(3), None, 1).unwrap();
-    tab.move_focus_right(1).unwrap();
+    tab.move_focus_right(1, false).unwrap();
     tab_resize_increase(&mut tab, 1);
 
     // should behave like `resize_left_with_multiple_panes_to_the_left`


### PR DESCRIPTION
> please do not review this pr yet, some clean up and further tweak is not completed

Try to address #2071 and #1444 

Wrap around pane focus if there is only one tab



How the fix works:

![wraparound](https://user-images.githubusercontent.com/85712372/223569625-18bc85b5-c376-4baf-927b-4168b35095b6.gif)

- [x] Run `cargo xtask test`