### PR TITLE
reversed primary comparisons of TiledPaneGrid.pane_id_on_edge

### DIFF
--- a/zellij-server/src/panes/tiled_panes/tiled_pane_grid.rs
+++ b/zellij-server/src/panes/tiled_panes/tiled_pane_grid.rs
@@ -1037,28 +1037,28 @@ impl<'a> TiledPaneGrid<'a> {
             .enumerate()
             .max_by(|(_, (_, a)), (_, (_, b))| match direction {
                 Direction::Left => {
-                    let x_comparison = a.x().cmp(&b.x());
-                    match x_comparison {
-                        Ordering::Equal => b.y().cmp(&a.y()),
-                        _ => x_comparison,
-                    }
-                },
-                Direction::Right => {
                     let x_comparison = b.x().cmp(&a.x());
                     match x_comparison {
                         Ordering::Equal => b.y().cmp(&a.y()),
                         _ => x_comparison,
                     }
                 },
+                Direction::Right => {
+                    let x_comparison = a.x().cmp(&b.x());
+                    match x_comparison {
+                        Ordering::Equal => b.y().cmp(&a.y()),
+                        _ => x_comparison,
+                    }
+                },
                 Direction::Up => {
-                    let y_comparison = a.y().cmp(&b.y());
+                    let y_comparison = b.y().cmp(&a.y());
                     match y_comparison {
                         Ordering::Equal => a.x().cmp(&b.x()),
                         _ => y_comparison,
                     }
                 },
                 Direction::Down => {
-                    let y_comparison = b.y().cmp(&a.y());
+                    let y_comparison = a.y().cmp(&b.y());
                     match y_comparison {
                         Ordering::Equal => b.x().cmp(&a.x()),
                         _ => y_comparison,


### PR DESCRIPTION
Calling this function with `Direction::Left` as its argument would yield the ID of the rightmost pane etc.
Addresses Issue #2537