### PR TITLE
feat(sessions): resurrect sessions through the session-manager (and plugin API)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3325,6 +3325,7 @@ dependencies = [
  "ansi_term",
  "chrono",
  "fuzzy-matcher",
+ "humantime",
  "unicode-width",
  "zellij-tile",
 ]

--- a/default-plugins/session-manager/Cargo.toml
+++ b/default-plugins/session-manager/Cargo.toml
@@ -10,3 +10,4 @@ zellij-tile = { path = "../../zellij-tile" }
 chrono = "0.4.0"
 fuzzy-matcher = "0.3.7"
 unicode-width = "0.1.10"
+humantime = "2.1.0"

--- a/default-plugins/session-manager/src/main.rs
+++ b/default-plugins/session-manager/src/main.rs
@@ -1,17 +1,20 @@
-mod session_list;
 mod resurrectable_sessions;
+mod session_list;
 mod ui;
 use zellij_tile::prelude::*;
 
 use std::collections::BTreeMap;
 
 use ui::{
-    components::{render_controls_line, render_new_session_line, render_prompt, render_resurrection_toggle, Colors},
+    components::{
+        render_controls_line, render_new_session_line, render_prompt, render_resurrection_toggle,
+        Colors,
+    },
     SessionUiInfo,
 };
 
-use session_list::SessionList;
 use resurrectable_sessions::ResurrectableSessions;
