### PR TITLE
[WIP]Feasibility of feature request 2434 - Add new action to retrieve active/current pane id

### DIFF
--- a/zellij-client/src/cli_client.rs
+++ b/zellij-client/src/cli_client.rs
@@ -32,6 +32,11 @@ pub fn start_cli_client(os_input: Box<dyn ClientOsApi>, session_name: &str, acti
                 log_lines.iter().for_each(|line| println!("{line}"));
                 process::exit(0);
             },
+            Some((ServerToClientMsg::CurrentPaneDetail(bytes), _)) => {
+                let mut stdout = os_input.get_stdout_writer();
+                let _ = stdout.write(&bytes).unwrap();
+                stdout.flush().unwrap();
+            },
             _ => {},
         }
     }

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -46,6 +46,7 @@ pub(crate) enum ClientInstruction {
     StartedParsingStdinQuery,
     DoneParsingStdinQuery,
     Log(Vec<String>),
+    CurrentPaneDetail(Vec<u8>),
 }
 
 impl From<ServerToClientMsg> for ClientInstruction {
@@ -60,6 +61,9 @@ impl From<ServerToClientMsg> for ClientInstruction {
             ServerToClientMsg::Connected => ClientInstruction::Connected,
             ServerToClientMsg::ActiveClients(clients) => ClientInstruction::ActiveClients(clients),
             ServerToClientMsg::Log(log_lines) => ClientInstruction::Log(log_lines),
+            ServerToClientMsg::CurrentPaneDetail(bytes) => {
+                ClientInstruction::CurrentPaneDetail(bytes)
+            },
         }
     }
 }
@@ -77,6 +81,7 @@ impl From<&ClientInstruction> for ClientContext {
             ClientInstruction::Log(_) => ClientContext::Log,
             ClientInstruction::StartedParsingStdinQuery => ClientContext::StartedParsingStdinQuery,
             ClientInstruction::DoneParsingStdinQuery => ClientContext::DoneParsingStdinQuery,
+            ClientInstruction::CurrentPaneDetail(_) => ClientContext::CurrentPaneDetail,
         }
     }
 }

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -78,6 +78,7 @@ pub enum ServerInstruction {
     ConnStatus(ClientId),
     ActiveClients(ClientId),
     Log(Vec<String>, ClientId),
+    CurrentPaneDetail(Vec<u8>),
 }
 
 impl From<&ServerInstruction> for ServerContext {
@@ -95,6 +96,7 @@ impl From<&ServerInstruction> for ServerContext {
             ServerInstruction::ConnStatus(..) => ServerContext::ConnStatus,
             ServerInstruction::ActiveClients(_) => ServerContext::ActiveClients,
             ServerInstruction::Log(..) => ServerContext::Log,
+            ServerInstruction::CurrentPaneDetail(..) => ServerContext::CurrentPaneDetail,
         }
     }
 }
@@ -471,11 +473,25 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                     );
                 }
             },
+            ServerInstruction::CurrentPaneDetail(bytes) => {
+                for client_id in session_state.read().unwrap().clients.keys() {
+                    send_to_client!(
+                        *client_id,
+                        os_input,
+                        ServerToClientMsg::CurrentPaneDetail(bytes.clone()),
+                        session_state
+                    );
+                }
+            },
             ServerInstruction::ClientExit(client_id) => {
+                info!("client {} exited", client_id);
                 let _ =
                     os_input.send_to_client(client_id, ServerToClientMsg::Exit(ExitReason::Normal));
+                info!("sending exit to client {}", client_id);
                 remove_client!(client_id, os_input, session_state);
+                info!("remove client {}", client_id);
                 if let Some(min_size) = session_state.read().unwrap().min_client_terminal_size() {
+                    info!("resizing to {:?}", min_size);
                     session_data
                         .write()
                         .unwrap()

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -617,7 +617,7 @@ impl TiledPanes {
         } else {
             self.active_panes
                 .iter()
-                .filter(|(client_id, _pane_id)| connected_clients.contains(client_id))
+                .filter(|(client_id, _)| connected_clients.contains(client_id))
                 .map(|(client_id, pane_id)| (*client_id, *pane_id))
                 .collect()
         };

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -702,6 +702,12 @@ pub(crate) fn route_action(
                 ))
                 .with_context(err_context)?;
         },
