### PR TITLE
Buy some flexibility for Option

### DIFF
--- a/default-plugins/compact-bar/src/line.rs
+++ b/default-plugins/compact-bar/src/line.rs
@@ -257,7 +257,7 @@ pub fn tab_line(
     capabilities: PluginCapabilities,
     hide_session_name: bool,
     mode: InputMode,
-    active_swap_layout_name: &Option<String>,
+    active_swap_layout_name: Option<&str>,
     is_swap_layout_dirty: bool,
 ) -> Vec<LinePart> {
     let mut tabs_after_active = all_tabs.split_off(active_tab_index);
@@ -320,7 +320,7 @@ pub fn tab_line(
 
 fn swap_layout_status(
     max_len: usize,
-    swap_layout_name: &Option<String>,
+    swap_layout_name: Option<&str>,
     is_swap_layout_damaged: bool,
     input_mode: InputMode,
     palette: &Palette,

--- a/default-plugins/compact-bar/src/main.rs
+++ b/default-plugins/compact-bar/src/main.rs
@@ -124,7 +124,7 @@ impl ZellijPlugin for State {
             self.mode_info.capabilities,
             self.mode_info.style.hide_session_name,
             self.mode_info.mode,
-            &active_swap_layout_name,
+            active_swap_layout_name.as_deref(),
             is_swap_layout_dirty,
         );
         let output = self

--- a/default-plugins/session-manager/src/main.rs
+++ b/default-plugins/session-manager/src/main.rs
@@ -68,7 +68,7 @@ impl ZellijPlugin for State {
             println!("{}", line.render());
         }
         render_new_session_line(
-            &self.new_session_name,
+            self.new_session_name.as_ref().map(|s| s.as_str()),
             self.sessions.is_searching,
             self.colors,
         );

--- a/default-plugins/session-manager/src/ui/components.rs
+++ b/default-plugins/session-manager/src/ui/components.rs
@@ -484,7 +484,7 @@ pub fn render_prompt(typing_session_name: bool, search_term: &str, colors: Color
     }
 }
 
-pub fn render_new_session_line(session_name: &Option<String>, is_searching: bool, colors: Colors) {
+pub fn render_new_session_line(session_name: Option<&str>, is_searching: bool, colors: Colors) {
     if is_searching {
         return;
     }

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -876,7 +876,7 @@ impl FloatingPanes {
         let run = Some(Run::Plugin(run_plugin.clone()));
         self.panes
             .iter()
-            .find(|(_id, s_p)| s_p.invoked_with() == &run)
+            .find(|(_id, s_p)| s_p.invoked_with() == run.as_ref())
             .map(|(id, _)| *id)
     }
     pub fn focus_pane_if_exists(&mut self, pane_id: PaneId, client_id: ClientId) -> Result<()> {
@@ -904,7 +904,7 @@ impl FloatingPanes {
         match self
             .panes
             .iter_mut()
-            .find(|(_, p)| p.invoked_with() == &run)
+            .find(|(_, p)| p.invoked_with() == run.as_ref())
         {
             Some((_, pane)) => {
                 pane.set_geom(geom);

--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -579,8 +579,8 @@ impl Pane for PluginPane {
             .as_ref()
             .map(|(color, _text)| *color)
     }
-    fn invoked_with(&self) -> &Option<Run> {
-        &self.invoked_with
+    fn invoked_with(&self) -> Option<&Run> {
+        self.invoked_with.as_ref()
     }
     fn set_title(&mut self, title: String) {
         self.pane_title = title;

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -715,8 +715,8 @@ impl Pane for TerminalPane {
             .as_ref()
             .map(|(color, _text)| *color)
     }
-    fn invoked_with(&self) -> &Option<Run> {
-        &self.invoked_with
+    fn invoked_with(&self) -> Option<&Run> {
+        self.invoked_with.as_ref()
     }
     fn set_title(&mut self, title: String) {
         self.pane_title = title;

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -763,7 +763,7 @@ impl TiledPanes {
         match self
             .panes
             .iter_mut()
-            .find(|(_, p)| p.invoked_with() == &run)
+            .find(|(_, p)| p.invoked_with() == run.as_ref())
         {
             Some((_, pane)) => {
                 pane.set_geom(geom);
@@ -1748,7 +1748,7 @@ impl TiledPanes {
         let run = Some(Run::Plugin(run_plugin.clone()));
         self.panes
             .iter()
-            .find(|(_id, s_p)| s_p.invoked_with() == &run)
+            .find(|(_id, s_p)| s_p.invoked_with() == run.as_ref())
             .map(|(id, _)| *id)
     }
     pub fn pane_info(&self) -> Vec<PaneInfo> {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1765,7 +1765,7 @@ impl Screen {
             let active_pane = active_tab
                 .close_pane(active_pane_id, false, Some(client_id))
                 .with_context(err_context)?;
-            let active_pane_run_instruction = active_pane.invoked_with().clone();
+            let active_pane_run_instruction = active_pane.invoked_with().cloned();
             let tab_index = self.get_new_tab_index();
             let swap_layouts = (
                 default_layout.swap_tiled_layouts.clone(),
@@ -1785,7 +1785,7 @@ impl Screen {
                 }
             } else {
                 tab.add_tiled_pane(active_pane, active_pane_id, Some(client_id))?;
-                tiled_panes_layout.ignore_run_instruction(active_pane_run_instruction.clone());
+                tiled_panes_layout.ignore_run_instruction(active_pane_run_instruction);
             }
             self.bus.senders.send_to_plugin(PluginInstruction::NewTab(
                 None,
@@ -1968,7 +1968,7 @@ impl Screen {
                         pane_id,
                         p.position_and_size(),
                         p.borderless(),
-                        p.invoked_with().clone(),
+                        p.invoked_with().cloned(),
                         p.custom_title(),
                         active_pane_id == Some(pane_id),
                         if self.serialize_pane_viewport {
@@ -1999,7 +1999,7 @@ impl Screen {
                         pane_id,
                         p.position_and_size(),
                         false, // floating panes are never borderless
-                        p.invoked_with().clone(),
+                        p.invoked_with().cloned(),
                         p.custom_title(),
                         active_pane_id == Some(pane_id),
                         if self.serialize_pane_viewport {

--- a/zellij-server/src/tab/layout_applier.rs
+++ b/zellij-server/src/tab/layout_applier.rs
@@ -134,7 +134,7 @@ impl<'a> LayoutApplier<'a> {
                 for (layout, position_and_size) in positions_in_layout {
                     // first try to find panes with contents matching the layout exactly
                     match existing_tab_state.find_and_extract_exact_match_pane(
-                        &layout.run,
+                        layout.run.as_ref(),
                         &position_and_size,
                         true,
                     ) {
@@ -159,7 +159,7 @@ impl<'a> LayoutApplier<'a> {
                 for (layout, position_and_size) in positions_left {
                     // now let's try to find panes on a best-effort basis
                     if let Some(mut pane) = existing_tab_state.find_and_extract_pane(
-                        &layout.run,
+                        layout.run.as_ref(),
                         &position_and_size,
                         layout.focus.unwrap_or(false),
                         true,
@@ -478,7 +478,7 @@ impl<'a> LayoutApplier<'a> {
                 .position_floating_pane_layout(&floating_pane_layout);
             let is_focused = floating_pane_layout.focus.unwrap_or(false);
             if let Some(mut pane) = existing_tab_state.find_and_extract_pane(
-                &floating_pane_layout.run,
+                floating_pane_layout.run.as_ref(),
                 &position_and_size,
                 is_focused,
                 false,
@@ -676,7 +676,7 @@ impl ExistingTabState {
     }
     pub fn find_and_extract_exact_match_pane(
         &mut self,
-        run: &Option<Run>,
+        run: Option<&Run>,
         position_and_size: &PaneGeom,
         default_to_closest_position: bool,
     ) -> Option<Box<dyn Pane>> {
@@ -692,7 +692,7 @@ impl ExistingTabState {
     }
     pub fn find_and_extract_pane(
         &mut self,
-        run: &Option<Run>,
+        run: Option<&Run>,
         position_and_size: &PaneGeom,
         is_focused: bool,
         default_to_closest_position: bool,
@@ -730,7 +730,7 @@ impl ExistingTabState {
     }
     fn pane_candidates(
         &self,
-        run: &Option<Run>,
+        run: Option<&Run>,
         position_and_size: &PaneGeom,
         default_to_closest_position: bool,
     ) -> Vec<(&PaneId, &Box<dyn Pane>)> {
@@ -787,7 +787,7 @@ impl ExistingTabState {
     fn find_pane_id_with_same_contents(
         &self,
         candidates: &Vec<(&PaneId, &Box<dyn Pane>)>,
-        run: &Option<Run>,
+        run: Option<&Run>,
     ) -> Option<PaneId> {
         candidates
             .iter()
@@ -798,7 +798,7 @@ impl ExistingTabState {
     fn find_pane_id_with_same_contents_and_location(
         &self,
         candidates: &Vec<(&PaneId, &Box<dyn Pane>)>,
-        run: &Option<Run>,
+        run: Option<&Run>,
         position: &PaneGeom,
     ) -> Option<PaneId> {
         candidates

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -454,7 +454,7 @@ pub trait Pane {
     fn add_red_pane_frame_color_override(&mut self, _error_text: Option<String>);
     fn clear_pane_frame_color_override(&mut self);
     fn frame_color_override(&self) -> Option<PaletteColor>;
-    fn invoked_with(&self) -> &Option<Run>;
+    fn invoked_with(&self) -> Option<&Run>;
     fn set_title(&mut self, title: String);
     fn update_loading_indication(&mut self, _loading_indication: LoadingIndication) {} // only relevant for plugins
     fn start_loading_indication(&mut self, _loading_indication: LoadingIndication) {} // only relevant for plugins
@@ -3536,7 +3536,7 @@ impl Tab {
                 let run = Some(Run::Plugin(run_plugin.clone()));
                 self.suppressed_panes
                     .iter()
-                    .find(|(_id, s_p)| s_p.1.invoked_with() == &run)
+                    .find(|(_id, s_p)| s_p.1.invoked_with() == run.as_ref())
                     .map(|(id, _)| *id)
             })
     }

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -192,7 +192,7 @@ impl Run {
             }
         }
     }
-    pub fn is_same_category(first: &Option<Run>, second: &Option<Run>) -> bool {
+    pub fn is_same_category(first: Option<&Run>, second: Option<&Run>) -> bool {
         match (first, second) {
             (Some(Run::Plugin(..)), Some(Run::Plugin(..))) => true,
             (Some(Run::Command(..)), Some(Run::Command(..))) => true,
@@ -201,7 +201,7 @@ impl Run {
             _ => false,
         }
     }
-    pub fn is_terminal(run: &Option<Run>) -> bool {
+    pub fn is_terminal(run: Option<&Run>) -> bool {
         match run {
             Some(Run::Command(..)) | Some(Run::EditFile(..)) | Some(Run::Cwd(..)) | None => true,
             _ => false,


### PR DESCRIPTION
Minor change to use Option<& T>:

1: Flexibility: We can pass None or a reference to a T without having to reference an existing Option<T> value.
2: More Expressive Semantics: Using Option<&T> makes it clear that the function may or may not use a reference to T.

