### PR TITLE
fix(terminal): properly handle resizes in alternate screen

### DIFF
--- a/zellij-server/src/output/mod.rs
+++ b/zellij-server/src/output/mod.rs
@@ -910,6 +910,12 @@ impl OutputBuffer {
         if row_width < viewport_width {
             let mut padding = vec![EMPTY_TERMINAL_CHARACTER; viewport_width - row_width];
             terminal_characters.append(&mut padding);
+        } else if row_width > viewport_width {
+            let width_offset = row.excess_width_until(viewport_width);
+            let truncate_position = viewport_width.saturating_sub(width_offset);
+            if truncate_position < terminal_characters.len() {
+                terminal_characters.truncate(truncate_position);
+            }
         }
         terminal_characters
     }

--- a/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__alternate_screen_change_size.snap
+++ b/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__alternate_screen_change_size.snap
@@ -1,16 +1,26 @@
 ---
 source: zellij-server/src/panes/./unit/grid_tests.rs
+assertion_line: 2137
 expression: "format!(\"{:?}\", grid)"
-
 ---
-00 (C): line12aaaa
-01 (C): line13aaaa
-02 (C): line14aaaa
-03 (C): line15aaaa
-04 (C): line16aaaa
-05 (C): line17aaaa
-06 (C): line18aaaa
-07 (C): line19a🦀a
-08 (C): line20a🦀
-09 (C): line21🦀🦀
+00 (C): line2aaaaaaaaaaaaaaa
+01 (C): line3aaaaaaaaaaaaaaa
+02 (C): line4aaaaaaaaaaaaaaa
+03 (C): line5aaaaaaaaaaaaaaa
+04 (C): line6aaaaaaaaaaaaaaa
+05 (C): line7aaaaaaaaaaaaaaa
+06 (C): line8aaaaaaaaaaaaaaa
+07 (C): line9aaaaaaaaaaaaaaa
+08 (C): line10aaaaaaaaaaaaaa
+09 (C): line11aaaaaaaaaaaaaa
+10 (C): line12aaaaaaaaaaaaaa
+11 (C): line13aaaaaaaaaaaaaa
+12 (C): line14aaaaaaaaaaaaaa
+13 (C): line15aaaaaaaaaaaaaa
+14 (C): line16aaaaaaaaaaaaaa
+15 (C): line17aaaaaaaaaaaaaa
+16 (C): line18aaaaaaaaaaaaaa
+17 (C): line19a🦀aaaaaaaaaaa
+18 (C): line20a🦀🦀aaaaaaaaa
+19 (C): line21🦀🦀🦀🦀🦀🦀🦀
 


### PR DESCRIPTION
This fixes some more glitches that happened while resizing. The user facing effects of this are that now when we switch focus for terminals while in full screen, their size will consistently stay the same. This also catches some bugs where we did not redraw our own state properly sometimes, causing a drift between the terminal program state and what appeared on screen.

On the technical side, this was fixed by:
1. Not doing any sort of line wrapping for alternate screen applications
2. Making the output buffer aware of the viewport width and only taking the characters it needs to render and no extras (needed to support 1).