### PR TITLE
feat(client): introduce ZELLIJ_TMP_LOG_FILE env variable

### DIFF
--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 use zellij_utils::{
     channels::{self, ChannelWithContext, SenderWithContext},
-    consts::ZELLIJ_IPC_PIPE,
+    consts::{ZELLIJ_IPC_PIPE, ZELLIJ_TMP_LOG_FILE},
     data::{ClientId, InputMode, Style},
     envs,
     errors::{ClientContext, ContextType, ErrorInstruction},
@@ -155,6 +155,7 @@ pub fn start_client(
         .write(clear_client_terminal_attributes.as_bytes())
         .unwrap();
     envs::set_zellij("0".to_string());
+    envs::set_tmp_log_file(ZELLIJ_TMP_LOG_FILE.display().to_string());
     config.env.set_vars();
 
     let palette = config

--- a/zellij-utils/src/envs.rs
+++ b/zellij-utils/src/envs.rs
@@ -31,6 +31,11 @@ pub fn get_socket_dir() -> Result<String> {
     Ok(var(SOCKET_DIR_ENV_KEY)?)
 }
 
+pub const ZELLIJ_TMP_LOG_FILE_ENV_KEY: &str = "ZELLIJ_TMP_LOG_FILE";
+pub fn set_tmp_log_file(v: String) {
+    set_var(ZELLIJ_TMP_LOG_FILE_ENV_KEY, v);
+}
+
 /// Manage ENVIRONMENT VARIABLES from the configuration and the layout files
 #[derive(Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EnvironmentVariables {


### PR DESCRIPTION
This introduces `ZELLIJ_TMP_LOG_FILE` env variable in zellij session. I believe this is useful is several ways. Developers can create some automation or even layouts that include a pane which runs a script with `tail -F $ZELLIJ_TMP_LOG_FILE` for debugging purposes. For users the docs can be updated with a note how to access the log file and share it.

Closes #2465 