### PR TITLE
feat: support download plugins from the web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,6 +1619,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb28741c9db9a713d93deb3bb9515c20788cef5815265bee4980e87bde7e0f25"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+]
+
+[[package]]
 name = "inotify"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,6 +2233,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "object"
 version = "0.28.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2573,6 +2592,12 @@ dependencies = [
  "wepoll-ffi",
  "winapi",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
 
 [[package]]
 name = "ppv-lite86"
@@ -5129,6 +5154,7 @@ dependencies = [
  "futures",
  "humantime",
  "include_dir",
+ "indicatif",
  "insta",
  "interprocess",
  "kdl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,7 +444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d20de3739b4fb45a17837824f40aa1769cc7655d7a83e68739a77fe7b30c87a"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
  "indexmap",
@@ -561,6 +567,16 @@ name = "const_fn"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -910,7 +926,7 @@ version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "add9a102807b524ec050363f09e06f1504214b0e1c7797f64261c891022dce8b"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "lazy_static",
  "proc-macro-error",
@@ -941,6 +957,15 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if 1.0.0",
+]
 
 [[package]]
 name = "enum-iterator"
@@ -1110,6 +1135,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,25 +1169,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.21"
+name = "futures"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-lite"
@@ -1162,6 +1229,47 @@ dependencies = [
  "parking",
  "pin-project-lite",
  "waker-fn",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1289,6 +1397,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1346,10 +1473,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3461b968f695ca312b968503261f5a345de0f02a39dbaa3021f20d53b426395d"
 
 [[package]]
+name = "http"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
 
 [[package]]
 name = "id-arena"
@@ -1426,7 +1624,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "inotify-sys",
  "libc",
 ]
@@ -1511,6 +1709,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,7 +1783,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
 ]
 
@@ -1797,6 +2001,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1867,12 +2077,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nix"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cc",
  "cfg-if 1.0.0",
  "libc",
@@ -1885,7 +2113,7 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "libc",
  "memoffset",
@@ -1917,7 +2145,7 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d9ba6c734de18ca27c8cef5cd7058aa4ac9f63596131e4c7e41e579319032a2"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -2019,12 +2247,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "openssl-sys"
-version = "0.9.74"
+name = "openssl"
+version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835363342df5fba8354c5b453325b110ffd54044e588c539cf2f20a8014e4cb1"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
 dependencies = [
- "autocfg",
+ "bitflags 2.4.0",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+dependencies = [
  "cc",
  "libc",
  "pkg-config",
@@ -2460,7 +2719,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "memchr",
  "unicase",
 ]
@@ -2585,7 +2844,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2634,7 +2893,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76e189c2369884dce920945e2ddf79b3dff49e071a167dd1817fa9c4c00d512e"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "mach",
  "winapi",
@@ -2656,6 +2915,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79af64b4b6362ffba04eef3a4e10829718a4896dac19daa741851c86781edf95"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+dependencies = [
+ "base64 0.21.0",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "winreg",
 ]
 
 [[package]]
@@ -2736,7 +3035,7 @@ version = "0.37.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -2760,6 +3059,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2770,6 +3078,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2857,6 +3188,18 @@ version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
  "itoa",
  "ryu",
  "serde",
@@ -3026,9 +3369,9 @@ checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -3049,7 +3392,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "269343e64430067a14937ae0e3c4ec604c178fb896dde0964b1acd22b3e2eeb1"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "libssh2-sys",
  "parking_lot 0.11.2",
