### PR TITLE
fix(resurrection): log failure instead of crashing in some edge cases

### DIFF
--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -535,23 +535,37 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
             PtyInstruction::DumpLayout(mut session_layout_metadata, client_id) => {
                 let err_context = || format!("Failed to dump layout");
                 pty.populate_session_layout_metadata(&mut session_layout_metadata);
-                let (kdl_layout, _pane_contents) =
-                    session_serialization::serialize_session_layout(session_layout_metadata.into());
-                pty.bus
-                    .senders
-                    .send_to_server(ServerInstruction::Log(vec![kdl_layout], client_id))
-                    .with_context(err_context)
-                    .non_fatal();
+                match session_serialization::serialize_session_layout(session_layout_metadata.into()) {
+                    Ok((kdl_layout, _pane_contents)) => {
+                        pty.bus
+                            .senders
+                            .send_to_server(ServerInstruction::Log(vec![kdl_layout], client_id))
+                            .with_context(err_context)
+                            .non_fatal();
+                    },
+                    Err(e) => {
+                        pty.bus
+                            .senders
+                            .send_to_server(ServerInstruction::Log(vec![e.to_owned()], client_id))
+                            .with_context(err_context)
+                            .non_fatal();
+                    }
+                }
             },
             PtyInstruction::LogLayoutToHd(mut session_layout_metadata) => {
                 let err_context = || format!("Failed to dump layout");
                 pty.populate_session_layout_metadata(&mut session_layout_metadata);
-                let kdl_layout =
-                    session_serialization::serialize_session_layout(session_layout_metadata.into());
-                pty.bus
-                    .senders
-                    .send_to_background_jobs(BackgroundJob::ReportLayoutInfo(kdl_layout))
-                    .with_context(err_context)?;
+                match session_serialization::serialize_session_layout(session_layout_metadata.into()) {
+                    Ok(kdl_layout_and_pane_contents) => {
+                        pty.bus
+                            .senders
+                            .send_to_background_jobs(BackgroundJob::ReportLayoutInfo(kdl_layout_and_pane_contents))
+                            .with_context(err_context)?;
+                    },
+                    Err(e) => {
+                        log::error!("Failed to log layout to HD: {}", e);
+                    }
+                }
             },
             PtyInstruction::Exit => break,
         }

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -535,7 +535,9 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
             PtyInstruction::DumpLayout(mut session_layout_metadata, client_id) => {
                 let err_context = || format!("Failed to dump layout");
                 pty.populate_session_layout_metadata(&mut session_layout_metadata);
-                match session_serialization::serialize_session_layout(session_layout_metadata.into()) {
+                match session_serialization::serialize_session_layout(
+                    session_layout_metadata.into(),
+                ) {
                     Ok((kdl_layout, _pane_contents)) => {
                         pty.bus
                             .senders
@@ -549,22 +551,26 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                             .send_to_server(ServerInstruction::Log(vec![e.to_owned()], client_id))
                             .with_context(err_context)
                             .non_fatal();
-                    }
+                    },
                 }
             },
             PtyInstruction::LogLayoutToHd(mut session_layout_metadata) => {
                 let err_context = || format!("Failed to dump layout");
                 pty.populate_session_layout_metadata(&mut session_layout_metadata);
-                match session_serialization::serialize_session_layout(session_layout_metadata.into()) {
+                match session_serialization::serialize_session_layout(
+                    session_layout_metadata.into(),
+                ) {
                     Ok(kdl_layout_and_pane_contents) => {
                         pty.bus
                             .senders
-                            .send_to_background_jobs(BackgroundJob::ReportLayoutInfo(kdl_layout_and_pane_contents))
+                            .send_to_background_jobs(BackgroundJob::ReportLayoutInfo(
+                                kdl_layout_and_pane_contents,
+                            ))
                             .with_context(err_context)?;
                     },
                     Err(e) => {
                         log::error!("Failed to log layout to HD: {}", e);
-                    }
+                    },
                 }
             },
             PtyInstruction::Exit => break,

--- a/zellij-utils/src/session_serialization.rs
+++ b/zellij-utils/src/session_serialization.rs
@@ -108,12 +108,12 @@ fn stringify_tab(
     match get_tiled_panes_layout_from_panegeoms(tiled_panes, None) {
         Some(tiled_panes_layout) => {
             let floating_panes_layout = get_floating_panes_layout_from_panegeoms(floating_panes);
-            let tiled_panes = if &tiled_panes_layout.children_split_direction != &SplitDirection::default()
-            {
-                vec![tiled_panes_layout]
-            } else {
-                tiled_panes_layout.children
-            };
+            let tiled_panes =
+                if &tiled_panes_layout.children_split_direction != &SplitDirection::default() {
+                    vec![tiled_panes_layout]
+                } else {
+                    tiled_panes_layout.children
+                };
             let mut tab_attributes = vec![format!("name=\"{}\"", tab_name,)];
             if is_focused {
                 tab_attributes.push(format!("focus=true"));
@@ -132,7 +132,7 @@ fn stringify_tab(
         },
         None => {
             return None;
-        }
+        },
     }
 }
 
@@ -535,7 +535,7 @@ fn stringify_multiple_tabs(
             },
             None => {
                 return Err("Failed to stringify tab");
-            }
+            },
         }
     }
     Ok(())
@@ -610,7 +610,12 @@ fn get_tiled_panes_layout_from_panegeoms(
 ) -> Option<TiledPaneLayout> {
     let (children_split_direction, splits) = match get_splits(&geoms) {
         Some(x) => x,
-        None => return Some(tiled_pane_layout_from_manifest(geoms.iter().next(), split_size))
+        None => {
+            return Some(tiled_pane_layout_from_manifest(
+                geoms.iter().next(),
+                split_size,
+            ))
+        },
     };
     let mut children = Vec::new();
     let mut remaining_geoms = geoms.clone();
@@ -636,7 +641,7 @@ fn get_tiled_panes_layout_from_panegeoms(
             },
             None => {
                 return None;
-            }
+            },
         }
     }
     let new_split_sizes = get_split_sizes(&new_constraints);
@@ -647,7 +652,7 @@ fn get_tiled_panes_layout_from_panegeoms(
             },
             None => {
                 return None;
-            }
+            },
         }
     }
     let children_are_stacked = children_split_direction == SplitDirection::Horizontal
@@ -839,7 +844,7 @@ fn get_domain_col_constraint(
             },
             None => {
                 return None;
-            }
+            },
         }
     }
     if percent == 0.0 {
@@ -868,7 +873,7 @@ fn get_domain_row_constraint(
             },
             None => {
                 return None;
-            }
+            },
         }
     }
     if percent == 0.0 {


### PR DESCRIPTION
In certain edge cases we are not able to properly construct a layout from the current session state. In these cases we should log the failure instead of crashing the app. This is what this change does.