+use session_list::SessionList;
 
 #[derive(Default)]
 struct State {
@@ -50,7 +53,8 @@ impl ZellijPlugin for State {
                 should_render = true;
             },
             Event::SessionUpdate(session_infos, resurrectable_session_list) => {
-                self.resurrectable_sessions.update(resurrectable_session_list);
+                self.resurrectable_sessions
+                    .update(resurrectable_session_list);
                 self.update_session_infos(session_infos);
                 should_render = true;
             },
@@ -181,7 +185,8 @@ impl State {
             }
         } else if let Key::Ctrl('d') = key {
             if self.browsing_resurrection_sessions {
-                self.resurrectable_sessions.show_delete_all_sessions_warning();
+                self.resurrectable_sessions
+                    .show_delete_all_sessions_warning();
                 should_render = true;
             }
         } else if let Key::Esc = key {
@@ -191,7 +196,9 @@ impl State {
     }
     fn handle_selection(&mut self) {
         if self.browsing_resurrection_sessions {
-            if let Some(session_name_to_resurrect) = self.resurrectable_sessions.get_selected_session_name() {
+            if let Some(session_name_to_resurrect) =
+                self.resurrectable_sessions.get_selected_session_name()
+            {
                 switch_session(Some(&session_name_to_resurrect));
             }
         } else if let Some(new_session_name) = &self.new_session_name {

--- a/default-plugins/session-manager/src/main.rs
+++ b/default-plugins/session-manager/src/main.rs
@@ -6,7 +6,7 @@ use zellij_tile::prelude::*;
 use std::collections::BTreeMap;
 
 use ui::{
-    components::{render_controls_line, render_new_session_line, render_prompt, Colors},
+    components::{render_controls_line, render_new_session_line, render_prompt, render_resurrection_toggle, Colors},
     SessionUiInfo,
 };
 
@@ -64,8 +64,7 @@ impl ZellijPlugin for State {
             self.resurrectable_sessions.render(rows, cols);
             return;
         }
-
-
+        render_resurrection_toggle(cols, false);
         render_prompt(
             self.new_session_name.is_some(),
             &self.search_term,
@@ -123,6 +122,8 @@ impl State {
                 self.handle_selection();
             } else if let Some(new_session_name) = self.new_session_name.as_mut() {
                 new_session_name.push(character);
+            } else if self.browsing_resurrection_sessions {
+                self.resurrectable_sessions.handle_character(character);
             } else {
                 self.search_term.push(character);
                 self.sessions
@@ -136,6 +137,8 @@ impl State {
                 } else {
                     new_session_name.pop();
                 }
+            } else if self.browsing_resurrection_sessions {
+                self.resurrectable_sessions.handle_backspace();
             } else {
                 self.search_term.pop();
                 self.sessions
@@ -178,7 +181,7 @@ impl State {
             }
         } else if let Key::Ctrl('d') = key {
             if self.browsing_resurrection_sessions {
-                self.resurrectable_sessions.delete_all_sessions();
+                self.resurrectable_sessions.show_delete_all_sessions_warning();
                 should_render = true;
             }
         } else if let Key::Esc = key {

--- a/default-plugins/session-manager/src/resurrectable_sessions.rs
+++ b/default-plugins/session-manager/src/resurrectable_sessions.rs
@@ -2,10 +2,7 @@ use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
 use humantime::format_duration;
 
-use crate::ui::{
-    components::{Colors, LineToRender, ListItem},
-    SessionUiInfo,
-};
+use crate::ui::components::render_resurrection_toggle;
 
 use std::time::Duration;
 
@@ -13,437 +10,283 @@ use zellij_tile::shim::*;
 
 #[derive(Debug, Default)]
 pub struct ResurrectableSessions {
-    pub name_and_creation_time: Vec<(String, Duration)>,
+    pub all_resurrectable_sessions: Vec<(String, Duration)>,
     pub selected_index: Option<usize>,
     pub selected_search_index: Option<usize>,
     pub search_results: Vec<SearchResult>,
     pub is_searching: bool,
+    pub search_term: String,
+    pub delete_all_dead_sessions_warning: bool,
 }
 
 
 impl ResurrectableSessions {
-    pub fn update(&mut self, list: Vec<(String, Duration)>) {
-        self.name_and_creation_time = list;
+    pub fn update(&mut self, mut list: Vec<(String, Duration)>) {
+        list.sort_by(|a, b| a.1.cmp(&b.1));
+        self.all_resurrectable_sessions = list;
     }
     pub fn render(&self, rows: usize, columns: usize) {
-        // title line
-        let mut table = Table::new()
-            .add_row(vec!["Session Name", "Creation Time"]);
-        // calculate first/last line of table to render
-        let (first_row_index_to_render, last_row_index_to_render) = if rows <= self.name_and_creation_time.len() {
-            let row_count_to_render = rows.saturating_sub(2); // 1 for the title, one for the more
-            let first_row_index_to_render = self.selected_index.unwrap_or(0).saturating_sub(row_count_to_render / 2);
-            let mut last_row_index_to_render = first_row_index_to_render + row_count_to_render;
-            if first_row_index_to_render > 0 && last_row_index_to_render > first_row_index_to_render + 1 {
-                last_row_index_to_render -= 1;
+        if self.delete_all_dead_sessions_warning {
+            self.render_delete_all_sessions_warning(rows, columns);
+            return;
+        }
+        render_resurrection_toggle(columns, true);
+        let search_indication = Text::new(format!("> {}_", self.search_term)).color_range(1, ..);
+        let table_rows = rows.saturating_sub(3);
+        let table_columns = columns;
+        let table = if self.is_searching {
+            self.render_search_results(table_rows, columns)
+        } else {
+            self.render_all_entries(table_rows, columns)
+        };
+        print_text_with_coordinates(search_indication, 0, 0, None, None);
+        print_table_with_coordinates(table, 0, 1, Some(table_columns), Some(table_rows));
+        self.render_controls_line(rows);
+    }
+    fn render_search_results(&self, table_rows: usize, _table_columns: usize) -> Table {
+        let mut table = Table::new().add_row(vec![" ", " ", " "]); // skip the title row
+        let (first_row_index_to_render, last_row_index_to_render) = self.range_to_render(
+            table_rows,
+            self.search_results.len(),
+            self.selected_search_index
+        );
+        for i in first_row_index_to_render..last_row_index_to_render {
+            if let Some(search_result) = self.search_results.get(i) {
+                let is_selected = Some(i) == self.selected_search_index;
+                let mut table_cells = vec![
+                    self.render_session_name(&search_result.session_name, Some(search_result.indices.clone())),
+                    self.render_ctime(&search_result.ctime),
+                    self.render_more_indication_or_enter_as_needed(i, first_row_index_to_render, last_row_index_to_render, self.search_results.len(), is_selected),
+                ];
+                if is_selected {
+                    table_cells = table_cells.drain(..).map(|t| t.selected()).collect();
+                }
+                table = table.add_styled_row(table_cells);
             }
+        }
+        table
+    }
+    fn render_all_entries(&self, table_rows: usize, _table_columns: usize) -> Table {
+        let mut table = Table::new().add_row(vec![" ", " ", " "]); // skip the title row
+        let (first_row_index_to_render, last_row_index_to_render) = self.range_to_render(
+            table_rows,
+            self.all_resurrectable_sessions.len(),
+            self.selected_index
+        );
+        for i in first_row_index_to_render..last_row_index_to_render {
+            if let Some(session) = self.all_resurrectable_sessions.get(i) {
+                let is_selected = Some(i) == self.selected_index;
+                let mut table_cells = vec![
+                    self.render_session_name(&session.0, None),
+                    self.render_ctime(&session.1),
+                    self.render_more_indication_or_enter_as_needed(i, first_row_index_to_render, last_row_index_to_render, self.all_resurrectable_sessions.len(), is_selected),
+                ];
+                if is_selected {
+                    table_cells = table_cells.drain(..).map(|t| t.selected()).collect();
+                }
+                table = table.add_styled_row(table_cells);
+            }
+        }
+        table
+    }
+    fn render_delete_all_sessions_warning(&self, rows: usize, columns: usize) {
+        if rows == 0 || columns == 0 {
+            return;
+        }
+        let session_count = self.all_resurrectable_sessions.len();
+        let session_count_len = session_count.to_string().chars().count();
+        let warning_description_text = format!(
+            "This will delete {} resurrectable sessions",
+            session_count,
+        );
+        let confirmation_text = "Are you sure? (y/n)";
+        let warning_y_location = (rows / 2).saturating_sub(1);
+        let confirmation_y_location = (rows / 2) + 1;
+        let warning_x_location = columns.saturating_sub(warning_description_text.chars().count()) / 2;
+        let confirmation_x_location = columns.saturating_sub(confirmation_text.chars().count()) / 2;
+        print_text_with_coordinates(
+            Text::new(warning_description_text).color_range(0, 17..18 + session_count_len),
+            warning_x_location,
+            warning_y_location,
+            None,
+            None,
+        );
+        print_text_with_coordinates(
+            Text::new(confirmation_text).color_indices(2, vec![15, 17]),
+            confirmation_x_location,
+            confirmation_y_location,
+            None,
+            None,
+        );
+    }
+    fn range_to_render(&self, table_rows: usize, results_len: usize, selected_index: Option<usize>) -> (usize, usize) {
+        if table_rows <= results_len {
+            let row_count_to_render = table_rows.saturating_sub(1); // 1 for the title
+            let first_row_index_to_render = selected_index.unwrap_or(0).saturating_sub(row_count_to_render / 2);
+            let last_row_index_to_render = first_row_index_to_render + row_count_to_render;
             (first_row_index_to_render, last_row_index_to_render)
         } else {
             let first_row_index_to_render = 0;
-            let last_row_index_to_render = self.name_and_creation_time.len();
+            let last_row_index_to_render = results_len;
             (first_row_index_to_render, last_row_index_to_render)
-        };
-
-        // above more indication
-        if first_row_index_to_render > 0 {
-            table = table.add_styled_row(vec![Text::new(format!("+ {} more", first_row_index_to_render)).color_range(1, ..), Text::new(" ")]);
         }
-
-        // table lines
-        for i in first_row_index_to_render..last_row_index_to_render {
-            if let Some((name, creation_time)) = self.name_and_creation_time.get(i) {
-                if Some(i) == self.selected_index {
-                    table = table.add_styled_row(vec![Text::new(name).color_range(0, ..).selected(), Text::new(format_duration(creation_time.clone()).to_string()).selected()]);
-                } else {
-                    table = table.add_styled_row(vec![Text::new(name).color_range(0, ..), Text::new(format_duration(creation_time.clone()).to_string())]);
-                }
+    }
+    fn render_session_name(&self, session_name: &str, indices: Option<Vec<usize>>) -> Text {
+        let text = Text::new(&session_name).color_range(0, ..);
+        match indices {
+            Some(indices) => text.color_indices(1, indices),
+            None => text
+        }
+    }
+    fn render_ctime(&self, ctime: &Duration) -> Text {
+        let duration = format_duration(ctime.clone()).to_string();
+        let duration_parts = duration.split_whitespace();
+        let mut formatted_duration = String::new();
+        for part in duration_parts {
+            if !part.ends_with('s') {
+                formatted_duration.push_str(part);
             }
+        };
+        if formatted_duration.is_empty() {
+            formatted_duration.push_str("<1m");
         }
-
-        // below more indication
-        let remaining_session_count_below = self.name_and_creation_time.len().saturating_sub(last_row_index_to_render);
-        if remaining_session_count_below > 0 {
-            table = table.add_styled_row(vec![Text::new(format!("+ {} more", remaining_session_count_below)).color_range(1, ..), Text::new(" ")]);
+        let duration_len = formatted_duration.chars().count();
+        Text::new(format!("Created {} ago", formatted_duration)).color_range(2, 8..9 + duration_len)
+    }
+    fn render_more_indication_or_enter_as_needed(&self, i: usize, first_row_index_to_render: usize, last_row_index_to_render: usize, results_len: usize, is_selected: bool) -> Text {
+        if is_selected {
+            Text::new(format!("<ENTER> - Resurrect Session")).color_range(3, 0..7)
+        } else if i == first_row_index_to_render && i > 0 {
+            Text::new(format!("+ {} more", first_row_index_to_render)).color_range(1, ..)
+        } else if i == last_row_index_to_render.saturating_sub(1) && last_row_index_to_render < results_len {
+            Text::new(format!("+ {} more", results_len.saturating_sub(last_row_index_to_render))).color_range(1, ..)
+        } else {
+            Text::new(" ")
         }
-        print_table_with_coordinates(table, 0, 0, Some(columns), Some(rows));
+    }
+    fn render_controls_line(&self, rows: usize) {
+        let controls_line = Text::new(
+            format!("Help: <↓↑> - Navigate, <DEL> - Delete Session, <Ctrl d> - Delete all sessions"),
+        )
+        .color_range(3, 6..10)
+        .color_range(3, 23..29)
+        .color_range(3, 47..56);
+        print_text_with_coordinates(controls_line, 0, rows.saturating_sub(1), None, None);
     }
     pub fn move_selection_down(&mut self) {
-        if let Some(selected_index) = self.selected_index.as_mut() {
-            if *selected_index == self.name_and_creation_time.len().saturating_sub(1) {
-                *selected_index = 0;
+        if self.is_searching {
+            if let Some(selected_index) = self.selected_search_index.as_mut() {
+                if *selected_index == self.search_results.len().saturating_sub(1) {
+                    *selected_index = 0;
+                } else {
+                    *selected_index = *selected_index + 1;
+                }
             } else {
-                *selected_index = *selected_index + 1;
+                self.selected_search_index = Some(0);
             }
         } else {
-            self.selected_index = Some(0);
+            if let Some(selected_index) = self.selected_index.as_mut() {
+                if *selected_index == self.all_resurrectable_sessions.len().saturating_sub(1) {
+                    *selected_index = 0;
+                } else {
+                    *selected_index = *selected_index + 1;
+                }
+            } else {
+                self.selected_index = Some(0);
+            }
         }
     }
     pub fn move_selection_up(&mut self) {
-        if let Some(selected_index) = self.selected_index.as_mut() {
-            if *selected_index == 0 {
-                *selected_index = self.name_and_creation_time.len().saturating_sub(1);
+        if self.is_searching {
+            if let Some(selected_index) = self.selected_search_index.as_mut() {
+                if *selected_index == 0 {
+                    *selected_index = self.search_results.len().saturating_sub(1);
+                } else {
+                    *selected_index = selected_index.saturating_sub(1);
+                }
             } else {
-                *selected_index = selected_index.saturating_sub(1);
+                self.selected_search_index = Some(self.search_results.len().saturating_sub(1));
             }
         } else {
-            self.selected_index = Some(self.name_and_creation_time.len().saturating_sub(1));
+            if let Some(selected_index) = self.selected_index.as_mut() {
+                if *selected_index == 0 {
+                    *selected_index = self.all_resurrectable_sessions.len().saturating_sub(1);
+                } else {
+                    *selected_index = selected_index.saturating_sub(1);
+                }
+            } else {
+                self.selected_index = Some(self.all_resurrectable_sessions.len().saturating_sub(1));
+            }
         }
     }
     pub fn get_selected_session_name(&self) -> Option<String> {
-        self.selected_index
-            .and_then(|i| self.name_and_creation_time.get(i))
-            .map(|session_name_and_creation_time| session_name_and_creation_time.0.clone())
+        if self.is_searching {
+            self.selected_search_index
+                .and_then(|i| self.search_results.get(i))
+                .map(|search_result| search_result.session_name.clone())
+        } else {
+            self.selected_index
+                .and_then(|i| self.all_resurrectable_sessions.get(i))
+                .map(|session_name_and_creation_time| session_name_and_creation_time.0.clone())
+        }
     }
-    // TODO: CONTINUE HERE - implement these
-    // * when deleting a single session, if the selected is the last session, saturating_sub it by
-    // 1, if it's the only session, remove the selected - DONE
-    // * do an optimistic update in delete_all_sessions - DONE
-    // * truncate the results to our rows when rendering - DONE
-    // * refactor the render function above - DONE ish
-    // * do a fuzzy search
-    // * do an "are you sure?" screen when deleting all sessions
-    // * indicate the keys
-    // * indicate the TAB with ribbons (between live and dead sessions)
     pub fn delete_selected_session(&mut self) {
         self.selected_index
             .and_then(|i| {
-                if self.name_and_creation_time.len() > i {
+                if self.all_resurrectable_sessions.len() > i {
                     // optimistic update
                     if i == 0 {
                         self.selected_index = None;
-                    } else if i == self.name_and_creation_time.len().saturating_sub(1) {
+                    } else if i == self.all_resurrectable_sessions.len().saturating_sub(1) {
                         self.selected_index = Some(i.saturating_sub(1));
                     }
-                    Some(self.name_and_creation_time.remove(i))
+                    Some(self.all_resurrectable_sessions.remove(i))
                 } else {
                     None
                 }
             })
             .map(|session_name_and_creation_time| delete_dead_session(&session_name_and_creation_time.0));
     }
-    pub fn delete_all_sessions(&mut self) {
+    fn delete_all_sessions(&mut self) {
         // optimistic update
-        self.name_and_creation_time = vec![];
+        self.all_resurrectable_sessions= vec![];
+        self.delete_all_dead_sessions_warning = false;
         delete_all_dead_sessions();
     }
-//     pub fn update_search_term(&mut self, search_term: &str, colors: &Colors) {
-//         let mut flattened_assets = self.flatten_assets(colors);
-//         let mut matches = vec![];
-//         let matcher = SkimMatcherV2::default().use_cache(true);
-//         for (list_item, session_name, tab_position, pane_id, is_current_session) in
-//             flattened_assets.drain(..)
-//         {
-//             if let Some((score, indices)) = matcher.fuzzy_indices(&list_item.name, &search_term) {
-//                 matches.push(SearchResult::new(
-//                     score,
-//                     indices,
-//                     list_item,
-//                     session_name,
-//                     tab_position,
-//                     pane_id,
-//                     is_current_session,
-//                 ));
-//             }
-//         }
-//         matches.sort_by(|a, b| b.score.cmp(&a.score));
-//         self.search_results = matches;
-//         self.is_searching = !search_term.is_empty();
-//         self.selected_search_index = Some(0);
-//     }
-//     fn flatten_assets(
-//         &self,
-//         colors: &Colors,
-//     ) -> Vec<(ListItem, String, Option<usize>, Option<(u32, bool)>, bool)> {
-//         // list_item, session_name, tab_position, (pane_id, is_plugin), is_current_session
-//         let mut list_items = vec![];
-//         for session in &self.session_ui_infos {
-//             let session_name = session.name.clone();
-//             let is_current_session = session.is_current_session;
-//             list_items.push((
-//                 ListItem::from_session_info(session, *colors),
-//                 session_name.clone(),
-//                 None,
-//                 None,
-//                 is_current_session,
-//             ));
-//             for tab in &session.tabs {
-//                 let tab_position = tab.position;
-//                 list_items.push((
-//                     ListItem::from_tab_info(session, tab, *colors),
-//                     session_name.clone(),
-//                     Some(tab_position),
-//                     None,
-//                     is_current_session,
-//                 ));
-//                 for pane in &tab.panes {
-//                     let pane_id = (pane.pane_id, pane.is_plugin);
-//                     list_items.push((
-//                         ListItem::from_pane_info(session, tab, pane, *colors),
-//                         session_name.clone(),
-//                         Some(tab_position),
-//                         Some(pane_id),
-//                         is_current_session,
-//                     ));
-//                 }
-//             }
-//         }
-//         list_items
-//     }
-//     pub fn get_selected_session_name(&self) -> Option<String> {
-//         if self.is_searching {
-//             self.selected_search_index
-//                 .and_then(|i| self.search_results.get(i))
-//                 .map(|s| s.session_name.clone())
-//         } else {
-//             self.selected_index
-//                 .0
-//                 .and_then(|i| self.session_ui_infos.get(i))
-//                 .map(|s_i| s_i.name.clone())
-//         }
-//     }
-//     pub fn selected_is_current_session(&self) -> bool {
-//         if self.is_searching {
-//             self.selected_search_index
-//                 .and_then(|i| self.search_results.get(i))
-//                 .map(|s| s.is_current_session)
-//                 .unwrap_or(false)
-//         } else {
-//             self.selected_index
-//                 .0
-//                 .and_then(|i| self.session_ui_infos.get(i))
-//                 .map(|s_i| s_i.is_current_session)
-//                 .unwrap_or(false)
-//         }
-//     }
-//     pub fn get_selected_tab_position(&self) -> Option<usize> {
-//         if self.is_searching {
-//             self.selected_search_index
-//                 .and_then(|i| self.search_results.get(i))
-//                 .and_then(|s| s.tab_position)
-//         } else {
-//             self.selected_index
-//                 .0
-//                 .and_then(|i| self.session_ui_infos.get(i))
-//                 .and_then(|s_i| {
-//                     self.selected_index
-//                         .1
-//                         .and_then(|i| s_i.tabs.get(i))
-//                         .map(|t| t.position)
-//                 })
-//         }
-//     }
-//     pub fn get_selected_pane_id(&self) -> Option<(u32, bool)> {
-//         // (pane_id, is_plugin)
-//         if self.is_searching {
-//             self.selected_search_index
-//                 .and_then(|i| self.search_results.get(i))
-//                 .and_then(|s| s.pane_id)
-//         } else {
-//             self.selected_index
-//                 .0
-//                 .and_then(|i| self.session_ui_infos.get(i))
-//                 .and_then(|s_i| {
-//                     self.selected_index
-//                         .1
-//                         .and_then(|i| s_i.tabs.get(i))
-//                         .and_then(|t| {
-//                             self.selected_index
-//                                 .2
-//                                 .and_then(|i| t.panes.get(i))
-//                                 .map(|p| (p.pane_id, p.is_plugin))
-//                         })
-//                 })
-//         }
-//     }
-//     pub fn move_selection_down(&mut self) {
-//         if self.is_searching {
-//             match self.selected_search_index.as_mut() {
-//                 Some(search_index) => {
-//                     *search_index = search_index.saturating_add(1);
-//                 },
-//                 None => {
-//                     if !self.search_results.is_empty() {
-//                         self.selected_search_index = Some(0);
-//                     }
-//                 },
-//             }
-//         } else {
-//             match self.selected_index {
-//                 SelectedIndex(None, None, None) => {
-//                     if !self.session_ui_infos.is_empty() {
-//                         self.selected_index.0 = Some(0);
-//                     }
-//                 },
-//                 SelectedIndex(Some(selected_session), None, None) => {
-//                     if self.session_ui_infos.len() > selected_session + 1 {
-//                         self.selected_index.0 = Some(selected_session + 1);
-//                     } else {
-//                         self.selected_index.0 = None;
-//                         self.selected_index.1 = None;
-//                         self.selected_index.2 = None;
-//                     }
-//                 },
-//                 SelectedIndex(Some(selected_session), Some(selected_tab), None) => {
-//                     if self
-//                         .get_session(selected_session)
-//                         .map(|s| s.tabs.len() > selected_tab + 1)
-//                         .unwrap_or(false)
-//                     {
-//                         self.selected_index.1 = Some(selected_tab + 1);
-//                     } else {
-//                         self.selected_index.1 = Some(0);
-//                     }
-//                 },
-//                 SelectedIndex(Some(selected_session), Some(selected_tab), Some(selected_pane)) => {
-//                     if self
-//                         .get_session(selected_session)
-//                         .and_then(|s| s.tabs.get(selected_tab))
-//                         .map(|t| t.panes.len() > selected_pane + 1)
-//                         .unwrap_or(false)
-//                     {
-//                         self.selected_index.2 = Some(selected_pane + 1);
-//                     } else {
-//                         self.selected_index.2 = Some(0);
-//                     }
-//                 },
-//                 _ => {},
-//             }
-//         }
-//     }
-//     pub fn move_selection_up(&mut self) {
-//         if self.is_searching {
-//             match self.selected_search_index.as_mut() {
-//                 Some(search_index) => {
-//                     *search_index = search_index.saturating_sub(1);
-//                 },
-//                 None => {
-//                     if !self.search_results.is_empty() {
-//                         self.selected_search_index = Some(0);
-//                     }
-//                 },
-//             }
-//         } else {
-//             match self.selected_index {
-//                 SelectedIndex(None, None, None) => {
-//                     if !self.session_ui_infos.is_empty() {
-//                         self.selected_index.0 = Some(self.session_ui_infos.len().saturating_sub(1))
-//                     }
-//                 },
-//                 SelectedIndex(Some(selected_session), None, None) => {
-//                     if selected_session > 0 {
-//                         self.selected_index.0 = Some(selected_session - 1);
-//                     } else {
-//                         self.selected_index.0 = None;
-//                     }
-//                 },
-//                 SelectedIndex(Some(selected_session), Some(selected_tab), None) => {
-//                     if selected_tab > 0 {
-//                         self.selected_index.1 = Some(selected_tab - 1);
-//                     } else {
-//                         let tab_count = self
-//                             .get_session(selected_session)
-//                             .map(|s| s.tabs.len())
-//                             .unwrap_or(0);
-//                         self.selected_index.1 = Some(tab_count.saturating_sub(1))
-//                     }
-//                 },
-//                 SelectedIndex(Some(selected_session), Some(selected_tab), Some(selected_pane)) => {
-//                     if selected_pane > 0 {
-//                         self.selected_index.2 = Some(selected_pane - 1);
-//                     } else {
-//                         let pane_count = self
-//                             .get_session(selected_session)
-//                             .and_then(|s| s.tabs.get(selected_tab))
-//                             .map(|t| t.panes.len())
-//                             .unwrap_or(0);
-//                         self.selected_index.2 = Some(pane_count.saturating_sub(1))
-//                     }
-//                 },
-//                 _ => {},
-//             }
-//         }
-//     }
-//     fn get_session(&self, index: usize) -> Option<&SessionUiInfo> {
-//         self.session_ui_infos.get(index)
-//     }
-//     pub fn result_expand(&mut self) {
-//         // we can't move this to SelectedIndex because the borrow checker is mean
-//         match self.selected_index {
-//             SelectedIndex(Some(selected_session), None, None) => {
-//                 let selected_session_has_tabs = self
-//                     .get_session(selected_session)
-//                     .map(|s| !s.tabs.is_empty())
-//                     .unwrap_or(false);
-//                 if selected_session_has_tabs {
-//                     self.selected_index.1 = Some(0);
-//                 }
-//             },
-//             SelectedIndex(Some(selected_session), Some(selected_tab), None) => {
-//                 let selected_tab_has_panes = self
-//                     .get_session(selected_session)
-//                     .and_then(|s| s.tabs.get(selected_tab))
-//                     .map(|t| !t.panes.is_empty())
-//                     .unwrap_or(false);
-//                 if selected_tab_has_panes {
-//                     self.selected_index.2 = Some(0);
-//                 }
-//             },
-//             _ => {},
-//         }
-//     }
-//     pub fn result_shrink(&mut self) {
-//         self.selected_index.result_shrink();
-//     }
-//     pub fn update_rows(&mut self, rows: usize) {
-//         if let Some(search_result_rows_until_selected) = self.selected_search_index.map(|i| {
-//             self.search_results
-//                 .iter()
-//                 .enumerate()
-//                 .take(i + 1)
-//                 .fold(0, |acc, s| acc + s.1.lines_to_render())
-//         }) {
-//             if search_result_rows_until_selected > rows
-//                 || self.selected_search_index >= Some(self.search_results.len())
-//             {
-//                 self.selected_search_index = None;
-//             }
-//         }
-//     }
-//     pub fn reset_selected_index(&mut self) {
-//         self.selected_index.reset();
-//     }
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct SelectedIndex(pub Option<usize>, pub Option<usize>, pub Option<usize>);
-
-impl SelectedIndex {
-    pub fn tabs_are_visible(&self) -> bool {
-        self.1.is_some()
+    pub fn show_delete_all_sessions_warning(&mut self) {
+        self.delete_all_dead_sessions_warning = true;
     }
-    pub fn panes_are_visible(&self) -> bool {
-        self.2.is_some()
-    }
-    pub fn selected_tab_index(&self) -> Option<usize> {
-        self.1
-    }
-    pub fn session_index_is_selected(&self, index: usize) -> bool {
-        self.0 == Some(index)
-    }
-    pub fn result_shrink(&mut self) {
-        match self {
-            SelectedIndex(Some(_selected_session), None, None) => self.0 = None,
-            SelectedIndex(Some(_selected_session), Some(_selected_tab), None) => self.1 = None,
-            SelectedIndex(Some(_selected_session), Some(_selected_tab), Some(_selected_pane)) => {
-                self.2 = None
-            },
-            _ => {},
+    pub fn handle_character(&mut self, character: char) {
+        if self.delete_all_dead_sessions_warning && character == 'y' {
+            self.delete_all_sessions();
+        } else if self.delete_all_dead_sessions_warning && character == 'n' {
+            self.delete_all_dead_sessions_warning = false;
+        } else {
+            self.search_term.push(character);
+            self.update_search_term();
         }
     }
-    pub fn reset(&mut self) {
-        self.0 = None;
-        self.1 = None;
-        self.2 = None;
+    pub fn handle_backspace(&mut self) {
+        self.search_term.pop();
+        self.update_search_term();
+    }
+    fn update_search_term(&mut self) {
+        let mut matches = vec![];
+        let matcher = SkimMatcherV2::default().use_cache(true);
+        for (session_name, ctime) in &self.all_resurrectable_sessions {
+            if let Some((score, indices)) = matcher.fuzzy_indices(&session_name, &self.search_term) {
+                matches.push(SearchResult {
+                    session_name: session_name.to_owned(),
+                    ctime: ctime.clone(),
+                    score,
+                    indices,
+                });
+            }
+        }
+        matches.sort_by(|a, b| b.score.cmp(&a.score));
+        self.search_results = matches;
+        self.is_searching = !self.search_term.is_empty();
+        self.selected_search_index = Some(0);
     }
 }
 
@@ -451,37 +294,6 @@ impl SelectedIndex {
 pub struct SearchResult {
     score: i64,
     indices: Vec<usize>,
-    list_item: ListItem,
     session_name: String,
-    tab_position: Option<usize>,
-    pane_id: Option<(u32, bool)>,
-    is_current_session: bool,
-}
-
-impl SearchResult {
-    pub fn new(
-        score: i64,
-        indices: Vec<usize>,
-        list_item: ListItem,
-        session_name: String,
-        tab_position: Option<usize>,
-        pane_id: Option<(u32, bool)>,
-        is_current_session: bool,
-    ) -> Self {
-        SearchResult {
-            score,
-            indices,
-            list_item,
-            session_name,
-            tab_position,
-            pane_id,
-            is_current_session,
-        }
-    }
-    pub fn lines_to_render(&self) -> usize {
-        self.list_item.line_count()
-    }
-    pub fn render(&self, max_width: usize) -> Vec<LineToRender> {
-        self.list_item.render(Some(self.indices.clone()), max_width)
-    }
+    ctime: Duration,
 }

--- a/default-plugins/session-manager/src/resurrectable_sessions.rs
+++ b/default-plugins/session-manager/src/resurrectable_sessions.rs
@@ -1,0 +1,487 @@
+use fuzzy_matcher::skim::SkimMatcherV2;
+use fuzzy_matcher::FuzzyMatcher;
+use humantime::format_duration;
+
+use crate::ui::{
+    components::{Colors, LineToRender, ListItem},
+    SessionUiInfo,
+};
+
+use std::time::Duration;
+
+use zellij_tile::shim::*;
+
+#[derive(Debug, Default)]
+pub struct ResurrectableSessions {
+    pub name_and_creation_time: Vec<(String, Duration)>,
+    pub selected_index: Option<usize>,
+    pub selected_search_index: Option<usize>,
+    pub search_results: Vec<SearchResult>,
+    pub is_searching: bool,
+}
+
+
+impl ResurrectableSessions {
+    pub fn update(&mut self, list: Vec<(String, Duration)>) {
+        self.name_and_creation_time = list;
+    }
+    pub fn render(&self, rows: usize, columns: usize) {
+        // title line
+        let mut table = Table::new()
+            .add_row(vec!["Session Name", "Creation Time"]);
+        // calculate first/last line of table to render
+        let (first_row_index_to_render, last_row_index_to_render) = if rows <= self.name_and_creation_time.len() {
+            let row_count_to_render = rows.saturating_sub(2); // 1 for the title, one for the more
+            let first_row_index_to_render = self.selected_index.unwrap_or(0).saturating_sub(row_count_to_render / 2);
+            let mut last_row_index_to_render = first_row_index_to_render + row_count_to_render;
+            if first_row_index_to_render > 0 && last_row_index_to_render > first_row_index_to_render + 1 {
+                last_row_index_to_render -= 1;
+            }
+            (first_row_index_to_render, last_row_index_to_render)
+        } else {
+            let first_row_index_to_render = 0;
+            let last_row_index_to_render = self.name_and_creation_time.len();
+            (first_row_index_to_render, last_row_index_to_render)
+        };
+
+        // above more indication
+        if first_row_index_to_render > 0 {
+            table = table.add_styled_row(vec![Text::new(format!("+ {} more", first_row_index_to_render)).color_range(1, ..), Text::new(" ")]);
+        }
+
+        // table lines
+        for i in first_row_index_to_render..last_row_index_to_render {
+            if let Some((name, creation_time)) = self.name_and_creation_time.get(i) {
+                if Some(i) == self.selected_index {
+                    table = table.add_styled_row(vec![Text::new(name).color_range(0, ..).selected(), Text::new(format_duration(creation_time.clone()).to_string()).selected()]);
+                } else {
+                    table = table.add_styled_row(vec![Text::new(name).color_range(0, ..), Text::new(format_duration(creation_time.clone()).to_string())]);
+                }
+            }
+        }
+
+        // below more indication
+        let remaining_session_count_below = self.name_and_creation_time.len().saturating_sub(last_row_index_to_render);
+        if remaining_session_count_below > 0 {
+            table = table.add_styled_row(vec![Text::new(format!("+ {} more", remaining_session_count_below)).color_range(1, ..), Text::new(" ")]);
+        }
+        print_table_with_coordinates(table, 0, 0, Some(columns), Some(rows));
+    }
+    pub fn move_selection_down(&mut self) {
+        if let Some(selected_index) = self.selected_index.as_mut() {
+            if *selected_index == self.name_and_creation_time.len().saturating_sub(1) {
+                *selected_index = 0;
+            } else {
+                *selected_index = *selected_index + 1;
+            }
+        } else {
+            self.selected_index = Some(0);
+        }
+    }
+    pub fn move_selection_up(&mut self) {
+        if let Some(selected_index) = self.selected_index.as_mut() {
+            if *selected_index == 0 {
+                *selected_index = self.name_and_creation_time.len().saturating_sub(1);
+            } else {
+                *selected_index = selected_index.saturating_sub(1);
+            }
+        } else {
+            self.selected_index = Some(self.name_and_creation_time.len().saturating_sub(1));
+        }
+    }
+    pub fn get_selected_session_name(&self) -> Option<String> {
+        self.selected_index
+            .and_then(|i| self.name_and_creation_time.get(i))
+            .map(|session_name_and_creation_time| session_name_and_creation_time.0.clone())
+    }
+    // TODO: CONTINUE HERE - implement these
+    // * when deleting a single session, if the selected is the last session, saturating_sub it by
+    // 1, if it's the only session, remove the selected - DONE
+    // * do an optimistic update in delete_all_sessions - DONE
+    // * truncate the results to our rows when rendering - DONE
+    // * refactor the render function above - DONE ish
+    // * do a fuzzy search
+    // * do an "are you sure?" screen when deleting all sessions
+    // * indicate the keys
+    // * indicate the TAB with ribbons (between live and dead sessions)
+    pub fn delete_selected_session(&mut self) {
+        self.selected_index
+            .and_then(|i| {
+                if self.name_and_creation_time.len() > i {
+                    // optimistic update
+                    if i == 0 {
+                        self.selected_index = None;
+                    } else if i == self.name_and_creation_time.len().saturating_sub(1) {
+                        self.selected_index = Some(i.saturating_sub(1));
+                    }
+                    Some(self.name_and_creation_time.remove(i))
+                } else {
+                    None
+                }
+            })
+            .map(|session_name_and_creation_time| delete_dead_session(&session_name_and_creation_time.0));
+    }
+    pub fn delete_all_sessions(&mut self) {
+        // optimistic update
+        self.name_and_creation_time = vec![];
+        delete_all_dead_sessions();
+    }
+//     pub fn update_search_term(&mut self, search_term: &str, colors: &Colors) {
+//         let mut flattened_assets = self.flatten_assets(colors);
+//         let mut matches = vec![];
+//         let matcher = SkimMatcherV2::default().use_cache(true);
+//         for (list_item, session_name, tab_position, pane_id, is_current_session) in
+//             flattened_assets.drain(..)
+//         {
+//             if let Some((score, indices)) = matcher.fuzzy_indices(&list_item.name, &search_term) {
+//                 matches.push(SearchResult::new(
+//                     score,
+//                     indices,
+//                     list_item,
+//                     session_name,
+//                     tab_position,
+//                     pane_id,
+//                     is_current_session,
+//                 ));
+//             }
+//         }
+//         matches.sort_by(|a, b| b.score.cmp(&a.score));
+//         self.search_results = matches;
+//         self.is_searching = !search_term.is_empty();
+//         self.selected_search_index = Some(0);
+//     }
+//     fn flatten_assets(
+//         &self,
+//         colors: &Colors,
+//     ) -> Vec<(ListItem, String, Option<usize>, Option<(u32, bool)>, bool)> {
+//         // list_item, session_name, tab_position, (pane_id, is_plugin), is_current_session
+//         let mut list_items = vec![];
+//         for session in &self.session_ui_infos {
+//             let session_name = session.name.clone();
+//             let is_current_session = session.is_current_session;
+//             list_items.push((
+//                 ListItem::from_session_info(session, *colors),
+//                 session_name.clone(),
+//                 None,
+//                 None,
+//                 is_current_session,
+//             ));
+//             for tab in &session.tabs {
+//                 let tab_position = tab.position;
+//                 list_items.push((
+//                     ListItem::from_tab_info(session, tab, *colors),
+//                     session_name.clone(),
+//                     Some(tab_position),
+//                     None,
+//                     is_current_session,
+//                 ));
+//                 for pane in &tab.panes {
+//                     let pane_id = (pane.pane_id, pane.is_plugin);
+//                     list_items.push((
+//                         ListItem::from_pane_info(session, tab, pane, *colors),
+//                         session_name.clone(),
+//                         Some(tab_position),
+//                         Some(pane_id),
+//                         is_current_session,
+//                     ));
+//                 }
+//             }
+//         }
+//         list_items
+//     }
+//     pub fn get_selected_session_name(&self) -> Option<String> {
+//         if self.is_searching {
+//             self.selected_search_index
+//                 .and_then(|i| self.search_results.get(i))
+//                 .map(|s| s.session_name.clone())
+//         } else {
+//             self.selected_index
+//                 .0
+//                 .and_then(|i| self.session_ui_infos.get(i))
+//                 .map(|s_i| s_i.name.clone())
+//         }
+//     }
+//     pub fn selected_is_current_session(&self) -> bool {
+//         if self.is_searching {
+//             self.selected_search_index
+//                 .and_then(|i| self.search_results.get(i))
+//                 .map(|s| s.is_current_session)
+//                 .unwrap_or(false)
+//         } else {
+//             self.selected_index
+//                 .0
+//                 .and_then(|i| self.session_ui_infos.get(i))
+//                 .map(|s_i| s_i.is_current_session)
+//                 .unwrap_or(false)
+//         }
+//     }
+//     pub fn get_selected_tab_position(&self) -> Option<usize> {
+//         if self.is_searching {
+//             self.selected_search_index
+//                 .and_then(|i| self.search_results.get(i))
+//                 .and_then(|s| s.tab_position)
+//         } else {
+//             self.selected_index
+//                 .0
+//                 .and_then(|i| self.session_ui_infos.get(i))
+//                 .and_then(|s_i| {
+//                     self.selected_index
+//                         .1
+//                         .and_then(|i| s_i.tabs.get(i))
+//                         .map(|t| t.position)
+//                 })
+//         }
+//     }
+//     pub fn get_selected_pane_id(&self) -> Option<(u32, bool)> {
+//         // (pane_id, is_plugin)
+//         if self.is_searching {
+//             self.selected_search_index
+//                 .and_then(|i| self.search_results.get(i))
+//                 .and_then(|s| s.pane_id)
+//         } else {
+//             self.selected_index
+//                 .0
+//                 .and_then(|i| self.session_ui_infos.get(i))
+//                 .and_then(|s_i| {
+//                     self.selected_index
+//                         .1
+//                         .and_then(|i| s_i.tabs.get(i))
+//                         .and_then(|t| {
+//                             self.selected_index
+//                                 .2
+//                                 .and_then(|i| t.panes.get(i))
+//                                 .map(|p| (p.pane_id, p.is_plugin))
+//                         })
+//                 })
+//         }
+//     }
+//     pub fn move_selection_down(&mut self) {
+//         if self.is_searching {
+//             match self.selected_search_index.as_mut() {
+//                 Some(search_index) => {
+//                     *search_index = search_index.saturating_add(1);
+//                 },
+//                 None => {
+//                     if !self.search_results.is_empty() {
+//                         self.selected_search_index = Some(0);
+//                     }
+//                 },
+//             }
+//         } else {
+//             match self.selected_index {
+//                 SelectedIndex(None, None, None) => {
+//                     if !self.session_ui_infos.is_empty() {
+//                         self.selected_index.0 = Some(0);
+//                     }
+//                 },
+//                 SelectedIndex(Some(selected_session), None, None) => {
+//                     if self.session_ui_infos.len() > selected_session + 1 {
+//                         self.selected_index.0 = Some(selected_session + 1);
+//                     } else {
+//                         self.selected_index.0 = None;
+//                         self.selected_index.1 = None;
+//                         self.selected_index.2 = None;
+//                     }
+//                 },
+//                 SelectedIndex(Some(selected_session), Some(selected_tab), None) => {
+//                     if self
+//                         .get_session(selected_session)
+//                         .map(|s| s.tabs.len() > selected_tab + 1)
+//                         .unwrap_or(false)
+//                     {
+//                         self.selected_index.1 = Some(selected_tab + 1);
+//                     } else {
+//                         self.selected_index.1 = Some(0);
+//                     }
+//                 },
+//                 SelectedIndex(Some(selected_session), Some(selected_tab), Some(selected_pane)) => {
+//                     if self
+//                         .get_session(selected_session)
+//                         .and_then(|s| s.tabs.get(selected_tab))
+//                         .map(|t| t.panes.len() > selected_pane + 1)
+//                         .unwrap_or(false)
+//                     {
+//                         self.selected_index.2 = Some(selected_pane + 1);
+//                     } else {
+//                         self.selected_index.2 = Some(0);
+//                     }
+//                 },
+//                 _ => {},
+//             }
+//         }
+//     }
+//     pub fn move_selection_up(&mut self) {
+//         if self.is_searching {
+//             match self.selected_search_index.as_mut() {
+//                 Some(search_index) => {
+//                     *search_index = search_index.saturating_sub(1);
+//                 },
+//                 None => {
+//                     if !self.search_results.is_empty() {
+//                         self.selected_search_index = Some(0);
+//                     }
+//                 },
+//             }
+//         } else {
+//             match self.selected_index {
+//                 SelectedIndex(None, None, None) => {
+//                     if !self.session_ui_infos.is_empty() {
+//                         self.selected_index.0 = Some(self.session_ui_infos.len().saturating_sub(1))
+//                     }
+//                 },
+//                 SelectedIndex(Some(selected_session), None, None) => {
+//                     if selected_session > 0 {
+//                         self.selected_index.0 = Some(selected_session - 1);
+//                     } else {
+//                         self.selected_index.0 = None;
+//                     }
+//                 },
+//                 SelectedIndex(Some(selected_session), Some(selected_tab), None) => {
+//                     if selected_tab > 0 {
+//                         self.selected_index.1 = Some(selected_tab - 1);
+//                     } else {
+//                         let tab_count = self
+//                             .get_session(selected_session)
+//                             .map(|s| s.tabs.len())
+//                             .unwrap_or(0);
+//                         self.selected_index.1 = Some(tab_count.saturating_sub(1))
+//                     }
+//                 },
+//                 SelectedIndex(Some(selected_session), Some(selected_tab), Some(selected_pane)) => {
+//                     if selected_pane > 0 {
+//                         self.selected_index.2 = Some(selected_pane - 1);
+//                     } else {
+//                         let pane_count = self
+//                             .get_session(selected_session)
+//                             .and_then(|s| s.tabs.get(selected_tab))
+//                             .map(|t| t.panes.len())
+//                             .unwrap_or(0);
+//                         self.selected_index.2 = Some(pane_count.saturating_sub(1))
+//                     }
+//                 },
+//                 _ => {},
+//             }
+//         }
+//     }
+//     fn get_session(&self, index: usize) -> Option<&SessionUiInfo> {
+//         self.session_ui_infos.get(index)
+//     }
+//     pub fn result_expand(&mut self) {
+//         // we can't move this to SelectedIndex because the borrow checker is mean
+//         match self.selected_index {
+//             SelectedIndex(Some(selected_session), None, None) => {
+//                 let selected_session_has_tabs = self
+//                     .get_session(selected_session)
+//                     .map(|s| !s.tabs.is_empty())
+//                     .unwrap_or(false);
+//                 if selected_session_has_tabs {
+//                     self.selected_index.1 = Some(0);
+//                 }
+//             },
+//             SelectedIndex(Some(selected_session), Some(selected_tab), None) => {
+//                 let selected_tab_has_panes = self
+//                     .get_session(selected_session)
+//                     .and_then(|s| s.tabs.get(selected_tab))
+//                     .map(|t| !t.panes.is_empty())
+//                     .unwrap_or(false);
+//                 if selected_tab_has_panes {
+//                     self.selected_index.2 = Some(0);
+//                 }
+//             },
+//             _ => {},
+//         }
+//     }
+//     pub fn result_shrink(&mut self) {
+//         self.selected_index.result_shrink();
+//     }
+//     pub fn update_rows(&mut self, rows: usize) {
+//         if let Some(search_result_rows_until_selected) = self.selected_search_index.map(|i| {
+//             self.search_results
+//                 .iter()
+//                 .enumerate()
+//                 .take(i + 1)
+//                 .fold(0, |acc, s| acc + s.1.lines_to_render())
+//         }) {
+//             if search_result_rows_until_selected > rows
+//                 || self.selected_search_index >= Some(self.search_results.len())
+//             {
+//                 self.selected_search_index = None;
+//             }
+//         }
+//     }
+//     pub fn reset_selected_index(&mut self) {
+//         self.selected_index.reset();
+//     }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SelectedIndex(pub Option<usize>, pub Option<usize>, pub Option<usize>);
+
+impl SelectedIndex {
+    pub fn tabs_are_visible(&self) -> bool {
+        self.1.is_some()
+    }
+    pub fn panes_are_visible(&self) -> bool {
+        self.2.is_some()
+    }
+    pub fn selected_tab_index(&self) -> Option<usize> {
+        self.1
+    }
+    pub fn session_index_is_selected(&self, index: usize) -> bool {
+        self.0 == Some(index)
+    }
+    pub fn result_shrink(&mut self) {
+        match self {
+            SelectedIndex(Some(_selected_session), None, None) => self.0 = None,
+            SelectedIndex(Some(_selected_session), Some(_selected_tab), None) => self.1 = None,
+            SelectedIndex(Some(_selected_session), Some(_selected_tab), Some(_selected_pane)) => {
+                self.2 = None
+            },
+            _ => {},
+        }
+    }
+    pub fn reset(&mut self) {
+        self.0 = None;
+        self.1 = None;
+        self.2 = None;
+    }
+}
+
+#[derive(Debug)]
+pub struct SearchResult {
+    score: i64,
+    indices: Vec<usize>,
+    list_item: ListItem,
+    session_name: String,
+    tab_position: Option<usize>,
+    pane_id: Option<(u32, bool)>,
+    is_current_session: bool,
+}
+
+impl SearchResult {
+    pub fn new(
+        score: i64,
+        indices: Vec<usize>,
+        list_item: ListItem,
+        session_name: String,
+        tab_position: Option<usize>,
+        pane_id: Option<(u32, bool)>,
+        is_current_session: bool,
+    ) -> Self {
+        SearchResult {
+            score,
+            indices,
+            list_item,
+            session_name,
+            tab_position,
+            pane_id,
+            is_current_session,
+        }
+    }
+    pub fn lines_to_render(&self) -> usize {
+        self.list_item.line_count()
+    }
+    pub fn render(&self, max_width: usize) -> Vec<LineToRender> {
+        self.list_item.render(Some(self.indices.clone()), max_width)
+    }
+}

--- a/default-plugins/session-manager/src/resurrectable_sessions.rs
+++ b/default-plugins/session-manager/src/resurrectable_sessions.rs
@@ -144,6 +144,9 @@ impl ResurrectableSessions {
         let mut formatted_duration = String::new();
         for part in duration_parts {
             if !part.ends_with('s') {
+                if !formatted_duration.is_empty() {
+                    formatted_duration.push(' ');
+                }
                 formatted_duration.push_str(part);
             }
         };

--- a/default-plugins/session-manager/src/ui/components.rs
+++ b/default-plugins/session-manager/src/ui/components.rs
@@ -491,16 +491,47 @@ pub fn render_resurrection_toggle(cols: usize, resurrection_screen_is_active: bo
     let key_indication_len = key_indication_text.chars().count() + 1;
     let first_ribbon_length = running_sessions_text.chars().count() + 4;
     let second_ribbon_length = exited_sessions_text.chars().count() + 4;
-    let key_indication_x = cols.saturating_sub(key_indication_len + first_ribbon_length + second_ribbon_length);
+    let key_indication_x =
+        cols.saturating_sub(key_indication_len + first_ribbon_length + second_ribbon_length);
     let first_ribbon_x = key_indication_x + key_indication_len;
     let second_ribbon_x = first_ribbon_x + first_ribbon_length;
-    print_text_with_coordinates(Text::new(key_indication_text).color_range(3, ..), key_indication_x, 0, None, None);
+    print_text_with_coordinates(
+        Text::new(key_indication_text).color_range(3, ..),
+        key_indication_x,
+        0,
+        None,
+        None,
+    );
     if resurrection_screen_is_active {
-        print_ribbon_with_coordinates(Text::new(running_sessions_text), first_ribbon_x, 0, None, None);
-        print_ribbon_with_coordinates(Text::new(exited_sessions_text).selected(), second_ribbon_x, 0, None, None);
+        print_ribbon_with_coordinates(
+            Text::new(running_sessions_text),
+            first_ribbon_x,
+            0,
+            None,
+            None,
+        );
+        print_ribbon_with_coordinates(
+            Text::new(exited_sessions_text).selected(),
+            second_ribbon_x,
+            0,
+            None,
+            None,
+        );
     } else {
-        print_ribbon_with_coordinates(Text::new(running_sessions_text).selected(), first_ribbon_x, 0, None, None);
-        print_ribbon_with_coordinates(Text::new(exited_sessions_text), second_ribbon_x, 0, None, None);
+        print_ribbon_with_coordinates(
+            Text::new(running_sessions_text).selected(),
+            first_ribbon_x,
+            0,
+            None,
+            None,
+        );
+        print_ribbon_with_coordinates(
+            Text::new(exited_sessions_text),
+            second_ribbon_x,
+            0,
+            None,
+            None,
+        );
     }
 }
 

--- a/default-plugins/session-manager/src/ui/components.rs
+++ b/default-plugins/session-manager/src/ui/components.rs
@@ -478,9 +478,29 @@ pub fn minimize_lines(
 pub fn render_prompt(typing_session_name: bool, search_term: &str, colors: Colors) {
     if !typing_session_name {
         let prompt = colors.bold(&format!("> {}_", search_term));
-        println!("{}\n", prompt);
+        println!("\u{1b}[H{}\n", prompt);
     } else {
         println!("\n");
+    }
+}
+
+pub fn render_resurrection_toggle(cols: usize, resurrection_screen_is_active: bool) {
+    let key_indication_text = "<TAB>";
+    let running_sessions_text = "Running";
+    let exited_sessions_text = "Exited";
+    let key_indication_len = key_indication_text.chars().count() + 1;
+    let first_ribbon_length = running_sessions_text.chars().count() + 4;
+    let second_ribbon_length = exited_sessions_text.chars().count() + 4;
+    let key_indication_x = cols.saturating_sub(key_indication_len + first_ribbon_length + second_ribbon_length);
+    let first_ribbon_x = key_indication_x + key_indication_len;
+    let second_ribbon_x = first_ribbon_x + first_ribbon_length;
+    print_text_with_coordinates(Text::new(key_indication_text).color_range(3, ..), key_indication_x, 0, None, None);
+    if resurrection_screen_is_active {
+        print_ribbon_with_coordinates(Text::new(running_sessions_text), first_ribbon_x, 0, None, None);
+        print_ribbon_with_coordinates(Text::new(exited_sessions_text).selected(), second_ribbon_x, 0, None, None);
+    } else {
+        print_ribbon_with_coordinates(Text::new(running_sessions_text).selected(), first_ribbon_x, 0, None, None);
+        print_ribbon_with_coordinates(Text::new(exited_sessions_text), second_ribbon_x, 0, None, None);
     }
 }
 

--- a/zellij-server/src/background_jobs.rs
+++ b/zellij-server/src/background_jobs.rs
@@ -34,7 +34,7 @@ pub enum BackgroundJob {
     StopPluginLoadingAnimation(u32),                      // u32 - plugin_id
     ReadAllSessionInfosOnMachine,                         // u32 - plugin_id
     ReportSessionInfo(String, SessionInfo),               // String - session name
-    ReportLayoutInfo((String, BTreeMap<String, String>)), // HashMap<file_name, pane_contents>
+    ReportLayoutInfo((String, BTreeMap<String, String>)), // BTreeMap<file_name, pane_contents>
     RunCommand(
         PluginId,
         ClientId,
@@ -162,126 +162,13 @@ pub(crate) fn background_jobs_main(bus: Bus<BackgroundJob>) -> Result<()> {
                     let current_session_layout = current_session_layout.clone();
                     async move {
                         loop {
-                            // write state of current session
-
-                            // write it to disk
                             let current_session_name =
                                 current_session_name.lock().unwrap().to_string();
-                            let metadata_cache_file_name =
-                                session_info_cache_file_name(&current_session_name);
                             let current_session_info = current_session_info.lock().unwrap().clone();
-                            let (current_session_layout, layout_files_to_write) =
-                                current_session_layout.lock().unwrap().clone();
-                            let _wrote_metadata_file = std::fs::create_dir_all(
-                                session_info_folder_for_session(&current_session_name).as_path(),
-                            )
-                            .and_then(|_| std::fs::File::create(metadata_cache_file_name))
-                            .and_then(|mut f| write!(f, "{}", current_session_info.to_string()));
-
-                            if !current_session_layout.is_empty() {
-                                let layout_cache_file_name =
-                                    session_layout_cache_file_name(&current_session_name);
-                                let _wrote_layout_file = std::fs::create_dir_all(
-                                    session_info_folder_for_session(&current_session_name)
-                                        .as_path(),
-                                )
-                                .and_then(|_| std::fs::File::create(layout_cache_file_name))
-                                .and_then(|mut f| write!(f, "{}", current_session_layout))
-                                .and_then(|_| {
-                                    let session_info_folder =
-                                        session_info_folder_for_session(&current_session_name);
-                                    for (external_file_name, external_file_contents) in
-                                        layout_files_to_write
-                                    {
-                                        std::fs::File::create(
-                                            session_info_folder.join(external_file_name),
-                                        )
-                                        .and_then(|mut f| write!(f, "{}", external_file_contents))
-                                        .unwrap_or_else(
-                                            |e| {
-                                                log::error!(
-                                                    "Failed to write layout metadata file: {:?}",
-                                                    e
-                                                );
-                                            },
-                                        );
-                                    }
-                                    Ok(())
-                                });
-                            }
-                            // start a background job (if not already running) that'll periodically read this and other
-                            // sesion infos and report back
-
-                            // read state of all sessions
-                            let mut other_session_names = vec![];
-                            let mut session_infos_on_machine = BTreeMap::new();
-                            // we do this so that the session infos will be actual and we're
-                            // reasonably sure their session is running
-                            if let Ok(files) = fs::read_dir(&*ZELLIJ_SOCK_DIR) {
-                                files.for_each(|file| {
-                                    if let Ok(file) = file {
-                                        if let Ok(file_name) = file.file_name().into_string() {
-                                            if file.file_type().unwrap().is_socket() {
-                                                other_session_names.push(file_name);
-                                            }
-                                        }
-                                    }
-                                });
-                            }
-
-                            for session_name in other_session_names {
-                                let session_cache_file_name =
-                                    session_info_cache_file_name(&session_name);
-                                if let Ok(raw_session_info) =
-                                    fs::read_to_string(&session_cache_file_name)
-                                {
-                                    if let Ok(session_info) = SessionInfo::from_string(
-                                        &raw_session_info,
-                                        &current_session_name,
-                                    ) {
-                                        session_infos_on_machine.insert(session_name, session_info);
-                                    }
-                                }
-                            }
-                            let resurrectable_sessions: BTreeMap<String, Duration> = match fs::read_dir(&*ZELLIJ_SESSION_INFO_CACHE_DIR) {
-                                Ok(files_in_session_info_folder) => {
-                                    let files_that_are_folders = files_in_session_info_folder
-                                        .filter_map(|f| f.ok().map(|f| f.path()))
-                                        .filter(|f| f.is_dir());
-                                    files_that_are_folders
-                                        .filter_map(|folder_name| {
-                                            let session_name = folder_name.file_name()?.to_str()?.to_owned();
-                                            if session_infos_on_machine.contains_key(&session_name) {
-                                                // this is not a dead session...
-                                                return None;
-                                            }
-                                            let layout_file_name =
-                                                session_layout_cache_file_name(&session_name);
-                                            let ctime = match std::fs::metadata(&layout_file_name)
-                                                .and_then(|metadata| metadata.created())
-                                            {
-                                                Ok(created) => Some(created),
-                                                Err(e) => {
-                                                    log::error!(
-                                                        "Failed to read created stamp of resurrection file: {:?}",
-                                                        e
-                                                    );
-                                                    None
-                                                },
-                                            };
-                                            let elapsed_duration = ctime
-                                                .map(|ctime| {
-                                                    Duration::from_secs(ctime.elapsed().ok().unwrap_or_default().as_secs())
-                                                })
-                                                .unwrap_or_default();
-                                            Some((session_name, elapsed_duration))
-                                        }).collect()
-                                },
-                                Err(e) => {
-                                    log::error!("Failed to read session info cache dir: {:?}", e);
-                                    BTreeMap::new()
-                                }
-                            };
+                            let current_session_layout = current_session_layout.lock().unwrap().clone();
+                            write_session_state_to_disk(current_session_name.clone(), current_session_info, current_session_layout);
+                            let session_infos_on_machine = read_other_live_session_states(&current_session_name);
+                            let resurrectable_sessions = find_resurrectable_sessions(&session_infos_on_machine);
                             let _ = senders.send_to_screen(ScreenInstruction::UpdateSessionInfos(
                                 session_infos_on_machine,
                                 resurrectable_sessions
@@ -433,5 +320,128 @@ fn job_already_running(
             running_jobs.insert(job.clone(), Instant::now());
             false
         },
+    }
+}
+
+fn write_session_state_to_disk(
+    current_session_name: String,
+    current_session_info: SessionInfo,
+    current_session_layout: (String, BTreeMap<String, String>),
+) {
+    let metadata_cache_file_name =
+        session_info_cache_file_name(&current_session_name);
+    let (current_session_layout, layout_files_to_write) = current_session_layout;
+    let _wrote_metadata_file = std::fs::create_dir_all(
+        session_info_folder_for_session(&current_session_name).as_path(),
+    )
+    .and_then(|_| std::fs::File::create(metadata_cache_file_name))
+    .and_then(|mut f| write!(f, "{}", current_session_info.to_string()));
+
+    if !current_session_layout.is_empty() {
+        let layout_cache_file_name =
+            session_layout_cache_file_name(&current_session_name);
+        let _wrote_layout_file = std::fs::create_dir_all(
+            session_info_folder_for_session(&current_session_name)
+                .as_path(),
+        )
+        .and_then(|_| std::fs::File::create(layout_cache_file_name))
+        .and_then(|mut f| write!(f, "{}", current_session_layout))
+        .and_then(|_| {
+            let session_info_folder =
+                session_info_folder_for_session(&current_session_name);
+            for (external_file_name, external_file_contents) in
+                layout_files_to_write
+            {
+                std::fs::File::create(
+                    session_info_folder.join(external_file_name),
+                )
+                .and_then(|mut f| write!(f, "{}", external_file_contents))
+                .unwrap_or_else(
+                    |e| {
+                        log::error!(
+                            "Failed to write layout metadata file: {:?}",
+                            e
+                        );
+                    },
+                );
+            }
+            Ok(())
+        });
+    }
+}
+
+fn read_other_live_session_states(current_session_name: &str) -> BTreeMap<String, SessionInfo> {
+    let mut other_session_names = vec![];
+    let mut session_infos_on_machine = BTreeMap::new();
+    // we do this so that the session infos will be actual and we're
+    // reasonably sure their session is running
+    if let Ok(files) = fs::read_dir(&*ZELLIJ_SOCK_DIR) {
+        files.for_each(|file| {
+            if let Ok(file) = file {
+                if let Ok(file_name) = file.file_name().into_string() {
+                    if file.file_type().unwrap().is_socket() {
+                        other_session_names.push(file_name);
+                    }
+                }
+            }
+        });
+    }
+
+    for session_name in other_session_names {
+        let session_cache_file_name =
+            session_info_cache_file_name(&session_name);
+        if let Ok(raw_session_info) =
+            fs::read_to_string(&session_cache_file_name)
+        {
+            if let Ok(session_info) = SessionInfo::from_string(
+                &raw_session_info,
+                &current_session_name,
+            ) {
+                session_infos_on_machine.insert(session_name, session_info);
+            }
+        }
+    }
+    session_infos_on_machine
+}
+
+fn find_resurrectable_sessions(session_infos_on_machine: &BTreeMap<String, SessionInfo>) -> BTreeMap<String, Duration> {
+    match fs::read_dir(&*ZELLIJ_SESSION_INFO_CACHE_DIR) {
+        Ok(files_in_session_info_folder) => {
+            let files_that_are_folders = files_in_session_info_folder
+                .filter_map(|f| f.ok().map(|f| f.path()))
+                .filter(|f| f.is_dir());
+            files_that_are_folders
+                .filter_map(|folder_name| {
+                    let session_name = folder_name.file_name()?.to_str()?.to_owned();
+                    if session_infos_on_machine.contains_key(&session_name) {
+                        // this is not a dead session...
+                        return None;
+                    }
+                    let layout_file_name =
+                        session_layout_cache_file_name(&session_name);
+                    let ctime = match std::fs::metadata(&layout_file_name)
+                        .and_then(|metadata| metadata.created())
+                    {
+                        Ok(created) => Some(created),
+                        Err(e) => {
+                            log::error!(
+                                "Failed to read created stamp of resurrection file: {:?}",
+                                e
+                            );
+                            None
+                        },
+                    };
+                    let elapsed_duration = ctime
+                        .map(|ctime| {
+                            Duration::from_secs(ctime.elapsed().ok().unwrap_or_default().as_secs())
+                        })
+                        .unwrap_or_default();
+                    Some((session_name, elapsed_duration))
+                }).collect()
+        },
+        Err(e) => {
+            log::error!("Failed to read session info cache dir: {:?}", e);
+            BTreeMap::new()
+        }
     }
 }

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -224,7 +224,9 @@ fn host_run_plugin_command(env: FunctionEnvMut<ForeignFunctionEnv>) {
                         connect_to_session.tab_position,
                         connect_to_session.pane_id,
                     )?,
-                    PluginCommand::DeleteDeadSession(session_name) => delete_dead_session(session_name)?,
+                    PluginCommand::DeleteDeadSession(session_name) => {
+                        delete_dead_session(session_name)?
+                    },
                     PluginCommand::DeleteAllDeadSessions => delete_all_dead_sessions()?,
                     PluginCommand::OpenFileInPlace(file_to_open) => {
                         open_file_in_place(env, file_to_open)
@@ -840,10 +842,11 @@ fn switch_session(
 }
 
 fn delete_dead_session(session_name: String) -> Result<()> {
-    std::fs::remove_dir_all(&*ZELLIJ_SESSION_INFO_CACHE_DIR.join(&session_name)).with_context(|| format!("Failed to delete dead session: {:?}", &session_name))
+    std::fs::remove_dir_all(&*ZELLIJ_SESSION_INFO_CACHE_DIR.join(&session_name))
+        .with_context(|| format!("Failed to delete dead session: {:?}", &session_name))
 }
 
-fn delete_all_dead_sessions () -> Result<()> {
+fn delete_all_dead_sessions() -> Result<()> {
     use std::os::unix::fs::FileTypeExt;
     let mut live_sessions = vec![];
     if let Ok(files) = std::fs::read_dir(&*ZELLIJ_SOCK_DIR) {
@@ -870,12 +873,13 @@ fn delete_all_dead_sessions () -> Result<()> {
                         return None;
                     }
                     Some(session_name)
-                }).collect()
+                })
+                .collect()
         },
         Err(e) => {
             log::error!("Failed to read session info cache dir: {:?}", e);
             vec![]
-        }
+        },
     };
     for session in dead_sessions {
         delete_dead_session(session)?;

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -4,8 +4,8 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 use std::rc::Rc;
-use std::time::Duration;
 use std::str;
+use std::time::Duration;
 
 use zellij_utils::data::{
     Direction, PaneManifest, PluginPermission, Resize, ResizeStrategy, SessionInfo,
@@ -304,7 +304,7 @@ pub enum ScreenInstruction {
     BreakPaneLeft(ClientId),
     UpdateSessionInfos(
         BTreeMap<String, SessionInfo>, // String is the session name
-        BTreeMap<String, Duration>, // resurrectable sessions - <name, created>
+        BTreeMap<String, Duration>,    // resurrectable sessions - <name, created>
     ),
     ReplacePane(
         PaneId,
@@ -563,7 +563,7 @@ pub(crate) struct Screen {
     session_infos_on_machine: BTreeMap<String, SessionInfo>, // String is the session name, can
     // also be this session
     resurrectable_sessions: BTreeMap<String, Duration>, // String is the session name, duration is
-                                                        // its creation time
+    // its creation time
     default_layout: Box<Layout>,
     default_shell: Option<PathBuf>,
     arrow_fonts: bool,
@@ -1434,7 +1434,13 @@ impl Screen {
             .send_to_plugin(PluginInstruction::Update(vec![(
                 None,
                 None,
-                Event::SessionUpdate(self.session_infos_on_machine.values().cloned().collect(), self.resurrectable_sessions.iter().map(|(n, c)| (n.clone(), c.clone())).collect()),
+                Event::SessionUpdate(
+                    self.session_infos_on_machine.values().cloned().collect(),
+                    self.resurrectable_sessions
+                        .iter()
+                        .map(|(n, c)| (n.clone(), c.clone()))
+                        .collect(),
+                ),
             )]))
             .context("failed to update session info")?;
         Ok(())

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -4,6 +4,7 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::time::Duration;
 use std::str;
 
 use zellij_utils::data::{
@@ -301,7 +302,10 @@ pub enum ScreenInstruction {
     BreakPane(Box<Layout>, Option<TerminalAction>, ClientId),
     BreakPaneRight(ClientId),
     BreakPaneLeft(ClientId),
-    UpdateSessionInfos(BTreeMap<String, SessionInfo>), // String is the session name
+    UpdateSessionInfos(
+        BTreeMap<String, SessionInfo>, // String is the session name
+        BTreeMap<String, Duration>, // resurrectable sessions - <name, created>
+    ),
     ReplacePane(
         PaneId,
         HoldForCommand,
@@ -558,6 +562,8 @@ pub(crate) struct Screen {
     session_name: String,
     session_infos_on_machine: BTreeMap<String, SessionInfo>, // String is the session name, can
     // also be this session
+    resurrectable_sessions: BTreeMap<String, Duration>, // String is the session name, duration is
+                                                        // its creation time
     default_layout: Box<Layout>,
     default_shell: Option<PathBuf>,
     arrow_fonts: bool,
@@ -585,6 +591,7 @@ impl Screen {
         let session_name = mode_info.session_name.clone().unwrap_or_default();
         let session_info = SessionInfo::new(session_name.clone());
         let mut session_infos_on_machine = BTreeMap::new();
+        let resurrectable_sessions = BTreeMap::new();
         session_infos_on_machine.insert(session_name.clone(), session_info);
         Screen {
             bus,
@@ -616,6 +623,7 @@ impl Screen {
             serialize_pane_viewport,
             scrollback_lines_to_serialize,
             arrow_fonts,
+            resurrectable_sessions,
         }
     }
 
@@ -1417,14 +1425,16 @@ impl Screen {
     pub fn update_session_infos(
         &mut self,
         new_session_infos: BTreeMap<String, SessionInfo>,
+        resurrectable_sessions: BTreeMap<String, Duration>,
     ) -> Result<()> {
         self.session_infos_on_machine = new_session_infos;
+        self.resurrectable_sessions = resurrectable_sessions;
         self.bus
             .senders
             .send_to_plugin(PluginInstruction::Update(vec![(
                 None,
                 None,
-                Event::SessionUpdate(self.session_infos_on_machine.values().cloned().collect()),
+                Event::SessionUpdate(self.session_infos_on_machine.values().cloned().collect(), self.resurrectable_sessions.iter().map(|(n, c)| (n.clone(), c.clone())).collect()),
             )]))
             .context("failed to update session info")?;
         Ok(())
@@ -3421,8 +3431,8 @@ pub(crate) fn screen_thread_main(
             ScreenInstruction::BreakPaneLeft(client_id) => {
                 screen.break_pane_to_new_tab(Direction::Left, client_id)?;
             },
-            ScreenInstruction::UpdateSessionInfos(new_session_infos) => {
-                screen.update_session_infos(new_session_infos)?;
+            ScreenInstruction::UpdateSessionInfos(new_session_infos, resurrectable_sessions) => {
+                screen.update_session_infos(new_session_infos, resurrectable_sessions)?;
             },
             ScreenInstruction::ReplacePane(
                 new_pane_id,

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -666,6 +666,22 @@ pub fn switch_session_with_focus(
     unsafe { host_run_plugin_command() };
 }
 
+/// Permanently delete a resurrectable session with the given name
+pub fn delete_dead_session(name: &str) {
+    let plugin_command = PluginCommand::DeleteDeadSession(name.to_owned());
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
+/// Permanently delete aall resurrectable sessions on this machine
+pub fn delete_all_dead_sessions() {
+    let plugin_command = PluginCommand::DeleteAllDeadSessions;
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
 // Utility Functions
 
 #[allow(unused)]

--- a/zellij-utils/assets/prost/api.event.rs
+++ b/zellij-utils/assets/prost/api.event.rs
@@ -55,6 +55,8 @@ pub mod event {
 pub struct SessionUpdatePayload {
     #[prost(message, repeated, tag = "1")]
     pub session_manifests: ::prost::alloc::vec::Vec<SessionManifest>,
+    #[prost(message, repeated, tag = "2")]
+    pub resurrectable_sessions: ::prost::alloc::vec::Vec<ResurrectableSession>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -170,6 +172,14 @@ pub struct SessionManifest {
     pub connected_clients: u32,
     #[prost(bool, tag = "5")]
     pub is_current_session: bool,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ResurrectableSession {
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(uint64, tag = "2")]
+    pub creation_time: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/zellij-utils/assets/prost/api.plugin_command.rs
+++ b/zellij-utils/assets/prost/api.plugin_command.rs
@@ -5,7 +5,7 @@ pub struct PluginCommand {
     pub name: i32,
     #[prost(
         oneof = "plugin_command::Payload",
-        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44"
+        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45"
     )]
     pub payload: ::core::option::Option<plugin_command::Payload>,
 }
@@ -100,6 +100,8 @@ pub mod plugin_command {
         RunCommandPayload(super::RunCommandPayload),
         #[prost(message, tag = "44")]
         WebRequestPayload(super::WebRequestPayload),
+        #[prost(string, tag = "45")]
+        DeleteDeadSessionPayload(::prost::alloc::string::String),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -311,6 +313,8 @@ pub enum CommandName {
     OpenFileInPlace = 70,
     RunCommand = 71,
     WebRequest = 72,
+    DeleteDeadSession = 73,
+    DeleteAllDeadSessions = 74,
 }
 impl CommandName {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -392,6 +396,8 @@ impl CommandName {
             CommandName::OpenFileInPlace => "OpenFileInPlace",
             CommandName::RunCommand => "RunCommand",
             CommandName::WebRequest => "WebRequest",
+            CommandName::DeleteDeadSession => "DeleteDeadSession",
+            CommandName::DeleteAllDeadSessions => "DeleteAllDeadSessions",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -470,6 +476,8 @@ impl CommandName {
             "OpenFileInPlace" => Some(Self::OpenFileInPlace),
             "RunCommand" => Some(Self::RunCommand),
             "WebRequest" => Some(Self::WebRequest),
+            "DeleteDeadSession" => Some(Self::DeleteDeadSession),
+            "DeleteAllDeadSessions" => Some(Self::DeleteAllDeadSessions),
             _ => None,
         }
     }

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -3,6 +3,7 @@ use crate::input::config::ConversionError;
 use clap::ArgEnum;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::time::Duration;
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -495,7 +496,10 @@ pub enum Event {
     FileSystemDelete(Vec<PathBuf>),
     /// A Result of plugin permission request
     PermissionRequestResult(PermissionStatus),
-    SessionUpdate(Vec<SessionInfo>),
+    SessionUpdate(
+        Vec<SessionInfo>,
+        Vec<(String, Duration)> // resurrectable sessions
+    ),
     RunCommandResult(Option<i32>, Vec<u8>, Vec<u8>, BTreeMap<String, String>), // exit_code, STDOUT, STDERR,
     // context
     WebRequestResult(
@@ -1082,6 +1086,8 @@ pub enum PluginCommand {
     ReportPanic(String),             // stringified panic
     RequestPluginPermissions(Vec<PermissionType>),
     SwitchSession(ConnectToSession),
+    DeleteDeadSession(String), // String -> session name
+    DeleteAllDeadSessions, // String -> session name
     OpenTerminalInPlace(FileToOpen), // only used for the path as cwd
     OpenFileInPlace(FileToOpen),
     OpenCommandPaneInPlace(CommandToRun),

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -3,10 +3,10 @@ use crate::input::config::ConversionError;
 use clap::ArgEnum;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::time::Duration;
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::time::Duration;
 use strum_macros::{Display, EnumDiscriminants, EnumIter, EnumString, ToString};
 
 pub type ClientId = u16; // TODO: merge with crate type?
@@ -498,7 +498,7 @@ pub enum Event {
     PermissionRequestResult(PermissionStatus),
     SessionUpdate(
         Vec<SessionInfo>,
-        Vec<(String, Duration)> // resurrectable sessions
+        Vec<(String, Duration)>, // resurrectable sessions
     ),
     RunCommandResult(Option<i32>, Vec<u8>, Vec<u8>, BTreeMap<String, String>), // exit_code, STDOUT, STDERR,
     // context
@@ -1086,8 +1086,8 @@ pub enum PluginCommand {
     ReportPanic(String),             // stringified panic
     RequestPluginPermissions(Vec<PermissionType>),
     SwitchSession(ConnectToSession),
-    DeleteDeadSession(String), // String -> session name
-    DeleteAllDeadSessions, // String -> session name
+    DeleteDeadSession(String),       // String -> session name
+    DeleteAllDeadSessions,           // String -> session name
     OpenTerminalInPlace(FileToOpen), // only used for the path as cwd
     OpenFileInPlace(FileToOpen),
     OpenCommandPaneInPlace(CommandToRun),

--- a/zellij-utils/src/plugin_api/event.proto
+++ b/zellij-utils/src/plugin_api/event.proto
@@ -70,6 +70,7 @@ message Event {
 
 message SessionUpdatePayload {
   repeated SessionManifest session_manifests = 1;
+  repeated ResurrectableSession resurrectable_sessions = 2;
 }
 
 message RunCommandResultPayload {
@@ -151,6 +152,11 @@ message SessionManifest {
   repeated PaneManifest panes = 3;
   uint32 connected_clients = 4;
   bool is_current_session = 5;
+}
+
+message ResurrectableSession {
+  string name = 1;
+  uint64 creation_time = 2;
 }
 
 message PaneInfo {

--- a/zellij-utils/src/plugin_api/event.rs
+++ b/zellij-utils/src/plugin_api/event.rs
@@ -1274,7 +1274,7 @@ fn serialize_file_system_delete_event() {
 #[test]
 fn serialize_session_update_event() {
     use prost::Message;
-    let session_update_event = Event::SessionUpdate(Default::default());
+    let session_update_event = Event::SessionUpdate(Default::default(), Default::default());
     let protobuf_event: ProtobufEvent = session_update_event.clone().try_into().unwrap();
     let serialized_protobuf_event = protobuf_event.encode_to_vec();
     let deserialized_protobuf_event: ProtobufEvent =
@@ -1385,8 +1385,9 @@ fn serialize_session_update_event_with_non_default_values() {
         is_current_session: false,
     };
     let session_infos = vec![session_info_1, session_info_2];
+    let resurrectable_sessions = vec![];
 
-    let session_update_event = Event::SessionUpdate(session_infos);
+    let session_update_event = Event::SessionUpdate(session_infos, resurrectable_sessions);
     let protobuf_event: ProtobufEvent = session_update_event.clone().try_into().unwrap();
     let serialized_protobuf_event = protobuf_event.encode_to_vec();
     let deserialized_protobuf_event: ProtobufEvent =

--- a/zellij-utils/src/plugin_api/event.rs
+++ b/zellij-utils/src/plugin_api/event.rs
@@ -6,7 +6,8 @@ pub use super::generated_api::api::{
         EventType as ProtobufEventType, InputModeKeybinds as ProtobufInputModeKeybinds,
         KeyBind as ProtobufKeyBind, ModeUpdatePayload as ProtobufModeUpdatePayload,
         PaneInfo as ProtobufPaneInfo, PaneManifest as ProtobufPaneManifest,
-        SessionManifest as ProtobufSessionManifest, TabInfo as ProtobufTabInfo, ResurrectableSession as ProtobufResurrectableSession, *,
+        ResurrectableSession as ProtobufResurrectableSession,
+        SessionManifest as ProtobufSessionManifest, TabInfo as ProtobufTabInfo, *,
     },
     input_mode::InputMode as ProtobufInputMode,
     key::Key as ProtobufKey,
@@ -21,9 +22,9 @@ use crate::errors::prelude::*;
 use crate::input::actions::Action;
 
 use std::collections::{HashMap, HashSet};
-use std::time::Duration;
 use std::convert::TryFrom;
 use std::path::PathBuf;
+use std::time::Duration;
 
 impl TryFrom<ProtobufEvent> for Event {
     type Error = &'static str;
@@ -181,10 +182,15 @@ impl TryFrom<ProtobufEvent> for Event {
                     for protobuf_session_info in protobuf_session_update_payload.session_manifests {
                         session_infos.push(SessionInfo::try_from(protobuf_session_info)?);
                     }
-                    for protobuf_resurrectable_session in protobuf_session_update_payload.resurrectable_sessions {
+                    for protobuf_resurrectable_session in
+                        protobuf_session_update_payload.resurrectable_sessions
+                    {
                         resurrectable_sessions.push(protobuf_resurrectable_session.into());
                     }
-                    Ok(Event::SessionUpdate(session_infos, resurrectable_sessions.into()))
+                    Ok(Event::SessionUpdate(
+                        session_infos,
+                        resurrectable_sessions.into(),
+                    ))
                 },
                 _ => Err("Malformed payload for the SessionUpdate Event"),
             },
@@ -899,7 +905,10 @@ impl TryFrom<EventType> for ProtobufEventType {
 
 impl From<ProtobufResurrectableSession> for (String, Duration) {
     fn from(protobuf_resurrectable_session: ProtobufResurrectableSession) -> (String, Duration) {
-        (protobuf_resurrectable_session.name, Duration::from_secs(protobuf_resurrectable_session.creation_time))
+        (
+            protobuf_resurrectable_session.name,
+            Duration::from_secs(protobuf_resurrectable_session.creation_time),
+        )
     }
 }
 
@@ -907,7 +916,7 @@ impl From<(String, Duration)> for ProtobufResurrectableSession {
     fn from(session_name_and_creation_time: (String, Duration)) -> ProtobufResurrectableSession {
         ProtobufResurrectableSession {
             name: session_name_and_creation_time.0,
-            creation_time:  session_name_and_creation_time.1.as_secs()
+            creation_time: session_name_and_creation_time.1.as_secs(),
         }
     }
 }

--- a/zellij-utils/src/plugin_api/plugin_command.proto
+++ b/zellij-utils/src/plugin_api/plugin_command.proto
@@ -84,6 +84,8 @@ enum CommandName {
   OpenFileInPlace = 70;
   RunCommand = 71;
   WebRequest = 72;
+  DeleteDeadSession = 73;
+  DeleteAllDeadSessions = 74;
 }
 
 message PluginCommand {
@@ -132,6 +134,7 @@ message PluginCommand {
     OpenCommandPanePayload open_command_pane_in_place_payload = 42;
     RunCommandPayload run_command_payload = 43;
     WebRequestPayload web_request_payload = 44;
+    string delete_dead_session_payload = 45;
   }
 }
 

--- a/zellij-utils/src/plugin_api/plugin_command.rs
+++ b/zellij-utils/src/plugin_api/plugin_command.rs
@@ -1051,18 +1051,14 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
                     })),
                 })
             },
-            PluginCommand::DeleteDeadSession(dead_session_name) => {
-                Ok(ProtobufPluginCommand {
-                    name: CommandName::DeleteDeadSession as i32,
-                    payload: Some(Payload::DeleteDeadSessionPayload(dead_session_name)),
-                })
-            },
-            PluginCommand::DeleteAllDeadSessions => {
-                Ok(ProtobufPluginCommand {
-                    name: CommandName::DeleteAllDeadSessions as i32,
-                    payload: None,
-                })
-            },
+            PluginCommand::DeleteDeadSession(dead_session_name) => Ok(ProtobufPluginCommand {
+                name: CommandName::DeleteDeadSession as i32,
+                payload: Some(Payload::DeleteDeadSessionPayload(dead_session_name)),
+            }),
+            PluginCommand::DeleteAllDeadSessions => Ok(ProtobufPluginCommand {
+                name: CommandName::DeleteAllDeadSessions as i32,
+                payload: None,
+            }),
         }
     }
 }

--- a/zellij-utils/src/plugin_api/plugin_command.rs
+++ b/zellij-utils/src/plugin_api/plugin_command.rs
@@ -628,6 +628,13 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
                 },
                 _ => Err("Mismatched payload for WebRequest"),
             },
+            Some(CommandName::DeleteDeadSession) => match protobuf_plugin_command.payload {
+                Some(Payload::DeleteDeadSessionPayload(dead_session_name)) => {
+                    Ok(PluginCommand::DeleteDeadSession(dead_session_name))
+                },
+                _ => Err("Mismatched payload for DeleteDeadSession"),
+            },
+            Some(CommandName::DeleteAllDeadSessions) => Ok(PluginCommand::DeleteAllDeadSessions),
             None => Err("Unrecognized plugin command"),
         }
     }
@@ -1042,6 +1049,18 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
                         headers,
                         context,
                     })),
+                })
+            },
+            PluginCommand::DeleteDeadSession(dead_session_name) => {
+                Ok(ProtobufPluginCommand {
+                    name: CommandName::DeleteDeadSession as i32,
+                    payload: Some(Payload::DeleteDeadSessionPayload(dead_session_name)),
+                })
+            },
+            PluginCommand::DeleteAllDeadSessions => {
+                Ok(ProtobufPluginCommand {
+                    name: CommandName::DeleteAllDeadSessions as i32,
+                    payload: None,
                 })
             },
         }


### PR DESCRIPTION
This adds a new screen to the session manager (exclusively using the recently added UI components) that allows users to resurrect sessions from within Zellij (including a fuzzy find for those sessions):

![img-2023-11-03-231401](https://github.com/zellij-org/zellij/assets/795598/2b9d6915-ffaa-49eb-9e15-ac781a951b9e)

This also adds two relevant APIs (behind the "change session state" permission):

`delete_dead_session(name: &str)`
and
`delete_all_dead_sessions()`

The `SessioUpdate` plugin event now also includes resurrectable sessions on the machine:
```rust
SessionUpdate(
    Vec<SessionInfo>,
    Vec<(String, Duration)>, // resurrectable sessions, (name, creation_time)
),
```