### PR TITLE
fix(grid): reap dropped links

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1716,6 +1716,7 @@ impl Grid {
         if let Some(images_to_reap) = self.sixel_grid.clear() {
             self.sixel_grid.reap_images(images_to_reap);
         }
+        self.link_handler.borrow_mut().clear();
     }
     fn set_preceding_character(&mut self, terminal_character: TerminalCharacter) {
         self.preceding_char = Some(terminal_character);

--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -30,7 +30,7 @@ pub const RESET_STYLES: CharacterStyles = CharacterStyles {
     bold: Some(AnsiCode::Reset),
     dim: Some(AnsiCode::Reset),
     italic: Some(AnsiCode::Reset),
-    link_anchor: Some(LinkAnchor::End),
+    link_anchor: Some(LinkAnchor::Reset),
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -251,7 +251,12 @@ impl CharacterStyles {
             diff.italic = new_styles.italic;
         }
         if self.link_anchor != new_styles.link_anchor {
-            diff.link_anchor = new_styles.link_anchor;
+            match (self.link_anchor, new_styles.link_anchor) {
+                // treat End and Reset as if they were the same to avoid outputting unnecessary escapes
+                (Some(LinkAnchor::End(_)), Some(LinkAnchor::Reset)) => {},
+                (Some(LinkAnchor::Reset), Some(LinkAnchor::End(_))) => {},
+                _ => diff.link_anchor = new_styles.link_anchor,
+            }
         }
 
         // apply new styles
@@ -572,7 +577,8 @@ impl Display for CharacterStyles {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum LinkAnchor {
     Start(u16),
-    End,
+    End(u16),
+    Reset,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -2564,3 +2564,32 @@ pub fn cursor_hide_persists_through_alternate_screen() {
         "Cursor still shown away from alternate screen"
     );
 }
+
+#[test]
+fn links_are_reaped_when_scrolled_off() {
+    let mut vte_parser = vte::Parser::new();
+    let sixel_image_store = Rc::new(RefCell::new(SixelImageStore::default()));
+    let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
+    let link_handler = Rc::new(RefCell::new(LinkHandler::new()));
+    let mut grid = Grid::new(
+        10,
+        10,
+        Rc::new(RefCell::new(Palette::default())),
+        terminal_emulator_color_codes,
+        link_handler.clone(),
+        Rc::new(RefCell::new(None)),
+        sixel_image_store,
+    );
+    let content = "\u{1b}]8;;http://example.com\u{1b}\\A Link\u{1b}]8;;\u{1b}\\ NOT A Link";
+    for byte in content.as_bytes() {
+        vte_parser.advance(&mut grid, *byte);
+    }
+    assert_eq!(link_handler.borrow().link_count(), 1);
+
+    for _ in 0..10_011 {
+        // scrollbuffer limit + viewport height
+        grid.add_canonical_line();
+    }
+
+    assert_eq!(link_handler.borrow().link_count(), 0);
+}


### PR DESCRIPTION
This fix solves solves a memory leak by ensuring that when `TerminalCharacters` that hold osc 8 links are removed from the scroll buffer, the related data is cleaned up.

Another fix is to clear all osc8 link data when a pane is reset.