### PR TITLE
feat(ui): new status bar mode

### DIFF
--- a/default-plugins/status-bar/src/first_line.rs
+++ b/default-plugins/status-bar/src/first_line.rs
@@ -210,7 +210,11 @@ fn short_key_indicators(
     mode_info: &ModeInfo,
     no_super: bool,
 ) -> LinePart {
-    let mut line_part = if no_super { LinePart::default() } else { superkey(palette, separator, mode_info) };
+    let mut line_part = if no_super {
+        LinePart::default()
+    } else {
+        superkey(palette, separator, mode_info)
+    };
     let shared_super = if no_super { true } else { line_part.len > 0 };
     for ctrl_key in keys {
         let line_empty = line_part.len == 0;
@@ -235,7 +239,11 @@ fn full_key_indicators(
     no_super: bool,
 ) -> LinePart {
     // Print full-width hints
-    let mut line_part = if no_super { LinePart::default() } else { superkey(palette, separator, mode_info) };
+    let mut line_part = if no_super {
+        LinePart::default()
+    } else {
+        superkey(palette, separator, mode_info)
+    };
     let shared_super = if no_super { true } else { line_part.len > 0 };
     for ctrl_key in keys {
         let line_empty = line_part.len == 0;
@@ -455,19 +463,16 @@ pub fn superkey(palette: ColoredElements, separator: &str, mode_info: &ModeInfo)
 fn standby_mode_shortcut_key(help: &ModeInfo) -> Key {
     let binds = &help.get_mode_keybinds();
     match help.mode {
-        InputMode::Locked => {
-            to_char(action_key(
-                binds,
-                &[Action::SwitchToMode(InputMode::Normal)],
-            ))
-        },
-        _ => {
-            to_char(action_key(
-                binds,
-                &[Action::SwitchToMode(InputMode::Locked)],
-            ))
-        }
-    }.unwrap_or(Key::Char('?'))
+        InputMode::Locked => to_char(action_key(
+            binds,
+            &[Action::SwitchToMode(InputMode::Normal)],
+        )),
+        _ => to_char(action_key(
+            binds,
+            &[Action::SwitchToMode(InputMode::Locked)],
+        )),
+    }
+    .unwrap_or(Key::Char('?'))
 }
 
 fn standby_mode_ui_indication(
@@ -490,13 +495,16 @@ fn standby_mode_ui_indication(
         input_mode_to_key_action(&standby_mode),
         None,
     );
-    let styled_text = colored_elements.unselected.styled_text.paint(format!(" {} ", key_shortcut.full_text()));
-    let suffix_separator = colored_elements.unselected.suffix_separator.paint(separator);
+    let styled_text = colored_elements
+        .unselected
+        .styled_text
+        .paint(format!(" {} ", key_shortcut.full_text()));
+    let suffix_separator = colored_elements
+        .unselected
+        .suffix_separator
+        .paint(separator);
     let standby_mode_text = LinePart {
-        part: ANSIStrings(&[
-            styled_text,
-            suffix_separator,
-        ]).to_string(),
+        part: ANSIStrings(&[styled_text, suffix_separator]).to_string(),
         len: key_shortcut.full_text().chars().count() + separator.chars().count() + 2, // 2 padding
     };
     line_part.part = format!("{}{}", line_part.part, standby_mode_shortcut.part);
@@ -506,22 +514,51 @@ fn standby_mode_ui_indication(
     line_part
 }
 
-fn standby_mode_single_letter_unselected(has_shared_super: bool, shortcut_key: Key, palette: ColoredElements, separator: &str) -> LinePart {
+fn standby_mode_single_letter_unselected(
+    has_shared_super: bool,
+    shortcut_key: Key,
+    palette: ColoredElements,
+    separator: &str,
+) -> LinePart {
     let prefix_separator = palette.unselected.prefix_separator.paint(separator);
-    let char_shortcut = palette.unselected.char_shortcut.paint(format!(" {} ", letter_shortcut(&shortcut_key, has_shared_super)));
+    let char_shortcut = palette.unselected.char_shortcut.paint(format!(
+        " {} ",
+        letter_shortcut(&shortcut_key, has_shared_super)
+    ));
     let suffix_separator = palette.unselected.suffix_separator.paint(separator);
-    let len = prefix_separator.chars().count() + char_shortcut.chars().count() + suffix_separator.chars().count();
+    let len = prefix_separator.chars().count()
+        + char_shortcut.chars().count()
+        + suffix_separator.chars().count();
     LinePart {
         part: ANSIStrings(&[prefix_separator, char_shortcut, suffix_separator]).to_string(),
         len,
     }
 }
 
-fn standby_mode_single_letter_selected(has_shared_super: bool, shortcut_key: Key, palette: ColoredElements, separator: &str) -> LinePart {
-    let prefix_separator = palette.selected_standby_shortcut.prefix_separator.paint(separator);
-    let char_shortcut = palette.selected_standby_shortcut.char_shortcut.paint(format!(" {} ", letter_shortcut(&shortcut_key, has_shared_super)));
-    let suffix_separator = palette.selected_standby_shortcut.suffix_separator.paint(separator);
-    let len = prefix_separator.chars().count() + char_shortcut.chars().count() + suffix_separator.chars().count();
+fn standby_mode_single_letter_selected(
+    has_shared_super: bool,
+    shortcut_key: Key,
+    palette: ColoredElements,
+    separator: &str,
+) -> LinePart {
+    let prefix_separator = palette
+        .selected_standby_shortcut
+        .prefix_separator
+        .paint(separator);
+    let char_shortcut = palette
+        .selected_standby_shortcut
+        .char_shortcut
+        .paint(format!(
+            " {} ",
+            letter_shortcut(&shortcut_key, has_shared_super)
+        ));
+    let suffix_separator = palette
+        .selected_standby_shortcut
+        .suffix_separator
+        .paint(separator);
+    let len = prefix_separator.chars().count()
+        + char_shortcut.chars().count()
+        + suffix_separator.chars().count();
     LinePart {
         part: ANSIStrings(&[prefix_separator, char_shortcut, suffix_separator]).to_string(),
         len,
@@ -619,29 +656,54 @@ pub fn first_line_supermode(
             line
         },
         _ => {
-
             let mut default_keys = generate_default_keys(help);
             default_keys.remove(0); // remove locked mode which is not relevant to the supermode ui
 
-            if let Some(position) = default_keys.iter().position(|d| d.action == input_mode_to_key_action(standby_mode)) {
-                let standby_mode_ui_ribbon = standby_mode_ui_indication(has_shared_super, &standby_mode, standby_mode_shortcut_key, colored_elements, separator);
-                let first_keybinds: Vec<KeyShortcut> = default_keys.iter().cloned().take(position).collect();
-                let second_keybinds: Vec<KeyShortcut> = default_keys.iter().cloned().skip(position + 1).collect();
+            if let Some(position) = default_keys
+                .iter()
+                .position(|d| d.action == input_mode_to_key_action(standby_mode))
+            {
+                let standby_mode_ui_ribbon = standby_mode_ui_indication(
+                    has_shared_super,
+                    &standby_mode,
+                    standby_mode_shortcut_key,
+                    colored_elements,
+                    separator,
+                );
+                let first_keybinds: Vec<KeyShortcut> =
+                    default_keys.iter().cloned().take(position).collect();
+                let second_keybinds: Vec<KeyShortcut> =
+                    default_keys.iter().cloned().skip(position + 1).collect();
                 let first_key_indicators =
                     full_key_indicators(&first_keybinds, colored_elements, separator, help, true);
                 let second_key_indicators =
                     full_key_indicators(&second_keybinds, colored_elements, separator, help, true);
 
-                if first_key_indicators.len + standby_mode_ui_ribbon.len + second_key_indicators.len < max_len_without_superkey {
+                if first_key_indicators.len + standby_mode_ui_ribbon.len + second_key_indicators.len
+                    < max_len_without_superkey
+                {
                     append_to_line(first_key_indicators);
                     append_to_line(standby_mode_ui_ribbon);
                     append_to_line(second_key_indicators);
                 } else {
-                    let length_of_each_half = max_len_without_superkey.saturating_sub(standby_mode_ui_ribbon.len) / 2;
-                    let first_key_indicators =
-                        short_key_indicators(length_of_each_half, &first_keybinds, colored_elements, separator, help, true);
-                    let second_key_indicators =
-                        short_key_indicators(length_of_each_half, &second_keybinds, colored_elements, separator, help, true);
+                    let length_of_each_half =
+                        max_len_without_superkey.saturating_sub(standby_mode_ui_ribbon.len) / 2;
+                    let first_key_indicators = short_key_indicators(
+                        length_of_each_half,
+                        &first_keybinds,
+                        colored_elements,
+                        separator,
+                        help,
+                        true,
+                    );
+                    let second_key_indicators = short_key_indicators(
+                        length_of_each_half,
+                        &second_keybinds,
+                        colored_elements,
+                        separator,
+                        help,
+                        true,
+                    );
                     append_to_line(first_key_indicators);
                     append_to_line(standby_mode_ui_ribbon);
                     append_to_line(second_key_indicators);
@@ -649,12 +711,18 @@ pub fn first_line_supermode(
                 if line.len < max_len {
                     if let Some(tab_info) = tab_info {
                         let remaining_space = max_len.saturating_sub(line.len);
-                        line.append(&swap_layout_status_and_padding(&tab_info, remaining_space, separator, colored_elements, help));
+                        line.append(&swap_layout_status_and_padding(
+                            &tab_info,
+                            remaining_space,
+                            separator,
+                            colored_elements,
+                            help,
+                        ));
                     }
                 }
             }
             line
-        }
+        },
     }
 }
 
@@ -663,7 +731,7 @@ fn swap_layout_status_and_padding(
     mut remaining_space: usize,
     separator: &str,
     colored_elements: ColoredElements,
-    help: &ModeInfo
+    help: &ModeInfo,
 ) -> LinePart {
     let mut line = LinePart::default();
     if let Some(swap_layout_status) = swap_layout_status(
@@ -677,9 +745,8 @@ fn swap_layout_status_and_padding(
     ) {
         remaining_space -= swap_layout_status.len;
         for _ in 0..remaining_space {
-            line.part.push_str(
-                &ANSIStrings(&[colored_elements.superkey_prefix.paint(" ")]).to_string(),
-            );
+            line.part
+                .push_str(&ANSIStrings(&[colored_elements.superkey_prefix.paint(" ")]).to_string());
             line.len += 1;
         }
         line.append(&swap_layout_status);
@@ -783,8 +850,14 @@ pub fn first_line(
     if key_indicators.len < max_len {
         if let Some(tab_info) = tab_info {
             let remaining_space = max_len - key_indicators.len;
-            key_indicators.append(&swap_layout_status_and_padding(&tab_info, remaining_space, separator, colored_elements, help));
-         }
+            key_indicators.append(&swap_layout_status_and_padding(
+                &tab_info,
+                remaining_space,
+                separator,
+                colored_elements,
+                help,
+            ));
+        }
     }
     key_indicators
 }

--- a/default-plugins/status-bar/src/first_line.rs
+++ b/default-plugins/status-bar/src/first_line.rs
@@ -8,13 +8,14 @@ use crate::{
 };
 use crate::{ColoredElements, LinePart};
 
+#[derive(Debug, Clone, Copy)]
 struct KeyShortcut {
     mode: KeyMode,
-    action: KeyAction,
+    pub action: KeyAction,
     key: Option<Key>,
 }
 
-#[derive(PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 enum KeyAction {
     Lock,
     Pane,
@@ -27,11 +28,26 @@ enum KeyAction {
     Tmux,
 }
 
+#[derive(Debug, Clone, Copy)]
 enum KeyMode {
     Unselected,
     UnselectedAlternate,
     Selected,
     Disabled,
+}
+
+fn letter_shortcut(key: &Key, with_prefix: bool) -> String {
+    if with_prefix {
+        format!("{}", key)
+    } else {
+        match key {
+            Key::F(c) => format!("{}", c),
+            Key::Ctrl(c) => format!("{}", c),
+            Key::Char(_) => format!("{}", key),
+            Key::Alt(c) => format!("{}", c),
+            _ => String::from("??"),
+        }
+    }
 }
 
 impl KeyShortcut {
@@ -57,17 +73,7 @@ impl KeyShortcut {
             Some(k) => k,
             None => return String::from("?"),
         };
-        if with_prefix {
-            format!("{}", key)
-        } else {
-            match key {
-                Key::F(c) => format!("{}", c),
-                Key::Ctrl(c) => format!("{}", c),
-                Key::Char(_) => format!("{}", key),
-                Key::Alt(c) => format!("{}", c),
-                _ => String::from("??"),
-            }
-        }
+        letter_shortcut(&key, with_prefix)
     }
 }
 
@@ -194,6 +200,50 @@ fn short_mode_shortcut(
             + 1                             // " "
             + separator.chars().count(), // Separator
     }
+}
+
+fn short_key_indicators(
+    max_len: usize,
+    keys: &[KeyShortcut],
+    palette: ColoredElements,
+    separator: &str,
+    mode_info: &ModeInfo,
+    no_super: bool,
+) -> LinePart {
+    let mut line_part = if no_super { LinePart::default() } else { superkey(palette, separator, mode_info) };
+    let shared_super = if no_super { true } else { line_part.len > 0 };
+    for ctrl_key in keys {
+        let line_empty = line_part.len == 0;
+        let key = short_mode_shortcut(ctrl_key, palette, separator, shared_super, line_empty);
+        line_part.part = format!("{}{}", line_part.part, key.part);
+        line_part.len += key.len;
+    }
+    if line_part.len < max_len {
+        return line_part;
+    }
+
+    // Shortened doesn't fit, print nothing
+    line_part = LinePart::default();
+    line_part
+}
+
+fn full_key_indicators(
+    keys: &[KeyShortcut],
+    palette: ColoredElements,
+    separator: &str,
+    mode_info: &ModeInfo,
+    no_super: bool,
+) -> LinePart {
+    // Print full-width hints
+    let mut line_part = if no_super { LinePart::default() } else { superkey(palette, separator, mode_info) };
+    let shared_super = if no_super { true } else { line_part.len > 0 };
+    for ctrl_key in keys {
+        let line_empty = line_part.len == 0;
+        let key = long_mode_shortcut(ctrl_key, palette, separator, shared_super, line_empty);
+        line_part.part = format!("{}{}", line_part.part, key.part);
+        line_part.len += key.len;
+    }
+    line_part
 }
 
 fn key_indicators(
@@ -402,6 +452,82 @@ pub fn superkey(palette: ColoredElements, separator: &str, mode_info: &ModeInfo)
     }
 }
 
+fn standby_mode_shortcut_key(help: &ModeInfo) -> Key {
+    let binds = &help.get_mode_keybinds();
+    match help.mode {
+        InputMode::Locked => {
+            to_char(action_key(
+                binds,
+                &[Action::SwitchToMode(InputMode::Normal)],
+            ))
+        },
+        _ => {
+            to_char(action_key(
+                binds,
+                &[Action::SwitchToMode(InputMode::Locked)],
+            ))
+        }
+    }.unwrap_or(Key::Char('?'))
+}
+
+fn standby_mode_ui_indication(
+    has_shared_super: bool,
+    standby_mode: &InputMode,
+    standby_mode_shortcut_key: Key,
+    colored_elements: ColoredElements,
+    separator: &str,
+) -> LinePart {
+    let mut line_part = LinePart::default();
+    let standby_mode_shortcut = standby_mode_single_letter_selected(
+        has_shared_super,
+        standby_mode_shortcut_key,
+        colored_elements,
+        separator,
+    );
+    // standby mode text hint
+    let key_shortcut = KeyShortcut::new(
+        KeyMode::Unselected,
+        input_mode_to_key_action(&standby_mode),
+        None,
+    );
+    let styled_text = colored_elements.unselected.styled_text.paint(format!(" {} ", key_shortcut.full_text()));
+    let suffix_separator = colored_elements.unselected.suffix_separator.paint(separator);
+    let standby_mode_text = LinePart {
+        part: ANSIStrings(&[
+            styled_text,
+            suffix_separator,
+        ]).to_string(),
+        len: key_shortcut.full_text().chars().count() + separator.chars().count() + 2, // 2 padding
+    };
+    line_part.part = format!("{}{}", line_part.part, standby_mode_shortcut.part);
+    line_part.len += standby_mode_shortcut.len;
+    line_part.part = format!("{}{}", line_part.part, standby_mode_text.part);
+    line_part.len += standby_mode_text.len;
+    line_part
+}
+
+fn standby_mode_single_letter_unselected(has_shared_super: bool, shortcut_key: Key, palette: ColoredElements, separator: &str) -> LinePart {
+    let prefix_separator = palette.unselected.prefix_separator.paint(separator);
+    let char_shortcut = palette.unselected.char_shortcut.paint(format!(" {} ", letter_shortcut(&shortcut_key, has_shared_super)));
+    let suffix_separator = palette.unselected.suffix_separator.paint(separator);
+    let len = prefix_separator.chars().count() + char_shortcut.chars().count() + suffix_separator.chars().count();
+    LinePart {
+        part: ANSIStrings(&[prefix_separator, char_shortcut, suffix_separator]).to_string(),
+        len,
+    }
+}
+
+fn standby_mode_single_letter_selected(has_shared_super: bool, shortcut_key: Key, palette: ColoredElements, separator: &str) -> LinePart {
+    let prefix_separator = palette.selected_standby_shortcut.prefix_separator.paint(separator);
+    let char_shortcut = palette.selected_standby_shortcut.char_shortcut.paint(format!(" {} ", letter_shortcut(&shortcut_key, has_shared_super)));
+    let suffix_separator = palette.selected_standby_shortcut.suffix_separator.paint(separator);
+    let len = prefix_separator.chars().count() + char_shortcut.chars().count() + suffix_separator.chars().count();
+    LinePart {
+        part: ANSIStrings(&[prefix_separator, char_shortcut, suffix_separator]).to_string(),
+        len,
+    }
+}
+
 pub fn to_char(kv: Vec<Key>) -> Option<Key> {
     let key = kv
         .iter()
@@ -417,6 +543,19 @@ pub fn to_char(kv: Vec<Key>) -> Option<Key> {
         return kv.first().cloned();
     }
     key.cloned()
+}
+
+fn input_mode_to_key_action(input_mode: &InputMode) -> KeyAction {
+    match input_mode {
+        InputMode::Normal | InputMode::Prompt | InputMode::Tmux => KeyAction::Lock,
+        InputMode::Locked => KeyAction::Lock,
+        InputMode::Pane | InputMode::RenamePane => KeyAction::Pane,
+        InputMode::Tab | InputMode::RenameTab => KeyAction::Tab,
+        InputMode::Resize => KeyAction::Resize,
+        InputMode::Move => KeyAction::Move,
+        InputMode::Scroll | InputMode::Search | InputMode::EnterSearch => KeyAction::Search,
+        InputMode::Session => KeyAction::Session,
+    }
 }
 
 /// Get the [`KeyShortcut`] for a specific [`InputMode`].
@@ -449,7 +588,8 @@ fn get_key_shortcut_for_mode<'a>(
     None
 }
 
-pub fn first_line(
+pub fn first_line_supermode(
+    standby_mode: &InputMode,
     help: &ModeInfo,
     tab_info: Option<&TabInfo>,
     max_len: usize,
@@ -457,9 +597,99 @@ pub fn first_line(
 ) -> LinePart {
     let supports_arrow_fonts = !help.capabilities.arrow_fonts;
     let colored_elements = color_elements(help.style.colors, !supports_arrow_fonts);
+
+    let standby_mode_shortcut_key = standby_mode_shortcut_key(&help);
+
+    let mut line = superkey(colored_elements, separator, help);
+    let has_shared_super = line.len == 0;
+    let max_len_without_superkey = max_len.saturating_sub(line.len);
+    let mut append_to_line = |line_part_to_append: LinePart| {
+        line.part = format!("{}{}", line.part, line_part_to_append.part);
+        line.len += line_part_to_append.len;
+    };
+    match help.mode {
+        InputMode::Locked => {
+            let standby_mode_shortcut = standby_mode_single_letter_unselected(
+                has_shared_super,
+                standby_mode_shortcut_key,
+                colored_elements,
+                separator,
+            );
+            append_to_line(standby_mode_shortcut);
+            line
+        },
+        _ => {
+
+            let mut default_keys = generate_default_keys(help);
+            default_keys.remove(0); // remove locked mode which is not relevant to the supermode ui
+
+            if let Some(position) = default_keys.iter().position(|d| d.action == input_mode_to_key_action(standby_mode)) {
+                let standby_mode_ui_ribbon = standby_mode_ui_indication(has_shared_super, &standby_mode, standby_mode_shortcut_key, colored_elements, separator);
+                let first_keybinds: Vec<KeyShortcut> = default_keys.iter().cloned().take(position).collect();
+                let second_keybinds: Vec<KeyShortcut> = default_keys.iter().cloned().skip(position + 1).collect();
+                let first_key_indicators =
+                    full_key_indicators(&first_keybinds, colored_elements, separator, help, true);
+                let second_key_indicators =
+                    full_key_indicators(&second_keybinds, colored_elements, separator, help, true);
+
+                if first_key_indicators.len + standby_mode_ui_ribbon.len + second_key_indicators.len < max_len_without_superkey {
+                    append_to_line(first_key_indicators);
+                    append_to_line(standby_mode_ui_ribbon);
+                    append_to_line(second_key_indicators);
+                } else {
+                    let length_of_each_half = max_len_without_superkey.saturating_sub(standby_mode_ui_ribbon.len) / 2;
+                    let first_key_indicators =
+                        short_key_indicators(length_of_each_half, &first_keybinds, colored_elements, separator, help, true);
+                    let second_key_indicators =
+                        short_key_indicators(length_of_each_half, &second_keybinds, colored_elements, separator, help, true);
+                    append_to_line(first_key_indicators);
+                    append_to_line(standby_mode_ui_ribbon);
+                    append_to_line(second_key_indicators);
+                }
+                if line.len < max_len {
+                    if let Some(tab_info) = tab_info {
+                        let remaining_space = max_len.saturating_sub(line.len);
+                        line.append(&swap_layout_status_and_padding(&tab_info, remaining_space, separator, colored_elements, help));
+                    }
+                }
+            }
+            line
+        }
+    }
+}
+
+fn swap_layout_status_and_padding(
+    tab_info: &TabInfo,
+    mut remaining_space: usize,
+    separator: &str,
+    colored_elements: ColoredElements,
+    help: &ModeInfo
+) -> LinePart {
+    let mut line = LinePart::default();
+    if let Some(swap_layout_status) = swap_layout_status(
+        remaining_space,
+        &tab_info.active_swap_layout_name,
+        tab_info.is_swap_layout_dirty,
+        help,
+        colored_elements,
+        &help.style.colors,
+        separator,
+    ) {
+        remaining_space -= swap_layout_status.len;
+        for _ in 0..remaining_space {
+            line.part.push_str(
+                &ANSIStrings(&[colored_elements.superkey_prefix.paint(" ")]).to_string(),
+            );
+            line.len += 1;
+        }
+        line.append(&swap_layout_status);
+    }
+    line
+}
+
+fn generate_default_keys(help: &ModeInfo) -> Vec<KeyShortcut> {
     let binds = &help.get_mode_keybinds();
-    // Unselect all by default
-    let mut default_keys = vec![
+    vec![
         KeyShortcut::new(
             KeyMode::Unselected,
             KeyAction::Lock,
@@ -512,7 +742,20 @@ pub fn first_line(
             KeyAction::Quit,
             to_char(action_key(binds, &[Action::Quit])),
         ),
-    ];
+    ]
+}
+
+pub fn first_line(
+    help: &ModeInfo,
+    tab_info: Option<&TabInfo>,
+    max_len: usize,
+    separator: &str,
+) -> LinePart {
+    let supports_arrow_fonts = !help.capabilities.arrow_fonts;
+    let colored_elements = color_elements(help.style.colors, !supports_arrow_fonts);
+    let binds = &help.get_mode_keybinds();
+    // Unselect all by default
+    let mut default_keys = generate_default_keys(help); // TODO: check that this still works
 
     if let Some(key_shortcut) = get_key_shortcut_for_mode(&mut default_keys, &help.mode) {
         key_shortcut.mode = KeyMode::Selected;
@@ -539,26 +782,9 @@ pub fn first_line(
         key_indicators(max_len, &default_keys, colored_elements, separator, help);
     if key_indicators.len < max_len {
         if let Some(tab_info) = tab_info {
-            let mut remaining_space = max_len - key_indicators.len;
-            if let Some(swap_layout_status) = swap_layout_status(
-                remaining_space,
-                &tab_info.active_swap_layout_name,
-                tab_info.is_swap_layout_dirty,
-                help,
-                colored_elements,
-                &help.style.colors,
-                separator,
-            ) {
-                remaining_space -= swap_layout_status.len;
-                for _ in 0..remaining_space {
-                    key_indicators.part.push_str(
-                        &ANSIStrings(&[colored_elements.superkey_prefix.paint(" ")]).to_string(),
-                    );
-                    key_indicators.len += 1;
-                }
-                key_indicators.append(&swap_layout_status);
-            }
-        }
+            let remaining_space = max_len - key_indicators.len;
+            key_indicators.append(&swap_layout_status_and_padding(&tab_info, remaining_space, separator, colored_elements, help));
+         }
     }
     key_indicators
 }

--- a/default-plugins/status-bar/src/main.rs
+++ b/default-plugins/status-bar/src/main.rs
@@ -15,8 +15,7 @@ use zellij_tile_utils::{palette_match, style};
 
 use first_line::{first_line, first_line_supermode};
 use second_line::{
-    floating_panes_are_visible, fullscreen_panes_to_hide, keybinds,
-    system_clipboard_error,
+    floating_panes_are_visible, fullscreen_panes_to_hide, keybinds, system_clipboard_error,
     text_copied_hint,
 };
 use tip::utils::get_cached_tip_name;
@@ -231,11 +230,16 @@ impl ZellijPlugin for State {
                     // that mode as the standby mode
                     // whenever the user switches away from the standby mode, we palce them in
                     // normal mode
-                    if mode_info.mode == InputMode::Normal && self.current_mode == InputMode::Locked {
+                    if mode_info.mode == InputMode::Normal && self.current_mode == InputMode::Locked
+                    {
                         switch_to_input_mode(&self.standby_mode);
-                    } else if mode_info.mode == InputMode::Normal && self.current_mode == self.standby_mode {
+                    } else if mode_info.mode == InputMode::Normal
+                        && self.current_mode == self.standby_mode
+                    {
                         switch_to_input_mode(&InputMode::Locked);
-                    } else if mode_info.mode != InputMode::Locked && mode_info.mode != InputMode::Normal {
+                    } else if mode_info.mode != InputMode::Locked
+                        && mode_info.mode != InputMode::Normal
+                    {
                         self.standby_mode = mode_info.mode;
                     }
                     self.current_mode = mode_info.mode;
@@ -293,7 +297,13 @@ impl ZellijPlugin for State {
 
         let active_tab = self.tabs.iter().find(|t| t.active);
         let first_line = if self.supermode {
-            first_line_supermode(&self.standby_mode, &self.mode_info, active_tab, cols, separator)
+            first_line_supermode(
+                &self.standby_mode,
+                &self.mode_info,
+                active_tab,
+                cols,
+                separator,
+            )
         } else {
             first_line(&self.mode_info, active_tab, cols, separator)
         };
@@ -356,7 +366,9 @@ impl State {
                 }
             } else if active_tab.are_floating_panes_visible {
                 match self.mode_info.mode {
-                    InputMode::Normal | InputMode:: Locked => floating_panes_are_visible(&self.mode_info),
+                    InputMode::Normal | InputMode::Locked => {
+                        floating_panes_are_visible(&self.mode_info)
+                    },
                     _ => keybinds(&self.mode_info, &self.tip_name, cols),
                 }
             } else {

--- a/default-plugins/status-bar/src/main.rs
+++ b/default-plugins/status-bar/src/main.rs
@@ -13,10 +13,10 @@ use zellij_tile::prelude::actions::Action;
 use zellij_tile::prelude::*;
 use zellij_tile_utils::{palette_match, style};
 
-use first_line::first_line;
+use first_line::{first_line, first_line_supermode};
 use second_line::{
     floating_panes_are_visible, fullscreen_panes_to_hide, keybinds,
-    locked_floating_panes_are_visible, locked_fullscreen_panes_to_hide, system_clipboard_error,
+    system_clipboard_error,
     text_copied_hint,
 };
 use tip::utils::get_cached_tip_name;
@@ -34,6 +34,10 @@ struct State {
     mode_info: ModeInfo,
     text_copy_destination: Option<CopyDestination>,
     display_system_clipboard_failure: bool,
+
+    supermode: bool,
+    standby_mode: InputMode,
+    current_mode: InputMode,
 }
 
 register_plugin!(State);
@@ -60,6 +64,7 @@ impl Display for LinePart {
 #[derive(Clone, Copy)]
 pub struct ColoredElements {
     pub selected: SegmentStyle,
+    pub selected_standby_shortcut: SegmentStyle,
     pub unselected: SegmentStyle,
     pub unselected_alternate: SegmentStyle,
     pub disabled: SegmentStyle,
@@ -109,6 +114,14 @@ fn color_elements(palette: Palette, different_color_alternates: bool) -> Colored
                 styled_text: style!(background, palette.green).bold(),
                 suffix_separator: style!(palette.green, background).bold(),
             },
+            selected_standby_shortcut: SegmentStyle {
+                prefix_separator: style!(background, palette.green),
+                char_left_separator: style!(background, palette.green).bold(),
+                char_shortcut: style!(palette.red, palette.green).bold(),
+                char_right_separator: style!(background, palette.green).bold(),
+                styled_text: style!(background, palette.green).bold(),
+                suffix_separator: style!(palette.green, palette.fg).bold(),
+            },
             unselected: SegmentStyle {
                 prefix_separator: style!(background, palette.fg),
                 char_left_separator: style!(background, palette.fg).bold(),
@@ -144,6 +157,14 @@ fn color_elements(palette: Palette, different_color_alternates: bool) -> Colored
                 char_right_separator: style!(palette.fg, palette.green).bold(),
                 styled_text: style!(background, palette.green).bold(),
                 suffix_separator: style!(palette.green, background).bold(),
+            },
+            selected_standby_shortcut: SegmentStyle {
+                prefix_separator: style!(background, palette.green),
+                char_left_separator: style!(background, palette.green).bold(),
+                char_shortcut: style!(palette.red, palette.green).bold(),
+                char_right_separator: style!(background, palette.green).bold(),
+                styled_text: style!(background, palette.green).bold(),
+                suffix_separator: style!(palette.green, palette.fg).bold(),
             },
             unselected: SegmentStyle {
                 prefix_separator: style!(background, palette.fg),
@@ -187,12 +208,39 @@ impl ZellijPlugin for State {
             EventType::InputReceived,
             EventType::SystemClipboardFailure,
         ]);
+        self.supermode = true; // TODO: from config
+        self.standby_mode = InputMode::Pane;
+        if self.supermode {
+            switch_to_input_mode(&InputMode::Locked); // supermode should start locked (TODO: only
+                                                      // once per app load, let's not do this on
+                                                      // each tab loading)
+        }
     }
 
     fn update(&mut self, event: Event) -> bool {
         let mut should_render = false;
         match event {
             Event::ModeUpdate(mode_info) => {
+                if self.supermode {
+                    // supermode is a "sticky" mode that is not Normal or Locked
+                    // using this configuration, we default to Locked mode in order to avoid key
+                    // collisions with terminal applications
+                    // whenever the user switches away from locked mode, we make sure to place them
+                    // in the standby mode
+                    // whenever the user switches to a mode that is not locked or normal, we set
+                    // that mode as the standby mode
+                    // whenever the user switches away from the standby mode, we palce them in
+                    // normal mode
+                    if mode_info.mode == InputMode::Normal && self.current_mode == InputMode::Locked {
+                        switch_to_input_mode(&self.standby_mode);
+                    } else if mode_info.mode == InputMode::Normal && self.current_mode == self.standby_mode {
+                        switch_to_input_mode(&InputMode::Locked);
+                    } else if mode_info.mode != InputMode::Locked && mode_info.mode != InputMode::Normal {
+                        self.standby_mode = mode_info.mode;
+                    }
+                    self.current_mode = mode_info.mode;
+                }
+
                 if self.mode_info != mode_info {
                     should_render = true;
                 }
@@ -244,7 +292,11 @@ impl ZellijPlugin for State {
         };
 
         let active_tab = self.tabs.iter().find(|t| t.active);
-        let first_line = first_line(&self.mode_info, active_tab, cols, separator);
+        let first_line = if self.supermode {
+            first_line_supermode(&self.standby_mode, &self.mode_info, active_tab, cols, separator)
+        } else {
+            first_line(&self.mode_info, active_tab, cols, separator)
+        };
         let second_line = self.second_line(cols);
 
         let background = match self.mode_info.style.colors.theme_hue {
@@ -296,11 +348,7 @@ impl State {
         } else if let Some(active_tab) = active_tab {
             if active_tab.is_fullscreen_active {
                 match self.mode_info.mode {
-                    InputMode::Normal => fullscreen_panes_to_hide(
-                        &self.mode_info.style.colors,
-                        active_tab.panes_to_hide,
-                    ),
-                    InputMode::Locked => locked_fullscreen_panes_to_hide(
+                    InputMode::Normal | InputMode::Locked => fullscreen_panes_to_hide(
                         &self.mode_info.style.colors,
                         active_tab.panes_to_hide,
                     ),
@@ -308,10 +356,7 @@ impl State {
                 }
             } else if active_tab.are_floating_panes_visible {
                 match self.mode_info.mode {
-                    InputMode::Normal => floating_panes_are_visible(&self.mode_info),
-                    InputMode::Locked => {
-                        locked_floating_panes_are_visible(&self.mode_info.style.colors)
-                    },
+                    InputMode::Normal | InputMode:: Locked => floating_panes_are_visible(&self.mode_info),
                     _ => keybinds(&self.mode_info, &self.tip_name, cols),
                 }
             } else {

--- a/default-plugins/status-bar/src/main.rs
+++ b/default-plugins/status-bar/src/main.rs
@@ -208,7 +208,7 @@ impl ZellijPlugin for State {
             EventType::InputReceived,
             EventType::SystemClipboardFailure,
         ]);
-        self.supermode = true; // TODO: from config
+        self.supermode = false; // TODO: from config
         self.standby_mode = InputMode::Pane;
         if self.supermode {
             switch_to_input_mode(&InputMode::Locked); // supermode should start locked (TODO: only

--- a/default-plugins/status-bar/src/second_line.rs
+++ b/default-plugins/status-bar/src/second_line.rs
@@ -297,7 +297,7 @@ fn best_effort_shortcut_list(help: &ModeInfo, tip: TipFn, max_len: usize) -> Lin
             } else {
                 LinePart::default()
             }
-        }
+        },
         _ => best_effort_shortcut_list_nonstandard_mode(help, max_len),
     }
 }

--- a/default-plugins/status-bar/src/second_line.rs
+++ b/default-plugins/status-bar/src/second_line.rs
@@ -605,7 +605,7 @@ mod tests {
 
         assert_eq!(
             ret,
-            " <←↓↑→> Move focus / <n> New / <x> Close / <f> Fullscreen"
+            " <n> New / <←↓↑→> Change Focus / <x> Close / <f> Toggle Fullscreen",
         );
     }
 
@@ -635,7 +635,7 @@ mod tests {
         let ret = keybinds(&mode_info, "quicknav", 35);
         let ret = unstyle(ret);
 
-        assert_eq!(ret, " <←↓↑→> Move / <n> New ... ");
+        assert_eq!(ret, " <n> New / <←↓↑→> Move ... ");
     }
 
     #[test]
@@ -660,6 +660,9 @@ mod tests {
         let ret = keybinds(&mode_info, "quicknav", 500);
         let ret = unstyle(ret);
 
-        assert_eq!(ret, " Ctrl + <a|ENTER|1|SPACE> Move focus / <BACKSPACE> New / <ESC> Close / <END> Fullscreen");
+        assert_eq!(
+            ret,
+            " <BACKSPACE> New / Ctrl + <a|ENTER|1|SPACE> Change Focus / <ESC> Close / <END> Toggle Fullscreen"
+        );
     }
 }

--- a/default-plugins/status-bar/src/tip/cache.rs
+++ b/default-plugins/status-bar/src/tip/cache.rs
@@ -47,7 +47,7 @@ impl LocalCache {
                     });
                 }
                 Err(LocalCacheError::Serde(err))
-            }
+            },
         }
     }
 
@@ -64,7 +64,7 @@ impl LocalCache {
 
                 let metadata = LocalCache::from_json(&json_cache)?;
                 Ok(LocalCache { path, metadata })
-            }
+            },
             Err(e) => Err(LocalCacheError::IoPath(e, path)),
         }
     }
@@ -77,7 +77,7 @@ impl LocalCache {
                 file.write_all(json_cache.as_bytes())
                     .map_err(LocalCacheError::Io)?;
                 Ok(())
-            }
+            },
             Err(e) => Err(LocalCacheError::Serde(e)),
         }
     }

--- a/default-plugins/status-bar/src/tip/cache.rs
+++ b/default-plugins/status-bar/src/tip/cache.rs
@@ -47,7 +47,7 @@ impl LocalCache {
                     });
                 }
                 Err(LocalCacheError::Serde(err))
-            },
+            }
         }
     }
 
