### PR TITLE
fix(performance): plug memory leak

### DIFF
--- a/zellij-server/src/output/mod.rs
+++ b/zellij-server/src/output/mod.rs
@@ -874,7 +874,7 @@ impl OutputBuffer {
         y_offset: usize,
     ) -> Vec<CharacterChunk> {
         if self.should_update_all_lines {
-            let mut changed_chunks = Vec::with_capacity(viewport.len());
+            let mut changed_chunks = Vec::new();
             for line_index in 0..viewport_height {
                 let terminal_characters =
                     self.extract_line_from_viewport(line_index, viewport, viewport_width);
@@ -888,7 +888,7 @@ impl OutputBuffer {
             let mut line_changes = self.changed_lines.to_vec();
             line_changes.sort_unstable();
             line_changes.dedup();
-            let mut changed_chunks = Vec::with_capacity(line_changes.len());
+            let mut changed_chunks = Vec::new();
             for line_index in line_changes {
                 let terminal_characters =
                     self.extract_line_from_viewport(line_index, viewport, viewport_width);

--- a/zellij-server/src/ui/pane_boundaries_frame.rs
+++ b/zellij-server/src/ui/pane_boundaries_frame.rs
@@ -9,7 +9,7 @@ use zellij_utils::pane_size::Viewport;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 fn foreground_color(characters: &str, color: Option<PaletteColor>) -> Vec<TerminalCharacter> {
-    let mut colored_string = Vec::with_capacity(characters.chars().count());
+    let mut colored_string = Vec::new();
     for character in characters.chars() {
         let styles = match color {
             Some(palette_color) => {
@@ -36,7 +36,7 @@ fn foreground_color(characters: &str, color: Option<PaletteColor>) -> Vec<Termin
 }
 
 fn background_color(characters: &str, color: Option<PaletteColor>) -> Vec<TerminalCharacter> {
-    let mut colored_string = Vec::with_capacity(characters.chars().count());
+    let mut colored_string = Vec::new();
     for character in characters.chars() {
         let styles = match color {
             Some(palette_color) => {
@@ -367,7 +367,7 @@ impl PaneFrame {
         } else {
             let length_of_each_half = (max_length - middle_truncated_sign.width()) / 2;
 
-            let mut first_part: String = String::with_capacity(length_of_each_half);
+            let mut first_part: String = String::new();
             for char in full_text.chars() {
                 if first_part.width() + char.width().unwrap_or(0) > length_of_each_half {
                     break;
@@ -376,7 +376,7 @@ impl PaneFrame {
                 }
             }
 
-            let mut second_part: String = String::with_capacity(length_of_each_half);
+            let mut second_part: String = String::new();
             for char in full_text.chars().rev() {
                 if second_part.width() + char.width().unwrap_or(0) > length_of_each_half {
                     break;


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/1625

For some reason (which I admittedly cannot fully explain) when we pre-allocate memory for the terminal viewport, scrollback and each line therein that memory is not deallocated when its container is dropped.

Removing this pre-allocation doesn't harm performance in a noticeable way and plugs this leak. If any Rustacean reading this has ideas for why this is happening, I'd be very curious to hear them. :)