### PR TITLE
fix 2459 - the banner does not show

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -524,14 +524,6 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                     .as_ref()
                     .unwrap()
                     .senders
-                    .send_to_screen(ScreenInstruction::RemoveClient(client_id))
-                    .unwrap();
-                session_data
-                    .write()
-                    .unwrap()
-                    .as_ref()
-                    .unwrap()
-                    .senders
                     .send_to_plugin(PluginInstruction::RemoveClient(client_id))
                     .unwrap();
             },

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -2030,7 +2030,8 @@ pub(crate) fn screen_thread_main(
                 screen.unblock_input()?;
             },
             ScreenInstruction::HoldPane(id, exit_status, run_command, tab_index, client_id) => {
-                let is_first_run = false;
+                // If the pane is set to hold_on_close, we always want to display the banner, rather than never showing it.
+                let is_first_run = true;
                 match (client_id, tab_index) {
                     (Some(client_id), _) => {
                         active_tab!(screen, client_id, |tab: &mut Tab| tab.hold_pane(


### PR DESCRIPTION
Fix #2459, the reason the banner does not show is that the callback triggers the screen instruction of `HoldPane`, the first_run is set to `false` before rendering

The fix is to display the banner every time when the command reruns, this might not be a perfect fix, so suggestion is welcome