### PR TITLE
fix(server): remember focused tab while disconnecting last client

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1187,7 +1187,7 @@ impl Screen {
                 tab.visible(false).with_context(err_context)?;
             }
         }
-        if self.active_tab_indices.contains_key(&client_id) {
+        if self.active_tab_indices.len() > 1 && self.active_tab_indices.contains_key(&client_id) {
             self.active_tab_indices.remove(&client_id);
         }
         if self.tab_history.contains_key(&client_id) {


### PR DESCRIPTION
Fixes #2456.

Fix found by @zummenix.