### PR TITLE
Added utility functions to find active pane and tab

### DIFF
--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -372,6 +372,31 @@ pub fn rename_tab<S: AsRef<str>>(tab_position: i32, new_name: S) {
     unsafe { host_rename_tab() };
 }
 
+// Utility Functions
+
+/// Returns the `TabInfo` corresponding to the currently active tab
+fn get_focused_tab(tab_infos: &Vec<TabInfo>) -> Option<TabInfo> {
+    for tab_info in tab_infos {
+        if tab_info.active {
+            return Some(tab_info.clone());
+        }
+    }
+    return None;
+}
+
+/// Returns the `PaneInfo` corresponding to the currently active pane (ignoring plugins)
+fn get_focused_pane(tab_position: usize, pane_manifest: &PaneManifest) -> Option<PaneInfo> {
+    let panes = pane_manifest.panes.get(&tab_position);
+    if let Some(panes) = panes {
+        for pane in panes {
+            if pane.is_focused & !pane.is_plugin {
+                return Some(pane.clone());
+            }
+        }
+    }
+    None
+}
+
 // Internal Functions
 
 #[doc(hidden)]


### PR DESCRIPTION
While porting harpoon to Zellij as a [plugin](https://github.com/Nacho114/harpoon), I had to know the currently active pane and tab via the `Vec<TabInfo>` and the `PaneManifest`. Since this might be a useful utility function I propose to add them in this PR. 

TL;DR

Given the `PaneManifest` and `Vec<TabInfo>`, I want to easily get the active pane and tab.