### PR TITLE
Switching focus of tiled panes wraps when tabs.len == 1

### DIFF
--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -946,7 +946,7 @@ impl TiledPanes {
         self.focus_pane(next_index, client_id);
         self.set_pane_active_at(next_index);
     }
-    pub fn move_focus_left(&mut self, client_id: ClientId) -> bool {
+    pub fn move_focus_left(&mut self, client_id: ClientId, wrap: bool) -> bool {
         match self.get_active_pane_id(client_id) {
             Some(active_pane_id) => {
                 let pane_grid = TiledPaneGrid::new(
@@ -955,34 +955,39 @@ impl TiledPanes {
                     *self.display_area.borrow(),
                     *self.viewport.borrow(),
                 );
-                let next_index = pane_grid.next_selectable_pane_id_to_the_left(&active_pane_id);
-                match next_index {
-                    Some(p) => {
-                        // render previously active pane so that its frame does not remain actively
-                        // colored
-                        let previously_active_pane = self
-                            .panes
-                            .get_mut(self.active_panes.get(&client_id).unwrap())
-                            .unwrap();
-
-                        previously_active_pane.set_should_render(true);
-                        // we render the full viewport to remove any ui elements that might have been
-                        // there before (eg. another user's cursor)
-                        previously_active_pane.render_full_viewport();
-
-                        let next_active_pane = self.panes.get_mut(&p).unwrap();
-                        next_active_pane.set_should_render(true);
-                        // we render the full viewport to remove any ui elements that might have been
-                        // there before (eg. another user's cursor)
-                        next_active_pane.render_full_viewport();
-
-                        self.focus_pane(p, client_id);
-                        self.set_pane_active_at(p);
-
-                        true
-                    },
-                    None => false,
+                let mut next_index = pane_grid.next_selectable_pane_id_to_the_left(&active_pane_id);
+                if next_index == None {
+                    if !wrap {
+                        return false
+                    }
+                    next_index = pane_grid.pane_id_on_edge(Direction::Right);
+                    if next_index == None || next_index.unwrap() == active_pane_id {
+                        return false
+                    }
                 }
+                // render previously active pane so that its frame does not remain actively
+                // colored
+                let p = next_index.unwrap();
+                let previously_active_pane = self
+                    .panes
+                    .get_mut(self.active_panes.get(&client_id).unwrap())
+                    .unwrap();
+
+                previously_active_pane.set_should_render(true);
+                // we render the full viewport to remove any ui elements that might have been
+                // there before (eg. another user's cursor)
+                previously_active_pane.render_full_viewport();
+
+                let next_active_pane = self.panes.get_mut(&p).unwrap();
+                next_active_pane.set_should_render(true);
+                // we render the full viewport to remove any ui elements that might have been
+                // there before (eg. another user's cursor)
+                next_active_pane.render_full_viewport();
+
+                self.focus_pane(p, client_id);
+                self.set_pane_active_at(p);
+
+                true
             },
             None => false,
         }
@@ -996,47 +1001,49 @@ impl TiledPanes {
                     *self.display_area.borrow(),
                     *self.viewport.borrow(),
                 );
-                let next_index = pane_grid
+                let mut next_index = pane_grid
                     .next_selectable_pane_id_below(&active_pane_id)
                     .or_else(|| pane_grid.progress_stack_down_if_in_stack(&active_pane_id));
-                match next_index {
-                    Some(p) => {
-                        // render previously active pane so that its frame does not remain actively
-                        // colored
-                        let previously_active_pane = self
-                            .panes
-                            .get_mut(self.active_panes.get(&client_id).unwrap())
-                            .unwrap();
-
-                        let previously_active_pane_is_stacked =
-                            previously_active_pane.current_geom().is_stacked;
-                        previously_active_pane.set_should_render(true);
-                        // we render the full viewport to remove any ui elements that might have been
-                        // there before (eg. another user's cursor)
-                        previously_active_pane.render_full_viewport();
-
-                        let next_active_pane = self.panes.get_mut(&p).unwrap();
-                        let next_active_pane_is_stacked =
-                            next_active_pane.current_geom().is_stacked;
-                        next_active_pane.set_should_render(true);
-                        // we render the full viewport to remove any ui elements that might have been
-                        // there before (eg. another user's cursor)
-                        next_active_pane.render_full_viewport();
-
-                        self.focus_pane(p, client_id);
-                        self.set_pane_active_at(p);
-                        if previously_active_pane_is_stacked || next_active_pane_is_stacked {
-                            // we do this because a stack pane focus change also changes its
-                            // geometry and we need to let the pty know about this (like in a
-                            // normal size change)
-                            self.focus_pane_for_all_clients(p); // TODO: for all client *in stack*
-                            self.reapply_pane_frames();
-                        }
-
-                        true
-                    },
-                    None => false,
+                if next_index == None {
+                    next_index = pane_grid.pane_id_on_edge(Direction::Up);
+                    if next_index == None || next_index.unwrap() == active_pane_id {
+                        return false
+                    }
                 }
+                // render previously active pane so that its frame does not remain actively
+                // colored
+                let p = next_index.unwrap();
+                let previously_active_pane = self
+                    .panes
+                    .get_mut(self.active_panes.get(&client_id).unwrap())
+                    .unwrap();
+
+                let previously_active_pane_is_stacked =
+                    previously_active_pane.current_geom().is_stacked;
+                previously_active_pane.set_should_render(true);
+                // we render the full viewport to remove any ui elements that might have been
+                // there before (eg. another user's cursor)
+                previously_active_pane.render_full_viewport();
+
+                let next_active_pane = self.panes.get_mut(&p).unwrap();
+                let next_active_pane_is_stacked =
+                    next_active_pane.current_geom().is_stacked;
+                next_active_pane.set_should_render(true);
+                // we render the full viewport to remove any ui elements that might have been
+                // there before (eg. another user's cursor)
+                next_active_pane.render_full_viewport();
+
+                self.focus_pane(p, client_id);
+                self.set_pane_active_at(p);
+                if previously_active_pane_is_stacked || next_active_pane_is_stacked {
+                    // we do this because a stack pane focus change also changes its
+                    // geometry and we need to let the pty know about this (like in a
+                    // normal size change)
+                    self.focus_pane_for_all_clients(p); // TODO: for all client *in stack*
+                    self.reapply_pane_frames();
+                }
+
+                true
             },
             None => false,
         }
@@ -1050,52 +1057,54 @@ impl TiledPanes {
                     *self.display_area.borrow(),
                     *self.viewport.borrow(),
                 );
-                let next_index = pane_grid
+                let mut next_index = pane_grid
                     .next_selectable_pane_id_above(&active_pane_id)
                     .or_else(|| pane_grid.progress_stack_up_if_in_stack(&active_pane_id));
-                match next_index {
-                    Some(p) => {
-                        // render previously active pane so that its frame does not remain actively
-                        // colored
-                        let previously_active_pane = self
-                            .panes
-                            .get_mut(self.active_panes.get(&client_id).unwrap())
-                            .unwrap();
-
-                        let previously_active_pane_is_stacked =
-                            previously_active_pane.current_geom().is_stacked;
-                        previously_active_pane.set_should_render(true);
-                        // we render the full viewport to remove any ui elements that might have been
-                        // there before (eg. another user's cursor)
-                        previously_active_pane.render_full_viewport();
-
-                        let next_active_pane = self.panes.get_mut(&p).unwrap();
-                        let next_active_pane_is_stacked =
-                            next_active_pane.current_geom().is_stacked;
-                        next_active_pane.set_should_render(true);
-                        // we render the full viewport to remove any ui elements that might have been
-                        // there before (eg. another user's cursor)
-                        next_active_pane.render_full_viewport();
-
-                        self.focus_pane(p, client_id);
-                        self.set_pane_active_at(p);
-                        if previously_active_pane_is_stacked || next_active_pane_is_stacked {
-                            // we do this because a stack pane focus change also changes its
-                            // geometry and we need to let the pty know about this (like in a
-                            // normal size change)
-                            self.focus_pane_for_all_clients(p); // TODO: for all client *in stack*
-                            self.reapply_pane_frames();
-                        }
-
-                        true
-                    },
-                    None => false,
+                if next_index == None {
+                    next_index = pane_grid.pane_id_on_edge(Direction::Down);
+                    if next_index == None || next_index.unwrap() == active_pane_id {
+                        return false
+                    }
                 }
+                // render previously active pane so that its frame does not remain actively
+                // colored
+                let p = next_index.unwrap();
+                let previously_active_pane = self
+                    .panes
+                    .get_mut(self.active_panes.get(&client_id).unwrap())
+                    .unwrap();
+
+                let previously_active_pane_is_stacked =
+                    previously_active_pane.current_geom().is_stacked;
+                previously_active_pane.set_should_render(true);
+                // we render the full viewport to remove any ui elements that might have been
+                // there before (eg. another user's cursor)
+                previously_active_pane.render_full_viewport();
+
+                let next_active_pane = self.panes.get_mut(&p).unwrap();
+                let next_active_pane_is_stacked =
+                    next_active_pane.current_geom().is_stacked;
+                next_active_pane.set_should_render(true);
+                // we render the full viewport to remove any ui elements that might have been
+                // there before (eg. another user's cursor)
+                next_active_pane.render_full_viewport();
+
+                self.focus_pane(p, client_id);
+                self.set_pane_active_at(p);
+                if previously_active_pane_is_stacked || next_active_pane_is_stacked {
+                    // we do this because a stack pane focus change also changes its
+                    // geometry and we need to let the pty know about this (like in a
+                    // normal size change)
+                    self.focus_pane_for_all_clients(p); // TODO: for all client *in stack*
+                    self.reapply_pane_frames();
+                }
+
+                true
             },
             None => false,
         }
     }
-    pub fn move_focus_right(&mut self, client_id: ClientId) -> bool {
+    pub fn move_focus_right(&mut self, client_id: ClientId, wrap: bool) -> bool {
         match self.get_active_pane_id(client_id) {
             Some(active_pane_id) => {
                 let pane_grid = TiledPaneGrid::new(
@@ -1104,34 +1113,39 @@ impl TiledPanes {
                     *self.display_area.borrow(),
                     *self.viewport.borrow(),
                 );
-                let next_index = pane_grid.next_selectable_pane_id_to_the_right(&active_pane_id);
-                match next_index {
-                    Some(p) => {
-                        // render previously active pane so that its frame does not remain actively
-                        // colored
-                        let previously_active_pane = self
-                            .panes
-                            .get_mut(self.active_panes.get(&client_id).unwrap())
-                            .unwrap();
-
-                        previously_active_pane.set_should_render(true);
-                        // we render the full viewport to remove any ui elements that might have been
-                        // there before (eg. another user's cursor)
-                        previously_active_pane.render_full_viewport();
-
-                        let next_active_pane = self.panes.get_mut(&p).unwrap();
-                        next_active_pane.set_should_render(true);
-                        // we render the full viewport to remove any ui elements that might have been
-                        // there before (eg. another user's cursor)
-                        next_active_pane.render_full_viewport();
-
-                        self.focus_pane(p, client_id);
-                        self.set_pane_active_at(p);
-
-                        true
-                    },
-                    None => false,
+                let mut next_index = pane_grid.next_selectable_pane_id_to_the_right(&active_pane_id);
+                if next_index == None {
+                    if !wrap {
+                        return false
+                    }
+                    next_index = pane_grid.pane_id_on_edge(Direction::Left);
+                    if next_index == None || next_index.unwrap() == active_pane_id {
+                        return false
+                    }
                 }
+                // render previously active pane so that its frame does not remain actively
+                // colored
+                let p = next_index.unwrap();
+                let previously_active_pane = self
+                    .panes
+                    .get_mut(self.active_panes.get(&client_id).unwrap())
+                    .unwrap();
+
+                previously_active_pane.set_should_render(true);
+                // we render the full viewport to remove any ui elements that might have been
+                // there before (eg. another user's cursor)
+                previously_active_pane.render_full_viewport();
+
+                let next_active_pane = self.panes.get_mut(&p).unwrap();
+                next_active_pane.set_should_render(true);
+                // we render the full viewport to remove any ui elements that might have been
+                // there before (eg. another user's cursor)
+                next_active_pane.render_full_viewport();
+
+                self.focus_pane(p, client_id);
+                self.set_pane_active_at(p);
+
+                true
             },
             None => false,
         }
@@ -1622,13 +1636,13 @@ impl TiledPanes {
 
     pub fn focus_pane_left_fullscreen(&mut self, client_id: ClientId) {
         self.unset_fullscreen();
-        self.move_focus_left(client_id);
+        self.move_focus_left(client_id, true);
         self.toggle_active_pane_fullscreen(client_id);
     }
 
     pub fn focus_pane_right_fullscreen(&mut self, client_id: ClientId) {
         self.unset_fullscreen();
-        self.move_focus_right(client_id);
+        self.move_focus_right(client_id, true);
         self.toggle_active_pane_fullscreen(client_id);
     }
 

--- a/zellij-server/src/panes/tiled_panes/tiled_pane_grid.rs
+++ b/zellij-server/src/panes/tiled_panes/tiled_pane_grid.rs
@@ -1037,28 +1037,28 @@ impl<'a> TiledPaneGrid<'a> {
             .enumerate()
             .max_by(|(_, (_, a)), (_, (_, b))| match direction {
                 Direction::Left => {
-                    let x_comparison = a.x().cmp(&b.x());
-                    match x_comparison {
-                        Ordering::Equal => b.y().cmp(&a.y()),
-                        _ => x_comparison,
-                    }
-                },
-                Direction::Right => {
                     let x_comparison = b.x().cmp(&a.x());
                     match x_comparison {
                         Ordering::Equal => b.y().cmp(&a.y()),
                         _ => x_comparison,
                     }
                 },
+                Direction::Right => {
+                    let x_comparison = a.x().cmp(&b.x());
+                    match x_comparison {
+                        Ordering::Equal => b.y().cmp(&a.y()),
+                        _ => x_comparison,
+                    }
+                },
                 Direction::Up => {
-                    let y_comparison = a.y().cmp(&b.y());
+                    let y_comparison = b.y().cmp(&a.y());
                     match y_comparison {
                         Ordering::Equal => a.x().cmp(&b.x()),
                         _ => y_comparison,
                     }
                 },
                 Direction::Down => {
-                    let y_comparison = b.y().cmp(&a.y());
+                    let y_comparison = a.y().cmp(&b.y());
                     match y_comparison {
                         Ordering::Equal => b.x().cmp(&a.x()),
                         _ => y_comparison,

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1400,11 +1400,12 @@ impl Screen {
         } else {
             self.get_first_client_id()
         };
+        let wrap_panes = self.tabs.len() == 1;
         if let Some(client_id) = client_id {
             match self.get_active_tab_mut(client_id) {
                 Ok(active_tab) => {
                     active_tab
-                        .move_focus_left(client_id)
+                        .move_focus_left(client_id, wrap_panes)
                         .and_then(|success| {
                             if !success {
                                 self.switch_tab_prev(Some(Direction::Left), client_id)
@@ -1434,11 +1435,12 @@ impl Screen {
             self.get_first_client_id()
         };
 
+        let wrap_panes = self.tabs.len() == 1;
         if let Some(client_id) = client_id {
             match self.get_active_tab_mut(client_id) {
                 Ok(active_tab) => {
                     active_tab
-                        .move_focus_right(client_id)
+                        .move_focus_right(client_id, wrap_panes)
                         .and_then(|success| {
                             if !success {
                                 self.switch_tab_next(Some(Direction::Right), client_id)
@@ -1780,7 +1782,7 @@ pub(crate) fn screen_thread_main(
                 active_tab_and_connected_client_id!(
                     screen,
                     client_id,
-                    |tab: &mut Tab, client_id: ClientId| tab.move_focus_left(client_id),
+                    |tab: &mut Tab, client_id: ClientId| tab.move_focus_left(client_id, false),
                     ?
                 );
                 screen.render()?;
@@ -1805,7 +1807,7 @@ pub(crate) fn screen_thread_main(
                 active_tab_and_connected_client_id!(
                     screen,
                     client_id,
-                    |tab: &mut Tab, client_id: ClientId| tab.move_focus_right(client_id),
+                    |tab: &mut Tab, client_id: ClientId| tab.move_focus_right(client_id, false),
                     ?
                 );
                 screen.render()?;

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1890,7 +1890,7 @@ impl Tab {
         }
     }
     // returns a boolean that indicates whether the focus moved
-    pub fn move_focus_left(&mut self, client_id: ClientId) -> Result<bool> {
+    pub fn move_focus_left(&mut self, client_id: ClientId, wrap_panes: bool) -> Result<bool> {
         let err_context = || format!("failed to move focus left for client {}", client_id);
 
         if self.floating_panes.panes_are_visible() {
@@ -1909,7 +1909,7 @@ impl Tab {
                 self.focus_pane_left_fullscreen(client_id);
                 return Ok(true);
             }
-            Ok(self.tiled_panes.move_focus_left(client_id))
+            Ok(self.tiled_panes.move_focus_left(client_id, wrap_panes))
         }
     }
     pub fn move_focus_down(&mut self, client_id: ClientId) -> Result<bool> {
@@ -1957,7 +1957,7 @@ impl Tab {
         }
     }
     // returns a boolean that indicates whether the focus moved
-    pub fn move_focus_right(&mut self, client_id: ClientId) -> Result<bool> {
+    pub fn move_focus_right(&mut self, client_id: ClientId, wrap_panes: bool) -> Result<bool> {
         let err_context = || format!("failed to move focus right for client {}", client_id);
 
         if self.floating_panes.panes_are_visible() {
@@ -1976,7 +1976,7 @@ impl Tab {
                 self.focus_pane_right_fullscreen(client_id);
                 return Ok(true);
             }
-            Ok(self.tiled_panes.move_focus_right(client_id))
+            Ok(self.tiled_panes.move_focus_right(client_id, wrap_panes))
         }
     }
     pub fn move_active_pane(&mut self, client_id: ClientId) {


### PR DESCRIPTION
This PR includes/depends PR #2538

Vertical  switching always wraps.
Horizontal switching always wraps when maximized.