### PR TITLE
performance(server): greatly improve dump_screen! performance

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -284,7 +284,7 @@ fn subtract_isize_from_usize(u: usize, i: isize) -> usize {
 macro_rules! dump_screen {
     ($lines:expr) => {{
         let mut is_first = true;
-        let mut buf = "".to_owned();
+        let mut buf = String::with_capacity($lines.iter().map(|l| l.len()).sum());
 
         for line in &$lines {
             if line.is_canonical && !is_first {
@@ -293,8 +293,7 @@ macro_rules! dump_screen {
             let s: String = (&line.columns).into_iter().map(|x| x.character).collect();
             // Replace the spaces at the end of the line. Sometimes, the lines are
             // collected with spaces until the end of the panel.
-            let re = Regex::new("([^ ])[ ]*$").unwrap();
-            buf.push_str(&(re.replace(&s, "${1}")));
+            buf.push_str(&s.trim_end_matches(' '));
             is_first = false;
         }
         buf


### PR DESCRIPTION
This PR dramatically improves the `dump_screen!` macro performance. 

### Motivation
First of all, I love the editing scrollback feature!
I was playing around with `scroll_buffer_size` setting. I tried setting it to 1,000,000.
I executed `yes` to fill up the screen buffer and then tried to edit the scrollback.
There was a big delay from issuing the command to editing in my editor.
So I tried to figure out what causing this delay. "1 million lines shouldn't be too big?", I thought.

### Method
* Pre-allocates `buf` string.
* Uses `trim_end_matches()` instead of using regex.

I wrote a simple benchmark [here](https://gist.github.com/zynaxsoft/c26f9e2e08be2d5315203e172596d5ab), simulating what I experienced.
```
Result
Old method: 7.55s
New method: 16.72ms
```
