### PR TITLE
should reset underline when the status is NONE

### DIFF
--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -532,10 +532,9 @@ impl Display for CharacterStyles {
                 AnsiCode::On => {
                     write!(f, "\u{1b}[4m")?;
                 },
-                AnsiCode::Reset => {
+                _ => {
                     write!(f, "\u{1b}[24m")?;
                 },
-                _ => {},
             }
         }
         if let Some(ansi_code) = self.dim {


### PR DESCRIPTION

https://github.com/zellij-org/zellij/assets/2351076/d959f9e5-f2f3-4107-9cca-3e93452322e7

I can reproduce this on the latest [main (1ccc973)](https://github.com/zellij-org/zellij/tree/1ccc973c686b5ee4e23889a6fb5144b384634566)

