### PR TITLE
Rename pid to terminal_id for pty 

### DIFF
--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -125,12 +125,12 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                     .spawn_terminal(terminal_action, client_or_tab_index)
                     .with_context(err_context)
                 {
-                    Ok((pid, starts_held)) => {
+                    Ok((terminal_id, starts_held)) => {
                         let hold_for_command = if starts_held { run_command } else { None };
                         pty.bus
                             .senders
                             .send_to_screen(ScreenInstruction::NewPane(
-                                PaneId::Terminal(pid),
+                                PaneId::Terminal(terminal_id),
                                 pane_title,
                                 should_float,
                                 hold_for_command,
@@ -194,12 +194,12 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                     .spawn_terminal(terminal_action, client_id_tab_index_or_pane_id)
                     .with_context(err_context)
                 {
-                    Ok((pid, starts_held)) => {
+                    Ok((terminal_id, starts_held)) => {
                         let hold_for_command = if starts_held { run_command } else { None };
                         pty.bus
                             .senders
                             .send_to_screen(ScreenInstruction::ReplacePane(
-                                PaneId::Terminal(pid),
+                                PaneId::Terminal(terminal_id),
                                 hold_for_command,
                                 pane_title,
                                 client_id_tab_index_or_pane_id,
@@ -246,11 +246,11 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                     Some(TerminalAction::OpenFile(temp_file, line_number, None)),
                     ClientTabIndexOrPaneId::ClientId(client_id),
                 ) {
-                    Ok((pid, _starts_held)) => {
+                    Ok((terminal_id, _starts_held)) => {
                         pty.bus
                             .senders
                             .send_to_screen(ScreenInstruction::OpenInPlaceEditor(
-                                PaneId::Terminal(pid),
+                                PaneId::Terminal(terminal_id),
                                 client_id,
                             ))
                             .with_context(err_context)?;
@@ -276,12 +276,12 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                     .spawn_terminal(terminal_action, ClientTabIndexOrPaneId::ClientId(client_id))
                     .with_context(err_context)
                 {
-                    Ok((pid, starts_held)) => {
+                    Ok((terminal_id, starts_held)) => {
                         let hold_for_command = if starts_held { run_command } else { None };
                         pty.bus
                             .senders
                             .send_to_screen(ScreenInstruction::VerticalSplit(
-                                PaneId::Terminal(pid),
+                                PaneId::Terminal(terminal_id),
                                 pane_title,
                                 hold_for_command,
                                 client_id,
@@ -347,12 +347,12 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                     .spawn_terminal(terminal_action, ClientTabIndexOrPaneId::ClientId(client_id))
                     .with_context(err_context)
                 {
-                    Ok((pid, starts_held)) => {
+                    Ok((terminal_id, starts_held)) => {
                         let hold_for_command = if starts_held { run_command } else { None };
                         pty.bus
                             .senders
                             .send_to_screen(ScreenInstruction::HorizontalSplit(
-                                PaneId::Terminal(pid),
+                                PaneId::Terminal(terminal_id),
                                 pane_title,
                                 hold_for_command,
                                 client_id,


### PR DESCRIPTION
The id returns from `spawn_terminal` is a unique identity for  identifying the pty master and slave FDs, thus, rename it to `terminal_id` to avoid confusion(like `pid` stands for `process id`)