### PR TITLE
fix(plugins): make hide_self api idempotent

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -2779,7 +2779,7 @@ pub(crate) fn screen_thread_main(
             ScreenInstruction::SuppressPane(pane_id, client_id) => {
                 let all_tabs = screen.get_tabs_mut();
                 for tab in all_tabs.values_mut() {
-                    if tab.has_pane_with_pid(&pane_id) {
+                    if tab.has_non_suppressed_pane_with_pid(&pane_id) {
                         tab.suppress_pane(pane_id, client_id);
                         drop(screen.render());
                         break;

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1308,6 +1308,10 @@ impl Tab {
             || self.floating_panes.panes_contain(pid)
             || self.suppressed_panes.values().any(|s_p| s_p.pid() == *pid)
     }
+    pub fn has_non_suppressed_pane_with_pid(&self, pid: &PaneId) -> bool {
+        self.tiled_panes.panes_contain(pid)
+            || self.floating_panes.panes_contain(pid)
+    }
     pub fn handle_pty_bytes(&mut self, pid: u32, bytes: VteBytes) -> Result<()> {
         if self.is_pending {
             self.pending_instructions


### PR DESCRIPTION
Fixes an issue where the `hide_self` plugin command would crash if the pane was already hidden.