### PR TITLE
fix(status-bar): add break tab hints

### DIFF
--- a/default-plugins/status-bar/src/second_line.rs
+++ b/default-plugins/status-bar/src/second_line.rs
@@ -180,6 +180,11 @@ fn get_keys_and_hints(mi: &ModeInfo) -> Vec<(String, String, Vec<Key>)> {
         (s("Rename"), s("Rename"),
             action_key(&km, &[A::SwitchToMode(IM::RenameTab), A::TabNameInput(vec![0])])),
         (s("Sync"), s("Sync"), action_key(&km, &[A::ToggleActiveSyncTab, TO_NORMAL])),
+        (s("Break pane to new tab"), s("Break out"), action_key(&km, &[A::BreakPane, TO_NORMAL])),
+        (s("Break pane left/right"), s("Break"), action_key_group(&km, &[
+            &[Action::BreakPaneLeft, TO_NORMAL],
+            &[Action::BreakPaneRight, TO_NORMAL],
+        ])),
         (s("Toggle"), s("Toggle"), action_key(&km, &[A::ToggleTab])),
         (s("Select pane"), s("Select"), to_normal_key),
     ]} else if mi.mode == IM::Resize { vec![

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__mirrored_sessions-2.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__mirrored_sessions-2.snap
@@ -26,4 +26,4 @@ expression: second_runner_snapshot
 │                                                          ││                                                          │
 └──────────────────────────────────────────────────────────┘└──────────────────────────────────────────────────────────┘
  Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT 
- <n> New / <←→> Change focus / <x> Close / <r> Rename / <s> Sync / <TAB> Toggle / <ENTER> Select pane                   
+ <n> New / <←→> Move / <x> Close / <r> Rename / <s> Sync / <b> Break out / <[]> Break / <TAB> Toggle ...                


### PR DESCRIPTION
Add status bar hints in `Tab` mode for the new `BreakPane`, `BreakPaneRight` and `BreakPaneLeft` actions.