### PR TITLE
fix: allow multiple global unbinds in KDL config

### DIFF
--- a/zellij-utils/src/input/unit/keybinds_test.rs
+++ b/zellij-utils/src/input/unit/keybinds_test.rs
@@ -362,6 +362,67 @@ fn can_unbind_multiple_keys_globally() {
 }
 
 #[test]
+fn can_unbind_multiple_keys_globally_multiple_lines() {
+    let default_config_contents = r#"
+        keybinds {
+            normal {
+                bind "Ctrl g" { SwitchToMode "Locked"; }
+            }
+            pane {
+                bind "Ctrl g" { SwitchToMode "Locked"; }
+                bind "z" { TogglePaneFrames; SwitchToMode "Normal"; }
+                bind "r" { TogglePaneFrames; }
+            }
+        }
+    "#;
+    let config_contents = r#"
+        keybinds {
+            unbind "Ctrl g"
+            unbind "z"
+            pane {
+                bind "t" { SwitchToMode "Tab"; }
+            }
+        }
+    "#;
+    let default_config = Config::from_kdl(default_config_contents, None).unwrap();
+    let config = Config::from_kdl(config_contents, Some(default_config)).unwrap();
+    let ctrl_g_normal_mode_action = config
+        .keybinds
+        .get_actions_for_key_in_mode(&InputMode::Normal, &Key::Ctrl('g'));
+    let ctrl_g_pane_mode_action = config
+        .keybinds
+        .get_actions_for_key_in_mode(&InputMode::Pane, &Key::Ctrl('g'));
+    let r_in_pane_mode = config
+        .keybinds
+        .get_actions_for_key_in_mode(&InputMode::Pane, &Key::Char('r'));
+    let z_in_pane_mode = config
+        .keybinds
+        .get_actions_for_key_in_mode(&InputMode::Pane, &Key::Char('z'));
+    let t_in_pane_mode = config
+        .keybinds
+        .get_actions_for_key_in_mode(&InputMode::Pane, &Key::Char('t'));
+    assert_eq!(
+        ctrl_g_normal_mode_action, None,
+        "First keybind uncleared in one mode"
+    );
+    assert_eq!(
+        ctrl_g_pane_mode_action, None,
+        "First keybind uncleared in another mode"
+    );
+    assert_eq!(z_in_pane_mode, None, "Second keybind cleared as well");
+    assert_eq!(
+        r_in_pane_mode,
+        Some(&vec![Action::TogglePaneFrames]),
+        "Unrelated keybinding in default config still bound"
+    );
+    assert_eq!(
+        t_in_pane_mode,
+        Some(&vec![Action::SwitchToMode(InputMode::Tab)]),
+        "Keybinding from custom config still bound"
+    );
+}
+
+#[test]
 fn can_unbind_multiple_keys_per_single_mode() {
     let default_config_contents = r#"
         keybinds {
@@ -379,6 +440,71 @@ fn can_unbind_multiple_keys_per_single_mode() {
         keybinds {
             pane {
                 unbind "Ctrl g" "z"
+                bind "t" { SwitchToMode "Tab"; }
+            }
+        }
+    "#;
+    let default_config = Config::from_kdl(default_config_contents, None).unwrap();
+    let config = Config::from_kdl(config_contents, Some(default_config)).unwrap();
+    let ctrl_g_normal_mode_action = config
+        .keybinds
+        .get_actions_for_key_in_mode(&InputMode::Normal, &Key::Ctrl('g'));
+    let ctrl_g_pane_mode_action = config
+        .keybinds
+        .get_actions_for_key_in_mode(&InputMode::Pane, &Key::Ctrl('g'));
+    let r_in_pane_mode = config
+        .keybinds
+        .get_actions_for_key_in_mode(&InputMode::Pane, &Key::Char('r'));
+    let z_in_pane_mode = config
+        .keybinds
+        .get_actions_for_key_in_mode(&InputMode::Pane, &Key::Char('z'));
+    let t_in_pane_mode = config
+        .keybinds
+        .get_actions_for_key_in_mode(&InputMode::Pane, &Key::Char('t'));
+    assert_eq!(
+        ctrl_g_normal_mode_action,
+        Some(&vec![Action::SwitchToMode(InputMode::Locked)]),
+        "Keybind in different mode not cleared"
+    );
+    assert_eq!(
+        ctrl_g_pane_mode_action, None,
+        "First Keybind cleared in its mode"
+    );
+    assert_eq!(
+        z_in_pane_mode, None,
+        "Second keybind cleared in its mode as well"
+    );
+    assert_eq!(
+        r_in_pane_mode,
+        Some(&vec![Action::TogglePaneFrames]),
+        "Unrelated keybinding in default config still bound"
+    );
+    assert_eq!(
+        t_in_pane_mode,
+        Some(&vec![Action::SwitchToMode(InputMode::Tab)]),
+        "Keybinding from custom config still bound"
+    );
+}
+
+#[test]
+fn can_unbind_multiple_keys_per_single_mode_multiple_lines() {
+    let default_config_contents = r#"
+        keybinds {
+            normal {
+                bind "Ctrl g" { SwitchToMode "Locked"; }
+            }
+            pane {
+                bind "Ctrl g" { SwitchToMode "Locked"; }
+                bind "z" { TogglePaneFrames; SwitchToMode "Normal"; }
+                bind "r" { TogglePaneFrames; }
+            }
+        }
+    "#;
+    let config_contents = r#"
+        keybinds {
+            pane {
+                unbind "Ctrl g"
+                unbind "z"
                 bind "t" { SwitchToMode "Tab"; }
             }
         }

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -1575,9 +1575,11 @@ impl Keybinds {
                 Keybinds::input_mode_keybindings(mode, &mut keybinds_from_config)?;
             Keybinds::bind_keys_in_block(mode, &mut input_mode_keybinds, config_options)?;
         }
-        if let Some(global_unbind) = kdl_keybinds.children().and_then(|c| c.get("unbind")) {
-            Keybinds::unbind_keys_in_all_modes(global_unbind, &mut keybinds_from_config)?;
-        };
+        for unbind in kdl_children_nodes_or_error!(kdl_keybinds, "keybindings with no children") {
+            if kdl_name!(unbind) == "unbind" {
+                Keybinds::unbind_keys_in_all_modes(unbind, &mut keybinds_from_config)?;
+            }
+        }
         Ok(keybinds_from_config)
     }
     fn bind_actions_for_each_key(


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/2354

The keybinding config logic didn't handle the case where there were multiple global unbinds:

```
keybinds {
    unbind "a"
    unbind "b"
    unbind "c"

    pane {
      unbind "d"
      unbind "e"
    }
}
```

The unbinds for "b" and "c" are ignored. Note that the unbinds for "d" and "e" both work properly though, so this seems like a bug.

This PR makes a small change to the config parsing logic to handle the case where there are multiple unbind nodes directly under the keybinds node.

It adds a test for the global unbind case, and also adds a test for the case where there are multiple unbind nodes under a particular mode's node within keybinds (a case that was already working but didn't have a test).