### PR TITLE
fix: do not hold on to router thread handle until server exit

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -20,7 +20,7 @@ use pty_writer::{pty_writer_main, PtyWriteInstruction};
 use std::collections::{HashMap, HashSet};
 use std::{
     path::PathBuf,
-    sync::{Arc, Mutex, RwLock},
+    sync::{Arc, RwLock},
     thread,
 };
 use zellij_utils::envs;
@@ -260,8 +260,6 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
         })
     });
 
-    let thread_handles = Arc::new(Mutex::new(Vec::new()));
-
     let _ = thread::Builder::new()
         .name("server_listener".to_string())
         .spawn({
@@ -274,7 +272,6 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
             let session_state = session_state.clone();
             let to_server = to_server.clone();
             let socket_path = socket_path.clone();
-            let thread_handles = thread_handles.clone();
             move || {
                 drop(std::fs::remove_file(&socket_path));
                 let listener = LocalSocketListener::bind(&*socket_path).unwrap();
@@ -288,22 +285,20 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                             let session_data = session_data.clone();
                             let session_state = session_state.clone();
                             let to_server = to_server.clone();
-                            thread_handles.lock().unwrap().push(
-                                thread::Builder::new()
-                                    .name("server_router".to_string())
-                                    .spawn(move || {
-                                        route_thread_main(
-                                            session_data,
-                                            session_state,
-                                            os_input,
-                                            to_server,
-                                            receiver,
-                                            client_id,
-                                        )
-                                        .fatal()
-                                    })
-                                    .unwrap(),
-                            );
+                            thread::Builder::new()
+                                .name("server_router".to_string())
+                                .spawn(move || {
+                                    route_thread_main(
+                                        session_data,
+                                        session_state,
+                                        os_input,
+                                        to_server,
+                                        receiver,
+                                        client_id,
+                                    )
+                                    .fatal()
+                                })
+                                .unwrap();
                         },
                         Err(err) => {
                             panic!("err {:?}", err);
@@ -639,11 +634,6 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
     // Drop cached session data before exit.
     *session_data.write().unwrap() = None;
 
-    thread_handles
-        .lock()
-        .unwrap()
-        .drain(..)
-        .for_each(|h| drop(h.join()));
     drop(std::fs::remove_file(&socket_path));
 }
 

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -2,7 +2,7 @@ use super::{Output, Tab};
 use crate::panes::sixel::SixelImageStore;
 use crate::screen::CopyOptions;
 use crate::Arc;
-use crate::Mutex;
+
 use crate::{
     os_input_output::{AsyncReader, Pid, ServerOsApi},
     panes::PaneId,
@@ -11,6 +11,8 @@ use crate::{
     ClientId,
 };
 use std::path::PathBuf;
+use std::sync::Mutex;
+
 use zellij_utils::channels::Receiver;
 use zellij_utils::data::Direction;
 use zellij_utils::data::Resize;


### PR DESCRIPTION
fixes #1948 (memory leak)

For each client, a thread `JoinHandle` was being held until the server exits.
As far as I can tell holding on to them explicitly to join them isn't really useful in this case.

Have tested this and observed memory usage stay constant even after `zellij ls` x 10000.
