### PR TITLE
chore: update uuid dependency to 1.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3646,9 +3646,9 @@ checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
  "getrandom 0.2.7",
  "serde",

--- a/zellij-server/Cargo.toml
+++ b/zellij-server/Cargo.toml
@@ -30,7 +30,7 @@ sysinfo = "0.22.5"
 sixel-tokenizer = "0.1.0"
 sixel-image = "0.1.0"
 arrayvec = "0.7.2"
-uuid = { version = "0.8.2", features = ["serde", "v4"] }
+uuid = { version = "1.4.1", features = ["serde", "v4"] }
 semver = "0.11.0"
 
 [dev-dependencies]

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -39,7 +39,7 @@ regex = "1.5.5"
 tempfile = "3.2.0"
 kdl = { version = "4.5.0", features = ["span"] }
 shellexpand = "3.0.0"
-uuid = { version = "0.8.2", features = ["serde", "v4"] }
+uuid = { version = "1.4.1", features = ["serde", "v4"] }
 async-channel = "1.8.0"
 include_dir = "0.7.3"
 prost = "0.11.9"


### PR DESCRIPTION
Another small PR updating a dependency. Appears to be used in an API-compatible way already, no code changes were required.