### PR TITLE
[Plugin][Worker] Refactor and clean up strucut

### DIFF
--- a/zellij-server/src/plugins/plugin_loader.rs
+++ b/zellij-server/src/plugins/plugin_loader.rs
@@ -606,8 +606,7 @@ impl<'a> PluginLoader<'a> {
                     .call(&[])
                     .with_context(err_context)?;
 
-                let worker =
-                    RunningWorker::new(instance, &function_name, plugin_config, plugin_env);
+                let worker = RunningWorker::new(instance, &function_name, plugin_env);
                 let worker_sender = plugin_worker(worker);
                 workers.insert(function_name.into(), worker_sender);
             }

--- a/zellij-server/src/plugins/plugin_worker.rs
+++ b/zellij-server/src/plugins/plugin_worker.rs
@@ -5,28 +5,20 @@ use wasmer::Instance;
 use zellij_utils::async_channel::{unbounded, Receiver, Sender};
 use zellij_utils::async_std::task;
 use zellij_utils::errors::prelude::*;
-use zellij_utils::input::plugins::PluginConfig;
 use zellij_utils::plugin_api::message::ProtobufMessage;
 use zellij_utils::prost::Message;
 
 pub struct RunningWorker {
     pub instance: Instance,
     pub name: String,
-    pub plugin_config: PluginConfig,
     pub plugin_env: PluginEnv,
 }
 
 impl RunningWorker {
-    pub fn new(
-        instance: Instance,
-        name: &str,
-        plugin_config: PluginConfig,
-        plugin_env: PluginEnv,
-    ) -> Self {
+    pub fn new(instance: Instance, name: &str, plugin_env: PluginEnv) -> Self {
         RunningWorker {
             instance,
             name: name.into(),
-            plugin_config,
             plugin_env,
         }
     }


### PR DESCRIPTION
This pr attempts to refactor the existing `RunningWorker` struct by removing the `PluginConfig` field because `PluginEvn` has already had a `PluginConfig`, and the extra config seems not to be used in the repo at all.

The other reason is - `create_plugin_instance_env_and_subscriptions` tries to mutate `PluginConfig\run` which can cause some confusion when using `RunningWorker` instance.

