### PR TITLE
Feature/go to tab name cwd

### DIFF
--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -308,7 +308,7 @@ impl InputHandler {
             | Action::GoToPreviousTab
             | Action::CloseTab
             | Action::GoToTab(_)
-            | Action::GoToTabName(_, _)
+            | Action::GoToTabName(_, _, _)
             | Action::ToggleTab
             | Action::MoveFocusOrTab(_) => {
                 self.command_is_executing.blocking_input_thread();

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -921,7 +921,7 @@ fn host_go_to_tab_name(env: &ForeignFunctionEnv) {
     wasi_read_string(&env.plugin_env.wasi_env)
         .and_then(|tab_name| {
             let create = false;
-            let action = Action::GoToTabName(tab_name, create);
+            let action = Action::GoToTabName(tab_name, create, None);
             apply_action!(action, error_msg, env);
             Ok(())
         })
@@ -939,7 +939,7 @@ fn host_focus_or_create_tab(env: &ForeignFunctionEnv) {
     wasi_read_string(&env.plugin_env.wasi_env)
         .and_then(|tab_name| {
             let create = true;
-            let action = Action::GoToTabName(tab_name, create);
+            let action = Action::GoToTabName(tab_name, create, None);
             apply_action!(action, error_msg, env);
             Ok(())
         })

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -453,7 +453,7 @@ pub(crate) fn route_action(
                 .send_to_screen(ScreenInstruction::GoToTab(i, Some(client_id)))
                 .with_context(err_context)?;
         },
-        Action::GoToTabName(name, create) => {
+        Action::GoToTabName(name, create, cwd) => {
             let shell = default_shell.clone();
             let swap_tiled_layouts = default_layout.swap_tiled_layouts.clone();
             let swap_floating_layouts = default_layout.swap_floating_layouts.clone();
@@ -464,6 +464,7 @@ pub(crate) fn route_action(
                     shell,
                     create,
                     Some(client_id),
+                    cwd,
                 ))
                 .with_context(err_context)?;
         },

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -219,6 +219,7 @@ pub enum ScreenInstruction {
         Option<TerminalAction>,                          // default_shell
         bool,
         Option<ClientId>,
+        Option<PathBuf>,
     ),
     ToggleTab(ClientId),
     UpdateTabName(Vec<u8>, ClientId),
@@ -2329,6 +2330,7 @@ pub(crate) fn screen_thread_main(
                 default_shell,
                 create,
                 client_id,
+                cwd,
             ) => {
                 let client_id = if client_id.is_none() {
                     None
@@ -2351,7 +2353,7 @@ pub(crate) fn screen_thread_main(
                                 .bus
                                 .senders
                                 .send_to_plugin(PluginInstruction::NewTab(
-                                    None,
+                                    cwd,
                                     default_shell,
                                     None,
                                     vec![],

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -345,6 +345,10 @@ pub enum CliAction {
         /// Create a tab if one does not exist.
         #[clap(short, long, value_parser)]
         create: bool,
+
+        /// Change the working directory of the new tab from create flag
+        #[clap(long, value_parser, requires("create"))]
+        cwd: Option<PathBuf>,
     },
     /// Renames the focused pane
     RenameTab {

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -193,7 +193,7 @@ pub enum Action {
     /// Close the current tab.
     CloseTab,
     GoToTab(u32),
-    GoToTabName(String, bool),
+    GoToTabName(String, bool, Option<PathBuf>),
     ToggleTab,
     TabNameInput(Vec<u8>),
     UndoRenameTab,
@@ -390,7 +390,9 @@ impl Action {
             CliAction::GoToPreviousTab => Ok(vec![Action::GoToPreviousTab]),
             CliAction::CloseTab => Ok(vec![Action::CloseTab]),
             CliAction::GoToTab { index } => Ok(vec![Action::GoToTab(index)]),
-            CliAction::GoToTabName { name, create } => Ok(vec![Action::GoToTabName(name, create)]),
+            CliAction::GoToTabName { name, create, cwd } => {
+                Ok(vec![Action::GoToTabName(name, create, cwd)])
+            },
             CliAction::RenameTab { name } => Ok(vec![
                 Action::TabNameInput(vec![0]),
                 Action::TabNameInput(name.as_bytes().to_vec()),


### PR DESCRIPTION
when using --create flag, allow cwd to be specified if tab needs to be created.

This will be very useful when using in a script to open a new tab per project.

Example:
```bash
zellij action go-to-tab-name --create test --cwd ~/.local/bin
```
when a tab named `test` does not exist, should use `~/.local/bin` as the start directory.

This is my first PR, and first time attempting to contribute to OSS. I really enjoy this project, and would love any recommendations / comments / concerns!

Thank you for your time!