### PR TITLE
Add action QueryPaneNames to list pane names

### DIFF
--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -602,6 +602,11 @@ pub(crate) fn route_action(
                 .send_to_screen(ScreenInstruction::QueryTabNames(client_id))
                 .with_context(err_context)?;
         },
+        Action::QueryPaneNames => {
+            senders
+                .send_to_screen(ScreenInstruction::QueryPaneNames(client_id))
+                .with_context(err_context)?;
+        },
         Action::NewTiledPluginPane(run_plugin, name) => {
             senders
                 .send_to_screen(ScreenInstruction::NewTiledPluginPane(

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_query_pane_names_action.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_query_pane_names_action.snap
@@ -1,0 +1,13 @@
+---
+source: zellij-server/src/./unit/screen_tests.rs
+assertion_line: 2561
+expression: "format!(\"{:#?}\", log_tab_names_instruction)"
+---
+Some(
+    Log(
+        [
+            "0: Pane #1",
+        ],
+        10,
+    ),
+)

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -374,6 +374,8 @@ pub enum CliAction {
     NextSwapLayout,
     /// Query all tab names
     QueryTabNames,
+    /// Query all pane names
+    QueryPaneNames,
     StartOrReloadPlugin {
         url: String,
     },

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -325,6 +325,7 @@ pub enum ScreenContext {
     PreviousSwapLayout,
     NextSwapLayout,
     QueryTabNames,
+    QueryPaneNames,
     NewTiledPluginPane,
     StartOrReloadPluginPane,
     NewFloatingPluginPane,

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -229,6 +229,8 @@ pub enum Action {
     NextSwapLayout,
     /// Query all tab names
     QueryTabNames,
+    /// Query all pane names
+    QueryPaneNames,
     /// Open a new tiled (embedded, non-floating) plugin pane
     NewTiledPluginPane(RunPluginLocation, Option<String>), // String is an optional name
     NewFloatingPluginPane(RunPluginLocation, Option<String>), // String is an optional name
@@ -480,6 +482,7 @@ impl Action {
             CliAction::PreviousSwapLayout => Ok(vec![Action::PreviousSwapLayout]),
             CliAction::NextSwapLayout => Ok(vec![Action::NextSwapLayout]),
             CliAction::QueryTabNames => Ok(vec![Action::QueryTabNames]),
+            CliAction::QueryPaneNames => Ok(vec![Action::QueryPaneNames]),
             CliAction::StartOrReloadPlugin { url } => {
                 let current_dir = get_current_dir();
                 let run_plugin_location = RunPluginLocation::parse(&url, Some(current_dir))


### PR DESCRIPTION
This adds an action to Zellij called `query-pane-names`. It is inspired by `query-tab-names` (see https://github.com/zellij-org/zellij/pull/2145).

It shows a list of all panes in the current tab.