### PR TITLE
Add default UI to config

### DIFF
--- a/zellij-utils/assets/config/default.kdl
+++ b/zellij-utils/assets/config/default.kdl
@@ -238,6 +238,13 @@ plugins {
 //     }
 // }
 
+// Define ui settings for Zellij
+// ui {
+//    pane_frames {
+//        rounded_corners false
+//        hide_session_name false
+//     }
+// }
 // Choose the theme that is specified in the themes section.
 // Default: default
 //


### PR DESCRIPTION
in PR #2301, it introduced a new option(ui) to turn off session name, but the default KDL does not have a setting of UI. This pr is to extend `default.kdl` so users can easily use the `ui` settings