+        Action::CurrentPaneInfo => {
+            session
+                .senders
+                .send_to_screen(ScreenInstruction::CurrentPaneInfo(client_id))
+                .with_context(err_context)?;
+        },
     }
     Ok(should_break)
 }

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1409,6 +1409,22 @@ impl Tab {
             }
         })
     }
+    pub fn get_active_pane_details(&mut self, client_id: ClientId) -> Option<Vec<u8>> {
+        let mut bytes = Vec::new();
+        if let Some(pane) = self.get_active_pane(client_id) {
+            if let PaneId::Terminal(pid) = pane.pid() {
+                let msg = format!(
+                    "client #{} : Current active pane id is {}. <WIP>",
+                    client_id, pid
+                );
+                bytes.append(&mut msg.as_bytes().to_vec());
+
+                return Some(bytes);
+            }
+        }
+
+        None
+    }
     pub fn get_active_pane_mut(&mut self, client_id: ClientId) -> Option<&mut Box<dyn Pane>> {
         self.get_active_pane_id(client_id).and_then(|ap| {
             if self.floating_panes.panes_are_visible() {

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -329,6 +329,7 @@ pub enum CliAction {
     },
     /// Remove a previously set pane name
     UndoRenamePane,
+    CurrentPaneInfo,
     /// Go to the next tab.
     GoToNextTab,
     /// Go to the previous tab.

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -333,6 +333,7 @@ pub enum ScreenContext {
     ProgressPluginLoadingOffset,
     StartPluginLoadingIndication,
     RequestStateUpdateForPlugins,
+    CurrentPaneInfo,
 }
 
 /// Stack call representations corresponding to the different types of [`PtyInstruction`]s.
@@ -385,6 +386,7 @@ pub enum ClientContext {
     OwnClientId,
     StartedParsingStdinQuery,
     DoneParsingStdinQuery,
+    CurrentPaneDetail,
 }
 
 /// Stack call representations corresponding to the different types of [`ServerInstruction`]s.
@@ -402,6 +404,7 @@ pub enum ServerContext {
     ConnStatus,
     ActiveClients,
     Log,
+    CurrentPaneDetail,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -233,6 +233,7 @@ pub enum Action {
     NewTiledPluginPane(RunPluginLocation, Option<String>), // String is an optional name
     NewFloatingPluginPane(RunPluginLocation, Option<String>), // String is an optional name
     StartOrReloadPlugin(Url),
+    CurrentPaneInfo,
 }
 
 impl Action {
@@ -474,6 +475,7 @@ impl Action {
             CliAction::NextSwapLayout => Ok(vec![Action::NextSwapLayout]),
             CliAction::QueryTabNames => Ok(vec![Action::QueryTabNames]),
             CliAction::StartOrReloadPlugin { url } => Ok(vec![Action::StartOrReloadPlugin(url)]),
+            CliAction::CurrentPaneInfo => Ok(vec![Action::CurrentPaneInfo]),
         }
     }
 }

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -110,6 +110,7 @@ pub enum ServerToClientMsg {
     Connected,
     ActiveClients(Vec<ClientId>),
     Log(Vec<String>),
+    CurrentPaneDetail(Vec<u8>),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
WIP to support feature request #2434, it would be great that someone could leave some comments or feedbacks, I just want to make sure I am on the right track of impl

---

- [x] client id's active/current pane id

![2434](https://github.com/zellij-org/zellij/assets/85712372/5d07dd11-8f5b-4588-8616-7f447ce6f063)

