### PR TITLE
fix(keybinds): add 'floating' and 'name' to the Run command keybinding

### DIFF
--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -895,10 +895,7 @@ impl TryFrom<(&KdlNode, &Options)> for Action {
                     hold_on_start,
                 };
                 if floating {
-                    Ok(Action::NewFloatingPane(
-                        Some(run_command_action),
-                        name,
-                    ))
+                    Ok(Action::NewFloatingPane(Some(run_command_action), name))
                 } else {
                     Ok(Action::NewTiledPane(
                         direction,


### PR DESCRIPTION
This fixes an oversight where it was impossible to start a floating pane or a pane with a title from a keybinding.

So now, we can do:

```kdl
keybinds {
// ...
    shared {
        Run "htop" "--tree" {
            floating true;
            name "my awesome floating pane";
        }
    }
//...
}
```