### PR TITLE
shorter tab names

### DIFF
--- a/src/tests/e2e/cases.rs
+++ b/src/tests/e2e/cases.rs
@@ -407,7 +407,7 @@ pub fn open_new_tab() {
                 let mut step_is_complete = false;
                 if remote_terminal.cursor_position_is(3, 2)
                     && remote_terminal.tip_appears()
-                    && remote_terminal.snapshot_contains("Tab #2")
+                    && remote_terminal.snapshot_contains("2")
                     && remote_terminal.status_bar_appears()
                 {
                     // cursor is in the newly opened second tab
@@ -471,7 +471,7 @@ pub fn close_tab() {
                     let mut step_is_complete = false;
                     if remote_terminal.cursor_position_is(3, 2)
                         && remote_terminal.tip_appears()
-                        && remote_terminal.snapshot_contains("Tab #2")
+                        && remote_terminal.snapshot_contains("2")
                         && remote_terminal.status_bar_appears()
                     {
                         // cursor is in the newly opened second tab
@@ -487,8 +487,7 @@ pub fn close_tab() {
             name: "Wait for tab to close",
             instruction: |mut remote_terminal: RemoteTerminal| -> bool {
                 let mut step_is_complete = false;
-                if remote_terminal.snapshot_contains("Tab #1")
-                    && !remote_terminal.snapshot_contains("Tab #2")
+                if remote_terminal.snapshot_contains("1") && !remote_terminal.snapshot_contains("2")
                 {
                     // cursor is in the first tab again
                     step_is_complete = true;
@@ -503,8 +502,8 @@ pub fn close_tab() {
             break last_snapshot;
         }
     };
-    assert!(last_snapshot.contains("Tab #1"));
-    assert!(!last_snapshot.contains("Tab #2"));
+    assert!(last_snapshot.contains('1'));
+    assert!(!last_snapshot.contains('2'));
 }
 
 #[test]
@@ -1270,7 +1269,7 @@ pub fn mirrored_sessions() {
                     let mut step_is_complete = false;
                     if remote_terminal.cursor_position_is(3, 2)
                         && remote_terminal.tip_appears()
-                        && remote_terminal.snapshot_contains("Tab #2")
+                        && remote_terminal.snapshot_contains("2")
                         && remote_terminal.status_bar_appears()
                     {
                         // cursor is in the newly opened second tab
@@ -1285,7 +1284,7 @@ pub fn mirrored_sessions() {
                     let mut step_is_complete = false;
                     if remote_terminal.cursor_position_is(3, 2)
                         && remote_terminal.tip_appears()
-                        && remote_terminal.snapshot_contains("Tab #2")
+                        && remote_terminal.snapshot_contains("2")
                     {
                         // cursor is in the newly opened second pane
                         remote_terminal.send_key("some text".as_bytes());
@@ -1592,7 +1591,7 @@ pub fn multiple_users_in_different_tabs() {
                 let mut step_is_complete = false;
                 if remote_terminal.cursor_position_is(3, 2)
                     && remote_terminal.tip_appears()
-                    && remote_terminal.snapshot_contains("Tab #2")
+                    && remote_terminal.snapshot_contains("2")
                     && remote_terminal.status_bar_appears()
                 {
                     // cursor is in the newly opened second tab
@@ -1608,7 +1607,7 @@ pub fn multiple_users_in_different_tabs() {
                 let mut step_is_complete = false;
                 if remote_terminal.cursor_position_is(3, 2)
                     && remote_terminal.tip_appears()
-                    && remote_terminal.snapshot_contains("Tab #2")
+                    && remote_terminal.snapshot_contains("2")
                     && remote_terminal.status_bar_appears()
                 {
                     // cursor is in the newly opened second tab
@@ -1846,9 +1845,7 @@ pub fn undo_rename_tab() {
             name: "Undo tab name change",
             instruction: |mut remote_terminal: RemoteTerminal| -> bool {
                 let mut step_is_complete = false;
-                if remote_terminal.status_bar_appears()
-                    && remote_terminal.snapshot_contains("Tab #1")
-                {
+                if remote_terminal.status_bar_appears() && remote_terminal.snapshot_contains("1") {
                     remote_terminal.send_key(&TAB_MODE);
                     remote_terminal.send_key(&RENAME_TAB_MODE);
                     remote_terminal.send_key(&[97, 97]);
@@ -1864,7 +1861,7 @@ pub fn undo_rename_tab() {
             name: "Wait for tab name to apper on screen",
             instruction: |remote_terminal: RemoteTerminal| -> bool {
                 let mut step_is_complete = false;
-                if remote_terminal.snapshot_contains("Tab #1") {
+                if remote_terminal.snapshot_contains("1") {
                     step_is_complete = true
                 }
                 step_is_complete

--- a/src/tests/e2e/cases.rs
+++ b/src/tests/e2e/cases.rs
@@ -1593,8 +1593,8 @@ pub fn multiple_users_in_different_tabs() {
                 let mut step_is_complete = false;
                 if remote_terminal.cursor_position_is(3, 2)
                     && remote_terminal.tip_appears()
-                    && remote_terminal.snapshot_contains("Tab #1 [ ]")
-                    && remote_terminal.snapshot_contains("Tab #2")
+                    && remote_terminal.snapshot_contains("1 [ ]")
+                    && remote_terminal.snapshot_contains("2")
                     && remote_terminal.status_bar_appears()
                 {
                     // cursor is in the newly opened second tab

--- a/src/tests/e2e/remote_runner.rs
+++ b/src/tests/e2e/remote_runner.rs
@@ -306,7 +306,7 @@ impl RemoteTerminal {
         self.last_snapshot.lock().unwrap().contains("Ctrl +")
     }
     pub fn tab_bar_appears(&self) -> bool {
-        self.last_snapshot.lock().unwrap().contains("Tab #1")
+        self.last_snapshot.lock().unwrap().contains("1")
     }
     pub fn snapshot_contains(&self, text: &str) -> bool {
         self.last_snapshot.lock().unwrap().contains(text)

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__bracketed_paste.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__bracketed_paste.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 1676
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (e2e-test)  1 
 ┌ Pane #1 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │$ ^Tnabc█                                                                                                             │
 │                                                                                                                      │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__close_pane.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__close_pane.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 557
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (e2e-test)  1 
 ┌ Pane #1 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │$ █                                                                                                                   │
 │                                                                                                                      │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__close_tab.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__close_tab.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 482
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1                                                                                            
+ Zellij (e2e-test)  1                                                                                            
 ┌ Pane #1 ─────────────────────────────────────────────────┐┌ Pane #2 ─────────────────────────────────────────────────┐
 │$ █                                                       ││$                                                         │
 │                                                          ││                                                          │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__detach_and_attach_session.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__detach_and_attach_session.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 975
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (e2e-test)  1 
 ┌ Pane #1 ─────────────────────────────────────────────────┐┌ Pane #2 ─────────────────────────────────────────────────┐
 │$                                                         ││$ I am some text█                                         │
 │                                                          ││                                                          │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__focus_pane_with_mouse.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__focus_pane_with_mouse.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 1071
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (e2e-test)  1 
 ┌ Pane #1 ─────────────────────────────────────────────────┐┌ Pane #2 ─────────────────────────────────────────────────┐
 │$ █                                                       ││$                                                         │
 │                                                          ││                                                          │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__focus_tab_with_layout.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__focus_tab_with_layout.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 1720
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1  Tab #2  Tab #3  Tab #4  Tab #5  Tab #6  Tab #7  Tab #8  Tab #9            
+ Zellij (e2e-test)  1  2  3  4  5  6  7  8  9            
 ┌ Pane #1 ─────────────────────────────────────────────────┐┌ Pane #2 ─────────────────────────────────────────────────┐
 │$                                                         ││$ █                                                       │
 │                                                          ││                                                          │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__lock_mode.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__lock_mode.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 836
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (e2e-test)  1 
 ┌ Pane #1 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │$ nabc█                                                                                                               │
 │                                                                                                                      │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__mirrored_sessions-2.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__mirrored_sessions-2.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 1341
 expression: second_runner_snapshot
 ---
- Zellij (mirrored_sessions)  Tab #1  Tab #2 
+ Zellij (mirrored_sessions)  1  2 
 ┌ Pane #1 ─────────────────────────────────────────────────┐┌ Pane #2 ─────────────────────────────────────────────────┐
 │$                                                         ││$ █                                                       │
 │                                                          ││                                                          │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__mirrored_sessions.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__mirrored_sessions.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 1340
 expression: first_runner_snapshot
 ---
- Zellij (mirrored_sessions)  Tab #1  Tab #2 
+ Zellij (mirrored_sessions)  1  2 
 ┌ Pane #1 ─────────────────────────────────────────────────┐┌ Pane #2 ─────────────────────────────────────────────────┐
 │$                                                         ││$ █                                                       │
 │                                                          ││                                                          │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_different_panes_and_same_tab-2.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_different_panes_and_same_tab-2.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 1523
 expression: second_runner_snapshot
 ---
- Zellij (multiple_users_in_same_pane_and_tab)  Tab #1 [ ]
+ Zellij (multiple_users_in_same_pane_and_tab)  1 [ ]
 ┌ Pane #1 ───────────┤ FOCUSED USER:   ├───────────────────┐┌ Pane #2 ──────────────┤ MY FOCUS ├───────────────────────┐
 │$                                                         ││$ █                                                       │
 │                                                          ││                                                          │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_different_panes_and_same_tab.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_different_panes_and_same_tab.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 1522
 expression: first_runner_snapshot
 ---
- Zellij (multiple_users_in_same_pane_and_tab)  Tab #1 [ ]
+ Zellij (multiple_users_in_same_pane_and_tab)  1 [ ]
 ┌ Pane #1 ──────────────┤ MY FOCUS ├───────────────────────┐┌ Pane #2 ───────────┤ FOCUSED USER:   ├───────────────────┐
 │$ █                                                       ││$                                                         │
 │                                                          ││                                                          │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_different_tabs-2.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_different_tabs-2.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 1620
 expression: second_runner_snapshot
 ---
- Zellij (multiple_users_in_different_tabs)  Tab #1 [ ] Tab #2 
+ Zellij (multiple_users_in_different_tabs)  1 [ ] 2 
 ┌ Pane #1 ────────────────────────────────────────────┤ MY FOCUS ├─────────────────────────────────────────────────────┐
 │$ █                                                                                                                   │
 │                                                                                                                      │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_different_tabs.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_different_tabs.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 1619
 expression: first_runner_snapshot
 ---
- Zellij (multiple_users_in_different_tabs)  Tab #1  Tab #2 [ ]
+ Zellij (multiple_users_in_different_tabs)  1  2 [ ]
 ┌ Pane #1 ────────────────────────────────────────────┤ MY FOCUS ├─────────────────────────────────────────────────────┐
 │$ █                                                                                                                   │
 │                                                                                                                      │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_same_pane_and_tab-2.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_same_pane_and_tab-2.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 1431
 expression: second_runner_snapshot
 ---
- Zellij (multiple_users_in_same_pane_and_tab)  Tab #1 [ ]
+ Zellij (multiple_users_in_same_pane_and_tab)  1 [ ]
 ┌ Pane #1 ─────────────────────────────────────────┤ MY FOCUS AND:   ├─────────────────────────────────────────────────┐
 │$ █                                                                                                                   │
 │                                                                                                                      │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_same_pane_and_tab.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_same_pane_and_tab.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 1430
 expression: first_runner_snapshot
 ---
- Zellij (multiple_users_in_same_pane_and_tab)  Tab #1 [ ]
+ Zellij (multiple_users_in_same_pane_and_tab)  1 [ ]
 ┌ Pane #1 ─────────────────────────────────────────┤ MY FOCUS AND:   ├─────────────────────────────────────────────────┐
 │$ █                                                                                                                   │
 │                                                                                                                      │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__open_new_tab.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__open_new_tab.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 416
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1  Tab #2 
+ Zellij (e2e-test)  1  2 
 ┌ Pane #1 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │$ █                                                                                                                   │
 │                                                                                                                      │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__resize_pane.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__resize_pane.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 765
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (e2e-test)  1 
 ┌ Pane #1 ───────────────────────────────────────────┐┌ Pane #2 ───────────────────────────────────────────────────────┐
 │$                                                   ││$ █                                                             │
 │                                                    ││                                                                │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__resize_terminal_window.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__resize_terminal_window.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 889
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (e2e-test)  1 
 ┌ Pane #1 ───────────────────────────────────────┐┌ Pane #2 ───────────────────────────────────────┐                    
 │$                                               ││$ █                                             │                    
 │                                                ││                                                │                    

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__scrolling_inside_a_pane.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__scrolling_inside_a_pane.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 290
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (e2e-test)  1 
 ┌ Pane #1 ─────────────────────────────────────────────────┐┌ Pane #2 ─────────────────────────────────── SCROLL:  1/4 ┐
 │$                                                         ││line3                                                     │
 │                                                          ││line4                                                     │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__scrolling_inside_a_pane_with_mouse.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__scrolling_inside_a_pane_with_mouse.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 1147
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (e2e-test)  1 
 ┌ Pane #1 ─────────────────────────────────────────────────┐┌ Pane #2 ─────────────────────────────────── SCROLL:  3/4 ┐
 │$                                                         ││line1                                                     │
 │                                                          ││line2                                                     │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__send_command_through_the_cli.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__send_command_through_the_cli.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 2031
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (e2e-test)  1 
 ┌ Pane #1 ─────────────────────────────────────────────────┐┌ /usr/src/zellij/fixtures/append-echo-script.sh ──────────┐
 │$ /usr/src/zellij/x86_64-unknown-linux-musl/release/zellij││foo                                                       │
 │ run -s -- "/usr/src/zellij/fixtures/append-echo-script.sh││foo                                                       │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__split_terminals_vertically.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__split_terminals_vertically.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 168
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (e2e-test)  1 
 ┌ Pane #1 ─────────────────────────────────────────────────┐┌ Pane #2 ─────────────────────────────────────────────────┐
 │$                                                         ││$ █                                                       │
 │                                                          ││                                                          │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__start_without_pane_frames.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__start_without_pane_frames.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 1194
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (e2e-test)  1 
 $                                                          │$ █                                                         
                                                            │                                                            
                                                            │                                                            

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__starts_with_one_terminal.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__starts_with_one_terminal.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 120
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (e2e-test)  1 
 ┌ Pane #1 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │$ █                                                                                                                   │
 │                                                                                                                      │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__status_bar_loads_custom_keybindings.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__status_bar_loads_custom_keybindings.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 1011
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (e2e-test)  1 
 ┌ Pane #1 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │$ █                                                                                                                   │
 │                                                                                                                      │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__tmux_mode.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__tmux_mode.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 1772
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (e2e-test)  1 
 ┌ Pane #1 ─────────────────────────────────────────────────┐┌ Pane #2 ─────────────────────────────────────────────────┐
 │$                                                         ││$ █                                                       │
 │                                                          ││                                                          │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__toggle_floating_panes.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__toggle_floating_panes.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 1724
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (e2e-test)  1 
 ┌ Pane #1 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │$                                                                                                                     │
 │                                                                                                                      │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__toggle_pane_fullscreen.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__toggle_pane_fullscreen.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 351
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (e2e-test)  1 
 ┌ Pane #2 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │$ █                                                                                                                   │
 │                                                                                                                      │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__typing_exit_closes_pane.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__typing_exit_closes_pane.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 702
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (e2e-test)  1 
 ┌ Pane #1 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │$ █                                                                                                                   │
 │                                                                                                                      │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__undo_rename_pane.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__undo_rename_pane.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 1921
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (e2e-test)  1 
 ┌ Pane #1 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │$ █                                                                                                                   │
 │                                                                                                                      │

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__undo_rename_tab.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__undo_rename_tab.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 1871
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (e2e-test)  1 
 ┌ Pane #1 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │$ █                                                                                                                   │
 │                                                                                                                      │

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -500,7 +500,7 @@ impl Tab {
         swap_layouts: (Vec<SwapTiledLayout>, Vec<SwapFloatingLayout>),
     ) -> Self {
         let name = if name.is_empty() {
-            format!("Tab #{}", index + 1)
+            format!("{}", index + 1)
         } else {
             name
         };

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -573,21 +573,21 @@ pub fn switch_to_tab_name() {
 
     assert_eq!(
         screen
-            .switch_active_tab_name("Tab #1".to_string(), 1)
+            .switch_active_tab_name("1".to_string(), 1)
             .expect("TEST"),
         false,
         "Active tab switched to tab by name"
     );
     assert_eq!(
         screen
-            .switch_active_tab_name("Tab #2".to_string(), 1)
+            .switch_active_tab_name("2".to_string(), 1)
             .expect("TEST"),
         true,
         "Active tab switched to tab by name"
     );
     assert_eq!(
         screen
-            .switch_active_tab_name("Tab #3".to_string(), 1)
+            .switch_active_tab_name("3".to_string(), 1)
             .expect("TEST"),
         true,
         "Active tab switched to tab by name"

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_query_tab_names_action.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_query_tab_names_action.snap
@@ -6,8 +6,8 @@ expression: "format!(\"{:#?}\", log_tab_names_action)"
 Some(
     Log(
         [
-            "Tab #1",
-            "Tab #2",
+            "1",
+            "2",
         ],
         10,
     ),

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_rename_tab.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_rename_tab.snap
@@ -170,7 +170,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
                     [
                         TabInfo {
                             position: 0,
-                            name: "Tab #1",
+                            name: "1",
                             active: true,
                             panes_to_hide: 0,
                             is_fullscreen_active: false,
@@ -334,7 +334,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
                     [
                         TabInfo {
                             position: 0,
-                            name: "Tab #1",
+                            name: "1",
                             active: false,
                             panes_to_hide: 0,
                             is_fullscreen_active: false,
@@ -348,7 +348,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
                         },
                         TabInfo {
                             position: 1,
-                            name: "Tab #2",
+                            name: "2",
                             active: true,
                             panes_to_hide: 0,
                             is_fullscreen_active: false,
@@ -376,7 +376,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
                     [
                         TabInfo {
                             position: 0,
-                            name: "Tab #1",
+                            name: "1",
                             active: false,
                             panes_to_hide: 0,
                             is_fullscreen_active: false,
@@ -418,7 +418,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
                     [
                         TabInfo {
                             position: 0,
-                            name: "Tab #1",
+                            name: "1",
                             active: false,
                             panes_to_hide: 0,
                             is_fullscreen_active: false,

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_undo_rename_tab.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_undo_rename_tab.snap
@@ -170,7 +170,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
                     [
                         TabInfo {
                             position: 0,
-                            name: "Tab #1",
+                            name: "1",
                             active: true,
                             panes_to_hide: 0,
                             is_fullscreen_active: false,
@@ -334,7 +334,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
                     [
                         TabInfo {
                             position: 0,
-                            name: "Tab #1",
+                            name: "1",
                             active: false,
                             panes_to_hide: 0,
                             is_fullscreen_active: false,
@@ -348,7 +348,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
                         },
                         TabInfo {
                             position: 1,
-                            name: "Tab #2",
+                            name: "2",
                             active: true,
                             panes_to_hide: 0,
                             is_fullscreen_active: false,
@@ -376,7 +376,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
                     [
                         TabInfo {
                             position: 0,
-                            name: "Tab #1",
+                            name: "1",
                             active: false,
                             panes_to_hide: 0,
                             is_fullscreen_active: false,
@@ -418,7 +418,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
                     [
                         TabInfo {
                             position: 0,
-                            name: "Tab #1",
+                            name: "1",
                             active: false,
                             panes_to_hide: 0,
                             is_fullscreen_active: false,
@@ -471,7 +471,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
                     [
                         TabInfo {
                             position: 0,
-                            name: "Tab #1",
+                            name: "1",
                             active: false,
                             panes_to_hide: 0,
                             is_fullscreen_active: false,
@@ -485,7 +485,7 @@ expression: "format!(\"{:#?}\", * received_plugin_instructions.lock().unwrap())"
                         },
                         TabInfo {
                             position: 1,
-                            name: "Tab #2",
+                            name: "2",
                             active: true,
                             panes_to_hide: 0,
                             is_fullscreen_active: false,


### PR DESCRIPTION
Solve #2177. Shorten tab name, change it from `Tab # 1` to `1`

