### PR TITLE
fix(cli): session names only for attach in fish completion

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -206,14 +206,14 @@ pub(crate) fn send_action_to_session(
                         "Session '{}' not found. The following sessions are active:",
                         session_name
                     );
-                    list_sessions(false);
+                    list_sessions(false, false);
                     std::process::exit(1);
                 }
             } else if let Ok(session_name) = envs::get_session_name() {
                 attach_with_cli_client(cli_action, &session_name, config);
             } else {
                 eprintln!("Please specify the session name to send actions to. The following sessions are active:");
-                list_sessions(false);
+                list_sessions(false, false);
                 std::process::exit(1);
             }
         },
@@ -355,6 +355,7 @@ fn attach_with_session_name(
                         .map(|s| (s.clone(), Duration::default(), false))
                         .collect(),
                     false,
+                    false,
                 );
                 process::exit(1);
             },
@@ -372,7 +373,7 @@ fn attach_with_session_name(
             ActiveSession::One(session_name) => ClientInfo::Attach(session_name, config_options),
             ActiveSession::Many => {
                 println!("Please specify the session to attach to, either by using the full name or a unique prefix.\nThe following sessions are active:");
-                list_sessions(false);
+                list_sessions(false, false);
                 process::exit(1);
             },
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,11 @@ fn main() {
         }
     }
 
-    if let Some(Command::Sessions(Sessions::ListSessions { no_formatting, short })) = opts.command {
+    if let Some(Command::Sessions(Sessions::ListSessions {
+        no_formatting,
+        short,
+    })) = opts.command
+    {
         commands::list_sessions(no_formatting, short);
     } else if let Some(Command::Sessions(Sessions::KillAllSessions { yes })) = opts.command {
         commands::kill_all_sessions(yes);

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,8 +87,8 @@ fn main() {
         }
     }
 
-    if let Some(Command::Sessions(Sessions::ListSessions { no_formatting })) = opts.command {
-        commands::list_sessions(no_formatting);
+    if let Some(Command::Sessions(Sessions::ListSessions { no_formatting, short })) = opts.command {
+        commands::list_sessions(no_formatting, short);
     } else if let Some(Command::Sessions(Sessions::KillAllSessions { yes })) = opts.command {
         commands::kill_all_sessions(yes);
     } else if let Some(Command::Sessions(Sessions::KillSession { ref target_session })) =

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -146,7 +146,11 @@ fn assert_socket(name: &str) -> bool {
     }
 }
 
-pub(crate) fn print_sessions(mut sessions: Vec<(String, Duration, bool)>, no_formatting: bool, short: bool) {
+pub(crate) fn print_sessions(
+    mut sessions: Vec<(String, Duration, bool)>,
+    no_formatting: bool,
+    short: bool,
+) {
     // (session_name, timestamp, is_dead)
     let curr_session = envs::get_session_name().unwrap_or_else(|_| "".into());
     sessions.sort_by(|a, b| a.1.cmp(&b.1));

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -146,13 +146,17 @@ fn assert_socket(name: &str) -> bool {
     }
 }
 
-pub(crate) fn print_sessions(mut sessions: Vec<(String, Duration, bool)>, no_formatting: bool) {
+pub(crate) fn print_sessions(mut sessions: Vec<(String, Duration, bool)>, no_formatting: bool, short: bool) {
     // (session_name, timestamp, is_dead)
     let curr_session = envs::get_session_name().unwrap_or_else(|_| "".into());
     sessions.sort_by(|a, b| a.1.cmp(&b.1));
     sessions
         .iter()
         .for_each(|(session_name, timestamp, is_dead)| {
+            if short {
+                println!("{}", session_name);
+                return;
+            }
             if no_formatting {
                 let suffix = if curr_session == *session_name {
                     format!("(current)")
@@ -245,7 +249,7 @@ pub(crate) fn delete_session(name: &str, force: bool) {
     }
 }
 
-pub(crate) fn list_sessions(no_formatting: bool) {
+pub(crate) fn list_sessions(no_formatting: bool, short: bool) {
     let exit_code = match get_sessions() {
         Ok(running_sessions) => {
             let resurrectable_sessions = get_resurrectable_sessions();
@@ -268,6 +272,7 @@ pub(crate) fn list_sessions(no_formatting: bool) {
                         })
                         .collect(),
                     no_formatting,
+                    short,
                 );
                 0
             }

--- a/zellij-utils/assets/completions/comp.fish
+++ b/zellij-utils/assets/completions/comp.fish
@@ -1,5 +1,5 @@
 function __fish_complete_sessions
-    zellij list-sessions 2>/dev/null
+    zellij list-sessions --short --no-formatting 2>/dev/null
 end
 complete -c zellij -n "__fish_seen_subcommand_from attach" -f -a "(__fish_complete_sessions)" -d "Session"
 complete -c zellij -n "__fish_seen_subcommand_from a" -f -a "(__fish_complete_sessions)" -d "Session"

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -102,6 +102,10 @@ pub enum Sessions {
         /// Do not add colors and formatting to the list (useful for parsing)
         #[clap(short, long, value_parser, takes_value(false), default_value("false"))]
         no_formatting: bool,
+
+        /// Print just the session name
+        #[clap(short, long, value_parser, takes_value(false), default_value("false"))]
+        short: bool,
     },
 
     /// Attach to a session


### PR DESCRIPTION
This pull request addresses https://github.com/zellij-org/zellij/issues/2852 . It implements a `--short` flag for `zellij ls`, that is then used in the fish autocompletion for completing session names without formatting and other information.

<img width="1059" alt="275173975-cd5f1e5c-ffa1-4465-9f7e-c427fc3da5a2" src="https://github.com/zellij-org/zellij/assets/4348959/d79732b7-9e26-41ea-a4f4-5aa33c00bd37">

<img width="770" alt="Screenshot 2023-10-14 at 23 13 20" src="https://github.com/zellij-org/zellij/assets/4348959/403fdeda-e25d-4eb1-a9fd-49a9a4a0facb">

