### PR TITLE
fix(scrollback-editor): properly invoke editor when command includes spaces

### DIFF
--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -250,7 +250,7 @@ fn separate_command_arguments(command: &mut PathBuf, args: &mut Vec<String>) {
     for part in command.display().to_string().split_ascii_whitespace() {
         current_part.push_str(part);
         if current_part.ends_with('\\') {
-            drop(current_part.pop());
+            let _ = current_part.pop();
             current_part.push(' ');
         } else {
             let current_part = std::mem::replace(&mut current_part, String::new());


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/2335 and https://github.com/zellij-org/zellij/issues/2302

This was happening because we weren't properly treating command strings that had spaces. This is a partial fix, fixing the most common cases: namely commands with one or more flags. It does not fix cases with substrings (eg. `nvim -c "set number"`), because I think this is a bit excessive and sets us down a rabbit hole of command line argument parsing support.