### PR TITLE
Add option to hide session name in tab-bar (deriving from #2172)

### DIFF
--- a/default-plugins/tab-bar/src/line.rs
+++ b/default-plugins/tab-bar/src/line.rs
@@ -223,7 +223,7 @@ pub fn tab_line(
     cols: usize,
     palette: Palette,
     capabilities: PluginCapabilities,
-    hide_prefix: bool,
+    hide_session_name: bool,
 ) -> Vec<LinePart> {
     let mut tabs_after_active = all_tabs.split_off(active_tab_index);
     let mut tabs_before_active = all_tabs;
@@ -232,10 +232,10 @@ pub fn tab_line(
     } else {
         tabs_before_active.pop().unwrap()
     };
-    let mut prefix = vec![];
-    if !hide_prefix {
-        prefix = tab_line_prefix(session_name, palette, cols);
-    }
+    let mut prefix = match hide_session_name {
+        true => tab_line_prefix(None, palette, cols),
+        false => tab_line_prefix(session_name, palette, cols),
+    };
     let prefix_len = get_current_title_len(&prefix);
 
     // if active tab alone won't fit in cols, don't draw any tabs

--- a/default-plugins/tab-bar/src/line.rs
+++ b/default-plugins/tab-bar/src/line.rs
@@ -223,6 +223,7 @@ pub fn tab_line(
     cols: usize,
     palette: Palette,
     capabilities: PluginCapabilities,
+    hide_prefix: bool,
 ) -> Vec<LinePart> {
     let mut tabs_after_active = all_tabs.split_off(active_tab_index);
     let mut tabs_before_active = all_tabs;
@@ -231,7 +232,10 @@ pub fn tab_line(
     } else {
         tabs_before_active.pop().unwrap()
     };
-    let mut prefix = tab_line_prefix(session_name, palette, cols);
+    let mut prefix = vec![];
+    if !hide_prefix {
+        prefix = tab_line_prefix(session_name, palette, cols);
+    }
     let prefix_len = get_current_title_len(&prefix);
 
     // if active tab alone won't fit in cols, don't draw any tabs

--- a/default-plugins/tab-bar/src/main.rs
+++ b/default-plugins/tab-bar/src/main.rs
@@ -120,6 +120,7 @@ impl ZellijPlugin for State {
             cols.saturating_sub(1),
             self.mode_info.style.colors,
             self.mode_info.capabilities,
+            self.mode_info.style.hide_tab_bar_prefix,
         );
         let mut s = String::new();
         let mut len_cnt = 0;

--- a/default-plugins/tab-bar/src/main.rs
+++ b/default-plugins/tab-bar/src/main.rs
@@ -120,7 +120,7 @@ impl ZellijPlugin for State {
             cols.saturating_sub(1),
             self.mode_info.style.colors,
             self.mode_info.capabilities,
-            self.mode_info.style.hide_tab_bar_prefix,
+            self.mode_info.style.hide_session_name,
         );
         let mut s = String::new();
         let mut len_cnt = 0;

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -167,6 +167,7 @@ pub fn start_client(
         style: Style {
             colors: palette,
             rounded_corners: config.ui.pane_frames.rounded_corners,
+            hide_tab_bar_prefix: config.ui.pane_frames.hide_tab_bar_prefix,
         },
         keybinds: config.keybinds.clone(),
     };

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -167,7 +167,7 @@ pub fn start_client(
         style: Style {
             colors: palette,
             rounded_corners: config.ui.pane_frames.rounded_corners,
-            hide_tab_bar_prefix: config.ui.pane_frames.hide_tab_bar_prefix,
+            hide_session_name: config.ui.pane_frames.hide_session_name,
         },
         keybinds: config.keybinds.clone(),
     };

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_rename_tab.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_rename_tab.snap
@@ -135,7 +135,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
                                 ),
                             },
                             rounded_corners: false,
-                            hide_tab_bar_prefix: false,
+                            hide_session_name: false,
                         },
                         capabilities: PluginCapabilities {
                             arrow_fonts: false,
@@ -292,7 +292,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
                                 ),
                             },
                             rounded_corners: false,
-                            hide_tab_bar_prefix: false,
+                            hide_session_name: false,
                         },
                         capabilities: PluginCapabilities {
                             arrow_fonts: false,

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_rename_tab.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_rename_tab.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 2629
 expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
 ---
 [
@@ -136,6 +135,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
                                 ),
                             },
                             rounded_corners: false,
+                            hide_tab_bar_prefix: false,
                         },
                         capabilities: PluginCapabilities {
                             arrow_fonts: false,
@@ -292,6 +292,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
                                 ),
                             },
                             rounded_corners: false,
