### PR TITLE
fix(plugins): start plugin pane in cwd of focused pane if possible

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,19 +65,3 @@ jobs:
         run: rustup show
       - name: Check Format
         run: cargo xtask format --check
-
-  clippy:
-    name: Check Clippy Lints
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup toolchain
-        run: rustup show
-      - uses: Swatinem/rust-cache@v2
-      - name: Check clippy lints
-        run: cargo xtask clippy

--- a/zellij-server/src/plugins/mod.rs
+++ b/zellij-server/src/plugins/mod.rs
@@ -50,6 +50,7 @@ pub enum PluginInstruction {
         Option<PaneId>, // pane id to replace if this is to be opened "in-place"
         ClientId,
         Size,
+        Option<PathBuf>, // cwd
     ),
     Update(Vec<(Option<PluginId>, Option<ClientId>, Event)>), // Focused plugin / broadcast, client_id, event data
     Unload(PluginId),                                         // plugin_id
@@ -182,7 +183,8 @@ pub(crate) fn plugin_thread_main(
                 pane_id_to_replace,
                 client_id,
                 size,
-            ) => match wasm_bridge.load_plugin(&run, tab_index, size, Some(client_id)) {
+                cwd,
+            ) => match wasm_bridge.load_plugin(&run, tab_index, size, cwd, Some(client_id)) {
                 Ok(plugin_id) => {
                     drop(bus.senders.send_to_screen(ScreenInstruction::AddPlugin(
                         should_float,
@@ -217,7 +219,7 @@ pub(crate) fn plugin_thread_main(
                             log::warn!("Plugin {} not found, starting it instead", run.location);
                             // we intentionally do not provide the client_id here because it belongs to
                             // the cli who spawned the command and is not an existing client_id
-                            match wasm_bridge.load_plugin(&run, tab_index, size, None) {
+                            match wasm_bridge.load_plugin(&run, tab_index, size, None, None) {
                                 Ok(plugin_id) => {
                                     let should_be_open_in_place = false;
                                     drop(bus.senders.send_to_screen(ScreenInstruction::AddPlugin(
@@ -281,8 +283,13 @@ pub(crate) fn plugin_thread_main(
                 extracted_run_instructions.append(&mut extracted_floating_plugins);
                 for run_instruction in extracted_run_instructions {
                     if let Some(Run::Plugin(run)) = run_instruction {
-                        let plugin_id =
-                            wasm_bridge.load_plugin(&run, tab_index, size, Some(client_id))?;
+                        let plugin_id = wasm_bridge.load_plugin(
+                            &run,
+                            tab_index,
+                            size,
+                            None,
+                            Some(client_id),
+                        )?;
                         plugin_ids
                             .entry((run.location, run.configuration))
                             .or_default()

--- a/zellij-server/src/plugins/unit/plugin_tests.rs
+++ b/zellij-server/src/plugins/unit/plugin_tests.rs
@@ -616,6 +616,7 @@ pub fn load_new_plugin_from_hd() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -686,6 +687,7 @@ pub fn plugin_workers() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     // we send a SystemClipboardFailure to trigger the custom handler in the fixture plugin that
@@ -760,6 +762,7 @@ pub fn plugin_workers_persist_state() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     // we send a SystemClipboardFailure to trigger the custom handler in the fixture plugin that
@@ -838,6 +841,7 @@ pub fn can_subscribe_to_hd_events() {
         None,
         client_id,
         size,
+        None,
     ));
     // extra long time because we only start the fs watcher on plugin load
     std::thread::sleep(std::time::Duration::from_millis(5000));
@@ -910,6 +914,7 @@ pub fn switch_to_mode_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -979,6 +984,7 @@ pub fn switch_to_mode_plugin_command_permission_denied() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -1048,6 +1054,7 @@ pub fn new_tabs_with_layout_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -1131,6 +1138,7 @@ pub fn new_tab_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -1200,6 +1208,7 @@ pub fn go_to_next_tab_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -1268,6 +1277,7 @@ pub fn go_to_previous_tab_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -1336,6 +1346,7 @@ pub fn resize_focused_pane_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -1404,6 +1415,7 @@ pub fn resize_focused_pane_with_direction_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -1472,6 +1484,7 @@ pub fn focus_next_pane_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -1540,6 +1553,7 @@ pub fn focus_previous_pane_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -1608,6 +1622,7 @@ pub fn move_focus_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -1676,6 +1691,7 @@ pub fn move_focus_or_tab_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -1744,6 +1760,7 @@ pub fn edit_scrollback_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -1812,6 +1829,7 @@ pub fn write_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -1880,6 +1898,7 @@ pub fn write_chars_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -1948,6 +1967,7 @@ pub fn toggle_tab_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -2016,6 +2036,7 @@ pub fn move_pane_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -2084,6 +2105,7 @@ pub fn move_pane_with_direction_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -2153,6 +2175,7 @@ pub fn clear_screen_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -2222,6 +2245,7 @@ pub fn scroll_up_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -2290,6 +2314,7 @@ pub fn scroll_down_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -2358,6 +2383,7 @@ pub fn scroll_to_top_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -2426,6 +2452,7 @@ pub fn scroll_to_bottom_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -2494,6 +2521,7 @@ pub fn page_scroll_up_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -2562,6 +2590,7 @@ pub fn page_scroll_down_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -2630,6 +2659,7 @@ pub fn toggle_focus_fullscreen_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -2698,6 +2728,7 @@ pub fn toggle_pane_frames_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -2766,6 +2797,7 @@ pub fn toggle_pane_embed_or_eject_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -2834,6 +2866,7 @@ pub fn undo_rename_pane_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -2902,6 +2935,7 @@ pub fn close_focus_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -2970,6 +3004,7 @@ pub fn toggle_active_tab_sync_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -3038,6 +3073,7 @@ pub fn close_focused_tab_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -3106,6 +3142,7 @@ pub fn undo_rename_tab_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -3174,6 +3211,7 @@ pub fn previous_swap_layout_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -3242,6 +3280,7 @@ pub fn next_swap_layout_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -3310,6 +3349,7 @@ pub fn go_to_tab_name_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -3378,6 +3418,7 @@ pub fn focus_or_create_tab_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -3446,6 +3487,7 @@ pub fn go_to_tab() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -3514,6 +3556,7 @@ pub fn start_or_reload_plugin() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -3589,6 +3632,7 @@ pub fn quit_zellij_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -3664,6 +3708,7 @@ pub fn detach_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -3739,6 +3784,7 @@ pub fn open_file_floating_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -3814,6 +3860,7 @@ pub fn open_file_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -3890,6 +3937,7 @@ pub fn open_file_with_line_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -3965,6 +4013,7 @@ pub fn open_file_with_line_floating_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -4040,6 +4089,7 @@ pub fn open_terminal_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -4115,6 +4165,7 @@ pub fn open_terminal_floating_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -4190,6 +4241,7 @@ pub fn open_command_pane_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -4265,6 +4317,7 @@ pub fn open_command_pane_floating_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -4333,6 +4386,7 @@ pub fn switch_to_tab_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -4396,6 +4450,7 @@ pub fn hide_self_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -4459,6 +4514,7 @@ pub fn show_self_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -4527,6 +4583,7 @@ pub fn close_terminal_pane_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -4595,6 +4652,7 @@ pub fn close_plugin_pane_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -4663,6 +4721,7 @@ pub fn focus_terminal_pane_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -4731,6 +4790,7 @@ pub fn focus_plugin_pane_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -4799,6 +4859,7 @@ pub fn rename_terminal_pane_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -4867,6 +4928,7 @@ pub fn rename_plugin_pane_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -4935,6 +4997,7 @@ pub fn rename_tab_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -5012,6 +5075,7 @@ pub fn send_configuration_to_plugins() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -5077,6 +5141,7 @@ pub fn request_plugin_permissions() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -5166,6 +5231,7 @@ pub fn granted_permission_request_result() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -5254,6 +5320,7 @@ pub fn denied_permission_request_result() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -5321,6 +5388,7 @@ pub fn run_command_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -5396,6 +5464,7 @@ pub fn run_command_with_env_vars_and_cwd_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
@@ -5471,6 +5540,7 @@ pub fn web_request_plugin_command() {
         None,
         client_id,
         size,
+        None,
     ));
     std::thread::sleep(std::time::Duration::from_millis(500));
     let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(

--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -113,6 +113,7 @@ impl WasmBridge {
         run: &RunPlugin,
         tab_index: usize,
         size: Size,
+        cwd: Option<PathBuf>,
         client_id: Option<ClientId>,
     ) -> Result<PluginId> {
         // returns the plugin id
@@ -153,7 +154,7 @@ impl WasmBridge {
             let plugin_map = self.plugin_map.clone();
             let connected_clients = self.connected_clients.clone();
             let path_to_default_shell = self.path_to_default_shell.clone();
-            let zellij_cwd = self.zellij_cwd.clone();
+            let zellij_cwd = cwd.unwrap_or_else(|| self.zellij_cwd.clone());
             let capabilities = self.capabilities.clone();
             let client_attributes = self.client_attributes.clone();
             let default_shell = self.default_shell.clone();

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_launch_or_focus_plugin_action.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_launch_or_focus_plugin_action.snap
@@ -1,10 +1,10 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 2596
-expression: "format!(\"{:#?}\", plugin_load_instruction)"
+assertion_line: 2614
+expression: "format!(\"{:#?}\", pty_fill_plugin_cwd_instruction)"
 ---
 Some(
-    Load(
+    FillPluginCwd(
         Some(
             true,
         ),

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -367,6 +367,7 @@ pub enum PtyContext {
     SpawnInPlaceTerminal,
     DumpLayout,
     LogLayoutToHd,
+    FillPluginCwd,
     Exit,
 }
 


### PR DESCRIPTION
Until this PR, new plugins that were launched at runtime always got the cwd that Zellij originally started with. This behavior is very desirable when starting a layout, but is almost never desirable when launching a new plugin.

This PR fixes this.