### PR TITLE
Use CARGO_TARGET_DIR when getting plugins

### DIFF
--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -73,8 +73,8 @@ mod not_wasm {
                 .to_vec(),
                 #[cfg(all(feature = "plugins_from_target", debug_assertions))]
                 include_bytes!(concat!(
-                    env!("CARGO_MANIFEST_DIR"),
-                    "/../target/wasm32-wasi/debug/",
+                    env!("CARGO_TARGET_DIR"),
+                    "/wasm32-wasi/debug/",
                     $plugin
                 ))
                 .to_vec(),


### PR DESCRIPTION
Using `CARGO_MANIFEST_DIR` is brittle when accessing the cargo target directory since the latter's path could be overriden by a user trying to compile `zellij`.