### PR TITLE
fix: zellij attach when the -c / --create option is passed

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -333,10 +333,6 @@ pub(crate) fn start_client(opts: CliArgs) {
     };
     let os_input = get_os_input(get_client_os_input);
 
-    let start_client_plan = |session_name: std::string::String| {
-        assert_session_ne(&session_name);
-    };
-
     if let Some(Command::Sessions(Sessions::Attach {
         session_name,
         create,
@@ -344,6 +340,10 @@ pub(crate) fn start_client(opts: CliArgs) {
         options,
     })) = opts.command.clone()
     {
+        let start_client_plan = |session_name: std::string::String| {
+            assert_session_ne(&session_name, create);
+        };
+
         let config_options = match options.as_deref() {
             Some(SessionCommand::Options(o)) => config_options.merge_from_cli(o.to_owned().into()),
             None => config_options,
@@ -383,6 +383,10 @@ pub(crate) fn start_client(opts: CliArgs) {
             attach_layout,
         );
     } else {
+        let start_client_plan = |session_name: std::string::String| {
+            assert_session_ne(&session_name, false);
+        };
+
         if let Some(session_name) = opts.session.clone() {
             start_client_plan(session_name.clone());
             start_client_impl(

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -197,7 +197,7 @@ pub(crate) fn assert_session(name: &str) {
     process::exit(1);
 }
 
-pub(crate) fn assert_session_ne(name: &str) {
+pub(crate) fn assert_session_ne(name: &str, create: bool) {
     if name.trim().is_empty() {
         eprintln!("Session name cannot be empty. Please provide a specific session name.");
         process::exit(1);
@@ -213,6 +213,7 @@ pub(crate) fn assert_session_ne(name: &str) {
 
     match session_exists(name) {
         Ok(result) if !result => return,
+        Ok(_) if create => return, // When zellij is started with 'attach -c <name>'
         Ok(_) => println!("Session with name {:?} already exists. Use attach command to connect to it or specify a different name.", name),
         Err(e) => eprintln!("Error occurred: {:?}", e),
     };


### PR DESCRIPTION
`assert_session_ne` is called before the value of `-c` is known to create a session when attaching if it doesn't exist.

Move the call (and duplicate) to perform the session name validation, passing a boolean along to denote creation.