### PR TITLE
fix(plugins): various ui fixes

### DIFF
--- a/default-plugins/session-manager/src/main.rs
+++ b/default-plugins/session-manager/src/main.rs
@@ -15,7 +15,6 @@ use session_list::SessionList;
 struct State {
     session_name: Option<String>,
     sessions: SessionList,
-    selected_index: Option<usize>,
     search_term: String,
     new_session_name: Option<String>,
     colors: Colors,
@@ -79,7 +78,7 @@ impl ZellijPlugin for State {
 
 impl State {
     fn reset_selected_index(&mut self) {
-        self.selected_index = None;
+        self.sessions.reset_selected_index();
     }
     fn handle_key(&mut self, key: Key) -> bool {
         let mut should_render = false;
@@ -186,6 +185,11 @@ impl State {
                 switch_session_with_focus(&selected_session_name, selected_tab, selected_pane);
             }
         }
+        self.reset_selected_index();
+        self.new_session_name = None;
+        self.search_term.clear();
+        self.sessions
+            .update_search_term(&self.search_term, &self.colors);
         hide_self();
     }
     fn update_session_infos(&mut self, session_infos: Vec<SessionInfo>) {

--- a/default-plugins/session-manager/src/session_list.rs
+++ b/default-plugins/session-manager/src/session_list.rs
@@ -311,6 +311,9 @@ impl SessionList {
             }
         }
     }
+    pub fn reset_selected_index(&mut self) {
+        self.selected_index.reset();
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -338,6 +341,11 @@ impl SelectedIndex {
             },
             _ => {},
         }
+    }
+    pub fn reset(&mut self) {
+        self.0 = None;
+        self.1 = None;
+        self.2 = None;
     }
 }
 

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -872,11 +872,6 @@ impl FloatingPanes {
     }
     pub fn get_plugin_pane_id(&self, run_plugin: &RunPlugin) -> Option<PaneId> {
         let run = Some(Run::Plugin(run_plugin.clone()));
-        let currently_running_invoked_with: Vec<Option<Run>> = self
-            .panes
-            .iter()
-            .map(|(_, p)| p.invoked_with().clone())
-            .collect();
         self.panes
             .iter()
             .find(|(_id, s_p)| s_p.invoked_with() == &run)

--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -674,7 +674,7 @@ impl PluginPane {
             ));
         } else {
             messages.push_str(&format!(
-                "{} {}. {} {}\n",
+                "{} {}. {} {}",
                 bold_white.paint("This plugin asks permission to:"),
                 orange.paint(
                     permissions

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -1143,6 +1143,7 @@ fn check_command_permission(
         | PluginCommand::FocusPluginPane(..)
         | PluginCommand::RenameTerminalPane(..)
         | PluginCommand::RenamePluginPane(..)
+        | PluginCommand::SwitchSession(..)
         | PluginCommand::RenameTab(..) => PermissionType::ChangeApplicationState,
         _ => return (PermissionStatus::Granted, None),
     };


### PR DESCRIPTION
This:

1. Fixes the permission request screen for plugins so that it renders properly on one-liner plugins
2. Fixes the session-manager built-in plugin so that it properly clears its own state after the user selects a session/tab/pane to switch to
3. Adds the `SwitchSession` plugin command to the permission system