### PR TITLE
fix(plugins): add zellij version to cached artifact path

### DIFF
--- a/zellij-client/src/stdin_ansi_parser.rs
+++ b/zellij-client/src/stdin_ansi_parser.rs
@@ -1,15 +1,14 @@
 use std::time::{Duration, Instant};
-use zellij_utils::consts::{VERSION, ZELLIJ_CACHE_DIR};
 
 const STARTUP_PARSE_DEADLINE_MS: u64 = 500;
 use zellij_utils::{
-    ipc::PixelDimensions, lazy_static::lazy_static, pane_size::SizeInPixels, regex::Regex,
+    consts::ZELLIJ_STDIN_CACHE_DIR, ipc::PixelDimensions, lazy_static::lazy_static,
+    pane_size::SizeInPixels, regex::Regex,
 };
 
 use serde::{Deserialize, Serialize};
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
-use std::path::PathBuf;
 use zellij_utils::anyhow::Result;
 
 #[derive(Debug)]
@@ -77,8 +76,10 @@ impl StdinAnsiParser {
         self.drain_pending_events()
     }
     pub fn read_cache(&self) -> Option<Vec<AnsiStdinInstruction>> {
-        let path = self.cache_dir_path();
-        match OpenOptions::new().read(true).open(path.as_path()) {
+        match OpenOptions::new()
+            .read(true)
+            .open(ZELLIJ_STDIN_CACHE_DIR.as_path())
+        {
             Ok(mut file) => {
                 let mut json_cache = String::new();
                 file.read_to_string(&mut json_cache).ok()?;
@@ -97,9 +98,8 @@ impl StdinAnsiParser {
         }
     }
     pub fn write_cache(&self, events: Vec<AnsiStdinInstruction>) {
-        let path = self.cache_dir_path();
         if let Ok(serialized_events) = serde_json::to_string(&events) {
-            if let Ok(mut file) = File::create(path.as_path()) {
+            if let Ok(mut file) = File::create(ZELLIJ_STDIN_CACHE_DIR.as_path()) {
                 let _ = file.write_all(serialized_events.as_bytes());
             }
         };
@@ -133,9 +133,6 @@ impl StdinAnsiParser {
         } else {
             self.raw_buffer.push(byte);
         }
-    }
-    fn cache_dir_path(&self) -> PathBuf {
-        ZELLIJ_CACHE_DIR.join(&format!("zellij-stdin-cache-v{}", VERSION))
     }
 }
 

--- a/zellij-client/src/stdin_ansi_parser.rs
+++ b/zellij-client/src/stdin_ansi_parser.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 const STARTUP_PARSE_DEADLINE_MS: u64 = 500;
 use zellij_utils::{
-    consts::ZELLIJ_STDIN_CACHE_DIR, ipc::PixelDimensions, lazy_static::lazy_static,
+    consts::ZELLIJ_STDIN_CACHE_FILE, ipc::PixelDimensions, lazy_static::lazy_static,
     pane_size::SizeInPixels, regex::Regex,
 };
 
@@ -78,7 +78,7 @@ impl StdinAnsiParser {
     pub fn read_cache(&self) -> Option<Vec<AnsiStdinInstruction>> {
         match OpenOptions::new()
             .read(true)
-            .open(ZELLIJ_STDIN_CACHE_DIR.as_path())
+            .open(ZELLIJ_STDIN_CACHE_FILE.as_path())
         {
             Ok(mut file) => {
                 let mut json_cache = String::new();
@@ -99,7 +99,7 @@ impl StdinAnsiParser {
     }
     pub fn write_cache(&self, events: Vec<AnsiStdinInstruction>) {
         if let Ok(serialized_events) = serde_json::to_string(&events) {
-            if let Ok(mut file) = File::create(ZELLIJ_STDIN_CACHE_DIR.as_path()) {
+            if let Ok(mut file) = File::create(ZELLIJ_STDIN_CACHE_FILE.as_path()) {
                 let _ = file.write_all(serialized_events.as_bytes());
             }
         };

--- a/zellij-server/src/plugins/plugin_loader.rs
+++ b/zellij-server/src/plugins/plugin_loader.rs
@@ -748,13 +748,12 @@ impl<'a> PluginLoader<'a> {
                 }
                 // The plugins blob as stored on the filesystem
                 let wasm_bytes = self.plugin.resolve_wasm_bytes(&self.plugin_dir)?;
-                let to_hash: Vec<_> = VERSION.bytes().chain(wasm_bytes.iter().cloned()).collect();
                 let hash: String = PortableHash::default()
-                    .hash256(&to_hash)
+                    .hash256(&wasm_bytes)
                     .iter()
                     .map(ToString::to_string)
                     .collect();
-                let cached_path = ZELLIJ_CACHE_DIR.join(&hash);
+                let cached_path = ZELLIJ_CACHE_DIR.join(VERSION).join(&hash);
                 self.wasm_blob_on_hd = Some((wasm_bytes.clone(), cached_path.clone()));
                 Ok((wasm_bytes, cached_path))
             },

--- a/zellij-server/src/plugins/plugin_loader.rs
+++ b/zellij-server/src/plugins/plugin_loader.rs
@@ -14,7 +14,7 @@ use std::{
 use url::Url;
 use wasmer::{AsStoreRef, Instance, Module, Store};
 use wasmer_wasi::{Pipe, WasiState};
-use zellij_utils::consts::VERSION;
+use zellij_utils::consts::ZELLIJ_PLUGIN_ARTIFACT_DIR;
 use zellij_utils::prost::Message;
 
 use crate::{
@@ -753,7 +753,7 @@ impl<'a> PluginLoader<'a> {
                     .iter()
                     .map(ToString::to_string)
                     .collect();
-                let cached_path = ZELLIJ_CACHE_DIR.join(VERSION).join(&hash);
+                let cached_path = ZELLIJ_PLUGIN_ARTIFACT_DIR.join(&hash);
                 self.wasm_blob_on_hd = Some((wasm_bytes.clone(), cached_path.clone()));
                 Ok((wasm_bytes, cached_path))
             },

--- a/zellij-server/src/plugins/plugin_loader.rs
+++ b/zellij-server/src/plugins/plugin_loader.rs
@@ -14,6 +14,7 @@ use std::{
 use url::Url;
 use wasmer::{AsStoreRef, Instance, Module, Store};
 use wasmer_wasi::{Pipe, WasiState};
+use zellij_utils::consts::VERSION;
 use zellij_utils::prost::Message;
 
 use crate::{
@@ -747,8 +748,9 @@ impl<'a> PluginLoader<'a> {
                 }
                 // The plugins blob as stored on the filesystem
                 let wasm_bytes = self.plugin.resolve_wasm_bytes(&self.plugin_dir)?;
+                let to_hash: Vec<_> = VERSION.bytes().chain(wasm_bytes.iter().cloned()).collect();
                 let hash: String = PortableHash::default()
-                    .hash256(&wasm_bytes)
+                    .hash256(&to_hash)
                     .iter()
                     .map(ToString::to_string)
                     .collect();

--- a/zellij-server/src/plugins/plugin_loader.rs
+++ b/zellij-server/src/plugins/plugin_loader.rs
@@ -522,7 +522,7 @@ impl<'a> PluginLoader<'a> {
         let (wasm_bytes, cached_path) = self.plugin_bytes_and_cache_path()?;
         let timer = std::time::Instant::now();
         let err_context = || "failed to recover cache dir";
-        let module = fs::create_dir_all(ZELLIJ_CACHE_DIR.to_owned())
+        let module = fs::create_dir_all(ZELLIJ_PLUGIN_ARTIFACT_DIR.as_path())
             .map_err(anyError::new)
             .and_then(|_| {
                 // compile module

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -40,6 +40,9 @@ lazy_static! {
         ZELLIJ_CACHE_DIR.join("permissions.kdl");
     pub static ref ZELLIJ_SESSION_INFO_CACHE_DIR: PathBuf =
         ZELLIJ_CACHE_DIR.join(VERSION).join("session_info");
+    pub static ref ZELLIJ_STDIN_CACHE_DIR: PathBuf =
+        ZELLIJ_CACHE_DIR.join(VERSION).join("stdin_cache");
+    pub static ref ZELLIJ_PLUGIN_ARTIFACT_DIR: PathBuf = ZELLIJ_CACHE_DIR.join(VERSION);
 }
 
 pub const FEATURES: &[&str] = &[

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -40,7 +40,7 @@ lazy_static! {
         ZELLIJ_CACHE_DIR.join("permissions.kdl");
     pub static ref ZELLIJ_SESSION_INFO_CACHE_DIR: PathBuf =
         ZELLIJ_CACHE_DIR.join(VERSION).join("session_info");
-    pub static ref ZELLIJ_STDIN_CACHE_DIR: PathBuf =
+    pub static ref ZELLIJ_STDIN_CACHE_FILE: PathBuf =
         ZELLIJ_CACHE_DIR.join(VERSION).join("stdin_cache");
     pub static ref ZELLIJ_PLUGIN_ARTIFACT_DIR: PathBuf = ZELLIJ_CACHE_DIR.join(VERSION);
 }


### PR DESCRIPTION
Also use the zellij version to cache compiled plugin artifacts.

This avoids breakage with the recent updates to the plugin system's dependencies, by ensuring we do not reuse artifacts that were built with a different version of wasmer, cranelift, etc.

