### PR TITLE
CI: create custom source artifact with rendered manpages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,55 @@ jobs:
           asset_name: zellij-${{matrix.target}}.sha256sum
           asset_content_type: text/plain
 
+  prepare-source-release:
+    runs-on: ubuntu-latest
+    needs: create-release
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup pandoc
+        uses: r-lib/actions/setup-pandoc@v2
+
+      - name: Render manpage
+        working-directory: ./docs
+        run: |
+          pandoc --standalone --from markdown --to man --output zellij.1 MANPAGE.md
+
+      - name: Remove git repo
+        run: |
+          rm -rf .git
+
+      - name: Tar source release
+        run: |
+          cd ..
+          tar cvzf zellij-src.tar.gz ${{ github.event.repository.name }}
+          mv zellij-src.tar.gz ${{ github.event.repository.name }}/
+
+      - name: Create source checksum
+        run: |
+          sha256sum zellij-src.tar.gz > zellij-src.tar.gz.sha256sum
+
+      - name: Upload source archive
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ./zellij-src.tar.gz
+          asset_name: zellij-src.tar.gz
+          asset_content_type: application/octet-stream
+
+      - name: Upload source checksum
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ./zellij-src.tar.gz.sha256sum
+          asset_name: zellij-src.tar.gz.sha256sum
+          asset_content_type: text/plain
+
   create-release:
     runs-on: ubuntu-latest
     outputs: 

--- a/docs/MANPAGE.md
+++ b/docs/MANPAGE.md
@@ -1,3 +1,5 @@
+% ZELLIJ(1)
+
 NAME
 ====
 
@@ -44,6 +46,7 @@ but this can be changed by using the `default_layout: [LAYOUT_NAME]` configurati
 
 
 For example a file like this:
+
 ```
 ---
 direction: Vertical
@@ -64,6 +67,7 @@ parts:
 ```
 
 will tell Zellij to create this layout:
+
 ```
 ┌─────┬─────┐
 │     │     │
@@ -79,6 +83,7 @@ A layout file is a nested tree structure. Each node describes either a pane
 (leaf), or a space in which its parts (children) will be created.
 
 Each node has following fields:
+
 * __direction: <Horizontal / Vertical\>__ - node's children will be created by a
   split in given direction.
 * **split_size:** - this indicates either a percentage of the node's parent's
@@ -117,24 +122,30 @@ should be unbound:
 keybinds:
     unbind: true
 ```
+
 Will unbind every default binding.
 
 ```
 keybinds:
     unbind: [ Ctrl: 'p']
 ```
+
 Will unbind every default `^P` binding for each mode.
+
 ```
 keybinds:
     normal:
         - unbind: true
 ```
+
 Will unbind every default keybind for the `normal` mode.
+
 ```
 keybinds:
     normal:
         - unbind: [ Alt: 'n', Ctrl: 'g']
 ```
+
 Will unbind every default keybind for `n` and `^g` for the `normal` mode.
 
 ACTIONS
@@ -217,23 +228,32 @@ MODES
 * __session__ - allows detaching from a session.
 
 
-Theme
+THEME
 =====
+
 A color theme can be defined either in truecolor, 256 or hex color format.
+
 Truecolor:
+
 ```
 fg: [0, 0, 0]
 ```
+
 256:
+
 ```
 fg: 0
 ```
+
 Hex color:
+
 ```
 fg: "#000000"
 bg: "#000"
 ```
+
 The color theme can be specified in the following way:
+
 ```
 themes:
   default:
@@ -252,9 +272,11 @@ themes:
 
 If the theme is called `default`, then zellij will pick it on startup.
 To specify a different theme, run zellij with:
+
 ```
 zellij options --theme [NAME]
 ```
+
 or put the name in the configuration file with `theme: [NAME]`.
 
 PLUGINS
@@ -269,26 +291,30 @@ FILES
 =====
 
 Default user configuration directory location:
-* Linux: _$XDG_HOME/zellij /home/alice/.config/zellij_
-* macOS: _/Users/Alice/Library/Application Support/com.Zellij-Contributors.zellij_
+
+* Linux: _$XDG_HOME/zellij_ _/home/alice/.config/zellij_
+* macOS: _/Users/Alice/Library/Application_ _Support/com.Zellij-Contributors.zellij_
 
 Default user layout directory location:
+
 * Subdirectory called `layouts` inside of the configuration directory.
-* Linux: _$XDG_HOME/zellij/layouts /home/alice/.config/zellij/layouts
-* macOS: _/Users/Alice/Library/Application/layouts Support/com.Zellij-Contributors.zellij/layouts_
+* Linux: _$XDG_HOME/zellij/layouts_ _/home/alice/.config/zellij/layouts_
+* macOS: _/Users/Alice/Library/Application/layouts_ _Support/com.Zellij-Contributors.zellij/layouts_
 
 Default plugin directory location:
-* Linux: _$XDG_DATA_HOME/zellij/plugins /home/alice/.local/share/plugins
 
+* Linux: _$XDG_DATA_HOME/zellij/plugins_ _/home/alice/.local/share/plugins_
 
 ENVIRONMENT
 ===========
+
 ZELLIJ_CONFIG_FILE
+------------------
   Path of Zellij config to load.
+
 ZELLIJ_CONFIG_DIR
+-----------------
   Path of the Zellij config directory.
-
-
 
 NOTES
 =====


### PR DESCRIPTION
Rationale: this change is useful for packaging in distributions that build zellij from source. Generating a rendered `zellij.1` manpage eliminates a build dependency and reduces guesswork when determining how to build it.

I picked `pandoc` for CI as it is a reasonable and versatile standard.

I briefly tested the Release workflow on my fork with success.

Highlights:

- Adjusted `docs/MANPAGE.md` format to what pandoc accepts
- Added generating the manpage and compressing it into a custom source code artifact in CI