@@ -64,7 +64,7 @@ impl LocalCache {
 
                 let metadata = LocalCache::from_json(&json_cache)?;
                 Ok(LocalCache { path, metadata })
-            },
+            }
             Err(e) => Err(LocalCacheError::IoPath(e, path)),
         }
     }
@@ -77,7 +77,7 @@ impl LocalCache {
                 file.write_all(json_cache.as_bytes())
                     .map_err(LocalCacheError::Io)?;
                 Ok(())
-            },
+            }
             Err(e) => Err(LocalCacheError::Serde(e)),
         }
     }

--- a/default-plugins/status-bar/src/tip/data/compact_layout.rs
+++ b/default-plugins/status-bar/src/tip/data/compact_layout.rs
@@ -77,7 +77,7 @@ pub fn compact_layout_short(help: &ModeInfo) -> LinePart {
 
 fn add_keybinds(help: &ModeInfo) -> Vec<ANSIString> {
     let to_pane = action_key(
-        &help.get_mode_keybinds(),
+        &help.get_keybinds_for_mode(InputMode::Normal),
         &[Action::SwitchToMode(InputMode::Pane)],
     );
     let pane_frames = action_key(

--- a/default-plugins/status-bar/src/tip/data/edit_scrollbuffer.rs
+++ b/default-plugins/status-bar/src/tip/data/edit_scrollbuffer.rs
@@ -67,7 +67,7 @@ pub fn edit_scrollbuffer_short(help: &ModeInfo) -> LinePart {
 
 fn add_keybinds(help: &ModeInfo) -> Vec<ANSIString> {
     let to_pane = action_key(
-        &help.get_mode_keybinds(),
+        &help.get_keybinds_for_mode(InputMode::Normal),
         &[Action::SwitchToMode(InputMode::Scroll)],
     );
     let edit_buffer = action_key(

--- a/default-plugins/status-bar/src/tip/data/floating_panes_mouse.rs
+++ b/default-plugins/status-bar/src/tip/data/floating_panes_mouse.rs
@@ -46,7 +46,7 @@ pub fn floating_panes_mouse_short(help: &ModeInfo) -> LinePart {
 
 fn add_keybinds(help: &ModeInfo) -> Vec<ANSIString> {
     let to_pane = action_key(
-        &help.get_mode_keybinds(),
+        &help.get_keybinds_for_mode(InputMode::Normal),
         &[Action::SwitchToMode(InputMode::Pane)],
     );
     let floating_toggle = action_key(

--- a/default-plugins/status-bar/src/tip/data/quicknav.rs
+++ b/default-plugins/status-bar/src/tip/data/quicknav.rs
@@ -61,7 +61,7 @@ struct Keygroups<'a> {
 }
 
 fn add_keybinds(help: &ModeInfo) -> Keygroups {
-    let normal_keymap = help.get_mode_keybinds();
+    let normal_keymap = help.get_keybinds_for_mode(InputMode::Normal);
     let new_pane_keys = action_key(&normal_keymap, &[Action::NewPane(None, None)]);
     let new_pane = if new_pane_keys.is_empty() {
         vec![Style::new().bold().paint("UNBOUND")]

--- a/default-plugins/status-bar/src/tip/data/sync_tab.rs
+++ b/default-plugins/status-bar/src/tip/data/sync_tab.rs
@@ -45,7 +45,7 @@ pub fn sync_tab_short(help: &ModeInfo) -> LinePart {
 
 fn add_keybinds(help: &ModeInfo) -> Vec<ANSIString> {
     let to_tab = action_key(
-        &help.get_mode_keybinds(),
+        &help.get_keybinds_for_mode(InputMode::Normal),
         &[Action::SwitchToMode(InputMode::Tab)],
     );
     let sync_tabs = action_key(

--- a/src/tests/e2e/cases.rs
+++ b/src/tests/e2e/cases.rs
@@ -808,7 +808,7 @@ pub fn lock_mode() {
                 name: "Send keys that should not be intercepted by the app",
                 instruction: |mut remote_terminal: RemoteTerminal| -> bool {
                     let mut step_is_complete = false;
-                    if remote_terminal.snapshot_contains("INTERFACE LOCKED") {
+                    if remote_terminal.snapshot_contains("<> PANE") {
                         remote_terminal.send_key(&TAB_MODE);
                         remote_terminal.send_key(&NEW_TAB_IN_TAB_MODE);
                         remote_terminal.send_key("abc".as_bytes());

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__lock_mode.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__lock_mode.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 836
+assertion_line: 840
 expression: last_snapshot
 ---
  Zellij (e2e-test)  Tab #1 
@@ -26,4 +26,4 @@ expression: last_snapshot
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
  Ctrl + <g> LOCK  <> PANE  <> TAB  <> RESIZE  <> MOVE  <> SEARCH  <> SESSION  <> QUIT 
- -- INTERFACE LOCKED --                                                                                                 
+ Tip: Alt + <n> => new pane. Alt + <←↓↑→> or Alt + <hjkl> => navigate. Alt + <+|-> => resize pane.                      

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__mirrored_sessions-2.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__mirrored_sessions-2.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 1341
+assertion_line: 1354
 expression: second_runner_snapshot
 ---
  Zellij (mirrored_sessions)  Tab #1  Tab #2 
@@ -26,4 +26,4 @@ expression: second_runner_snapshot
 │                                                          ││                                                          │
 └──────────────────────────────────────────────────────────┘└──────────────────────────────────────────────────────────┘
  Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT 
- <←→> Move focus / <n> New / <x> Close / <r> Rename / <s> Sync / <TAB> Toggle / <ENTER> Select pane                     
+ <n> New / <←→> Change focus / <x> Close / <r> Rename / <s> Sync / <TAB> Toggle / <ENTER> Select pane                   

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__scrolling_inside_a_pane.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__scrolling_inside_a_pane.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 290
+assertion_line: 305
 expression: last_snapshot
 ---
  Zellij (e2e-test)  Tab #1 
@@ -26,4 +26,4 @@ expression: last_snapshot
 │                                                          ││li█e21                                                    │
 └──────────────────────────────────────────────────────────┘└──────────────────────────────────────────────────────────┘
  Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT 
- <↓↑> Scroll / <PgDn|PgUp> Scroll / <d|u> Scroll / <e> Edit / <s> Search / <ENTER> Select                               
+ <s> Search / <↓↑> Scroll / <PgDn|PgUp> Scroll / <d|u> Scroll / <e> Edit / <ENTER> Select                               


### PR DESCRIPTION
This is an effort to finally solve the "colliding keys" problem.

This adds a new mode to the status bar, basically defaulting to "locked" mode and treating any other non-normal mode as a "sticky" mode. So that whenever a user moves from "locked" to "normal", they will be placed in said sticky mode. When the user then returns from the sticky mode to normal, they will be placed back in locked mode.

This would effectively mean that when most times, Zellij will only take up 1 keybinding (by default `Ctrl g` to enter the sticky mode).

Right now, this is behind a feature flag, but after this I plan to do work to allow plugins to be configurable and users will be able to goggle this off/on.