### PR TITLE
docs(api): docs for shim.rs

### DIFF
--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -566,6 +566,7 @@ impl ServerOsApi for ServerOsInputOutput {
         }
         Ok(())
     }
+    #[allow(unused_assignments)]
     fn spawn_terminal(
         &self,
         terminal_action: TerminalAction,
@@ -617,6 +618,7 @@ impl ServerOsApi for ServerOsInputOutput {
             None => Err(anyhow!("no more terminal IDs left to allocate")),
         }
     }
+    #[allow(unused_assignments)]
     fn reserve_terminal_id(&self) -> Result<u32> {
         let err_context = || "failed to reserve a terminal ID".to_string();
 

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -115,6 +115,7 @@ pub struct TerminalPane {
     // held on startup and can possibly be used to display some errors
     pane_frame_color_override: Option<(PaletteColor, Option<String>)>,
     invoked_with: Option<Run>,
+    #[allow(dead_code)]
     arrow_fonts: bool,
 }
 

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -91,7 +91,7 @@ pub fn open_file_floating(file_to_open: FileToOpen) {
     unsafe { host_run_plugin_command() };
 }
 
-/// Open a file in the user's default `$EDITOR` in a new floating pane
+/// Open a file in the user's default `$EDITOR`, replacing the focused pane
 pub fn open_file_in_place(file_to_open: FileToOpen) {
     let plugin_command = PluginCommand::OpenFileInPlace(file_to_open);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
@@ -117,7 +117,8 @@ pub fn open_terminal_floating<P: AsRef<Path>>(path: P) {
     unsafe { host_run_plugin_command() };
 }
 
-/// Open a new floating terminal pane to the specified location on the host filesystem
+/// Open a new terminal pane to the specified location on the host filesystem, temporarily
+/// replacing the focused pane
 pub fn open_terminal_in_place<P: AsRef<Path>>(path: P) {
     let file_to_open = FileToOpen::new(path.as_ref().to_path_buf());
     let plugin_command = PluginCommand::OpenTerminalInPlace(file_to_open);
@@ -208,6 +209,9 @@ pub fn run_command_with_env_variables_and_cwd(
     unsafe { host_run_plugin_command() };
 }
 
+/// Make a web request, optionally being notified of its output
+/// if subscribed to the `WebRequestResult` Event, the context will be returned verbatim in this
+/// event and can be used for eg. marking the request_id
 pub fn web_request<S: AsRef<str>>(
     url: S,
     verb: HttpVerb,


### PR DESCRIPTION
This adds some missing documentation to the rust plugin SDK as well as clear up some compilation warnings.