### PR TITLE
chore: add rust-analyzer to toolchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,11 +776,12 @@ checksum = "3c877555693c14d2f84191cfd3ad8582790fc52b5e2274b40b59cf5f5cea25c7"
 
 [[package]]
 name = "dialoguer"
-version = "0.10.1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c8ae48e400addc32a8710c8d62d55cb84249a7d58ac4cd959daecfbaddc545"
+checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
 dependencies = [
  "console",
+ "shell-words",
  "tempfile",
  "zeroize",
 ]
@@ -2595,6 +2596,12 @@ dependencies = [
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shellexpand"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # This file is updated by `update-toolchain.sh`
 [toolchain]
 channel = "1.67.0"
-components = ["rustfmt", "clippy", "rust-analysis"]
+components = ["rustfmt", "clippy", "rust-analysis", "rust-analyzer"]
 targets = ["wasm32-wasi", "x86_64-unknown-linux-musl"]


### PR DESCRIPTION
For better DX as rust-analyzer has joined the rustup's components collection