### PR TITLE
Add option to invert selection colors

### DIFF
--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -168,6 +168,7 @@ pub fn start_client(
             colors: palette,
             rounded_corners: config.ui.pane_frames.rounded_corners,
             hide_session_name: config.ui.pane_frames.hide_session_name,
+            invert_selection_colors: config_options.invert_selection_colors.unwrap_or_default(),
         },
         keybinds: config.keybinds.clone(),
     };

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1060,6 +1060,7 @@ impl Grid {
                     self.selection,
                     background_color,
                     None,
+                    style.invert_selection_colors,
                     content_x,
                     content_y,
                 );
@@ -1084,6 +1085,7 @@ impl Grid {
                             *res,
                             background_color,
                             Some(foreground_color),
+                            false,
                             content_x,
                             content_y,
                         );

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -648,6 +648,7 @@ pub struct Style {
     pub colors: Palette,
     pub rounded_corners: bool,
     pub hide_session_name: bool,
+    pub invert_selection_colors: bool,
 }
 
 // FIXME: Poor devs hashtable since HashTable can't derive `Default`...

--- a/zellij-utils/src/input/config.rs
+++ b/zellij-utils/src/input/config.rs
@@ -315,6 +315,7 @@ mod config_test {
             scrollback_editor "/path/to/my/scrollback-editor"
             session_name "my awesome session"
             attach_to_session true
+            invert_selection_colors true
         "#;
         let config = Config::from_kdl(config_contents, None).unwrap();
         assert_eq!(
@@ -409,6 +410,11 @@ mod config_test {
         );
         assert_eq!(
             config.options.attach_to_session,
+            Some(true),
+            "Option set in config"
+        );
+        assert_eq!(
+            config.options.invert_selection_colors,
             Some(true),
             "Option set in config"
         );

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -124,6 +124,12 @@ pub struct Options {
     #[clap(long, value_parser)]
     #[serde(default)]
     pub auto_layout: Option<bool>,
+
+    /// When enabled, inverts the selection's fg and bg colors. Otherwise, selections
+    /// are highlighted using the theme's `palette.black` color.
+    #[clap(long, value_parser)]
+    #[serde(default)]
+    pub invert_selection_colors: Option<bool>,
 }
 
 #[derive(ArgEnum, Deserialize, Serialize, Debug, Clone, Copy, PartialEq)]
@@ -187,6 +193,9 @@ impl Options {
         let attach_to_session = other
             .attach_to_session
             .or_else(|| self.attach_to_session.clone());
+        let invert_selection_colors = other
+            .invert_selection_colors
+            .or(self.invert_selection_colors);
 
         Options {
             simplified_ui,
@@ -209,6 +218,7 @@ impl Options {
             session_name,
             attach_to_session,
             auto_layout,
+            invert_selection_colors,
         }
     }
 
@@ -232,6 +242,8 @@ impl Options {
         let pane_frames = merge_bool(other.pane_frames, self.pane_frames);
         let auto_layout = merge_bool(other.auto_layout, self.auto_layout);
         let mirror_session = merge_bool(other.mirror_session, self.mirror_session);
+        let invert_selection_colors =
+            merge_bool(other.invert_selection_colors, self.invert_selection_colors);
 
         let default_mode = other.default_mode.or(self.default_mode);
         let default_shell = other.default_shell.or_else(|| self.default_shell.clone());
@@ -274,6 +286,7 @@ impl Options {
             session_name,
             attach_to_session,
             auto_layout,
+            invert_selection_colors,
         }
     }
 
@@ -333,6 +346,7 @@ impl From<CliOptions> for Options {
             session_name: opts.session_name,
             attach_to_session: opts.attach_to_session,
             auto_layout: opts.auto_layout,
+            invert_selection_colors: opts.invert_selection_colors,
             ..Default::default()
         }
     }

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -1353,6 +1353,10 @@ impl Options {
         let attach_to_session =
             kdl_property_first_arg_as_bool_or_error!(kdl_options, "attach_to_session")
                 .map(|(v, _)| v);
+        let invert_selection_colors =
+            kdl_property_first_arg_as_bool_or_error!(kdl_options, "invert_selection_colors")
+                .map(|(v, _)| v);
+
         Ok(Options {
             simplified_ui,
             theme,
@@ -1374,6 +1378,7 @@ impl Options {
             session_name,
             attach_to_session,
             auto_layout,
+            invert_selection_colors,
         })
     }
 }


### PR DESCRIPTION
Resolves #2395 

This adds a new option that inverts the fg / bg colors of the selection instead of coloring w/ palette.black.

I've just passed along a `bool` with `chunk_selection_and_colors` but I can refactor into a better defined enum type if desired.