### PR TITLE
Fix killing of process groups

### DIFF
--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -5,7 +5,7 @@ use interprocess::local_socket::LocalSocketStream;
 use nix::{
     pty::{openpty, OpenptyResult, Winsize},
     sys::{
-        signal::{kill, Signal},
+        signal::{kill, killpg, Signal},
         termios,
     },
     unistd,
@@ -686,11 +686,11 @@ impl ServerOsApi for ServerOsInputOutput {
         Box::new((*self).clone())
     }
     fn kill(&self, pid: Pid) -> Result<()> {
-        let _ = kill(pid, Some(Signal::SIGHUP));
+        let _ = killpg(pid, Some(Signal::SIGINT));
         Ok(())
     }
     fn force_kill(&self, pid: Pid) -> Result<()> {
-        let _ = kill(pid, Some(Signal::SIGKILL));
+        let _ = killpg(pid, Some(Signal::SIGKILL));
         Ok(())
     }
     fn send_to_client(&self, client_id: ClientId, msg: ServerToClientMsg) -> Result<()> {


### PR DESCRIPTION
When running [Consul](https://www.consul.io/) in zellij, the Consul daemon is not terminated properly when killing the pane or exiting zellij entirely. This is because the consul daemon forks itself several times, and the `kill` syscall is only sent to one process instead of the entire [process group](https://en.wikipedia.org/wiki/Process_group). This means that Consul fails to restart due to the old daemon still being bound to the same port, requiring a manual `killall`.

To fix this, I've changed the `kill` function to always invoke `killpg` internally. This matches the standard job control behaviour that POSIX shells use, and ensures that processes like Consul can be terminated properly.

You can reproduce the issue as follows:
1. Install consul
2. Run zellij with the following layout file (you may need to adjust the bind IP address depending on network configuration):
    ```kdl
    layout {
        default_tab_template {
            pane size=1 borderless=true {
                plugin location="zellij:tab-bar"
            }
            children
            pane size=2 borderless=true {
                plugin location="zellij:status-bar"
            }
        }
        tab {
            pane {
                command "consul"
                args "agent" "-bind" "172.20.192.145" "-data-dir" "/tmp/foo"
            }
        }
    }
    ```
3. Press Ctrl+Q to exit zellij, or Ctrl-P, X to kill the pane
4. Consul is still running