### PR TITLE
Initial implementation of --only-unattached

### DIFF
--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -87,6 +87,10 @@ pub enum Sessions {
         #[clap(short, long, value_parser)]
         create: bool,
 
+        /// Only attach to unattached sessions.
+        #[clap(short, long, value_parser)]
+        only_unattached: bool,
+
         /// Number of the session index in the active sessions ordered creation date.
         #[clap(long, value_parser)]
         index: Option<usize>,


### PR DESCRIPTION
This PR adds a new flag to `zellij attach` which will allow attaching only to unattached sessions.

It also updates the output of `zellij ls` to indicate which sessions currently are attached to a client.

The goal is to enable behaviour described in https://github.com/zellij-org/zellij/discussions/2461