### PR TITLE
fix(input): block input thread for newtiledpane and newfloatingpane as well

### DIFF
--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -304,6 +304,8 @@ impl InputHandler {
             | Action::ClearScreen
             | Action::NewPane(..)
             | Action::Run(_)
+            | Action::NewTiledPane(..)
+            | Action::NewFloatingPane(..)
             | Action::ToggleFloatingPanes
             | Action::TogglePaneEmbedOrFloating
             | Action::NewTab(..)

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -178,7 +178,6 @@ pub fn start_client(
         .unwrap_or_else(|| os_input.load_palette());
 
     let full_screen_ws = os_input.get_terminal_size_using_fd(0);
-    log::info!("full_screen_ws: {:?}", full_screen_ws);
     let client_attributes = ClientAttributes {
         size: full_screen_ws,
         style: Style {


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/2752

In the recent version we switched how the `Run` keybinding is handled, breaking it into specific "run tiled" and "run floating" variants, and I forgot to make these specific variants block until complete. For this reason, the toggle-full-screen instruction came to the server before the run action and so this did not work. Sorry about that!