### PR TITLE
fix(panes): refocus pane properly on tab change

### DIFF
--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -697,12 +697,8 @@ impl FloatingPanes {
     }
     pub fn focus_pane_if_client_not_focused(&mut self, pane_id: PaneId, client_id: ClientId) {
         match self.active_panes.get(&client_id) {
-            Some(already_focused_pane_id) => {
-                self.focus_pane(*already_focused_pane_id, client_id)
-            },
-            None => {
-                self.focus_pane(pane_id, client_id)
-            }
+            Some(already_focused_pane_id) => self.focus_pane(*already_focused_pane_id, client_id),
+            None => self.focus_pane(pane_id, client_id),
         }
     }
     pub fn defocus_pane(&mut self, pane_id: PaneId, client_id: ClientId) {

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -696,8 +696,13 @@ impl FloatingPanes {
         self.focus_pane_for_all_clients(pane_id);
     }
     pub fn focus_pane_if_client_not_focused(&mut self, pane_id: PaneId, client_id: ClientId) {
-        if self.active_panes.get(&client_id).is_none() {
-            self.focus_pane(pane_id, client_id)
+        match self.active_panes.get(&client_id) {
+            Some(already_focused_pane_id) => {
+                self.focus_pane(*already_focused_pane_id, client_id)
+            },
+            None => {
+                self.focus_pane(pane_id, client_id)
+            }
         }
     }
     pub fn defocus_pane(&mut self, pane_id: PaneId, client_id: ClientId) {

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -589,12 +589,8 @@ impl TiledPanes {
     }
     pub fn focus_pane_if_client_not_focused(&mut self, pane_id: PaneId, client_id: ClientId) {
         match self.active_panes.get(&client_id) {
-            Some(already_focused_pane_id) => {
-                self.focus_pane(*already_focused_pane_id, client_id)
-            },
-            None => {
-                self.focus_pane(pane_id, client_id)
-            }
+            Some(already_focused_pane_id) => self.focus_pane(*already_focused_pane_id, client_id),
+            None => self.focus_pane(pane_id, client_id),
         }
     }
     pub fn clear_active_panes(&mut self) {

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -588,8 +588,13 @@ impl TiledPanes {
         }
     }
     pub fn focus_pane_if_client_not_focused(&mut self, pane_id: PaneId, client_id: ClientId) {
-        if self.active_panes.get(&client_id).is_none() {
-            self.focus_pane(pane_id, client_id)
+        match self.active_panes.get(&client_id) {
+            Some(already_focused_pane_id) => {
+                self.focus_pane(*already_focused_pane_id, client_id)
+            },
+            None => {
+                self.focus_pane(pane_id, client_id)
+            }
         }
     }
     pub fn clear_active_panes(&mut self) {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1920,13 +1920,14 @@ pub(crate) fn screen_thread_main(
             ) => {
                 match client_or_tab_index {
                     ClientOrTabIndex::ClientId(client_id) => {
-                        active_tab_and_connected_client_id!(screen, client_id, |tab: &mut Tab,
-                                                            client_id: ClientId| tab .new_pane(pid,
-                                                                                               initial_pane_title,
-                                                                                               should_float,
-                                                                                               None,
-                                                                                               Some(client_id)),
-                                                                                               ?);
+                        active_tab_and_connected_client_id!(screen, client_id, |tab: &mut Tab, client_id: ClientId| {
+                            tab.new_pane(pid,
+                               initial_pane_title,
+                               should_float,
+                               None,
+                               Some(client_id)
+                           )
+                        }, ?);
                         if let Some(hold_for_command) = hold_for_command {
                             let is_first_run = true;
                             active_tab_and_connected_client_id!(

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -292,7 +292,7 @@ pub enum CliAction {
             requires("command")
         )]
         start_suspended: bool,
-        #[clap(short, long, value_parser)]
+        #[clap(long, value_parser)]
         configuration: Option<PluginUserConfiguration>,
     },
     /// Open the specified file in a new zellij pane with your default EDITOR


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/2733

This problem was happening because in certain cases, when switching focus between tabs we'd forgo some initialization steps that made sure for example that the proper pane in the stacked panes was focused.