@@ -3260,6 +3603,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tab-bar"
 version = "0.1.0"
 dependencies = [
@@ -3339,7 +3703,7 @@ checksum = "9509a978a10fcbace4991deae486ae10885e0f4c2c465123e08c9714a90648fa"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
- "bitflags",
+ "bitflags 1.3.2",
  "filedescriptor",
  "finl_unicode",
  "fixedbitset",
@@ -3495,6 +3859,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7c4ceeeca15c8384bbc3e011dbd8fccb7f068a440b752b7d9b32ceb0ca0e2e8"
 
 [[package]]
+name = "tokio"
+version = "1.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "mio 0.8.6",
+ "num_cpus",
+ "parking_lot 0.12.1",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3502,6 +3920,12 @@ checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -3535,6 +3959,12 @@ checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typemap-ors"
@@ -3755,6 +4185,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3868,6 +4307,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31f0c17267a5ffd6ae3d897589460e21db1673c84fb7016b909c9691369a75ea"
 dependencies = [
  "leb128",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -4133,7 +4585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "968747f1271f74aab9b70d9c5d4921db9bd13b4ec3ba5506506e6e7dc58c918c"
 dependencies = [
  "async-trait",
- "bitflags",
+ "bitflags 1.3.2",
  "wasmer-wit-bindgen-rust-impl",
 ]
 
@@ -4515,6 +4967,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "xflags"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4664,6 +5126,7 @@ dependencies = [
  "crossbeam",
  "directories",
  "expect-test",
+ "futures",
  "humantime",
  "include_dir",
  "insta",
@@ -4681,6 +5144,7 @@ dependencies = [
  "prost",
  "prost-build",
  "regex",
+ "reqwest",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -4692,6 +5156,7 @@ dependencies = [
  "tempfile",
  "termwiz",
  "thiserror",
+ "tokio",
  "unicode-width",
  "url",
  "uuid",

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -57,6 +57,7 @@ humantime = "2.1.0"
 reqwest = { version = "0.11.22", features = ["stream"] }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3.28"
+indicatif = "0.17.7"
 
 [dev-dependencies]
 insta = { version = "1.6.0", features = ["backtrace"] }

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -54,6 +54,9 @@ interprocess = "1.2.1"
 async-std = { version = "1.3.0", features = ["unstable"] }
 notify-debouncer-full = "0.1.0"
 humantime = "2.1.0"
+reqwest = { version = "0.11.22", features = ["stream"] }
+tokio = { version = "1", features = ["full"] }
+futures = "0.3.28"
 
 [dev-dependencies]
 insta = { version = "1.6.0", features = ["backtrace"] }

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -44,6 +44,7 @@ async-channel = "1.8.0"
 include_dir = "0.7.3"
 prost = "0.11.9"
 common-path = "1.0.0"
+reqwest = { version = "0.11.22", features = ["stream"] }
 
 #[cfg(not(target_family = "wasm"))]
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
@@ -54,7 +55,6 @@ interprocess = "1.2.1"
 async-std = { version = "1.3.0", features = ["unstable"] }
 notify-debouncer-full = "0.1.0"
 humantime = "2.1.0"
-reqwest = { version = "0.11.22", features = ["stream"] }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3.28"
 indicatif = "0.17.7"

--- a/zellij-utils/src/downloader/download.rs
+++ b/zellij-utils/src/downloader/download.rs
@@ -1,6 +1,7 @@
 use reqwest::Url;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
 pub struct Download {
     pub url: String,
     pub file_name: String,

--- a/zellij-utils/src/downloader/download.rs
+++ b/zellij-utils/src/downloader/download.rs
@@ -1,0 +1,48 @@
+use reqwest::Url;
+
+#[derive(Debug, Default)]
+pub struct Download {
+    pub url: String,
+    pub file_name: String,
+}
+
+impl Download {
+    pub fn from<S: Into<String> + AsRef<str>>(url: S) -> Self {
+        match Url::parse(url.as_ref()) {
+            Ok(u) => u
+                .path_segments()
+                .map_or_else(Download::default, |segments| {
+                    let file_name = segments.last().unwrap_or("");
+
+                    Download {
+                        url: url.into(),
+                        file_name: file_name.into(),
+                    }
+                }),
+            Err(_) => Download::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_download() {
+        let download = Download::from("https://github.com/example/plugin.wasm");
+        assert_eq!(download.url, "https://github.com/example/plugin.wasm");
+        assert_eq!(download.file_name, "plugin.wasm");
+    }
+
+    #[test]
+    fn test_empty_download() {
+        let d1 = Download::from("https://example.com");
+        assert_eq!(d1.url, "https://example.com");
+        assert_eq!(d1.file_name, "");
+
+        let d2 = Download::from("github.com");
+        assert_eq!(d2.url, "");
+        assert_eq!(d2.file_name, "");
+    }
+}

--- a/zellij-utils/src/downloader/downloader.rs
+++ b/zellij-utils/src/downloader/downloader.rs
@@ -1,0 +1,115 @@
+use futures::{stream, StreamExt, TryStreamExt};
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use reqwest::Client;
+use std::path::PathBuf;
+use tokio::{fs::File, io::AsyncWriteExt};
+
+use crate::consts::ZELLIJ_CACHE_DIR;
+
+use super::{download::Download, DownloaderError};
+
+pub struct Downloader {
+    client: Client,
+    directory: PathBuf,
+    concurrent: usize,
+}
+
+impl Downloader {
+    const DEFAULT_CONCURRENT: usize = 4;
+
+    pub fn new() -> Self {
+        Self {
+            client: Client::new(),
+            directory: ZELLIJ_CACHE_DIR.to_path_buf(),
+            concurrent: Downloader::DEFAULT_CONCURRENT,
+        }
+    }
+
+    pub fn set_directory(&mut self, directory: PathBuf) {
+        self.directory = directory;
+    }
+
+    pub fn download(&self, downloads: &[Download]) -> Vec<Result<(), DownloaderError>> {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let progress = MultiProgress::new();
+
+            stream::iter(downloads)
+                .map(|d| self.fetch(d, &progress))
+                .buffer_unordered(self.concurrent)
+                .collect::<Vec<_>>()
+                .await
+        })
+    }
+
+    async fn fetch(
+        &self,
+        download: &Download,
+        progress: &MultiProgress,
+    ) -> Result<(), DownloaderError> {
+        let mut output_file_size: u64 = 0;
+        // TODO: A unique path using url-based hash is required.
+        let output_path = self.directory.join(&download.file_name);
+
+        if output_path.exists() {
+            output_file_size = match output_path.metadata() {
+                Ok(metadata) => metadata.len(),
+                Err(e) => return Err(DownloaderError::Metadata(e, output_path)),
+            }
+        }
+
+        let url = download.url.as_str();
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| DownloaderError::Request(e, download.url.clone()))?;
+
+        match response.error_for_status_ref() {
+            Ok(_) => {},
+            Err(e) => return Err(DownloaderError::Request(e, download.url.clone())),
+        }
+
+        let length = response.content_length().unwrap();
+
+        if length > 0 && length == output_file_size {
+            return Ok(());
+        }
+
+        let mut output_file = File::create(output_path.as_path())
+            .await
+            .map_err(|e| DownloaderError::Io(e, output_path.clone()))?;
+
+        let pb = progress.add(ProgressBar::new(length));
+        pb.set_style(
+            ProgressStyle::with_template(
+                "[{elapsed_precise}] {bar:40.cyan/blue} {pos:>7}/{len:7} {msg}",
+            )
+            .unwrap()
+            .progress_chars("##-"),
+        );
+
+        pb.set_message(format!("'{}' downloading...", download.file_name));
+
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream
+            .try_next()
+            .await
+            .map_err(|e| DownloaderError::Request(e, download.url.clone()))?
+        {
+            let chunk_size = chunk.len() as u64;
+
+            output_file
+                .write_all(&chunk)
+                .await
+                .map_err(|e| DownloaderError::Io(e, output_path.clone()))?;
+
+            pb.inc(chunk_size);
+        }
+
+        pb.finish_and_clear();
+
+        Ok(())
+    }
+}

--- a/zellij-utils/src/downloader/mod.rs
+++ b/zellij-utils/src/downloader/mod.rs
@@ -1,15 +1,10 @@
-mod download;
+pub mod download;
 
-use futures::{stream, StreamExt, TryStreamExt};
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use reqwest::Client;
+#[cfg(not(target_family = "wasm"))]
+pub mod downloader;
+
 use std::path::PathBuf;
 use thiserror::Error;
-use tokio::{fs::File, io::AsyncWriteExt};
-
-use crate::consts::ZELLIJ_CACHE_DIR;
-
-use self::download::Download;
 
 #[derive(Error, Debug)]
 pub enum DownloaderError {
@@ -19,107 +14,4 @@ pub enum DownloaderError {
     Metadata(std::io::Error, PathBuf),
     #[error("Io error: {0}, File: {1}")]
     Io(std::io::Error, PathBuf),
-}
-
-pub struct Downloader {
-    client: Client,
-    directory: PathBuf,
-    concurrent: usize,
-}
-
-impl Downloader {
-    const DEFAULT_CONCURRENT: usize = 4;
-    const DEFAULT_PROGRESS_STYLE: ProgressStyle = ProgressStyle::with_template(
-        "[{elapsed_precise}] {bar:40.cyan/blue} {pos:>7}/{len:7} {msg}",
-    )
-    .unwrap()
-    .progress_chars("##-");
-
-    pub fn new() -> Self {
-        Self {
-            client: Client::new(),
-            directory: ZELLIJ_CACHE_DIR.to_path_buf(),
-            concurrent: Downloader::DEFAULT_CONCURRENT,
-        }
-    }
-
-    pub fn set_directory(&mut self, directory: PathBuf) {
-        self.directory = directory;
-    }
-
-    pub fn download(&self, downloads: &[Download]) -> Vec<Result<(), DownloaderError>> {
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async {
-            let progress = MultiProgress::new();
-
-            stream::iter(downloads)
-                .map(|d| self.fetch(d, &progress))
-                .buffer_unordered(4)
-                .collect::<Vec<_>>()
-                .await
-        })
-    }
-
-    async fn fetch(
-        &self,
-        download: &Download,
-        progress: &MultiProgress,
-    ) -> Result<(), DownloaderError> {
-        let mut output_file_size: u64 = 0;
-        // TODO: A unique path using url-based hash is required.
-        let output_path = self.directory.join(&download.file_name);
-
-        if output_path.exists() {
-            output_file_size = match output_path.metadata() {
-                Ok(metadata) => metadata.len(),
-                Err(e) => return Err(DownloaderError::Metadata(e, output_path)),
-            }
-        }
-
-        let url = download.url.as_str();
-        let response = self
-            .client
-            .get(url)
-            .send()
-            .await
-            .map_err(|e| DownloaderError::Request(e, download.url.clone()))?;
-
-        match response.error_for_status_ref() {
-            Ok(_) => {},
-            Err(e) => return Err(DownloaderError::Request(e, download.url.clone())),
-        }
-
-        let length = response.content_length().unwrap();
-
-        if length > 0 && length == output_file_size {
-            return Ok(());
-        }
-
-        let mut output_file = File::create(output_path.as_path())
-            .await
-            .map_err(|e| DownloaderError::Io(e, output_path.clone()))?;
-
-        let pb = progress.add(ProgressBar::new(length));
-        pb.set_style(Downloader::DEFAULT_PROGRESS_STYLE);
-
-        pb.set_message(format!("'{}' downloading...", download.file_name));
-
-        let mut stream = response.bytes_stream();
-        while let Some(chunk) = stream
-            .try_next()
-            .await
-            .map_err(|e| DownloaderError::Request(e, download.url.clone()))?
-        {
-            let chunk_size = chunk.len() as u64;
-
-            output_file
-                .write_all(&chunk)
-                .await
-                .map_err(|e| DownloaderError::Io(e, output_path.clone()))?;
-        }
-
-        pb.finish_and_clear();
-
-        Ok(())
-    }
 }

--- a/zellij-utils/src/downloader/mod.rs
+++ b/zellij-utils/src/downloader/mod.rs
@@ -1,0 +1,106 @@
+mod download;
+
+use futures::{stream, StreamExt, TryStreamExt};
+use reqwest::Client;
+use std::path::PathBuf;
+use thiserror::Error;
+use tokio::{fs::File, io::AsyncWriteExt};
+
+use crate::consts::ZELLIJ_CACHE_DIR;
+
+use self::download::Download;
+
+#[derive(Error, Debug)]
+pub enum DownloaderError {
+    #[error("Request error: {0}, URL: {1}")]
+    Request(reqwest::Error, String),
+    #[error("Metadata error: {0}, File: {1}")]
+    Metadata(std::io::Error, PathBuf),
+    #[error("Io error: {0}, File: {1}")]
+    Io(std::io::Error, PathBuf),
+}
+
+pub struct Downloader {
+    client: Client,
+    directory: PathBuf,
+    concurrent: usize,
+}
+
+impl Downloader {
+    const DEFAULT_CONCURRENT: usize = 4;
+
+    pub fn new() -> Self {
+        Self {
+            client: Client::new(),
+            directory: ZELLIJ_CACHE_DIR.to_path_buf(),
+            concurrent: Downloader::DEFAULT_CONCURRENT,
+        }
+    }
+
+    pub fn set_directory(&mut self, directory: PathBuf) {
+        self.directory = directory;
+    }
+
+    pub fn download(&self, downloads: &[Download]) -> Vec<Result<(), DownloaderError>> {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            stream::iter(downloads)
+                .map(|d| self.fetch(d))
+                .buffer_unordered(4)
+                .collect::<Vec<_>>()
+                .await
+        })
+    }
+
+    async fn fetch(&self, download: &Download) -> Result<(), DownloaderError> {
+        let mut output_file_size: u64 = 0;
+        // TODO: A unique path using url-based hash is required.
+        let output_path = self.directory.join(&download.file_name);
+
+        if output_path.exists() {
+            output_file_size = match output_path.metadata() {
+                Ok(metadata) => metadata.len(),
+                Err(e) => return Err(DownloaderError::Metadata(e, output_path)),
+            }
+        }
+
+        let url = download.url.as_str();
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| DownloaderError::Request(e, download.url.clone()))?;
+
+        match response.error_for_status_ref() {
+            Ok(_) => {},
+            Err(e) => return Err(DownloaderError::Request(e, download.url.clone())),
+        }
+
+        let length = response.content_length().unwrap();
+
+        if length > 0 && length == output_file_size {
+            return Ok(());
+        }
+
+        let mut output_file = File::create(output_path.as_path())
+            .await
+            .map_err(|e| DownloaderError::Io(e, output_path.clone()))?;
+
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream
+            .try_next()
+            .await
+            .map_err(|e| DownloaderError::Request(e, download.url.clone()))?
+        {
+            let chunk_size = chunk.len() as u64;
+
+            output_file
+                .write_all(&chunk)
+                .await
+                .map_err(|e| DownloaderError::Io(e, output_path.clone()))?;
+        }
+
+        Ok(())
+    }
+}

--- a/zellij-utils/src/input/plugins.rs
+++ b/zellij-utils/src/input/plugins.rs
@@ -11,6 +11,7 @@ use url::Url;
 use super::layout::{PluginUserConfiguration, RunPlugin, RunPluginLocation};
 #[cfg(not(target_family = "wasm"))]
 use crate::consts::ASSET_MAP;
+use crate::consts::ZELLIJ_CACHE_DIR;
 pub use crate::data::PluginTag;
 use crate::errors::prelude::*;
 
@@ -55,6 +56,17 @@ impl PluginsConfig {
                 userspace_configuration: run.configuration.clone(),
                 ..plugin
             }),
+            RunPluginLocation::Remote(download) => {
+                let path = ZELLIJ_CACHE_DIR.join(&download.file_name);
+
+                Some(PluginConfig {
+                    path,
+                    run: PluginType::Pane(None),
+                    _allow_exec_host_cmd: run._allow_exec_host_cmd,
+                    location: run.location.clone(),
+                    userspace_configuration: run.configuration.clone(),
+                })
+            },
         }
     }
 

