### PR TITLE
Do not unwrap() the sticky bit setting!

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -278,7 +278,8 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                 // set the sticky bit to avoid the socket file being potentially cleaned up
                 // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html states that for XDG_RUNTIME_DIR:
                 // "To ensure that your files are not removed, they should have their access time timestamp modified at least once every 6 hours of monotonic time or the 'sticky' bit should be set on the file. "
-                set_permissions(&socket_path, 0o1700).unwrap();
+                // It is not guaranteed that all platforms allow setting the sticky bit on sockets!
+                drop(set_permissions(&socket_path, 0o1700));
                 for stream in listener.incoming() {
                     match stream {
                         Ok(stream) => {


### PR DESCRIPTION
It fails on FreeBSD, making the zellij server quit and the client spin endlessly retrying to connect.

```
INFO   |zellij_client            | 2023-05-04 02:11:28.505 [main      ] [zellij-client/src/lib.rs:143]: Starting Zellij client!
INFO   |zellij_server            | 2023-05-04 02:11:28.516 [main      ] [zellij-server/src/lib.rs:237]: Starting Zellij server!
ERROR  |zellij_utils::errors::not| 2023-05-04 02:11:28.519 [server_listener] [zellij-utils/src/errors.rs:585]: Panic occured:
             thread: server_listener
             location: At zellij-server/src/lib.rs:281:55
             message: called `Result::unwrap()` on an `Err` value: Os { code: 79, kind: Uncategorized, message: "Inappropriate file type or format" }
```

ping @ephemeralriggs – this actually slipped into the latest packaged release…