### PR TITLE
Fix typo in help page

### DIFF
--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -456,7 +456,7 @@ pub enum CliAction {
     },
     /// Embed focused pane if floating or float focused pane if embedded
     TogglePaneEmbedOrFloating,
-    /// Toggle the visibility of all fdirectionloating panes in the current Tab, open one if none exist
+    /// Toggle the visibility of all floating panes in the current Tab, open one if none exist
     ToggleFloatingPanes,
     /// Close the focused pane.
     ClosePane,


### PR DESCRIPTION
I noticed this small typo in the help pages. I'm not familiar with the code so I assumed these comments are also used to populate the help pages. If this is not the case the typo should also be wherever the help page is getting it from.

Great work btw, i'm loving zellij.