+                            hide_tab_bar_prefix: false,
                         },
                         capabilities: PluginCapabilities {
                             arrow_fonts: false,

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_undo_rename_tab.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_undo_rename_tab.snap
@@ -292,7 +292,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
                                 ),
                             },
                             rounded_corners: false,
-                            hide_tab_bar_prefix: false,
+                            hide_session_name: false,
                         },
                         capabilities: PluginCapabilities {
                             arrow_fonts: false,

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_undo_rename_tab.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_undo_rename_tab.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 2672
 expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
 ---
 [
@@ -136,6 +135,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
                                 ),
                             },
                             rounded_corners: false,
+                            hide_tab_bar_prefix: false,
                         },
                         capabilities: PluginCapabilities {
                             arrow_fonts: false,
@@ -292,6 +292,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
                                 ),
                             },
                             rounded_corners: false,
+                            hide_tab_bar_prefix: false,
                         },
                         capabilities: PluginCapabilities {
                             arrow_fonts: false,

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_undo_rename_tab.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_undo_rename_tab.snap
@@ -135,7 +135,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
                                 ),
                             },
                             rounded_corners: false,
-                            hide_tab_bar_prefix: false,
+                            hide_session_name: false,
                         },
                         capabilities: PluginCapabilities {
                             arrow_fonts: false,

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -643,6 +643,7 @@ pub struct Palette {
 pub struct Style {
     pub colors: Palette,
     pub rounded_corners: bool,
+    pub hide_tab_bar_prefix: bool,
 }
 
 // FIXME: Poor devs hashtable since HashTable can't derive `Default`...

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -643,7 +643,7 @@ pub struct Palette {
 pub struct Style {
     pub colors: Palette,
     pub rounded_corners: bool,
-    pub hide_tab_bar_prefix: bool,
+    pub hide_session_name: bool,
 }
 
 // FIXME: Poor devs hashtable since HashTable can't derive `Default`...

--- a/zellij-utils/src/input/config.rs
+++ b/zellij-utils/src/input/config.rs
@@ -639,7 +639,7 @@ mod config_test {
             ui {
                 pane_frames {
                     rounded_corners true
-                    hide_tab_bar_prefix true
+                    hide_session_name true
                 }
             }
         "#;
@@ -647,7 +647,7 @@ mod config_test {
         let expected_ui_config = UiConfig {
             pane_frames: FrameConfig {
                 rounded_corners: true,
-                hide_tab_bar_prefix: true,
+                hide_session_name: true,
             },
         };
         assert_eq!(config.ui, expected_ui_config, "Ui config defined in config");

--- a/zellij-utils/src/input/config.rs
+++ b/zellij-utils/src/input/config.rs
@@ -639,6 +639,7 @@ mod config_test {
             ui {
                 pane_frames {
                     rounded_corners true
+                    hide_tab_bar_prefix true
                 }
             }
         "#;
@@ -646,6 +647,7 @@ mod config_test {
         let expected_ui_config = UiConfig {
             pane_frames: FrameConfig {
                 rounded_corners: true,
+                hide_tab_bar_prefix: true,
             },
         };
         assert_eq!(config.ui, expected_ui_config, "Ui config defined in config");

--- a/zellij-utils/src/input/theme.rs
+++ b/zellij-utils/src/input/theme.rs
@@ -25,14 +25,14 @@ impl UiConfig {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Deserialize, Serialize)]
 pub struct FrameConfig {
     pub rounded_corners: bool,
-    pub hide_tab_bar_prefix: bool,
+    pub hide_session_name: bool,
 }
 
 impl FrameConfig {
     pub fn merge(&self, other: FrameConfig) -> Self {
         let mut merged = self.clone();
         merged.rounded_corners = other.rounded_corners;
-        merged.hide_tab_bar_prefix = other.hide_tab_bar_prefix;
+        merged.hide_session_name = other.hide_session_name;
         merged
     }
 }

--- a/zellij-utils/src/input/theme.rs
+++ b/zellij-utils/src/input/theme.rs
@@ -25,12 +25,14 @@ impl UiConfig {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Deserialize, Serialize)]
 pub struct FrameConfig {
     pub rounded_corners: bool,
+    pub hide_tab_bar_prefix: bool,
 }
 
 impl FrameConfig {
     pub fn merge(&self, other: FrameConfig) -> Self {
         let mut merged = self.clone();
         merged.rounded_corners = other.rounded_corners;
+        merged.hide_tab_bar_prefix = other.hide_tab_bar_prefix;
         merged
     }
 }

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -1699,7 +1699,13 @@ impl UiConfig {
             let rounded_corners =
                 kdl_children_property_first_arg_as_bool!(pane_frames, "rounded_corners")
                     .unwrap_or(false);
-            let frame_config = FrameConfig { rounded_corners };
+            let hide_tab_bar_prefix =
+                kdl_get_child_entry_bool_value!(pane_frames, "hide_tab_bar_prefix")
+                    .unwrap_or(false);
+            let frame_config = FrameConfig {
+                rounded_corners,
+                hide_tab_bar_prefix,
+            };
             ui_config.pane_frames = frame_config;
         }
         Ok(ui_config)

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -1699,12 +1699,11 @@ impl UiConfig {
             let rounded_corners =
                 kdl_children_property_first_arg_as_bool!(pane_frames, "rounded_corners")
                     .unwrap_or(false);
-            let hide_tab_bar_prefix =
-                kdl_get_child_entry_bool_value!(pane_frames, "hide_tab_bar_prefix")
-                    .unwrap_or(false);
+            let hide_session_name =
+                kdl_get_child_entry_bool_value!(pane_frames, "hide_session_name").unwrap_or(false);
             let frame_config = FrameConfig {
                 rounded_corners,
-                hide_tab_bar_prefix,
+                hide_session_name,
             };
             ui_config.pane_frames = frame_config;
         }

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/setup.rs
-assertion_line: 621
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -3604,6 +3603,7 @@ Config {
     ui: UiConfig {
         pane_frames: FrameConfig {
             rounded_corners: false,
+            hide_tab_bar_prefix: false,
         },
     },
     env: {},

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
@@ -3603,7 +3603,7 @@ Config {
     ui: UiConfig {
         pane_frames: FrameConfig {
             rounded_corners: false,
-            hide_tab_bar_prefix: false,
+            hide_session_name: false,
         },
     },
     env: {},

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
@@ -3603,7 +3603,7 @@ Config {
     ui: UiConfig {
         pane_frames: FrameConfig {
             rounded_corners: false,
-            hide_tab_bar_prefix: false,
+            hide_session_name: false,
         },
     },
     env: {

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/setup.rs
-assertion_line: 679
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -3604,6 +3603,7 @@ Config {
     ui: UiConfig {
         pane_frames: FrameConfig {
             rounded_corners: false,
+            hide_tab_bar_prefix: false,
         },
     },
     env: {

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/setup.rs
-assertion_line: 696
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -144,6 +143,7 @@ Config {
     ui: UiConfig {
         pane_frames: FrameConfig {
             rounded_corners: false,
+            hide_tab_bar_prefix: false,
         },
     },
     env: {},

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
@@ -143,7 +143,7 @@ Config {
     ui: UiConfig {
         pane_frames: FrameConfig {
             rounded_corners: false,
-            hide_tab_bar_prefix: false,
+            hide_session_name: false,
         },
     },
     env: {},

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_plugins_override_config_plugins.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_plugins_override_config_plugins.snap
@@ -3617,7 +3617,7 @@ Config {
     ui: UiConfig {
         pane_frames: FrameConfig {
             rounded_corners: false,
-            hide_tab_bar_prefix: false,
+            hide_session_name: false,
         },
     },
     env: {},

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_plugins_override_config_plugins.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_plugins_override_config_plugins.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/setup.rs
-assertion_line: 707
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -3618,6 +3617,7 @@ Config {
     ui: UiConfig {
         pane_frames: FrameConfig {
             rounded_corners: false,
+            hide_tab_bar_prefix: false,
         },
     },
     env: {},

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
@@ -3907,7 +3907,7 @@ Config {
     ui: UiConfig {
         pane_frames: FrameConfig {
             rounded_corners: false,
-            hide_tab_bar_prefix: false,
+            hide_session_name: false,
         },
     },
     env: {},

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/setup.rs
-assertion_line: 721
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -3908,6 +3907,7 @@ Config {
     ui: UiConfig {
         pane_frames: FrameConfig {
             rounded_corners: false,
+            hide_tab_bar_prefix: false,
         },
     },
     env: {},

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/setup.rs
-assertion_line: 693
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -3604,6 +3603,7 @@ Config {
     ui: UiConfig {
         pane_frames: FrameConfig {
             rounded_corners: true,
+            hide_tab_bar_prefix: false,
         },
     },
     env: {},

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
@@ -3603,7 +3603,7 @@ Config {
     ui: UiConfig {
         pane_frames: FrameConfig {
             rounded_corners: true,
-            hide_tab_bar_prefix: false,
+            hide_session_name: false,
         },
     },
     env: {},


### PR DESCRIPTION
Summary
---
This patch adds a `config.ui.pane_frames.hide_session_name` parameter to hide session name from the the Zellij (<session_name>) prefix, as requested in issue https://github.com/zellij-org/zellij/issues/2172

As discussed in https://github.com/zellij-org/zellij/pull/2300, I have adjusted the issue scope to only give the option hide the session name while keeping the tools name in the tab-bar prefix.

I'm open to add tests for this functionality, I would however appreciate guidance on where and how to add those specific tests. Thanks!