### PR TITLE
Fix 2205 - Support cwd

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -349,6 +349,7 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                         ..Default::default()
                     })
                 });
+                let cwd = config_options.default_cwd;
 
                 let spawn_tabs = |tab_layout, floating_panes_layout, tab_name, swap_layouts| {
                     session_data
@@ -358,6 +359,7 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                         .unwrap()
                         .senders
                         .send_to_screen(ScreenInstruction::NewTab(
+                            cwd.clone(),
                             default_shell.clone(),
                             tab_layout,
                             floating_panes_layout,

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -345,7 +345,7 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                 let default_shell = config_options.default_shell.map(|shell| {
                     TerminalAction::RunCommand(RunCommand {
                         command: shell,
-                        cwd: config_options.default_cwd.clone(),
+                        cwd: config_options.override_cwd.clone(),
                         ..Default::default()
                     })
                 });
@@ -706,7 +706,7 @@ fn init_session(
     let default_shell = config_options.default_shell.clone().map(|command| {
         TerminalAction::RunCommand(RunCommand {
             command,
-            cwd: config_options.default_cwd.clone(),
+            cwd: config_options.override_cwd.clone(),
             ..Default::default()
         })
     });

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -345,6 +345,7 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                 let default_shell = config_options.default_shell.map(|shell| {
                     TerminalAction::RunCommand(RunCommand {
                         command: shell,
+                        cwd: config_options.default_cwd.clone(),
                         ..Default::default()
                     })
                 });
@@ -705,6 +706,7 @@ fn init_session(
     let default_shell = config_options.default_shell.clone().map(|command| {
         TerminalAction::RunCommand(RunCommand {
             command,
+            cwd: config_options.default_cwd.clone(),
             ..Default::default()
         })
     });

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -345,7 +345,7 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                 let default_shell = config_options.default_shell.map(|shell| {
                     TerminalAction::RunCommand(RunCommand {
                         command: shell,
-                        cwd: config_options.override_cwd.clone(),
+                        cwd: config_options.default_cwd.clone(),
                         ..Default::default()
                     })
                 });
@@ -706,7 +706,6 @@ fn init_session(
     let default_shell = config_options.default_shell.clone().map(|command| {
         TerminalAction::RunCommand(RunCommand {
             command,
-            cwd: config_options.override_cwd.clone(),
             ..Default::default()
         })
     });

--- a/zellij-server/src/plugins/mod.rs
+++ b/zellij-server/src/plugins/mod.rs
@@ -27,6 +27,7 @@ pub enum PluginInstruction {
     AddClient(ClientId),
     RemoveClient(ClientId),
     NewTab(
+        Option<PathBuf>,
         Option<TerminalAction>,
         Option<TiledPaneLayout>,
         Vec<FloatingPaneLayout>,
@@ -88,6 +89,7 @@ pub(crate) fn plugin_thread_main(
                 wasm_bridge.remove_client(client_id);
             },
             PluginInstruction::NewTab(
+                cwd,
                 terminal_action,
                 tab_layout,
                 floating_panes_layout,
@@ -118,6 +120,7 @@ pub(crate) fn plugin_thread_main(
                     }
                 }
                 drop(bus.senders.send_to_pty(PtyInstruction::NewTab(
+                    cwd,
                     terminal_action,
                     tab_layout,
                     floating_panes_layout,

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -458,6 +458,7 @@ pub(crate) fn route_action(
             session
                 .senders
                 .send_to_screen(ScreenInstruction::NewTab(
+                    None,
                     shell,
                     tab_layout,
                     floating_panes_layout,

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -2,6 +2,7 @@
 
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::PathBuf;
 use std::rc::Rc;
 use std::str;
 
@@ -185,6 +186,7 @@ pub enum ScreenInstruction {
     UpdatePaneName(Vec<u8>, ClientId),
     UndoRenamePane(ClientId),
     NewTab(
+        Option<PathBuf>,
         Option<TerminalAction>,
         Option<TiledPaneLayout>,
         Vec<FloatingPaneLayout>,
@@ -2019,6 +2021,7 @@ pub(crate) fn screen_thread_main(
                 screen.render()?;
             },
             ScreenInstruction::NewTab(
+                cwd,
                 default_shell,
                 layout,
                 floating_panes_layout,
@@ -2033,6 +2036,7 @@ pub(crate) fn screen_thread_main(
                     .bus
                     .senders
                     .send_to_plugin(PluginInstruction::NewTab(
+                        cwd,
                         default_shell,
                         layout,
                         floating_panes_layout,
@@ -2119,6 +2123,7 @@ pub(crate) fn screen_thread_main(
                                 .bus
                                 .senders
                                 .send_to_plugin(PluginInstruction::NewTab(
+                                    None,
                                     default_shell,
                                     None,
                                     vec![],

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -299,6 +299,7 @@ impl MockScreen {
         let tab_name = None;
         let tab_index = self.last_opened_tab_index.map(|l| l + 1).unwrap_or(0);
         let _ = self.to_screen.send(ScreenInstruction::NewTab(
+            None,
             default_shell,
             Some(pane_layout.clone()),
             vec![], // floating_panes_layout
@@ -329,6 +330,7 @@ impl MockScreen {
             pane_ids.push((i as u32, None));
         }
         let _ = self.to_screen.send(ScreenInstruction::NewTab(
+            None,
             default_shell,
             Some(tab_layout.clone()),
             vec![], // floating_panes_layout

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_tab_action_default_params.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_tab_action_default_params.snap
@@ -6,6 +6,7 @@ expression: "format!(\"{:#?}\", new_tab_action)"
 Some(
     NewTab(
         None,
+        None,
         Some(
             TiledPaneLayout {
                 children_split_direction: Vertical,

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_tab_action_with_name_and_layout.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_tab_action_with_name_and_layout.snap
@@ -5,6 +5,7 @@ expression: "format!(\"{:#?}\", new_tab_instruction)"
 ---
 NewTab(
     None,
+    None,
     Some(
         TiledPaneLayout {
             children_split_direction: Horizontal,

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_rename_tab.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_rename_tab.snap
@@ -28,6 +28,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
     ),
     NewTab(
         None,
+        None,
         Some(
             TiledPaneLayout {
                 children_split_direction: Horizontal,
@@ -180,6 +181,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
         ],
     ),
     NewTab(
+        None,
         None,
         Some(
             TiledPaneLayout {

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_undo_rename_tab.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_undo_rename_tab.snap
@@ -28,6 +28,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
     ),
     NewTab(
         None,
+        None,
         Some(
             TiledPaneLayout {
                 children_split_direction: Horizontal,
@@ -180,6 +181,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
         ],
     ),
     NewTab(
+        None,
         None,
         Some(
             TiledPaneLayout {

--- a/zellij-utils/assets/config/default.kdl
+++ b/zellij-utils/assets/config/default.kdl
@@ -202,7 +202,7 @@ plugins {
 
 // Choose the path to override cwd that zellij will use for opening new panes
 //
-// override_cwd ""
+// default_cwd ""
 
 // Toggle between having pane frames around the panes
 // Options:

--- a/zellij-utils/assets/config/default.kdl
+++ b/zellij-utils/assets/config/default.kdl
@@ -200,9 +200,9 @@ plugins {
 //
 // default_shell "fish"
 
-// Choose the path to the default cwd that zellij will use for opening new panes
+// Choose the path to override cwd that zellij will use for opening new panes
 //
-// default_cwd ""
+// override_cwd ""
 
 // Toggle between having pane frames around the panes
 // Options:

--- a/zellij-utils/assets/config/default.kdl
+++ b/zellij-utils/assets/config/default.kdl
@@ -200,6 +200,10 @@ plugins {
 //
 // default_shell "fish"
 
+// Choose the path to the default cwd that zellij will use for opening new panes
+//
+// default_cwd ""
+
 // Toggle between having pane frames around the panes
 // Options:
 //   - true (default)

--- a/zellij-utils/src/input/config.rs
+++ b/zellij-utils/src/input/config.rs
@@ -303,7 +303,7 @@ mod config_test {
             theme "my cool theme"
             default_mode "locked"
             default_shell "/path/to/my/shell"
-            default_cwd "/path"
+            override_cwd "/path"
             default_layout "/path/to/my/layout.kdl"
             layout_dir "/path/to/my/layout-dir"
             theme_dir "/path/to/my/theme-dir"
@@ -341,7 +341,7 @@ mod config_test {
             "Option set in config"
         );
         assert_eq!(
-            config.options.default_cwd,
+            config.options.override_cwd,
             Some(PathBuf::from("/path")),
             "Option set in config"
         );

--- a/zellij-utils/src/input/config.rs
+++ b/zellij-utils/src/input/config.rs
@@ -303,6 +303,7 @@ mod config_test {
             theme "my cool theme"
             default_mode "locked"
             default_shell "/path/to/my/shell"
+            default_cwd "/path"
             default_layout "/path/to/my/layout.kdl"
             layout_dir "/path/to/my/layout-dir"
             theme_dir "/path/to/my/theme-dir"
@@ -337,6 +338,11 @@ mod config_test {
         assert_eq!(
             config.options.default_shell,
             Some(PathBuf::from("/path/to/my/shell")),
+            "Option set in config"
+        );
+        assert_eq!(
+            config.options.default_cwd,
+            Some(PathBuf::from("/path")),
             "Option set in config"
         );
         assert_eq!(

--- a/zellij-utils/src/input/config.rs
+++ b/zellij-utils/src/input/config.rs
@@ -303,7 +303,7 @@ mod config_test {
             theme "my cool theme"
             default_mode "locked"
             default_shell "/path/to/my/shell"
-            override_cwd "/path"
+            default_cwd "/path"
             default_layout "/path/to/my/layout.kdl"
             layout_dir "/path/to/my/layout-dir"
             theme_dir "/path/to/my/theme-dir"
@@ -341,7 +341,7 @@ mod config_test {
             "Option set in config"
         );
         assert_eq!(
-            config.options.override_cwd,
+            config.options.default_cwd,
             Some(PathBuf::from("/path")),
             "Option set in config"
         );

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -54,7 +54,7 @@ pub struct Options {
     pub default_shell: Option<PathBuf>,
     /// Set the default cwd
     #[clap(long, value_parser)]
-    pub default_cwd: Option<PathBuf>,
+    pub override_cwd: Option<PathBuf>,
     /// Set the default layout
     #[clap(long, value_parser)]
     pub default_layout: Option<PathBuf>,
@@ -170,7 +170,7 @@ impl Options {
         let simplified_ui = other.simplified_ui.or(self.simplified_ui);
         let default_mode = other.default_mode.or(self.default_mode);
         let default_shell = other.default_shell.or_else(|| self.default_shell.clone());
-        let default_cwd = other.default_cwd.or_else(|| self.default_cwd.clone());
+        let override_cwd = other.override_cwd.or_else(|| self.override_cwd.clone());
         let default_layout = other.default_layout.or_else(|| self.default_layout.clone());
         let layout_dir = other.layout_dir.or_else(|| self.layout_dir.clone());
         let theme_dir = other.theme_dir.or_else(|| self.theme_dir.clone());
@@ -193,7 +193,7 @@ impl Options {
             theme,
             default_mode,
             default_shell,
-            default_cwd,
+            override_cwd,
             default_layout,
             layout_dir,
             theme_dir,
@@ -235,7 +235,7 @@ impl Options {
 
         let default_mode = other.default_mode.or(self.default_mode);
         let default_shell = other.default_shell.or_else(|| self.default_shell.clone());
-        let default_cwd = other.default_cwd.or_else(|| self.default_cwd.clone());
+        let override_cwd = other.override_cwd.or_else(|| self.override_cwd.clone());
         let default_layout = other.default_layout.or_else(|| self.default_layout.clone());
         let layout_dir = other.layout_dir.or_else(|| self.layout_dir.clone());
         let theme_dir = other.theme_dir.or_else(|| self.theme_dir.clone());
@@ -258,7 +258,7 @@ impl Options {
             theme,
             default_mode,
             default_shell,
-            default_cwd,
+            override_cwd,
             default_layout,
             layout_dir,
             theme_dir,
@@ -317,7 +317,7 @@ impl From<CliOptions> for Options {
             theme: opts.theme,
             default_mode: opts.default_mode,
             default_shell: opts.default_shell,
-            default_cwd: opts.default_cwd,
+            override_cwd: opts.override_cwd,
             default_layout: opts.default_layout,
             layout_dir: opts.layout_dir,
             theme_dir: opts.theme_dir,

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -52,6 +52,9 @@ pub struct Options {
     /// Set the default shell
     #[clap(long, value_parser)]
     pub default_shell: Option<PathBuf>,
+    /// Set the default cwd
+    #[clap(long, value_parser)]
+    pub default_cwd: Option<PathBuf>,
     /// Set the default layout
     #[clap(long, value_parser)]
     pub default_layout: Option<PathBuf>,
@@ -167,6 +170,7 @@ impl Options {
         let simplified_ui = other.simplified_ui.or(self.simplified_ui);
         let default_mode = other.default_mode.or(self.default_mode);
         let default_shell = other.default_shell.or_else(|| self.default_shell.clone());
+        let default_cwd = other.default_cwd.or_else(|| self.default_cwd.clone());
         let default_layout = other.default_layout.or_else(|| self.default_layout.clone());
         let layout_dir = other.layout_dir.or_else(|| self.layout_dir.clone());
         let theme_dir = other.theme_dir.or_else(|| self.theme_dir.clone());
@@ -189,6 +193,7 @@ impl Options {
             theme,
             default_mode,
             default_shell,
+            default_cwd,
             default_layout,
             layout_dir,
             theme_dir,
@@ -230,6 +235,7 @@ impl Options {
 
         let default_mode = other.default_mode.or(self.default_mode);
         let default_shell = other.default_shell.or_else(|| self.default_shell.clone());
+        let default_cwd = other.default_cwd.or_else(|| self.default_cwd.clone());
         let default_layout = other.default_layout.or_else(|| self.default_layout.clone());
         let layout_dir = other.layout_dir.or_else(|| self.layout_dir.clone());
         let theme_dir = other.theme_dir.or_else(|| self.theme_dir.clone());
@@ -252,6 +258,7 @@ impl Options {
             theme,
             default_mode,
             default_shell,
+            default_cwd,
             default_layout,
             layout_dir,
             theme_dir,
@@ -310,6 +317,7 @@ impl From<CliOptions> for Options {
             theme: opts.theme,
             default_mode: opts.default_mode,
             default_shell: opts.default_shell,
+            default_cwd: opts.default_cwd,
             default_layout: opts.default_layout,
             layout_dir: opts.layout_dir,
             theme_dir: opts.theme_dir,

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -54,7 +54,7 @@ pub struct Options {
     pub default_shell: Option<PathBuf>,
     /// Set the default cwd
     #[clap(long, value_parser)]
-    pub override_cwd: Option<PathBuf>,
+    pub default_cwd: Option<PathBuf>,
     /// Set the default layout
     #[clap(long, value_parser)]
     pub default_layout: Option<PathBuf>,
@@ -170,7 +170,7 @@ impl Options {
         let simplified_ui = other.simplified_ui.or(self.simplified_ui);
         let default_mode = other.default_mode.or(self.default_mode);
         let default_shell = other.default_shell.or_else(|| self.default_shell.clone());
-        let override_cwd = other.override_cwd.or_else(|| self.override_cwd.clone());
+        let default_cwd = other.default_cwd.or_else(|| self.default_cwd.clone());
         let default_layout = other.default_layout.or_else(|| self.default_layout.clone());
         let layout_dir = other.layout_dir.or_else(|| self.layout_dir.clone());
         let theme_dir = other.theme_dir.or_else(|| self.theme_dir.clone());
@@ -193,7 +193,7 @@ impl Options {
             theme,
             default_mode,
             default_shell,
-            override_cwd,
+            default_cwd,
             default_layout,
             layout_dir,
             theme_dir,
@@ -235,7 +235,7 @@ impl Options {
 
         let default_mode = other.default_mode.or(self.default_mode);
         let default_shell = other.default_shell.or_else(|| self.default_shell.clone());
-        let override_cwd = other.override_cwd.or_else(|| self.override_cwd.clone());
+        let default_cwd = other.default_cwd.or_else(|| self.default_cwd.clone());
         let default_layout = other.default_layout.or_else(|| self.default_layout.clone());
         let layout_dir = other.layout_dir.or_else(|| self.layout_dir.clone());
         let theme_dir = other.theme_dir.or_else(|| self.theme_dir.clone());
@@ -258,7 +258,7 @@ impl Options {
             theme,
             default_mode,
             default_shell,
-            override_cwd,
+            default_cwd,
             default_layout,
             layout_dir,
             theme_dir,
@@ -317,7 +317,7 @@ impl From<CliOptions> for Options {
             theme: opts.theme,
             default_mode: opts.default_mode,
             default_shell: opts.default_shell,
-            override_cwd: opts.override_cwd,
+            default_cwd: opts.default_cwd,
             default_layout: opts.default_layout,
             layout_dir: opts.layout_dir,
             theme_dir: opts.theme_dir,

--- a/zellij-utils/src/input/unit/layout_test.rs
+++ b/zellij-utils/src/input/unit/layout_test.rs
@@ -1340,7 +1340,7 @@ fn close_on_exit_added_to_close_on_exit_in_template() {
 }
 
 #[test]
-fn cwd_default_cwd_in_template() {
+fn cwd_override_cwd_in_template() {
     let kdl_layout = r#"
         layout {
             pane_template name="tail" {

--- a/zellij-utils/src/input/unit/layout_test.rs
+++ b/zellij-utils/src/input/unit/layout_test.rs
@@ -1340,7 +1340,7 @@ fn close_on_exit_added_to_close_on_exit_in_template() {
 }
 
 #[test]
-fn cwd_override_cwd_in_template() {
+fn cwd_default_cwd_in_template() {
     let kdl_layout = r#"
         layout {
             pane_template name="tail" {

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -1302,7 +1302,7 @@ impl Options {
         let default_shell =
             kdl_property_first_arg_as_string_or_error!(kdl_options, "default_shell")
                 .map(|(string, _entry)| PathBuf::from(string));
-        let default_cwd = kdl_property_first_arg_as_string_or_error!(kdl_options, "default_cwd")
+        let override_cwd = kdl_property_first_arg_as_string_or_error!(kdl_options, "override_cwd")
             .map(|(string, _entry)| PathBuf::from(string));
         let pane_frames =
             kdl_property_first_arg_as_bool_or_error!(kdl_options, "pane_frames").map(|(v, _)| v);
@@ -1358,7 +1358,7 @@ impl Options {
             theme,
             default_mode,
             default_shell,
-            default_cwd,
+            override_cwd,
             default_layout,
             layout_dir,
             theme_dir,

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -1302,7 +1302,7 @@ impl Options {
         let default_shell =
             kdl_property_first_arg_as_string_or_error!(kdl_options, "default_shell")
                 .map(|(string, _entry)| PathBuf::from(string));
-        let override_cwd = kdl_property_first_arg_as_string_or_error!(kdl_options, "override_cwd")
+        let default_cwd = kdl_property_first_arg_as_string_or_error!(kdl_options, "default_cwd")
             .map(|(string, _entry)| PathBuf::from(string));
         let pane_frames =
             kdl_property_first_arg_as_bool_or_error!(kdl_options, "pane_frames").map(|(v, _)| v);
@@ -1358,7 +1358,7 @@ impl Options {
             theme,
             default_mode,
             default_shell,
-            override_cwd,
+            default_cwd,
             default_layout,
             layout_dir,
             theme_dir,

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -1302,6 +1302,8 @@ impl Options {
         let default_shell =
             kdl_property_first_arg_as_string_or_error!(kdl_options, "default_shell")
                 .map(|(string, _entry)| PathBuf::from(string));
+        let default_cwd = kdl_property_first_arg_as_string_or_error!(kdl_options, "default_cwd")
+            .map(|(string, _entry)| PathBuf::from(string));
         let pane_frames =
             kdl_property_first_arg_as_bool_or_error!(kdl_options, "pane_frames").map(|(v, _)| v);
         let auto_layout =
@@ -1356,6 +1358,7 @@ impl Options {
             theme,
             default_mode,
             default_shell,
+            default_cwd,
             default_layout,
             layout_dir,
             theme_dir,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
@@ -10,7 +10,7 @@ Options {
     theme: None,
     default_mode: None,
     default_shell: None,
-    override_cwd: None,
+    default_cwd: None,
     default_layout: None,
     layout_dir: None,
     theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
@@ -10,6 +10,7 @@ Options {
     theme: None,
     default_mode: None,
     default_shell: None,
+    default_cwd: None,
     default_layout: None,
     layout_dir: None,
     theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
@@ -10,7 +10,7 @@ Options {
     theme: None,
     default_mode: None,
     default_shell: None,
-    default_cwd: None,
+    override_cwd: None,
     default_layout: None,
     layout_dir: None,
     theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
@@ -8,6 +8,7 @@ Options {
     theme: None,
     default_mode: None,
     default_shell: None,
+    default_cwd: None,
     default_layout: None,
     layout_dir: None,
     theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
@@ -8,7 +8,7 @@ Options {
     theme: None,
     default_mode: None,
     default_shell: None,
-    default_cwd: None,
+    override_cwd: None,
     default_layout: None,
     layout_dir: None,
     theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
@@ -8,7 +8,7 @@ Options {
     theme: None,
     default_mode: None,
     default_shell: None,
-    override_cwd: None,
+    default_cwd: None,
     default_layout: None,
     layout_dir: None,
     theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
@@ -8,6 +8,7 @@ Options {
     theme: None,
     default_mode: None,
     default_shell: None,
+    default_cwd: None,
     default_layout: None,
     layout_dir: None,
     theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
@@ -8,7 +8,7 @@ Options {
     theme: None,
     default_mode: None,
     default_shell: None,
-    default_cwd: None,
+    override_cwd: None,
     default_layout: None,
     layout_dir: None,
     theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
@@ -8,7 +8,7 @@ Options {
     theme: None,
     default_mode: None,
     default_shell: None,
-    override_cwd: None,
+    default_cwd: None,
     default_layout: None,
     layout_dir: None,
     theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
@@ -3526,6 +3526,7 @@ Config {
         theme: None,
         default_mode: None,
         default_shell: None,
+        default_cwd: None,
         default_layout: None,
         layout_dir: None,
         theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
@@ -3526,7 +3526,7 @@ Config {
         theme: None,
         default_mode: None,
         default_shell: None,
-        override_cwd: None,
+        default_cwd: None,
         default_layout: None,
         layout_dir: None,
         theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
@@ -3526,7 +3526,7 @@ Config {
         theme: None,
         default_mode: None,
         default_shell: None,
-        default_cwd: None,
+        override_cwd: None,
         default_layout: None,
         layout_dir: None,
         theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
@@ -3526,6 +3526,7 @@ Config {
         theme: None,
         default_mode: None,
         default_shell: None,
+        default_cwd: None,
         default_layout: None,
         layout_dir: None,
         theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
@@ -3526,7 +3526,7 @@ Config {
         theme: None,
         default_mode: None,
         default_shell: None,
-        override_cwd: None,
+        default_cwd: None,
         default_layout: None,
         layout_dir: None,
         theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
@@ -3526,7 +3526,7 @@ Config {
         theme: None,
         default_mode: None,
         default_shell: None,
-        default_cwd: None,
+        override_cwd: None,
         default_layout: None,
         layout_dir: None,
         theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
@@ -66,7 +66,7 @@ Config {
         theme: None,
         default_mode: None,
         default_shell: None,
-        override_cwd: None,
+        default_cwd: None,
         default_layout: None,
         layout_dir: None,
         theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
@@ -66,6 +66,7 @@ Config {
         theme: None,
         default_mode: None,
         default_shell: None,
+        default_cwd: None,
         default_layout: None,
         layout_dir: None,
         theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
@@ -66,7 +66,7 @@ Config {
         theme: None,
         default_mode: None,
         default_shell: None,
-        default_cwd: None,
+        override_cwd: None,
         default_layout: None,
         layout_dir: None,
         theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
@@ -8,6 +8,7 @@ Options {
     theme: None,
     default_mode: None,
     default_shell: None,
+    default_cwd: None,
     default_layout: None,
     layout_dir: None,
     theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
@@ -8,7 +8,7 @@ Options {
     theme: None,
     default_mode: None,
     default_shell: None,
-    default_cwd: None,
+    override_cwd: None,
     default_layout: None,
     layout_dir: None,
     theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
@@ -8,7 +8,7 @@ Options {
     theme: None,
     default_mode: None,
     default_shell: None,
-    override_cwd: None,
+    default_cwd: None,
     default_layout: None,
     layout_dir: None,
     theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_plugins_override_config_plugins.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_plugins_override_config_plugins.snap
@@ -3526,6 +3526,7 @@ Config {
         theme: None,
         default_mode: None,
         default_shell: None,
+        default_cwd: None,
         default_layout: None,
         layout_dir: None,
         theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_plugins_override_config_plugins.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_plugins_override_config_plugins.snap
@@ -3526,7 +3526,7 @@ Config {
         theme: None,
         default_mode: None,
         default_shell: None,
-        override_cwd: None,
+        default_cwd: None,
         default_layout: None,
         layout_dir: None,
         theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_plugins_override_config_plugins.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_plugins_override_config_plugins.snap
@@ -3526,7 +3526,7 @@ Config {
         theme: None,
         default_mode: None,
         default_shell: None,
-        default_cwd: None,
+        override_cwd: None,
         default_layout: None,
         layout_dir: None,
         theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
@@ -3526,6 +3526,7 @@ Config {
         theme: None,
         default_mode: None,
         default_shell: None,
+        default_cwd: None,
         default_layout: None,
         layout_dir: None,
         theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
@@ -3526,7 +3526,7 @@ Config {
         theme: None,
         default_mode: None,
         default_shell: None,
-        override_cwd: None,
+        default_cwd: None,
         default_layout: None,
         layout_dir: None,
         theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
@@ -3526,7 +3526,7 @@ Config {
         theme: None,
         default_mode: None,
         default_shell: None,
-        default_cwd: None,
+        override_cwd: None,
         default_layout: None,
         layout_dir: None,
         theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
@@ -3526,6 +3526,7 @@ Config {
         theme: None,
         default_mode: None,
         default_shell: None,
+        default_cwd: None,
         default_layout: None,
         layout_dir: None,
         theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
@@ -3526,7 +3526,7 @@ Config {
         theme: None,
         default_mode: None,
         default_shell: None,
-        override_cwd: None,
+        default_cwd: None,
         default_layout: None,
         layout_dir: None,
         theme_dir: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
@@ -3526,7 +3526,7 @@ Config {
         theme: None,
         default_mode: None,
         default_shell: None,
-        default_cwd: None,
+        override_cwd: None,
         default_layout: None,
         layout_dir: None,
         theme_dir: None,


### PR DESCRIPTION
#2205 - supports cwd as option

- [x] `Zellij options --default-cwd <path>` without config
- [x]  `Zellij` with `default_cwd` = <path> in zellij config file → set path to `usr`
- [x]   `cargo xtask test`

Screenshot

![2205](https://user-images.githubusercontent.com/85712372/225173249-711652df-ac76-4a21-8920-5010d7649d45.gif)

