### PR TITLE
fix(plugin): respect hide session option on compact-bar

### DIFF
--- a/default-plugins/compact-bar/src/line.rs
+++ b/default-plugins/compact-bar/src/line.rs
@@ -255,6 +255,7 @@ pub fn tab_line(
     cols: usize,
     palette: Palette,
     capabilities: PluginCapabilities,
+    hide_session_name: bool,
     mode: InputMode,
     active_swap_layout_name: &Option<String>,
     is_swap_layout_dirty: bool,
@@ -266,7 +267,10 @@ pub fn tab_line(
     } else {
         tabs_before_active.pop().unwrap()
     };
-    let mut prefix = tab_line_prefix(session_name, mode, palette, cols);
+    let mut prefix = match hide_session_name {
+        true => tab_line_prefix(None, mode, palette, cols),
+        false => tab_line_prefix(session_name, mode, palette, cols),
+    };
     let prefix_len = get_current_title_len(&prefix);
 
     // if active tab alone won't fit in cols, don't draw any tabs

--- a/default-plugins/compact-bar/src/main.rs
+++ b/default-plugins/compact-bar/src/main.rs
@@ -124,6 +124,7 @@ impl ZellijPlugin for State {
             cols.saturating_sub(1),
             self.mode_info.style.colors,
             self.mode_info.capabilities,
+            self.mode_info.style.hide_session_name,
             self.mode_info.mode,
             &active_swap_layout_name,
             is_swap_layout_dirty,


### PR DESCRIPTION
This PR extends the "hide session name" option  from #2301 for the compact-bar plugin.