### PR TITLE
fix(layouts): nested attribute truncating

### DIFF
--- a/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__when_applying_a_truncated_swap_layout_child_attributes_are_not_ignored.snap
+++ b/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__when_applying_a_truncated_swap_layout_child_attributes_are_not_ignored.snap
@@ -1,0 +1,26 @@
+---
+source: zellij-server/src/tab/./unit/tab_integration_tests.rs
+assertion_line: 6791
+expression: snapshot
+---
+00 (C):                                                                                                                           
+01 (C):                                                                                                                           
+02 (C):                                                                                                                           
+03 (C):                                                                                                                           
+04 (C):                                                                                                                           
+05 (C):                                                                                                                           
+06 (C):                                                                                                                           
+07 (C):                                                                                                                           
+08 (C):                                                                                                                           
+09 (C):                                                                                                                           
+10 (C):                                                                                                                           
+11 (C):                                                                                                                           
+12 (C):                                                                                                                           
+13 (C):                                                                                                                           
+14 (C):                                                                                                                           
+15 (C):                                                                                                                           
+16 (C):                                                                                                                           
+17 (C):                                                                                                                           
+18 (C):                                                                                                                           
+19 (C):                                                                                                                           
+

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -6759,3 +6759,37 @@ fn when_resizing_whole_tab_with_auto_layout_and_floating_panes_the_layout_is_mai
     );
     assert_snapshot!(snapshot);
 }
+
+#[test]
+fn when_applying_a_truncated_swap_layout_child_attributes_are_not_ignored() {
+    // here we want to make sure that the nested borderless is preserved on resize (when the layout
+    // is reapplied, and thus is truncated to just one pane rather than a logical container pane
+    // and an actual pane as it is described here)
+    let layout = r#"
+        layout {
+            pane {
+                pane borderless=true
+            }
+        }
+    "#;
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let client_id = 1;
+    let mut tab = create_new_tab_with_layout(size, ModeInfo::default(), layout);
+    let mut output = Output::default();
+    let new_size = Size {
+        cols: 122,
+        rows: 20,
+    };
+    let _ = tab.resize_whole_tab(new_size);
+    tab.render(&mut output, None).unwrap();
+    let snapshot = take_snapshot(
+        output.serialize().unwrap().get(&client_id).unwrap(),
+        new_size.rows,
+        new_size.cols,
+        Palette::default(),
+    );
+    assert_snapshot!(snapshot);
+}

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -569,6 +569,13 @@ impl TiledPaneLayout {
         // if max_panes is 1, it means there's only enough panes for this node,
         // if max_panes is 0, this is probably the root layout being called with 0 max panes
         if max_panes <= 1 {
+            while !self.children.is_empty() {
+                // this is a special case: we're truncating a pane that was previously a logical
+                // container but now should be an actual pane - so here we'd like to use its
+                // deepest "non-logical" child in order to get all its attributes (eg. borderless)
+                let first_child = self.children.remove(0);
+                drop(std::mem::replace(self, first_child));
+            }
             self.children.clear();
         } else if max_panes <= self.children.len() {
             self.children.truncate(max_panes);


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/2292

How this relates to the issue at hand is... involved. But it comes down to this bug:

When reapplying this layout to existing panes:
```kdl
layout {
    tab {
        pane borderless=true
    }
}
```

We identify the `tab` node as its own pane, and remove the `pane borderless=true` completely as one pane too many (since this layout can potentially be applied to any number of panes). While this behaviour is correct for panes without attributes (eg. borderless) it removes those attributes if they exist.

This fix makes sure we always take the deepest "non-logical-container" pane when truncating a layout to fit the panes on screen.