### PR TITLE
Fix error loading non-existant themes directory and use default themes as the base when merging

### DIFF
--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -322,14 +322,16 @@ impl Setup {
 
         config.themes = get_default_themes().merge(config.themes);
 
-        let user_theme_dir = config_options.theme_dir.clone().or_else(|| {
-            get_theme_dir(cli_args.config_dir.clone().or_else(find_default_config_dir))
-                // If theme dir is not explicitly specified in config_options,
-                // only try to use it if it exists.
-                .filter(|dir| dir.exists())
-        });
-        if let Some(user_theme_dir) = user_theme_dir {
-            config.themes = config.themes.merge(Themes::from_dir(user_theme_dir)?);
+        if let Some(Command::Setup(Setup { clean: false, .. })) = &cli_args.command {
+            let user_theme_dir = config_options.theme_dir.clone().or_else(|| {
+                get_theme_dir(cli_args.config_dir.clone().or_else(find_default_config_dir))
+                    // If theme dir is not explicitly specified in config_options,
+                    // only try to use it if it exists.
+                    .filter(|dir| dir.exists())
+            });
+            if let Some(user_theme_dir) = user_theme_dir {
+                config.themes = config.themes.merge(Themes::from_dir(user_theme_dir)?);
+            }
         }
 
         if let Some(Command::Setup(ref setup)) = &cli_args.command {

--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -324,6 +324,9 @@ impl Setup {
 
         let user_theme_dir = config_options.theme_dir.clone().or_else(|| {
             get_theme_dir(cli_args.config_dir.clone().or_else(find_default_config_dir))
+                // If theme dir is not explicitly specified in config_options,
+                // only try to use it if it exists.
+                .filter(|dir| dir.exists())
         });
         if let Some(user_theme_dir) = user_theme_dir {
             config.themes = config.themes.merge(Themes::from_dir(user_theme_dir)?);

--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -320,7 +320,7 @@ impl Setup {
             None => config.options.clone(),
         };
 
-        config.themes = config.themes.merge(get_default_themes());
+        config.themes = get_default_themes().merge(config.themes);
 
         let user_theme_dir = config_options.theme_dir.clone().or_else(|| {
             get_theme_dir(cli_args.config_dir.clone().or_else(find_default_config_dir))


### PR DESCRIPTION
When I cloned the repo and ran `cargo xtask run` I encountered an issue where the `zellij` was trying to load a themes directory at `~/.config/zellij/themes` that did not exist.

If looks like a recent PR (https://github.com/zellij-org/zellij/pull/2307), removed the `if theme_dir.is_dir() {` that was checking if the theme directory exists before trying to use it. I assume we do want to produce a hard error when the theme dir is specifically specified in the config, so I added an equivalent check that only occurs in the case where the theme dir is **not** specified in the config.

While fixing this, I also noticed that the default themes are applied over the top of the themes specified in the config. Presumably, the opposite is better since it allows overriding the defaults (and is more consistent since the themes from the themes directory are applied on top of everything else and so are able to override the defaults regardless).

One other thing I noticed (but haven't made any changes on), is that there is an option in `Command::Setup` called `clean` that indicates to only use the defaults for the config provided by zellij. I was wondering, if this should also apply to themes, since right now (afaict from the code) zellij will still load themes from the themes directory with this enabled.

P.S. I joined the discord server, feel free to contact me there as `@imbris`