### PR TITLE
fix(layouts): don't default to default swap layouts on new-tab action

### DIFF
--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -440,16 +440,8 @@ impl Action {
                     if tabs.len() > 1 {
                         return Err(format!("Tab layout cannot itself have tabs"));
                     } else if !tabs.is_empty() {
-                        let swap_tiled_layouts = if layout.swap_tiled_layouts.is_empty() {
-                            None
-                        } else {
-                            Some(layout.swap_tiled_layouts.clone())
-                        };
-                        let swap_floating_layouts = if layout.swap_floating_layouts.is_empty() {
-                            None
-                        } else {
-                            Some(layout.swap_floating_layouts.clone())
-                        };
+                        let swap_tiled_layouts = Some(layout.swap_tiled_layouts.clone());
+                        let swap_floating_layouts = Some(layout.swap_floating_layouts.clone());
                         let (tab_name, layout, floating_panes_layout) =
                             tabs.drain(..).next().unwrap();
                         let name = tab_name.or(name);
@@ -461,16 +453,8 @@ impl Action {
                             name,
                         )])
                     } else {
-                        let swap_tiled_layouts = if layout.swap_tiled_layouts.is_empty() {
-                            None
-                        } else {
-                            Some(layout.swap_tiled_layouts.clone())
-                        };
-                        let swap_floating_layouts = if layout.swap_floating_layouts.is_empty() {
-                            None
-                        } else {
-                            Some(layout.swap_floating_layouts.clone())
-                        };
+                        let swap_tiled_layouts = Some(layout.swap_tiled_layouts.clone());
+                        let swap_floating_layouts = Some(layout.swap_floating_layouts.clone());
                         let (layout, floating_panes_layout) = layout.new_tab();
                         Ok(vec![Action::NewTab(
                             Some(layout),


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/2280

Before this fix, when opening a new tab with a layout that did not itself have swap layouts, we would default to the swap layouts of the original session layout. This is a behaviour we never want and this PR removes it.