### PR TITLE
fix(reconnect): do not clear terminal state when entering alternate screen

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -340,6 +340,7 @@ pub(crate) fn start_client(opts: CliArgs) {
         let layout = layout.clone();
         let mut config_options = config_options.clone();
         let mut opts = opts.clone();
+        let mut debug = false;
 
         if let Some(reconnect_to_session) = &reconnect_to_session {
             // this is integration code to make session reconnects work with this existing,
@@ -358,6 +359,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                 opts.session = None;
                 config_options.attach_to_session = None;
             }
+            debug = true;
         }
 
         let start_client_plan = |session_name: std::string::String| {
@@ -417,6 +419,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                 attach_layout,
                 tab_position_to_focus,
                 pane_id_to_focus,
+                false,
             );
         } else {
             if let Some(session_name) = opts.session.clone() {
@@ -430,6 +433,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                     Some(layout),
                     None,
                     None,
+                    debug,
                 );
             } else {
                 if let Some(session_name) = config_options.session_name.as_ref() {
@@ -466,6 +470,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                                 attach_layout,
                                 None,
                                 None,
+                                debug,
                             );
                         },
                         _ => {
@@ -479,6 +484,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                                 Some(layout),
                                 None,
                                 None,
+                                debug,
                             );
                         },
                     }
@@ -501,6 +507,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                     Some(layout),
                     None,
                     None,
+                    debug,
                 );
             }
         }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -340,7 +340,7 @@ pub(crate) fn start_client(opts: CliArgs) {
         let layout = layout.clone();
         let mut config_options = config_options.clone();
         let mut opts = opts.clone();
-        let mut debug = false;
+        let mut is_a_reconnect = false;
 
         if let Some(reconnect_to_session) = &reconnect_to_session {
             // this is integration code to make session reconnects work with this existing,
@@ -359,7 +359,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                 opts.session = None;
                 config_options.attach_to_session = None;
             }
-            debug = true;
+            is_a_reconnect = true;
         }
 
         let start_client_plan = |session_name: std::string::String| {
@@ -419,7 +419,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                 attach_layout,
                 tab_position_to_focus,
                 pane_id_to_focus,
-                false,
+                is_a_reconnect,
             );
         } else {
             if let Some(session_name) = opts.session.clone() {
@@ -433,7 +433,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                     Some(layout),
                     None,
                     None,
-                    debug,
+                    is_a_reconnect,
                 );
             } else {
                 if let Some(session_name) = config_options.session_name.as_ref() {
@@ -470,7 +470,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                                 attach_layout,
                                 None,
                                 None,
-                                debug,
+                                is_a_reconnect,
                             );
                         },
                         _ => {
@@ -484,7 +484,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                                 Some(layout),
                                 None,
                                 None,
-                                debug,
+                                is_a_reconnect,
                             );
                         },
                     }
@@ -507,7 +507,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                     Some(layout),
                     None,
                     None,
-                    debug,
+                    is_a_reconnect,
                 );
             }
         }

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -147,7 +147,7 @@ pub fn start_client(
     layout: Option<Layout>,
     tab_position_to_focus: Option<usize>,
     pane_id_to_focus: Option<(u32, bool)>, // (pane_id, is_plugin)
-    debug: bool,
+    is_a_reconnect: bool,
 ) -> Option<ConnectToSession> {
     info!("Starting Zellij client!");
 
@@ -157,7 +157,10 @@ pub fn start_client(
     let bracketed_paste = "\u{1b}[?2004h";
     os_input.unset_raw_mode(0).unwrap();
 
-    if debug {
+    if !is_a_reconnect {
+        // we don't do this for a reconnect because our controlling terminal already has the
+        // attributes we want from it, and some terminals don't treat these atomically (looking at
+        // your Windows Terminal...)
         let _ = os_input
             .get_stdout_writer()
             .write(take_snapshot.as_bytes())
@@ -379,7 +382,7 @@ pub fn start_client(
 
     let mut stdout = os_input.get_stdout_writer();
     stdout
-        .write_all("\u{1b}[1mLoading Zellij\u{1b}[m\n\r".as_bytes())
+        .write_all("\u{1b}[1m\u{1b}[HLoading Zellij\u{1b}[m\n\r".as_bytes())
         .expect("cannot write to stdout");
     stdout.flush().expect("could not flush");
 

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -147,6 +147,7 @@ pub fn start_client(
     layout: Option<Layout>,
     tab_position_to_focus: Option<usize>,
     pane_id_to_focus: Option<(u32, bool)>, // (pane_id, is_plugin)
+    debug: bool,
 ) -> Option<ConnectToSession> {
     info!("Starting Zellij client!");
 
@@ -156,14 +157,16 @@ pub fn start_client(
     let bracketed_paste = "\u{1b}[?2004h";
     os_input.unset_raw_mode(0).unwrap();
 
-    let _ = os_input
-        .get_stdout_writer()
-        .write(take_snapshot.as_bytes())
-        .unwrap();
-    let _ = os_input
-        .get_stdout_writer()
-        .write(clear_client_terminal_attributes.as_bytes())
-        .unwrap();
+    if debug {
+        let _ = os_input
+            .get_stdout_writer()
+            .write(take_snapshot.as_bytes())
+            .unwrap();
+        let _ = os_input
+            .get_stdout_writer()
+            .write(clear_client_terminal_attributes.as_bytes())
+            .unwrap();
+    }
     envs::set_zellij("0".to_string());
     config.env.set_vars();
 
@@ -172,6 +175,7 @@ pub fn start_client(
         .unwrap_or_else(|| os_input.load_palette());
 
     let full_screen_ws = os_input.get_terminal_size_using_fd(0);
+    log::info!("full_screen_ws: {:?}", full_screen_ws);
     let client_attributes = ClientAttributes {
         size: full_screen_ws,
         style: Style {


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/2736#issuecomment-1698653454

Seems like windows terminal does not treat some of these ANSI instructions (namely I suspect `CSI ? 1049 h`) as atomic, so we make sure to only send it when starting the session.