### PR TITLE
fix(terminal): wrap lines when adding characters in alternate screen

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1331,7 +1331,7 @@ impl Grid {
         if character_width == 0 {
             return;
         }
-        if self.cursor.x + character_width > self.width && self.alternate_screen_state.is_none() {
+        if self.cursor.x + character_width > self.width {
             if self.disable_linewrap {
                 return;
             }


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/2785

This was my bad, and happened when implementing https://github.com/zellij-org/zellij/pull/2654 - most changes in that PR are desired, except the one change where we actually *should* wrap lines while typing when in alternate screen mode.

Incidentally, this was only caught a week after this release because (as far as I understand), neovim 0.9.1 does not rely on this behavior while neovim 0.9.2 (which was released while I was on vacation) does. Anyhoo - we should totally support this, so this is the fix.