### PR TITLE
fix(plugins): address potential security issue

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -910,8 +910,15 @@ fn init_session(
 
 #[cfg(not(feature = "singlepass"))]
 fn get_store() -> Store {
+    use wasmer::{BaseTunables, Cranelift, Engine, Pages, Target};
     log::info!("Compiling plugins using Cranelift");
-    Store::new(wasmer::Cranelift::default())
+    let mut tunables = BaseTunables::for_target(&Target::default());
+    tunables.static_memory_bound = Pages(0);
+    let compiler = Cranelift::default();
+    let mut engine: Engine = compiler.into();
+    engine.set_tunables(tunables);
+    let store = Store::new(engine);
+    store
 }
 
 #[cfg(feature = "singlepass")]

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -912,13 +912,15 @@ fn init_session(
 fn get_store() -> Store {
     use wasmer::{BaseTunables, Cranelift, Engine, Pages, Target};
     log::info!("Compiling plugins using Cranelift");
+
+    // workaround for https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-ff4p-7xrq-q5r8
     let mut tunables = BaseTunables::for_target(&Target::default());
     tunables.static_memory_bound = Pages(0);
     let compiler = Cranelift::default();
     let mut engine: Engine = compiler.into();
     engine.set_tunables(tunables);
-    let store = Store::new(engine);
-    store
+
+    Store::new(engine)
 }
 
 #[cfg(feature = "singlepass")]


### PR DESCRIPTION
- the upgrade from wasmer 2.3 to 3.1 brought in a version of cranelift-codegen with a security vulnerability: https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-ff4p-7xrq-q5r8
- for the removal of doubt: we caught this issue before releasing a version, so there is no version with this vulnerability
- we intend to move away from wasmer, and so decided on this temporary mitigation which does not affect our performance rather than another lengthy breaking upgrade