### PR TITLE
fix(plugins): prevent Strider from opening double-panes when editing files

### DIFF
--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -449,13 +449,6 @@ impl WasmBridge {
             .lock()
             .unwrap()
             .retain(|c| c != &client_id);
-        let mut plugin_map = self.plugin_map.lock().unwrap();
-        let ids_in_plugin_map: Vec<(u32, ClientId)> = plugin_map.keys().copied().collect();
-        for (p_id, c_id) in ids_in_plugin_map {
-            if c_id == client_id {
-                drop(plugin_map.remove(&(p_id, c_id)));
-            }
-        }
     }
     pub fn cleanup(&mut self) {
         for (_plugin_id, loading_plugin_task) in self.loading_plugins.drain() {

--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -449,6 +449,13 @@ impl WasmBridge {
             .lock()
             .unwrap()
             .retain(|c| c != &client_id);
+        let mut plugin_map = self.plugin_map.lock().unwrap();
+        let ids_in_plugin_map: Vec<(u32, ClientId)> = plugin_map.keys().copied().collect();
+        for (p_id, c_id) in ids_in_plugin_map {
+            if c_id == client_id {
+                drop(plugin_map.remove(&(p_id, c_id)));
+            }
+        }
     }
     pub fn cleanup(&mut self) {
         for (_plugin_id, loading_plugin_task) in self.loading_plugins.drain() {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1664,7 +1664,7 @@ pub(crate) fn screen_thread_main(
                     client_id,
                     |tab: &mut Tab, client_id: ClientId| {
                         let write_result = match tab.is_sync_panes_active() {
-                            true => tab.write_to_terminals_on_current_tab(bytes),
+                            true => tab.write_to_terminals_on_current_tab(bytes, client_id),
                             false => tab.write_to_active_terminal(bytes, client_id),
                         };
                         if let Ok(true) = write_result {

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1561,7 +1561,11 @@ impl Tab {
         Ok(())
     }
 
-    pub fn write_to_terminals_on_current_tab(&mut self, input_bytes: Vec<u8>, client_id: ClientId) -> Result<bool> {
+    pub fn write_to_terminals_on_current_tab(
+        &mut self,
+        input_bytes: Vec<u8>,
+        client_id: ClientId,
+    ) -> Result<bool> {
         // returns true if a UI update should be triggered (eg. when closing a command pane with
         // ctrl-c)
         let mut should_trigger_ui_change = false;
@@ -1615,7 +1619,7 @@ impl Tab {
         &mut self,
         input_bytes: Vec<u8>,
         position: &Position,
-        client_id: ClientId
+        client_id: ClientId,
     ) -> Result<()> {
         let err_context = || format!("failed to write to terminal at position {position:?}");
 
@@ -1642,7 +1646,12 @@ impl Tab {
         Ok(())
     }
 
-    pub fn write_to_pane_id(&mut self, input_bytes: Vec<u8>, pane_id: PaneId, client_id: Option<ClientId>) -> Result<bool> {
+    pub fn write_to_pane_id(
+        &mut self,
+        input_bytes: Vec<u8>,
+        pane_id: PaneId,
+        client_id: Option<ClientId>,
+    ) -> Result<bool> {
         // returns true if we need to update the UI (eg. when a command pane is closed with ctrl-c)
         let err_context = || format!("failed to write to pane with id {pane_id:?}");
 

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -330,7 +330,7 @@ fn write_to_suppressed_pane() {
     // Make sure it's suppressed now
     tab.suppressed_panes.get(&PaneId::Terminal(2)).unwrap();
     // Write content to it
-    tab.write_to_pane_id(vec![34, 127, 31, 82, 17, 182], PaneId::Terminal(2))
+    tab.write_to_pane_id(vec![34, 127, 31, 82, 17, 182], PaneId::Terminal(2), None)
         .unwrap();
 }
 


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/2118

This fix includes 2 bug fixes, each of which solves this one individually but better to include them both as they also solve other stuff:
1. When sending key presses to a plugin pane, we now make sure to include the `ClientId` of the client originating the keypress. This is so that the keypress won't default to being sent to all plugins and thus cause the above issue.
2. ~~We now make sure to clean up lingering plugins from memory when their originating client disconnects and not just when the program ends or the plugin exits.~~ (EDIT: this was found to be harmful when detaching and so I undid this change - thank you e2e tests!)