### PR TITLE
Add file path context to all IO errors in ConfigError

### DIFF
--- a/zellij-utils/src/input/config.rs
+++ b/zellij-utils/src/input/config.rs
@@ -83,9 +83,6 @@ pub enum ConfigError {
     KdlDeserializationError(#[from] kdl::KdlError),
     #[error("KdlDeserialization error: {0}")]
     KdlError(KdlError), // TODO: consolidate these
-    // Io error
-    #[error("IoError: {0}")]
-    Io(#[from] io::Error),
     #[error("Config error: {0}")]
     Std(#[from] Box<dyn std::error::Error>),
     // Io error with path context

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -730,7 +730,9 @@ impl Layout {
         let swap_layout_and_path = Layout::swap_layout_and_path(&layout_path);
 
         let mut kdl_layout = String::new();
-        layout_file.read_to_string(&mut kdl_layout)?;
+        layout_file
+            .read_to_string(&mut kdl_layout)
+            .map_err(|e| ConfigError::IoPath(e, layout_path.into()))?;
         Ok((
             layout_path.as_os_str().to_string_lossy().into(),
             kdl_layout,


### PR DESCRIPTION
When I encountered the issue noted in https://github.com/zellij-org/zellij/pull/2411, it was a bit difficult to understand what was happening since the missing file path was not included in the displayed error.

This PR removes `ConfigError::Io` and replaces all usages of it with `ConfigError::IoPath`. Hopefully, this will improve the experience when debugging unexpected errors in the future (although there may be more room to add useful context, such as where in the code these errors are being produced).