### PR TITLE
refactor(server): remove unnecessary mut

### DIFF
--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -409,7 +409,7 @@ impl WasmBridge {
                 });
             }
         }
-        for (plugin_id, mut current_size) in self.cached_resizes_for_pending_plugins.iter_mut() {
+        for (plugin_id, current_size) in self.cached_resizes_for_pending_plugins.iter_mut() {
             if *plugin_id == pid {
                 current_size.0 = new_rows;
                 current_size.1 = new_columns;

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1732,7 +1732,7 @@ impl Screen {
             if pane_to_break_is_floating {
                 tab.show_floating_panes();
                 tab.add_floating_pane(active_pane, active_pane_id, Some(client_id))?;
-                if let Some(mut already_running_layout) = floating_panes_layout
+                if let Some(already_running_layout) = floating_panes_layout
                     .iter_mut()
                     .find(|i| i.run == active_pane_run_instruction)
                 {


### PR DESCRIPTION
Hey!

I got the following compiler warnings while building `Zellij` `0.38.0` for Arch Linux:


```
warning: variable does not need to be mutable
   --> zellij-server/src/plugins/wasm_bridge.rs:412:25
    |
412 |         for (plugin_id, mut current_size) in self.cached_resizes_for_pending_plugins.iter_mut() {
    |                         ----^^^^^^^^^^^^
    |                         |
    |                         help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` on by default

warning: variable does not need to be mutable
    --> zellij-server/src/screen.rs:1735:29
     |
1735 |                 if let Some(mut already_running_layout) = floating_panes_layout
     |                             ----^^^^^^^^^^^^^^^^^^^^^^
     |                             |
     |                             help: remove this `mut`

warning: `zellij-server` (lib) generated 2 warnings (run `cargo fix --lib -p zellij-server` to apply 2 suggestions)
   Compiling zellij v0.38.0 (/build/zellij/src/zellij-0.38.0)
    Finished release [optimized] target(s) in 7m 22s
```

This PR simply fixes these 🐻
