### PR TITLE
fix(plugins): make sure configuration is also part of the plugin keys

### DIFF
--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -872,6 +872,11 @@ impl FloatingPanes {
     }
     pub fn get_plugin_pane_id(&self, run_plugin: &RunPlugin) -> Option<PaneId> {
         let run = Some(Run::Plugin(run_plugin.clone()));
+        let currently_running_invoked_with: Vec<Option<Run>> = self
+            .panes
+            .iter()
+            .map(|(_, p)| p.invoked_with().clone())
+            .collect();
         self.panes
             .iter()
             .find(|(_id, s_p)| s_p.invoked_with() == &run)

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -15,7 +15,10 @@ use zellij_utils::{
     errors::{ContextType, PtyContext},
     input::{
         command::{RunCommand, TerminalAction},
-        layout::{FloatingPaneLayout, Layout, Run, RunPluginLocation, TiledPaneLayout},
+        layout::{
+            FloatingPaneLayout, Layout, PluginUserConfiguration, Run, RunPluginLocation,
+            TiledPaneLayout,
+        },
     },
 };
 
@@ -52,8 +55,8 @@ pub enum PtyInstruction {
         Option<TerminalAction>,
         Option<TiledPaneLayout>,
         Vec<FloatingPaneLayout>,
-        usize,                                // tab_index
-        HashMap<RunPluginLocation, Vec<u32>>, // plugin_ids
+        usize,                                                           // tab_index
+        HashMap<(RunPluginLocation, PluginUserConfiguration), Vec<u32>>, // plugin_ids
         ClientId,
     ), // the String is the tab name
     ClosePane(PaneId),
@@ -595,7 +598,7 @@ impl Pty {
         layout: TiledPaneLayout,
         floating_panes_layout: Vec<FloatingPaneLayout>,
         default_shell: Option<TerminalAction>,
-        plugin_ids: HashMap<RunPluginLocation, Vec<u32>>,
+        plugin_ids: HashMap<(RunPluginLocation, PluginUserConfiguration), Vec<u32>>,
         tab_index: usize,
         client_id: ClientId,
     ) -> Result<()> {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -16,8 +16,8 @@ use zellij_utils::pane_size::{Size, SizeInPixels};
 use zellij_utils::{
     input::command::TerminalAction,
     input::layout::{
-        FloatingPaneLayout, Layout, Run, RunPlugin, RunPluginLocation, SwapFloatingLayout,
-        SwapTiledLayout, TiledPaneLayout,
+        FloatingPaneLayout, Layout, PluginUserConfiguration, Run, RunPlugin, RunPluginLocation,
+        SwapFloatingLayout, SwapTiledLayout, TiledPaneLayout,
     },
     position::Position,
 };
@@ -208,7 +208,7 @@ pub enum ScreenInstruction {
         Vec<FloatingPaneLayout>,
         Vec<(u32, HoldForCommand)>, // new pane pids
         Vec<(u32, HoldForCommand)>, // new floating pane pids
-        HashMap<RunPluginLocation, Vec<u32>>,
+        HashMap<(RunPluginLocation, PluginUserConfiguration), Vec<u32>>,
         usize, // tab_index
         ClientId,
     ),
@@ -1125,7 +1125,7 @@ impl Screen {
         floating_panes_layout: Vec<FloatingPaneLayout>,
         new_terminal_ids: Vec<(u32, HoldForCommand)>,
         new_floating_terminal_ids: Vec<(u32, HoldForCommand)>,
-        new_plugin_ids: HashMap<RunPluginLocation, Vec<u32>>,
+        new_plugin_ids: HashMap<(RunPluginLocation, PluginUserConfiguration), Vec<u32>>,
         tab_index: usize,
         client_id: ClientId,
     ) -> Result<()> {

--- a/zellij-server/src/tab/layout_applier.rs
+++ b/zellij-server/src/tab/layout_applier.rs
@@ -18,7 +18,9 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::rc::Rc;
 use zellij_utils::{
     data::{Palette, Style},
-    input::layout::{FloatingPaneLayout, Run, RunPluginLocation, TiledPaneLayout},
+    input::layout::{
+        FloatingPaneLayout, PluginUserConfiguration, Run, RunPluginLocation, TiledPaneLayout,
+    },
     pane_size::{Offset, PaneGeom, Size, SizeInPixels, Viewport},
 };
 
@@ -96,7 +98,7 @@ impl<'a> LayoutApplier<'a> {
         floating_panes_layout: Vec<FloatingPaneLayout>,
         new_terminal_ids: Vec<(u32, HoldForCommand)>,
         new_floating_terminal_ids: Vec<(u32, HoldForCommand)>,
-        mut new_plugin_ids: HashMap<RunPluginLocation, Vec<u32>>,
+        mut new_plugin_ids: HashMap<(RunPluginLocation, PluginUserConfiguration), Vec<u32>>,
         client_id: ClientId,
     ) -> Result<bool> {
         // true => layout has floating panes
@@ -198,7 +200,7 @@ impl<'a> LayoutApplier<'a> {
         &mut self,
         layout: TiledPaneLayout,
         new_terminal_ids: Vec<(u32, HoldForCommand)>,
-        new_plugin_ids: &mut HashMap<RunPluginLocation, Vec<u32>>,
+        new_plugin_ids: &mut HashMap<(RunPluginLocation, PluginUserConfiguration), Vec<u32>>,
         client_id: ClientId,
     ) -> Result<()> {
         let err_context = || format!("failed to apply tiled panes layout");
@@ -230,7 +232,7 @@ impl<'a> LayoutApplier<'a> {
                     } else if let Some(Run::Plugin(run)) = layout.run.clone() {
                         let pane_title = run.location.to_string();
                         let pid = new_plugin_ids
-                            .get_mut(&run.location)
+                            .get_mut(&(run.location, run.configuration))
                             .and_then(|ids| ids.pop())
                             .with_context(err_context)?;
                         let mut new_plugin = PluginPane::new(
@@ -324,7 +326,7 @@ impl<'a> LayoutApplier<'a> {
         &mut self,
         floating_panes_layout: Vec<FloatingPaneLayout>,
         new_floating_terminal_ids: Vec<(u32, HoldForCommand)>,
-        new_plugin_ids: &mut HashMap<RunPluginLocation, Vec<u32>>,
+        new_plugin_ids: &mut HashMap<(RunPluginLocation, PluginUserConfiguration), Vec<u32>>,
         layout_name: Option<String>,
     ) -> Result<bool> {
         // true => has floating panes
@@ -346,7 +348,7 @@ impl<'a> LayoutApplier<'a> {
             } else if let Some(Run::Plugin(run)) = floating_pane_layout.run.clone() {
                 let pane_title = run.location.to_string();
                 let pid = new_plugin_ids
-                    .get_mut(&run.location)
+                    .get_mut(&(run.location, run.configuration))
                     .and_then(|ids| ids.pop())
                     .with_context(err_context)?;
                 let mut new_pane = PluginPane::new(

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -49,8 +49,8 @@ use zellij_utils::{
     input::{
         command::TerminalAction,
         layout::{
-            FloatingPaneLayout, Run, RunPlugin, RunPluginLocation, SwapFloatingLayout,
-            SwapTiledLayout, TiledPaneLayout,
+            FloatingPaneLayout, PluginUserConfiguration, Run, RunPlugin, RunPluginLocation,
+            SwapFloatingLayout, SwapTiledLayout, TiledPaneLayout,
         },
         parse_keys,
     },
@@ -621,7 +621,7 @@ impl Tab {
         floating_panes_layout: Vec<FloatingPaneLayout>,
         new_terminal_ids: Vec<(u32, HoldForCommand)>,
         new_floating_terminal_ids: Vec<(u32, HoldForCommand)>,
-        new_plugin_ids: HashMap<RunPluginLocation, Vec<u32>>,
+        new_plugin_ids: HashMap<(RunPluginLocation, PluginUserConfiguration), Vec<u32>>,
         client_id: ClientId,
     ) -> Result<()> {
         self.swap_layouts

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -20,8 +20,8 @@ use zellij_utils::data::ResizeStrategy;
 use zellij_utils::envs::set_session_name;
 use zellij_utils::errors::{prelude::*, ErrorContext};
 use zellij_utils::input::layout::{
-    FloatingPaneLayout, Layout, RunPluginLocation, SwapFloatingLayout, SwapTiledLayout,
-    TiledPaneLayout,
+    FloatingPaneLayout, Layout, PluginUserConfiguration, RunPluginLocation, SwapFloatingLayout,
+    SwapTiledLayout, TiledPaneLayout,
 };
 use zellij_utils::input::plugins::PluginTag;
 use zellij_utils::ipc::IpcReceiverWithContext;
@@ -268,7 +268,7 @@ fn create_new_tab_with_swap_layouts(
         Vec<FloatingPaneLayout>,
         Vec<(u32, Option<RunCommand>)>,
         Vec<(u32, Option<RunCommand>)>,
-        HashMap<RunPluginLocation, Vec<u32>>,
+        HashMap<(RunPluginLocation, PluginUserConfiguration), Vec<u32>>,
     )>,
     draw_pane_frames: bool,
 ) -> Tab {
@@ -4955,11 +4955,17 @@ fn layout_with_plugins_and_commands_swaped_properly() {
     let new_floating_terminal_ids = vec![];
     let mut new_plugin_ids = HashMap::new();
     new_plugin_ids.insert(
-        RunPluginLocation::Zellij(PluginTag::new("tab-bar")),
+        (
+            RunPluginLocation::Zellij(PluginTag::new("tab-bar")),
+            Default::default(),
+        ),
         vec![1],
     );
     new_plugin_ids.insert(
-        RunPluginLocation::Zellij(PluginTag::new("status-bar")),
+        (
+            RunPluginLocation::Zellij(PluginTag::new("status-bar")),
+            Default::default(),
+        ),
         vec![2],
     );
 
@@ -5050,11 +5056,17 @@ fn base_layout_is_included_in_swap_layouts() {
     let new_floating_terminal_ids = vec![];
     let mut new_plugin_ids = HashMap::new();
     new_plugin_ids.insert(
-        RunPluginLocation::Zellij(PluginTag::new("tab-bar")),
+        (
+            RunPluginLocation::Zellij(PluginTag::new("tab-bar")),
+            Default::default(),
+        ),
         vec![1],
     );
     new_plugin_ids.insert(
-        RunPluginLocation::Zellij(PluginTag::new("status-bar")),
+        (
+            RunPluginLocation::Zellij(PluginTag::new("status-bar")),
+            Default::default(),
+        ),
         vec![2],
     );
 
@@ -5142,11 +5154,17 @@ fn swap_layouts_including_command_panes_absent_from_existing_layout() {
     let new_floating_terminal_ids = vec![];
     let mut new_plugin_ids = HashMap::new();
     new_plugin_ids.insert(
-        RunPluginLocation::Zellij(PluginTag::new("tab-bar")),
+        (
+            RunPluginLocation::Zellij(PluginTag::new("tab-bar")),
+            Default::default(),
+        ),
         vec![1],
     );
     new_plugin_ids.insert(
-        RunPluginLocation::Zellij(PluginTag::new("status-bar")),
+        (
+            RunPluginLocation::Zellij(PluginTag::new("status-bar")),
+            Default::default(),
+        ),
         vec![2],
     );
 
@@ -5237,11 +5255,17 @@ fn swap_layouts_not_including_command_panes_present_in_existing_layout() {
     let new_floating_terminal_ids = vec![];
     let mut new_plugin_ids = HashMap::new();
     new_plugin_ids.insert(
-        RunPluginLocation::Zellij(PluginTag::new("tab-bar")),
+        (
+            RunPluginLocation::Zellij(PluginTag::new("tab-bar")),
+            Default::default(),
+        ),
         vec![1],
     );
     new_plugin_ids.insert(
-        RunPluginLocation::Zellij(PluginTag::new("status-bar")),
+        (
+            RunPluginLocation::Zellij(PluginTag::new("status-bar")),
+            Default::default(),
+        ),
         vec![2],
     );
 
@@ -5405,11 +5429,17 @@ fn swap_layouts_not_including_plugin_panes_present_in_existing_layout() {
     let new_floating_terminal_ids = vec![];
     let mut new_plugin_ids = HashMap::new();
     new_plugin_ids.insert(
-        RunPluginLocation::Zellij(PluginTag::new("tab-bar")),
+        (
+            RunPluginLocation::Zellij(PluginTag::new("tab-bar")),
+            Default::default(),
+        ),
         vec![1],
     );
     new_plugin_ids.insert(
-        RunPluginLocation::Zellij(PluginTag::new("status-bar")),
+        (
+            RunPluginLocation::Zellij(PluginTag::new("status-bar")),
+            Default::default(),
+        ),
         vec![2],
     );
 
@@ -5889,11 +5919,17 @@ fn floating_layout_with_plugins_and_commands_swaped_properly() {
     let new_terminal_ids = vec![(4, None)];
     let mut new_plugin_ids = HashMap::new();
     new_plugin_ids.insert(
-        RunPluginLocation::Zellij(PluginTag::new("tab-bar")),
+        (
+            RunPluginLocation::Zellij(PluginTag::new("tab-bar")),
+            Default::default(),
+        ),
         vec![1],
     );
     new_plugin_ids.insert(
-        RunPluginLocation::Zellij(PluginTag::new("status-bar")),
+        (
+            RunPluginLocation::Zellij(PluginTag::new("status-bar")),
+            Default::default(),
+        ),
         vec![2],
     );
 
@@ -5982,11 +6018,17 @@ fn base_floating_layout_is_included_in_swap_layouts() {
     let new_terminal_ids = vec![(4, None)];
     let mut new_plugin_ids = HashMap::new();
     new_plugin_ids.insert(
-        RunPluginLocation::Zellij(PluginTag::new("tab-bar")),
+        (
+            RunPluginLocation::Zellij(PluginTag::new("tab-bar")),
+            Default::default(),
+        ),
         vec![1],
     );
     new_plugin_ids.insert(
-        RunPluginLocation::Zellij(PluginTag::new("status-bar")),
+        (
+            RunPluginLocation::Zellij(PluginTag::new("status-bar")),
+            Default::default(),
+        ),
         vec![2],
     );
 
@@ -6074,11 +6116,17 @@ fn swap_floating_layouts_including_command_panes_absent_from_existing_layout() {
     let new_terminal_ids = vec![(4, None)];
     let mut new_plugin_ids = HashMap::new();
     new_plugin_ids.insert(
-        RunPluginLocation::Zellij(PluginTag::new("tab-bar")),
+        (
+            RunPluginLocation::Zellij(PluginTag::new("tab-bar")),
+            Default::default(),
+        ),
         vec![1],
     );
     new_plugin_ids.insert(
-        RunPluginLocation::Zellij(PluginTag::new("status-bar")),
+        (
+            RunPluginLocation::Zellij(PluginTag::new("status-bar")),
+            Default::default(),
+        ),
         vec![2],
     );
 
@@ -6169,11 +6217,17 @@ fn swap_floating_layouts_not_including_command_panes_present_in_existing_layout(
     let new_terminal_ids = vec![(4, None)];
     let mut new_plugin_ids = HashMap::new();
     new_plugin_ids.insert(
-        RunPluginLocation::Zellij(PluginTag::new("tab-bar")),
+        (
+            RunPluginLocation::Zellij(PluginTag::new("tab-bar")),
+            Default::default(),
+        ),
         vec![1],
     );
     new_plugin_ids.insert(
-        RunPluginLocation::Zellij(PluginTag::new("status-bar")),
+        (
+            RunPluginLocation::Zellij(PluginTag::new("status-bar")),
+            Default::default(),
+        ),
         vec![2],
     );
 
@@ -6326,11 +6380,17 @@ fn swap_floating_layouts_not_including_plugin_panes_present_in_existing_layout()
     let new_terminal_ids = vec![(4, None)];
     let mut new_plugin_ids = HashMap::new();
     new_plugin_ids.insert(
-        RunPluginLocation::Zellij(PluginTag::new("tab-bar")),
+        (
+            RunPluginLocation::Zellij(PluginTag::new("tab-bar")),
+            Default::default(),
+        ),
         vec![1],
     );
     new_plugin_ids.insert(
-        RunPluginLocation::Zellij(PluginTag::new("status-bar")),
+        (
+            RunPluginLocation::Zellij(PluginTag::new("status-bar")),
+            Default::default(),
+        ),
         vec![2],
     );
 

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -311,7 +311,10 @@ impl MockScreen {
         let mut floating_pane_ids = vec![];
         let mut plugin_ids = HashMap::new();
         plugin_ids.insert(
-            RunPluginLocation::File(PathBuf::from("/path/to/fake/plugin")),
+            (
+                RunPluginLocation::File(PathBuf::from("/path/to/fake/plugin")),
+                Default::default(),
+            ),
             vec![1],
         );
         for i in 0..pane_count {

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -207,7 +207,7 @@ impl Run {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Serialize, Deserialize, Clone, Hash, Default)]
 pub struct RunPlugin {
     #[serde(default)]
     pub _allow_exec_host_cmd: bool,
@@ -225,11 +225,29 @@ impl RunPlugin {
     }
 }
 
+impl PartialEq for RunPlugin {
+    fn eq(&self, other: &Self) -> bool {
+        // TODO: normalize paths here if the location is a file so that relative/absolute paths
+        // will work properly
+        (&self.location, &self.configuration) == (&other.location, &other.configuration)
+    }
+}
+impl Eq for RunPlugin {}
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct PluginUserConfiguration(BTreeMap<String, String>);
 
 impl PluginUserConfiguration {
-    pub fn new(configuration: BTreeMap<String, String>) -> Self {
+    pub fn new(mut configuration: BTreeMap<String, String>) -> Self {
+        // reserved words
+        configuration.remove("hold_on_close");
+        configuration.remove("hold_on_start");
+        configuration.remove("cwd");
+        configuration.remove("name");
+        configuration.remove("direction");
+        configuration.remove("floating");
+        configuration.remove("move_to_focused_tab");
+
         PluginUserConfiguration(configuration)
     }
     pub fn inner(&self) -> &BTreeMap<String, String> {

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -207,6 +207,7 @@ impl Run {
     }
 }
 
+#[allow(clippy::derive_hash_xor_eq)]
 #[derive(Debug, Serialize, Deserialize, Clone, Hash, Default)]
 pub struct RunPlugin {
     #[serde(default)]
@@ -225,6 +226,7 @@ impl RunPlugin {
     }
 }
 
+#[allow(clippy::derive_hash_xor_eq)]
 impl PartialEq for RunPlugin {
     fn eq(&self, other: &Self) -> bool {
         // TODO: normalize paths here if the location is a file so that relative/absolute paths

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
@@ -2501,10 +2501,7 @@ Config {
                             ),
                         ),
                         configuration: PluginUserConfiguration(
-                            {
-                                "floating": "true",
-                                "move_to_focused_tab": "true",
-                            },
+                            {},
                         ),
                     },
                     true,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
@@ -2501,10 +2501,7 @@ Config {
                             ),
                         ),
                         configuration: PluginUserConfiguration(
-                            {
-                                "floating": "true",
-                                "move_to_focused_tab": "true",
-                            },
+                            {},
                         ),
                     },
                     true,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_plugins_override_config_plugins.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_plugins_override_config_plugins.snap
@@ -2501,10 +2501,7 @@ Config {
                             ),
                         ),
                         configuration: PluginUserConfiguration(
-                            {
-                                "floating": "true",
-                                "move_to_focused_tab": "true",
-                            },
+                            {},
                         ),
                     },
                     true,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
@@ -2501,10 +2501,7 @@ Config {
                             ),
                         ),
                         configuration: PluginUserConfiguration(
-                            {
-                                "floating": "true",
-                                "move_to_focused_tab": "true",
-                            },
+                            {},
                         ),
                     },
                     true,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
@@ -2501,10 +2501,7 @@ Config {
                             ),
                         ),
                         configuration: PluginUserConfiguration(
-                            {
-                                "floating": "true",
-                                "move_to_focused_tab": "true",
-                            },
+                            {},
                         ),
                     },
                     true,


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/2674 and some other similar issues.

The issue was that the plugin configuration was not used as part of the plugin identification.

This PR also introduces the following reserved words that cannot be used as plugin user configuration (because they will collide with various zellij configurations): "hold_on_start", "hold_on_close", "cwd", "name", "direction", "floating", "move_to_focused_tab".
