### PR TITLE
Add documentation to crates

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,5 @@
+# zellij cli
+
+This directory is related to the CLI tool of zellij. It's a way to interact with the zellij sesson with arguments. 
+
+See `zellij --help` for what more information.

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -1,0 +1,5 @@
+# xtask
+
+Not part of the shipped zellij product, but rather a development tool for cargo.
+
+See [cargo-xtask](https://github.com/matklad/cargo-xtask) for more information.

--- a/zellij-tile-utils/README.md
+++ b/zellij-tile-utils/README.md
@@ -1,0 +1,5 @@
+# zellij-tile-utils
+
+Helper and utility macros for zellij and plugins, mostly related to coloring text.
+
+Generated documentation can be found at [crates.io](https://docs.rs/zellij-tile-utils/latest/zellij-tile-utils)

--- a/zellij-tile/README.md
+++ b/zellij-tile/README.md
@@ -1,0 +1,5 @@
+# zellij-tile
+
+Source code of the `ZellijPlugin` trait, a core detail for implementing your own plugin. With this crate you can interact with the zellij session through [shims](https://docs.rs/zellij-tile/latest/zellij_tile/shim/index.html)
+
+Generated documentation can be found at [crates.io](https://docs.rs/zellij-tile/latest/zellij_tile/)

--- a/zellij-utils/README.md
+++ b/zellij-utils/README.md
@@ -1,0 +1,6 @@
+# zellij-utils
+
+Utility macros for how to read KDL-files(layout & other config). Also holds types like [Event](https://docs.rs/zellij-utils/latest/zellij_utils/data/enum.Event.html) which is how a zellij plugin receives information from the zellij session.
+
+Generated documentation can be found at [crates.io](https://docs.rs/zellij-utils/latest/zellij_utils/)
+


### PR DESCRIPTION
As a result of trying to familiarize myself with the project, I'd thought it would be good to start to make the crates more digestible.

There are no readmes for client and server, mainly because I don't understand what they are. Could use some help describing what they do and what they contain.