### PR TITLE
Fix: fg color for gruvbox light theme

### DIFF
--- a/zellij-utils/assets/themes/gruvbox.kdl
+++ b/zellij-utils/assets/themes/gruvbox.kdl
@@ -1,6 +1,6 @@
 themes {
     gruvbox-light {
-        fg 60 56 54
+        fg 124 111 100
         bg 251 82 75
         black 40 40 40
         red 205 75 69


### PR DESCRIPTION
Linked to https://github.com/zellij-org/zellij/issues/2790, I have change the FG color for better clarity.

See screenshots.

Before : 

![image](https://github.com/zellij-org/zellij/assets/17273325/dd9b02bf-9345-4fd9-87ed-cdf3be1ef32f)

After : 

![2023-09-17-163944_1251x299_scrot](https://github.com/zellij-org/zellij/assets/17273325/cc7b328f-9a5c-4abf-9b17-704cd74e4add)