--- a/zellij-utils/src/lib.rs
+++ b/zellij-utils/src/lib.rs
@@ -17,9 +17,11 @@ pub mod shared;
 #[cfg(not(target_family = "wasm"))]
 pub mod channels; // Requires async_std
 #[cfg(not(target_family = "wasm"))]
+pub mod downloader;
+#[cfg(not(target_family = "wasm"))]
 pub mod ipc; // Requires interprocess
 #[cfg(not(target_family = "wasm"))]
-pub mod logging; // Requires log4rs
+pub mod logging; // Requires log4rs // Requires tokio
 
 #[cfg(not(target_family = "wasm"))]
 pub use ::{

--- a/zellij-utils/src/lib.rs
+++ b/zellij-utils/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cli;
 pub mod consts;
 pub mod data;
+pub mod downloader;
 pub mod envs;
 pub mod errors;
 pub mod home;
@@ -16,8 +17,6 @@ pub mod shared;
 // The following modules can't be used when targeting wasm
 #[cfg(not(target_family = "wasm"))]
 pub mod channels; // Requires async_std
-#[cfg(not(target_family = "wasm"))]
-pub mod downloader;
 #[cfg(not(target_family = "wasm"))]
 pub mod ipc; // Requires interprocess
 #[cfg(not(target_family = "wasm"))]


### PR DESCRIPTION
This PR is currently in very rough.
I have only implemented a few concepts and there are still more to be implemented.

### What is this feature?
Zellij now adds a new format for plugin location. If the location is an external URL such as http or https, zellij will download and load the plugin from that URL.

following is example:
```kdl
layout {
    pane
    pane {
        plugin location="https://github.com/imsnif/monocle/releases/download/0.37.2/monocle.wasm"
    }
    pane size=1 borderless=true {
        plugin location="zellij:compact-bar"
    }
}
```

### To-Do
- [ ] loading plugins directly with the `action` command (currently only support layout file)
- [ ]  add URL-based hash to the cache folder path where plugins are stored. (ex. `ZELLIJ_CACHE_DIR/{URL_HASH}/plguins.wasm`)