### PR TITLE
fix(panes): closing a stacked pane should relayout

### DIFF
--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -2202,12 +2202,7 @@ impl Tab {
             let closed_pane = self.tiled_panes.remove_pane(id);
             self.set_force_render();
             self.tiled_panes.set_force_render();
-            let closed_pane_is_stacked = closed_pane
-                .as_ref()
-                .map(|p| p.position_and_size().is_stacked)
-                .unwrap_or(false);
-            if self.auto_layout && !self.swap_layouts.is_tiled_damaged() && !closed_pane_is_stacked
-            {
+            if self.auto_layout && !self.swap_layouts.is_tiled_damaged() {
                 self.swap_layouts.set_is_tiled_damaged();
                 // only relayout if the user is already "in" a layout, otherwise this might be
                 // confusing


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/2262

This happened because some left-over logic from a previous paradigm I was experimenting with. Removed it and it works as expected now.