### PR TITLE
Add Hide title config option

### DIFF
--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -335,6 +335,7 @@ fn spawn_terminal(
                 cwd,
                 hold_on_close: false,
                 hold_on_start: false,
+                hide_title: false,
             }
         },
         TerminalAction::RunCommand(command) => command,

--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -69,6 +69,7 @@ pub(crate) struct PluginPane {
     prev_pane_name: String,
     frame: HashMap<ClientId, PaneFrame>,
     borderless: bool,
+    hide_title: bool,
     exclude_from_sync: bool,
     pane_frame_color_override: Option<(PaletteColor, Option<String>)>,
     invoked_with: Option<Run>,
@@ -107,6 +108,7 @@ impl PluginPane {
             content_offset: Offset::default(),
             pane_title: title,
             borderless: false,
+            hide_title: false,
             pane_name: pane_name.clone(),
             prev_pane_name: pane_name,
             terminal_emulator_colors,
@@ -514,6 +516,14 @@ impl Pane for PluginPane {
     fn exclude_from_sync(&self) -> bool {
         self.exclude_from_sync
     }
+
+    fn set_hide_title(&mut self, hide_title: bool) {
+        self.hide_title = hide_title;
+    }
+    fn hide_title(&self) -> bool {
+        self.hide_title
+    }
+
     fn handle_right_click(&mut self, to: &Position, client_id: ClientId) {
         self.send_plugin_instructions
             .send(PluginInstruction::Update(vec![(

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -105,6 +105,7 @@ pub struct TerminalPane {
     prev_pane_name: String,
     frame: HashMap<ClientId, PaneFrame>,
     borderless: bool,
+    hide_title: bool,
     exclude_from_sync: bool,
     fake_cursor_locations: HashSet<(usize, usize)>, // (x, y) - these hold a record of previous fake cursors which we need to clear on render
     search_term: String,
@@ -350,6 +351,8 @@ impl Pane for TerminalPane {
                 modifier_text.push(']');
             }
             format!("SEARCHING: {}{}", self.search_term, modifier_text)
+        } else if self.hide_title {
+            String::new()
         } else if self.pane_name.is_empty() {
             self.grid
                 .title
@@ -611,6 +614,13 @@ impl Pane for TerminalPane {
         self.exclude_from_sync
     }
 
+    fn set_hide_title(&mut self, hide_title: bool) {
+        self.hide_title = hide_title;
+    }
+    fn hide_title(&self) -> bool {
+        self.hide_title
+    }
+
     fn mouse_left_click(&self, position: &Position, is_held: bool) -> Option<String> {
         self.grid.mouse_left_click_signal(position, is_held)
     }
@@ -797,6 +807,7 @@ impl TerminalPane {
             pane_name: pane_name.clone(),
             prev_pane_name: pane_name,
             borderless: false,
+            hide_title: false,
             exclude_from_sync: false,
             fake_cursor_locations: HashSet::new(),
             search_term: String::new(),

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -377,6 +377,7 @@ fn host_open_command_pane(env: &ForeignFunctionEnv) {
             let direction = None;
             let hold_on_close = true;
             let hold_on_start = false;
+            let hide_title = false;
             let name = None;
             let run_command_action = RunCommandAction {
                 command,
@@ -385,6 +386,7 @@ fn host_open_command_pane(env: &ForeignFunctionEnv) {
                 direction,
                 hold_on_close,
                 hold_on_start,
+                hide_title,
             };
             let action = Action::NewTiledPane(direction, Some(run_command_action), name);
             apply_action!(action, error_msg, env);
@@ -402,6 +404,7 @@ fn host_open_command_pane_floating(env: &ForeignFunctionEnv) {
             let direction = None;
             let hold_on_close = true;
             let hold_on_start = false;
+            let hide_title = false;
             let name = None;
             let run_command_action = RunCommandAction {
                 command,
@@ -410,6 +413,7 @@ fn host_open_command_pane_floating(env: &ForeignFunctionEnv) {
                 direction,
                 hold_on_close,
                 hold_on_start,
+                hide_title,
             };
             let action = Action::NewFloatingPane(Some(run_command_action), name);
             apply_action!(action, error_msg, env);

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -475,6 +475,7 @@ impl Pty {
                     cwd, // note: this might also be filled by the calling function, eg. spawn_terminal
                     hold_on_close: false,
                     hold_on_start: false,
+                    hide_title: false,
                 })
             },
         }

--- a/zellij-server/src/tab/layout_applier.rs
+++ b/zellij-server/src/tab/layout_applier.rs
@@ -239,6 +239,7 @@ impl<'a> LayoutApplier<'a> {
                             self.debug,
                         );
                         new_plugin.set_borderless(layout.borderless);
+                        new_plugin.set_hide_title(layout.hide_title);
                         if let Some(exclude_from_sync) = layout.exclude_from_sync {
                             new_plugin.set_exclude_from_sync(exclude_from_sync);
                         }

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -372,6 +372,9 @@ pub trait Pane {
     fn load_pane_name(&mut self);
     fn set_borderless(&mut self, borderless: bool);
     fn borderless(&self) -> bool;
+    fn set_hide_title(&mut self, hide_title: bool);
+    fn hide_title(&self) -> bool;
+
     fn set_exclude_from_sync(&mut self, exclude_from_sync: bool);
     fn exclude_from_sync(&self) -> bool;
 

--- a/zellij-server/src/ui/pane_boundaries_frame.rs
+++ b/zellij-server/src/ui/pane_boundaries_frame.rs
@@ -584,11 +584,24 @@ impl PaneFrame {
             foreground_color(self.get_corner(boundary_type::TOP_LEFT), self.color);
         let mut right_boundary =
             foreground_color(self.get_corner(boundary_type::TOP_RIGHT), self.color);
-        let total_title_length = self.geom.cols.saturating_sub(2); // 2 for the left and right corners
         let mut middle_padding = String::new();
-        for _ in 0..total_title_length {
-            middle_padding.push_str(boundary_type::HORIZONTAL);
+        let total_title_length = self.geom.cols.saturating_sub(2); // 2 for the left and right corners
+        if let Some((scroll_text, scroll_text_len)) =
+            self.render_title_right_side(total_title_length)
+        {
+            let scroll_text_idx_start = total_title_length - scroll_text_len;
+            for _ in 0..scroll_text_idx_start {
+                middle_padding.push_str(boundary_type::HORIZONTAL);
+            }
+            for tc in scroll_text {
+                middle_padding.push(tc.character);
+            }
+        } else {
+            for _ in 0..total_title_length {
+                middle_padding.push_str(boundary_type::HORIZONTAL);
+            }
         }
+
         let mut ret = vec![];
         ret.append(&mut left_boundary);
         ret.append(&mut foreground_color(&middle_padding, self.color));

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -322,6 +322,7 @@ impl Action {
                     let (command, args) = (PathBuf::from(command.remove(0)), command);
                     let hold_on_start = start_suspended;
                     let hold_on_close = !close_on_exit;
+                    let hide_title = false;
                     let run_command_action = RunCommandAction {
                         command,
                         args,
@@ -329,6 +330,7 @@ impl Action {
                         direction,
                         hold_on_close,
                         hold_on_start,
+                        hide_title,
                     };
                     if floating {
                         Ok(vec![Action::NewFloatingPane(

--- a/zellij-utils/src/input/command.rs
+++ b/zellij-utils/src/input/command.rs
@@ -41,7 +41,6 @@ pub struct RunCommand {
 
 impl std::fmt::Display for RunCommand {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // uhhh..
         if self.hide_title {
             return write!(f, "");
         }

--- a/zellij-utils/src/input/command.rs
+++ b/zellij-utils/src/input/command.rs
@@ -35,10 +35,17 @@ pub struct RunCommand {
     pub hold_on_close: bool,
     #[serde(default)]
     pub hold_on_start: bool,
+    #[serde(default)]
+    pub hide_title: bool,
 }
 
 impl std::fmt::Display for RunCommand {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // uhhh..
+        if self.hide_title {
+            return write!(f, "");
+        }
+
         let mut command: String = self
             .command
             .as_path()
@@ -68,6 +75,8 @@ pub struct RunCommandAction {
     pub hold_on_close: bool,
     #[serde(default)]
     pub hold_on_start: bool,
+    #[serde(default)]
+    pub hide_title: bool,
 }
 
 impl From<RunCommandAction> for RunCommand {
@@ -78,6 +87,7 @@ impl From<RunCommandAction> for RunCommand {
             cwd: action.cwd,
             hold_on_close: action.hold_on_close,
             hold_on_start: action.hold_on_start,
+            hide_title: action.hide_title,
         }
     }
 }
@@ -91,6 +101,7 @@ impl From<RunCommand> for RunCommandAction {
             direction: None,
             hold_on_close: run_command.hold_on_close,
             hold_on_start: run_command.hold_on_start,
+            hide_title: run_command.hide_title,
         }
     }
 }

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -404,6 +404,7 @@ pub struct TiledPaneLayout {
     pub split_size: Option<SplitSize>,
     pub run: Option<Run>,
     pub borderless: bool,
+    pub hide_title: bool,
     pub focus: Option<bool>,
     pub external_children_index: Option<usize>,
     pub children_are_stacked: bool,

--- a/zellij-utils/src/kdl/kdl_layout_parser.rs
+++ b/zellij-utils/src/kdl/kdl_layout_parser.rs
@@ -360,9 +360,7 @@ impl<'a> KdlLayoutParser<'a> {
         let args = self.parse_args(pane_node)?;
         let close_on_exit =
             kdl_get_bool_property_or_child_value_with_error!(pane_node, "close_on_exit");
-        // uhhh..
-        let hide_title = 
-            kdl_get_bool_property_or_child_value_with_error!(pane_node, "hide_title");
+        let hide_title = kdl_get_bool_property_or_child_value_with_error!(pane_node, "hide_title");
         let start_suspended =
             kdl_get_bool_property_or_child_value_with_error!(pane_node, "start_suspended");
         if !is_template {

--- a/zellij-utils/src/kdl/kdl_layout_parser.rs
+++ b/zellij-utils/src/kdl/kdl_layout_parser.rs
@@ -67,6 +67,7 @@ impl<'a> KdlLayoutParser<'a> {
             || word == "close_on_exit"
             || word == "start_suspended"
             || word == "borderless"
+            || word == "hide_title"
             || word == "focus"
             || word == "name"
             || word == "size"
@@ -86,6 +87,7 @@ impl<'a> KdlLayoutParser<'a> {
             || property_name == "cwd"
             || property_name == "args"
             || property_name == "close_on_exit"
+            || property_name == "hide_title"
             || property_name == "start_suspended"
             || property_name == "split_direction"
             || property_name == "pane"
@@ -358,6 +360,9 @@ impl<'a> KdlLayoutParser<'a> {
         let args = self.parse_args(pane_node)?;
         let close_on_exit =
             kdl_get_bool_property_or_child_value_with_error!(pane_node, "close_on_exit");
+        // uhhh..
+        let hide_title = 
+            kdl_get_bool_property_or_child_value_with_error!(pane_node, "hide_title");
         let start_suspended =
             kdl_get_bool_property_or_child_value_with_error!(pane_node, "start_suspended");
         if !is_template {
@@ -371,6 +376,7 @@ impl<'a> KdlLayoutParser<'a> {
         }
         let hold_on_close = close_on_exit.map(|c| !c).unwrap_or(true);
         let hold_on_start = start_suspended.map(|c| c).unwrap_or(false);
+        let hide_title = hide_title.map(|c| c).unwrap_or(false);
         match (command, edit, cwd) {
             (None, None, Some(cwd)) => Ok(Some(Run::Cwd(cwd))),
             (Some(command), None, cwd) => Ok(Some(Run::Command(RunCommand {
@@ -379,6 +385,7 @@ impl<'a> KdlLayoutParser<'a> {
                 cwd,
                 hold_on_close,
                 hold_on_start,
+                hide_title,
             }))),
             (None, Some(edit), Some(cwd)) => {
                 Ok(Some(Run::EditFile(cwd.join(edit), None, Some(cwd))))
@@ -449,6 +456,7 @@ impl<'a> KdlLayoutParser<'a> {
         let is_expanded_in_stack =
             kdl_get_bool_property_or_child_value_with_error!(kdl_node, "expanded").unwrap_or(false);
         let borderless = kdl_get_bool_property_or_child_value_with_error!(kdl_node, "borderless");
+        let hide_title = kdl_get_bool_property_or_child_value_with_error!(kdl_node, "hide_title");
         let focus = kdl_get_bool_property_or_child_value_with_error!(kdl_node, "focus");
         let name = kdl_get_string_property_or_child_value_with_error!(kdl_node, "name")
             .map(|name| name.to_string());
@@ -486,6 +494,7 @@ impl<'a> KdlLayoutParser<'a> {
         self.assert_no_mixed_children_and_properties(kdl_node)?;
         Ok(TiledPaneLayout {
             borderless: borderless.unwrap_or_default(),
+            hide_title: hide_title.unwrap_or_default(),
             focus,
             name,
             split_size,

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -866,6 +866,9 @@ impl TryFrom<(&KdlNode, &Options)> for Action {
                 let hold_on_start = command_metadata
                     .and_then(|c_m| kdl_child_bool_value_for_entry(c_m, "start_suspended"))
                     .unwrap_or(false);
+                let hide_title = command_metadata
+                    .and_then(|c_m| kdl_child_bool_value_for_entry(c_m, "hide_title"))
+                    .unwrap_or(false);
                 let run_command_action = RunCommandAction {
                     command: PathBuf::from(command),
                     args,
@@ -873,6 +876,7 @@ impl TryFrom<(&KdlNode, &Options)> for Action {
                     direction,
                     hold_on_close,
                     hold_on_start,
+                    hide_title,
                 };
                 Ok(Action::Run(run_command_action))
             },


### PR DESCRIPTION
config option will hide pane titles while keeping scroll list.  Added hide_title field to PluginPane, TerminalPane, RunCommand, RunCommandAction, TitledPaneLayout and associated getters/setters.  