### PR TITLE
Action dump tab

### DIFF
--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -172,6 +172,11 @@ pub(crate) fn route_action(
                 .send_to_screen(ScreenInstruction::DumpScreen(val, client_id, full))
                 .with_context(err_context)?;
         },
+        Action::DumpTab(val, full) => {
+            senders
+                .send_to_screen(ScreenInstruction::DumpTab(val, client_id, full))
+                .with_context(err_context)?;
+        },
         Action::EditScrollback => {
             senders
                 .send_to_screen(ScreenInstruction::EditScrollback(client_id))

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -164,6 +164,7 @@ pub enum ScreenInstruction {
     Exit,
     ClearScreen(ClientId),
     DumpScreen(String, ClientId, bool),
+    DumpTab(String, ClientId, bool),
     EditScrollback(ClientId),
     ScrollUp(ClientId),
     ScrollUpAt(Position, ClientId),
@@ -341,6 +342,7 @@ impl From<&ScreenInstruction> for ScreenContext {
             ScreenInstruction::Exit => ScreenContext::Exit,
             ScreenInstruction::ClearScreen(..) => ScreenContext::ClearScreen,
             ScreenInstruction::DumpScreen(..) => ScreenContext::DumpScreen,
+            ScreenInstruction::DumpTab(..) => ScreenContext::DumpTab,
             ScreenInstruction::EditScrollback(..) => ScreenContext::EditScrollback,
             ScreenInstruction::ScrollUp(..) => ScreenContext::ScrollUp,
             ScreenInstruction::ScrollDown(..) => ScreenContext::ScrollDown,
@@ -1916,6 +1918,20 @@ pub(crate) fn screen_thread_main(
                     screen,
                     client_id,
                     |tab: &mut Tab, client_id: ClientId| tab.dump_active_terminal_screen(
+                        Some(file.to_string()),
+                        client_id,
+                        full
+                    ),
+                    ?
+                );
+                screen.render()?;
+                screen.unblock_input()?;
+            },
+            ScreenInstruction::DumpTab(file, client_id, full) => {
+                active_tab_and_connected_client_id!(
+                    screen,
+                    client_id,
+                    |tab: &mut Tab, client_id: ClientId| tab.dump_current_terminal_tab(
                         Some(file.to_string()),
                         client_id,
                         full

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1772,6 +1772,9 @@ impl Tab {
     fn get_tiled_panes(&self) -> impl Iterator<Item = (&PaneId, &Box<dyn Pane>)> {
         self.tiled_panes.get_panes()
     }
+    fn get_floating_panes(&self) -> impl Iterator<Item = (&PaneId, &Box<dyn Pane>)> {
+        self.floating_panes.get_panes()
+    }
     fn get_selectable_tiled_panes(&self) -> impl Iterator<Item = (&PaneId, &Box<dyn Pane>)> {
         self.get_tiled_panes().filter(|(_, p)| p.selectable())
     }
@@ -2101,6 +2104,9 @@ impl Tab {
     pub fn get_tiled_pane_ids(&self) -> Vec<PaneId> {
         self.get_tiled_panes().map(|(&pid, _)| pid).collect()
     }
+    pub fn get_floating_pane_ids(&self) -> Vec<PaneId> {
+        self.get_floating_panes().map(|(&pid, _)| pid).collect()
+    }
     pub fn get_all_pane_ids(&self) -> Vec<PaneId> {
         // this is here just as a naming thing to make things more explicit
         self.get_static_and_floating_pane_ids()
@@ -2309,6 +2315,57 @@ impl Tab {
                 .write_to_file(dump, file)
                 .with_context(err_context)?;
         }
+        Ok(())
+    }
+    pub fn dump_current_terminal_tab(
+        &mut self,
+        file: Option<String>,
+        client_id: ClientId,
+        full: bool,
+    ) -> Result<()> {
+        let err_context =
+            || format!("failed to dump active terminal tab for client {client_id}");
+
+        let mut merged_dump: String = "".to_owned();
+        for pane_id in self.get_tiled_pane_ids() {
+            if let PaneId::Terminal(id) = pane_id  {
+                let tmp_panel = self.tiled_panes.get_pane_mut(pane_id).unwrap();
+                let dump = tmp_panel.dump_screen(client_id, full);
+                let header = match merged_dump.chars().last() {
+                    Some(c) => {
+                        match c {
+                            '\n' => format!("[Tiled pane: {}]\n", id),
+                            _ => format!("\n[Tiled pane: {}]\n", id),
+                        }
+                    }
+                    None => format!("[Tiled pane: {}]\n", id),
+                };
+                merged_dump.push_str(&header);
+                merged_dump.push_str(&dump);
+            }
+        }
+
+        for pane_id in self.get_floating_pane_ids() {
+            if let PaneId::Terminal(id) = pane_id {
+                let tmp_panel = self.floating_panes.get_pane_mut(pane_id).unwrap();
+                let dump = tmp_panel.dump_screen(client_id, full);
+                let header = match merged_dump.chars().last() {
+                    Some(c) => {
+                        match c {
+                            '\n' => format!("[Floating pane: {}]\n", id),
+                            _ => format!("\n[Floating pane: {}]\n", id),
+                        }
+                    }
+                    None => format!("[Floating pane: {}]\n", id),
+                };
+                merged_dump.push_str(&header);
+                merged_dump.push_str(&dump);
+            }
+        }
+
+        self.os_api
+            .write_to_file(merged_dump, file)
+            .with_context(err_context)?;
         Ok(())
     }
     pub fn edit_scrollback(&mut self, client_id: ClientId) -> Result<()> {

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -2323,21 +2323,18 @@ impl Tab {
         client_id: ClientId,
         full: bool,
     ) -> Result<()> {
-        let err_context =
-            || format!("failed to dump active terminal tab for client {client_id}");
+        let err_context = || format!("failed to dump active terminal tab for client {client_id}");
 
         let mut merged_dump: String = "".to_owned();
         for pane_id in self.get_tiled_pane_ids() {
-            if let PaneId::Terminal(id) = pane_id  {
+            if let PaneId::Terminal(id) = pane_id {
                 let tmp_panel = self.tiled_panes.get_pane_mut(pane_id).unwrap();
                 let dump = tmp_panel.dump_screen(client_id, full);
                 let header = match merged_dump.chars().last() {
-                    Some(c) => {
-                        match c {
-                            '\n' => format!("[Tiled pane: {}]\n", id),
-                            _ => format!("\n[Tiled pane: {}]\n", id),
-                        }
-                    }
+                    Some(c) => match c {
+                        '\n' => format!("[Tiled pane: {}]\n", id),
+                        _ => format!("\n[Tiled pane: {}]\n", id),
+                    },
                     None => format!("[Tiled pane: {}]\n", id),
                 };
                 merged_dump.push_str(&header);
@@ -2350,12 +2347,10 @@ impl Tab {
                 let tmp_panel = self.floating_panes.get_pane_mut(pane_id).unwrap();
                 let dump = tmp_panel.dump_screen(client_id, full);
                 let header = match merged_dump.chars().last() {
-                    Some(c) => {
-                        match c {
-                            '\n' => format!("[Floating pane: {}]\n", id),
-                            _ => format!("\n[Floating pane: {}]\n", id),
-                        }
-                    }
+                    Some(c) => match c {
+                        '\n' => format!("[Floating pane: {}]\n", id),
+                        _ => format!("\n[Floating pane: {}]\n", id),
+                    },
                     None => format!("[Floating pane: {}]\n", id),
                 };
                 merged_dump.push_str(&header);

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -223,6 +223,14 @@ pub enum CliAction {
         #[clap(short, long, value_parser, default_value("false"), takes_value(false))]
         full: bool,
     },
+    /// Dump the current tab to a file
+    DumpTab {
+        path: PathBuf,
+
+        /// Dump the tab with full scrollback
+        #[clap(short, long, value_parser, default_value("false"), takes_value(false))]
+        full: bool,
+    },
     /// Open the pane scrollback in your default editor
     EditScrollback,
     /// Scroll up in the focused pane

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -257,6 +257,7 @@ pub enum ScreenContext {
     Exit,
     ClearScreen,
     DumpScreen,
+    DumpTab,
     EditScrollback,
     ScrollUp,
     ScrollUpAt,

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -124,6 +124,8 @@ pub enum Action {
     ClearScreen,
     /// Dumps the screen to a file
     DumpScreen(String, bool),
+    /// Dumps the tab to a file
+    DumpTab(String, bool),
     /// Scroll up in focus pane.
     EditScrollback,
     ScrollUp,
@@ -268,6 +270,10 @@ impl Action {
             CliAction::MovePaneBackwards => Ok(vec![Action::MovePaneBackwards]),
             CliAction::Clear => Ok(vec![Action::ClearScreen]),
             CliAction::DumpScreen { path, full } => Ok(vec![Action::DumpScreen(
+                path.as_os_str().to_string_lossy().into(),
+                full,
+            )]),
+            CliAction::DumpTab{ path, full } => Ok(vec![Action::DumpTab(
                 path.as_os_str().to_string_lossy().into(),
                 full,
             )]),

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -273,7 +273,7 @@ impl Action {
                 path.as_os_str().to_string_lossy().into(),
                 full,
             )]),
-            CliAction::DumpTab{ path, full } => Ok(vec![Action::DumpTab(
+            CliAction::DumpTab { path, full } => Ok(vec![Action::DumpTab(
                 path.as_os_str().to_string_lossy().into(),
                 full,
             )]),

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -455,6 +455,7 @@ impl Action {
             },
             "MovePaneBackwards" => Ok(Action::MovePaneBackwards),
             "DumpScreen" => Ok(Action::DumpScreen(string, false)),
+            "DumpTab" => Ok(Action::DumpTab(string, false)),
             "NewPane" => {
                 if string.is_empty() {
                     return Ok(Action::NewPane(None, None));


### PR DESCRIPTION
Requested in [#1461 ](https://github.com/zellij-org/zellij/issues/1461).
A new action is added which can be called using the following syntax:
zellij action dump-tab [OPTIONS] <PATH>.
This action will dump the Tiled panel and Floating Panel in this order.
Tiled panels content's starts with an header with the following format:
[Tiled pane: {pane_id}]
Floating panels content's starts with an header with the following format:
[Floating pane: {pane_id}]