### PR TITLE
fix(ux): LaunchPlugin and some cwd fixes

### DIFF
--- a/zellij-server/src/plugins/mod.rs
+++ b/zellij-server/src/plugins/mod.rs
@@ -184,7 +184,8 @@ pub(crate) fn plugin_thread_main(
                 client_id,
                 size,
                 cwd,
-            ) => match wasm_bridge.load_plugin(&run, tab_index, size, cwd.clone(), Some(client_id)) {
+            ) => match wasm_bridge.load_plugin(&run, tab_index, size, cwd.clone(), Some(client_id))
+            {
                 Ok(plugin_id) => {
                     drop(bus.senders.send_to_screen(ScreenInstruction::AddPlugin(
                         should_float,

--- a/zellij-server/src/plugins/mod.rs
+++ b/zellij-server/src/plugins/mod.rs
@@ -184,7 +184,7 @@ pub(crate) fn plugin_thread_main(
                 client_id,
                 size,
                 cwd,
-            ) => match wasm_bridge.load_plugin(&run, tab_index, size, cwd, Some(client_id)) {
+            ) => match wasm_bridge.load_plugin(&run, tab_index, size, cwd.clone(), Some(client_id)) {
                 Ok(plugin_id) => {
                     drop(bus.senders.send_to_screen(ScreenInstruction::AddPlugin(
                         should_float,
@@ -194,6 +194,7 @@ pub(crate) fn plugin_thread_main(
                         tab_index,
                         plugin_id,
                         pane_id_to_replace,
+                        cwd,
                         Some(client_id),
                     )));
                 },
@@ -229,6 +230,7 @@ pub(crate) fn plugin_thread_main(
                                         pane_title,
                                         tab_index,
                                         plugin_id,
+                                        None,
                                         None,
                                         None,
                                     )));

--- a/zellij-server/src/plugins/plugin_loader.rs
+++ b/zellij-server/src/plugins/plugin_loader.rs
@@ -805,6 +805,7 @@ impl<'a> PluginLoader<'a> {
             client_attributes: self.client_attributes.clone(),
             default_shell: self.default_shell.clone(),
             default_layout: self.default_layout.clone(),
+            plugin_cwd: self.zellij_cwd.clone(),
         };
 
         let subscriptions = Arc::new(Mutex::new(HashSet::new()));

--- a/zellij-server/src/plugins/plugin_map.rs
+++ b/zellij-server/src/plugins/plugin_map.rs
@@ -227,6 +227,7 @@ pub struct PluginEnv {
     pub client_attributes: ClientAttributes,
     pub default_shell: Option<TerminalAction>,
     pub default_layout: Box<Layout>,
+    pub plugin_cwd: PathBuf,
 }
 
 impl PluginEnv {

--- a/zellij-server/src/plugins/unit/plugin_tests.rs
+++ b/zellij-server/src/plugins/unit/plugin_tests.rs
@@ -5398,7 +5398,7 @@ pub fn run_command_plugin_command() {
     )]));
     background_jobs_thread.join().unwrap(); // this might take a while if the cache is cold
     teardown();
-    let new_tab_event = received_background_jobs_instructions
+    let new_background_job = received_background_jobs_instructions
         .lock()
         .unwrap()
         .iter()
@@ -5410,7 +5410,7 @@ pub fn run_command_plugin_command() {
             }
         })
         .clone();
-    assert_snapshot!(format!("{:#?}", new_tab_event));
+    assert!(format!("{:#?}", new_background_job).contains("user_value_1"));
 }
 
 #[test]

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -374,10 +374,12 @@ fn open_file(env: &ForeignFunctionEnv, file_to_open: FileToOpen) {
     let error_msg = || format!("failed to open file in plugin {}", env.plugin_env.name());
     let floating = false;
     let in_place = false;
+    let path = env.plugin_env.plugin_cwd.join(file_to_open.path);
+    let cwd = file_to_open.cwd.map(|cwd| env.plugin_env.plugin_cwd.join(cwd));
     let action = Action::EditFile(
-        file_to_open.path,
+        path,
         file_to_open.line_number,
-        file_to_open.cwd,
+        cwd,
         None,
         floating,
         in_place,
@@ -389,10 +391,12 @@ fn open_file_floating(env: &ForeignFunctionEnv, file_to_open: FileToOpen) {
     let error_msg = || format!("failed to open file in plugin {}", env.plugin_env.name());
     let floating = true;
     let in_place = false;
+    let path = env.plugin_env.plugin_cwd.join(file_to_open.path);
+    let cwd = file_to_open.cwd.map(|cwd| env.plugin_env.plugin_cwd.join(cwd));
     let action = Action::EditFile(
-        file_to_open.path,
+        path,
         file_to_open.line_number,
-        file_to_open.cwd,
+        cwd,
         None,
         floating,
         in_place,
@@ -404,10 +408,12 @@ fn open_file_in_place(env: &ForeignFunctionEnv, file_to_open: FileToOpen) {
     let error_msg = || format!("failed to open file in plugin {}", env.plugin_env.name());
     let floating = false;
     let in_place = true;
+    let path = env.plugin_env.plugin_cwd.join(file_to_open.path);
+    let cwd = file_to_open.cwd.map(|cwd| env.plugin_env.plugin_cwd.join(cwd));
     let action = Action::EditFile(
-        file_to_open.path,
+        path,
         file_to_open.line_number,
-        file_to_open.cwd,
+        cwd,
         None,
         floating,
         in_place,
@@ -417,6 +423,7 @@ fn open_file_in_place(env: &ForeignFunctionEnv, file_to_open: FileToOpen) {
 
 fn open_terminal(env: &ForeignFunctionEnv, cwd: PathBuf) {
     let error_msg = || format!("failed to open file in plugin {}", env.plugin_env.name());
+    let cwd = env.plugin_env.plugin_cwd.join(cwd);
     let mut default_shell = env
         .plugin_env
         .default_shell
@@ -433,6 +440,7 @@ fn open_terminal(env: &ForeignFunctionEnv, cwd: PathBuf) {
 
 fn open_terminal_floating(env: &ForeignFunctionEnv, cwd: PathBuf) {
     let error_msg = || format!("failed to open file in plugin {}", env.plugin_env.name());
+    let cwd = env.plugin_env.plugin_cwd.join(cwd);
     let mut default_shell = env
         .plugin_env
         .default_shell
@@ -449,6 +457,7 @@ fn open_terminal_floating(env: &ForeignFunctionEnv, cwd: PathBuf) {
 
 fn open_terminal_in_place(env: &ForeignFunctionEnv, cwd: PathBuf) {
     let error_msg = || format!("failed to open file in plugin {}", env.plugin_env.name());
+    let cwd = env.plugin_env.plugin_cwd.join(cwd);
     let mut default_shell = env
         .plugin_env
         .default_shell
@@ -466,7 +475,7 @@ fn open_terminal_in_place(env: &ForeignFunctionEnv, cwd: PathBuf) {
 fn open_command_pane(env: &ForeignFunctionEnv, command_to_run: CommandToRun) {
     let error_msg = || format!("failed to open command in plugin {}", env.plugin_env.name());
     let command = command_to_run.path;
-    let cwd = command_to_run.cwd;
+    let cwd = command_to_run.cwd.map(|cwd| env.plugin_env.plugin_cwd.join(cwd));
     let args = command_to_run.args;
     let direction = None;
     let hold_on_close = true;
@@ -487,7 +496,7 @@ fn open_command_pane(env: &ForeignFunctionEnv, command_to_run: CommandToRun) {
 fn open_command_pane_floating(env: &ForeignFunctionEnv, command_to_run: CommandToRun) {
     let error_msg = || format!("failed to open command in plugin {}", env.plugin_env.name());
     let command = command_to_run.path;
-    let cwd = command_to_run.cwd;
+    let cwd = command_to_run.cwd.map(|cwd| env.plugin_env.plugin_cwd.join(cwd));
     let args = command_to_run.args;
     let direction = None;
     let hold_on_close = true;
@@ -508,7 +517,7 @@ fn open_command_pane_floating(env: &ForeignFunctionEnv, command_to_run: CommandT
 fn open_command_pane_in_place(env: &ForeignFunctionEnv, command_to_run: CommandToRun) {
     let error_msg = || format!("failed to open command in plugin {}", env.plugin_env.name());
     let command = command_to_run.path;
-    let cwd = command_to_run.cwd;
+    let cwd = command_to_run.cwd.map(|cwd| env.plugin_env.plugin_cwd.join(cwd));
     let args = command_to_run.args;
     let direction = None;
     let hold_on_close = true;
@@ -621,6 +630,7 @@ fn run_command(
         log::error!("Command cannot be empty");
     } else {
         let command = command_line.remove(0);
+        let cwd = env.plugin_env.plugin_cwd.join(cwd);
         let _ = env
             .plugin_env
             .senders

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -375,7 +375,9 @@ fn open_file(env: &ForeignFunctionEnv, file_to_open: FileToOpen) {
     let floating = false;
     let in_place = false;
     let path = env.plugin_env.plugin_cwd.join(file_to_open.path);
-    let cwd = file_to_open.cwd.map(|cwd| env.plugin_env.plugin_cwd.join(cwd));
+    let cwd = file_to_open
+        .cwd
+        .map(|cwd| env.plugin_env.plugin_cwd.join(cwd));
     let action = Action::EditFile(
         path,
         file_to_open.line_number,
@@ -392,7 +394,9 @@ fn open_file_floating(env: &ForeignFunctionEnv, file_to_open: FileToOpen) {
     let floating = true;
     let in_place = false;
     let path = env.plugin_env.plugin_cwd.join(file_to_open.path);
-    let cwd = file_to_open.cwd.map(|cwd| env.plugin_env.plugin_cwd.join(cwd));
+    let cwd = file_to_open
+        .cwd
+        .map(|cwd| env.plugin_env.plugin_cwd.join(cwd));
     let action = Action::EditFile(
         path,
         file_to_open.line_number,
@@ -409,7 +413,9 @@ fn open_file_in_place(env: &ForeignFunctionEnv, file_to_open: FileToOpen) {
     let floating = false;
     let in_place = true;
     let path = env.plugin_env.plugin_cwd.join(file_to_open.path);
-    let cwd = file_to_open.cwd.map(|cwd| env.plugin_env.plugin_cwd.join(cwd));
+    let cwd = file_to_open
+        .cwd
+        .map(|cwd| env.plugin_env.plugin_cwd.join(cwd));
     let action = Action::EditFile(
         path,
         file_to_open.line_number,
@@ -475,7 +481,9 @@ fn open_terminal_in_place(env: &ForeignFunctionEnv, cwd: PathBuf) {
 fn open_command_pane(env: &ForeignFunctionEnv, command_to_run: CommandToRun) {
     let error_msg = || format!("failed to open command in plugin {}", env.plugin_env.name());
     let command = command_to_run.path;
-    let cwd = command_to_run.cwd.map(|cwd| env.plugin_env.plugin_cwd.join(cwd));
+    let cwd = command_to_run
+        .cwd
+        .map(|cwd| env.plugin_env.plugin_cwd.join(cwd));
     let args = command_to_run.args;
     let direction = None;
     let hold_on_close = true;
@@ -496,7 +504,9 @@ fn open_command_pane(env: &ForeignFunctionEnv, command_to_run: CommandToRun) {
 fn open_command_pane_floating(env: &ForeignFunctionEnv, command_to_run: CommandToRun) {
     let error_msg = || format!("failed to open command in plugin {}", env.plugin_env.name());
     let command = command_to_run.path;
-    let cwd = command_to_run.cwd.map(|cwd| env.plugin_env.plugin_cwd.join(cwd));
+    let cwd = command_to_run
+        .cwd
+        .map(|cwd| env.plugin_env.plugin_cwd.join(cwd));
     let args = command_to_run.args;
     let direction = None;
     let hold_on_close = true;
@@ -517,7 +527,9 @@ fn open_command_pane_floating(env: &ForeignFunctionEnv, command_to_run: CommandT
 fn open_command_pane_in_place(env: &ForeignFunctionEnv, command_to_run: CommandToRun) {
     let error_msg = || format!("failed to open command in plugin {}", env.plugin_env.name());
     let command = command_to_run.path;
-    let cwd = command_to_run.cwd.map(|cwd| env.plugin_env.plugin_cwd.join(cwd));
+    let cwd = command_to_run
+        .cwd
+        .map(|cwd| env.plugin_env.plugin_cwd.join(cwd));
     let args = command_to_run.args;
     let direction = None;
     let hold_on_close = true;

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -705,6 +705,23 @@ pub(crate) fn route_action(
                 ))
                 .with_context(err_context)?;
         },
+        Action::LaunchPlugin(
+            run_plugin,
+            should_float,
+            move_to_focused_tab,
+            should_open_in_place,
+        ) => {
+            senders
+                .send_to_screen(ScreenInstruction::LaunchPlugin(
+                    run_plugin,
+                    should_float,
+                    move_to_focused_tab,
+                    should_open_in_place,
+                    pane_id,
+                    client_id,
+                ))
+                .with_context(err_context)?;
+        },
         Action::CloseTerminalPane(terminal_pane_id) => {
             senders
                 .send_to_screen(ScreenInstruction::ClosePane(

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -708,14 +708,12 @@ pub(crate) fn route_action(
         Action::LaunchPlugin(
             run_plugin,
             should_float,
-            move_to_focused_tab,
             should_open_in_place,
         ) => {
             senders
                 .send_to_screen(ScreenInstruction::LaunchPlugin(
                     run_plugin,
                     should_float,
-                    move_to_focused_tab,
                     should_open_in_place,
                     pane_id,
                     client_id,

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -705,11 +705,7 @@ pub(crate) fn route_action(
                 ))
                 .with_context(err_context)?;
         },
-        Action::LaunchPlugin(
-            run_plugin,
-            should_float,
-            should_open_in_place,
-        ) => {
+        Action::LaunchPlugin(run_plugin, should_float, should_open_in_place) => {
             senders
                 .send_to_screen(ScreenInstruction::LaunchPlugin(
                     run_plugin,

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -295,8 +295,8 @@ pub enum ScreenInstruction {
     RequestStateUpdateForPlugins,
     LaunchOrFocusPlugin(RunPlugin, bool, bool, bool, Option<PaneId>, ClientId), // bools are: should_float, move_to_focused_tab, should_open_in_place Option<PaneId> is the pane id to replace
     LaunchPlugin(RunPlugin, bool, bool, bool, Option<PaneId>, ClientId), // bools are: should_float, move_to_focused_tab, should_open_in_place Option<PaneId> is the pane id to replace
-    SuppressPane(PaneId, ClientId),          // bool is should_float
-    FocusPaneWithId(PaneId, bool, ClientId), // bool is should_float
+    SuppressPane(PaneId, ClientId),                                      // bool is should_float
+    FocusPaneWithId(PaneId, bool, ClientId),                             // bool is should_float
     RenamePane(PaneId, Vec<u8>),
     RenameTab(usize, Vec<u8>),
     RequestPluginPermissions(
@@ -3247,8 +3247,14 @@ pub(crate) fn screen_thread_main(
                 cwd,
                 client_id,
             ) => {
-                let pane_title =
-                    pane_title.unwrap_or_else(|| format!("({}) - {}", cwd.map(|cwd| cwd.display().to_string()).unwrap_or(".".to_owned()), run_plugin_location.location));
+                let pane_title = pane_title.unwrap_or_else(|| {
+                    format!(
+                        "({}) - {}",
+                        cwd.map(|cwd| cwd.display().to_string())
+                            .unwrap_or(".".to_owned()),
+                        run_plugin_location.location
+                    )
+                });
                 let run_plugin = Run::Plugin(run_plugin_location);
 
                 if should_be_in_place {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -294,7 +294,7 @@ pub enum ScreenInstruction {
     ProgressPluginLoadingOffset(u32),                 // u32 - plugin id
     RequestStateUpdateForPlugins,
     LaunchOrFocusPlugin(RunPlugin, bool, bool, bool, Option<PaneId>, ClientId), // bools are: should_float, move_to_focused_tab, should_open_in_place Option<PaneId> is the pane id to replace
-    LaunchPlugin(RunPlugin, bool, bool, bool, Option<PaneId>, ClientId), // bools are: should_float, move_to_focused_tab, should_open_in_place Option<PaneId> is the pane id to replace
+    LaunchPlugin(RunPlugin, bool, bool, Option<PaneId>, ClientId), // bools are: should_float, should_open_in_place Option<PaneId> is the pane id to replace
     SuppressPane(PaneId, ClientId),                                      // bool is should_float
     FocusPaneWithId(PaneId, bool, ClientId),                             // bool is should_float
     RenamePane(PaneId, Vec<u8>),
@@ -3411,7 +3411,6 @@ pub(crate) fn screen_thread_main(
             ScreenInstruction::LaunchPlugin(
                 run_plugin,
                 should_float,
-                move_to_focused_tab,
                 should_open_in_place,
                 pane_id_to_replace,
                 client_id,

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -295,8 +295,8 @@ pub enum ScreenInstruction {
     RequestStateUpdateForPlugins,
     LaunchOrFocusPlugin(RunPlugin, bool, bool, bool, Option<PaneId>, ClientId), // bools are: should_float, move_to_focused_tab, should_open_in_place Option<PaneId> is the pane id to replace
     LaunchPlugin(RunPlugin, bool, bool, Option<PaneId>, ClientId), // bools are: should_float, should_open_in_place Option<PaneId> is the pane id to replace
-    SuppressPane(PaneId, ClientId),                                      // bool is should_float
-    FocusPaneWithId(PaneId, bool, ClientId),                             // bool is should_float
+    SuppressPane(PaneId, ClientId),                                // bool is should_float
+    FocusPaneWithId(PaneId, bool, ClientId),                       // bool is should_float
     RenamePane(PaneId, Vec<u8>),
     RenameTab(usize, Vec<u8>),
     RequestPluginPermissions(

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -286,6 +286,7 @@ pub enum ScreenInstruction {
         usize,          // tab index
         u32,            // plugin id
         Option<PaneId>,
+        Option<PathBuf>, // cwd
         Option<ClientId>,
     ),
     UpdatePluginLoadingStage(u32, LoadingIndication), // u32 - plugin_id
@@ -293,6 +294,7 @@ pub enum ScreenInstruction {
     ProgressPluginLoadingOffset(u32),                 // u32 - plugin id
     RequestStateUpdateForPlugins,
     LaunchOrFocusPlugin(RunPlugin, bool, bool, bool, Option<PaneId>, ClientId), // bools are: should_float, move_to_focused_tab, should_open_in_place Option<PaneId> is the pane id to replace
+    LaunchPlugin(RunPlugin, bool, bool, bool, Option<PaneId>, ClientId), // bools are: should_float, move_to_focused_tab, should_open_in_place Option<PaneId> is the pane id to replace
     SuppressPane(PaneId, ClientId),          // bool is should_float
     FocusPaneWithId(PaneId, bool, ClientId), // bool is should_float
     RenamePane(PaneId, Vec<u8>),
@@ -481,6 +483,7 @@ impl From<&ScreenInstruction> for ScreenContext {
                 ScreenContext::RequestStateUpdateForPlugins
             },
             ScreenInstruction::LaunchOrFocusPlugin(..) => ScreenContext::LaunchOrFocusPlugin,
+            ScreenInstruction::LaunchPlugin(..) => ScreenContext::LaunchPlugin,
             ScreenInstruction::SuppressPane(..) => ScreenContext::SuppressPane,
             ScreenInstruction::FocusPaneWithId(..) => ScreenContext::FocusPaneWithId,
             ScreenInstruction::RenamePane(..) => ScreenContext::RenamePane,
@@ -3241,10 +3244,11 @@ pub(crate) fn screen_thread_main(
                 tab_index,
                 plugin_id,
                 pane_id_to_replace,
+                cwd,
                 client_id,
             ) => {
                 let pane_title =
-                    pane_title.unwrap_or_else(|| run_plugin_location.location.to_string());
+                    pane_title.unwrap_or_else(|| format!("({}) - {}", cwd.map(|cwd| cwd.display().to_string()).unwrap_or(".".to_owned()), run_plugin_location.location));
                 let run_plugin = Run::Plugin(run_plugin_location);
 
                 if should_be_in_place {
@@ -3391,6 +3395,71 @@ pub(crate) fn screen_thread_main(
                                         Size::default(),
                                     ))?;
                             }
+                        },
+                        None => {
+                            log::error!("No connected clients found - cannot load or focus plugin")
+                        },
+                    }
+                },
+            },
+            ScreenInstruction::LaunchPlugin(
+                run_plugin,
+                should_float,
+                move_to_focused_tab,
+                should_open_in_place,
+                pane_id_to_replace,
+                client_id,
+            ) => match pane_id_to_replace {
+                Some(pane_id_to_replace) => match screen.active_tab_indices.values().next() {
+                    Some(tab_index) => {
+                        let size = Size::default();
+                        screen
+                            .bus
+                            .senders
+                            .send_to_pty(PtyInstruction::FillPluginCwd(
+                                Some(should_float),
+                                should_open_in_place,
+                                None,
+                                run_plugin,
+                                *tab_index,
+                                Some(pane_id_to_replace),
+                                client_id,
+                                size,
+                            ))?;
+                    },
+                    None => {
+                        log::error!(
+                            "Could not find an active tab - is there at least 1 connected user?"
+                        );
+                    },
+                },
+                None => {
+                    let client_id = if screen.active_tab_indices.contains_key(&client_id) {
+                        Some(client_id)
+                    } else {
+                        screen.get_first_client_id()
+                    };
+                    let client_id_and_focused_tab = client_id.and_then(|client_id| {
+                        screen
+                            .active_tab_indices
+                            .get(&client_id)
+                            .map(|tab_index| (*tab_index, client_id))
+                    });
+                    match client_id_and_focused_tab {
+                        Some((tab_index, client_id)) => {
+                            screen
+                                .bus
+                                .senders
+                                .send_to_pty(PtyInstruction::FillPluginCwd(
+                                    Some(should_float),
+                                    should_open_in_place,
+                                    None,
+                                    run_plugin,
+                                    tab_index,
+                                    None,
+                                    client_id,
+                                    Size::default(),
+                                ))?;
                         },
                         None => {
                             log::error!("No connected clients found - cannot load or focus plugin")

--- a/zellij-utils/assets/prost/api.action.rs
+++ b/zellij-utils/assets/prost/api.action.rs
@@ -5,7 +5,7 @@ pub struct Action {
     pub name: i32,
     #[prost(
         oneof = "action::OptionalPayload",
-        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45"
+        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46"
     )]
     pub optional_payload: ::core::option::Option<action::OptionalPayload>,
 }
@@ -102,6 +102,8 @@ pub mod action {
         RenameTabPayload(super::IdAndName),
         #[prost(string, tag = "45")]
         RenameSessionPayload(::prost::alloc::string::String),
+        #[prost(message, tag = "46")]
+        LaunchPluginPayload(super::LaunchOrFocusPluginPayload),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -403,6 +405,7 @@ pub enum ActionName {
     BreakPaneRight = 78,
     BreakPaneLeft = 79,
     RenameSession = 80,
+    LaunchPlugin = 81,
 }
 impl ActionName {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -492,6 +495,7 @@ impl ActionName {
             ActionName::BreakPaneRight => "BreakPaneRight",
             ActionName::BreakPaneLeft => "BreakPaneLeft",
             ActionName::RenameSession => "RenameSession",
+            ActionName::LaunchPlugin => "LaunchPlugin",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -578,6 +582,7 @@ impl ActionName {
             "BreakPaneRight" => Some(Self::BreakPaneRight),
             "BreakPaneLeft" => Some(Self::BreakPaneLeft),
             "RenameSession" => Some(Self::RenameSession),
+            "LaunchPlugin" => Some(Self::LaunchPlugin),
             _ => None,
         }
     }

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -527,6 +527,17 @@ pub enum CliAction {
         #[clap(short, long, value_parser)]
         configuration: Option<PluginUserConfiguration>,
     },
+    LaunchPlugin {
+        #[clap(short, long, value_parser)]
+        floating: bool,
+        #[clap(short, long, value_parser)]
+        in_place: bool,
+        #[clap(short, long, value_parser)]
+        move_to_focused_tab: bool,
+        url: Url,
+        #[clap(short, long, value_parser)]
+        configuration: Option<PluginUserConfiguration>,
+    },
     RenameSession {
         name: String,
     },

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -532,8 +532,6 @@ pub enum CliAction {
         floating: bool,
         #[clap(short, long, value_parser)]
         in_place: bool,
-        #[clap(short, long, value_parser)]
-        move_to_focused_tab: bool,
         url: Url,
         #[clap(short, long, value_parser)]
         configuration: Option<PluginUserConfiguration>,

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -335,6 +335,7 @@ pub enum ScreenContext {
     StartPluginLoadingIndication,
     RequestStateUpdateForPlugins,
     LaunchOrFocusPlugin,
+    LaunchPlugin,
     SuppressPane,
     FocusPaneWithId,
     RenamePane,

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -555,11 +555,7 @@ impl Action {
                     _allow_exec_host_cmd: false,
                     configuration: configuration.unwrap_or_default(),
                 };
-                Ok(vec![Action::LaunchPlugin(
-                    run_plugin,
-                    floating,
-                    in_place,
-                )])
+                Ok(vec![Action::LaunchPlugin(run_plugin, floating, in_place)])
             },
             CliAction::RenameSession { name } => Ok(vec![Action::RenameSession(name)]),
         }

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -210,7 +210,9 @@ pub enum Action {
     RightClick(Position),
     MiddleClick(Position),
     LaunchOrFocusPlugin(RunPlugin, bool, bool, bool), // bools => should float,
-    // move_to_focused_tab, should_open_in_place
+                                                      // move_to_focused_tab, should_open_in_place
+    LaunchPlugin(RunPlugin, bool, bool, bool), // bools => should float,
+                                               // move_to_focused_tab, should_open_in_place
     LeftMouseRelease(Position),
     RightMouseRelease(Position),
     MiddleMouseRelease(Position),
@@ -259,6 +261,7 @@ impl Action {
         match (self, other_action) {
             (Action::NewTab(..), Action::NewTab(..)) => true,
             (Action::LaunchOrFocusPlugin(..), Action::LaunchOrFocusPlugin(..)) => true,
+            (Action::LaunchPlugin(..), Action::LaunchPlugin(..)) => true,
             _ => self == other_action,
         }
     }
@@ -532,6 +535,28 @@ impl Action {
                     configuration: configuration.unwrap_or_default(),
                 };
                 Ok(vec![Action::LaunchOrFocusPlugin(
+                    run_plugin,
+                    floating,
+                    move_to_focused_tab,
+                    in_place,
+                )])
+            },
+            CliAction::LaunchPlugin {
+                url,
+                floating,
+                in_place,
+                move_to_focused_tab,
+                configuration,
+            } => {
+                let current_dir = get_current_dir();
+                let run_plugin_location = RunPluginLocation::parse(url.as_str(), Some(current_dir))
+                    .map_err(|e| format!("Failed to parse plugin location: {}", e))?;
+                let run_plugin = RunPlugin {
+                    location: run_plugin_location,
+                    _allow_exec_host_cmd: false,
+                    configuration: configuration.unwrap_or_default(),
+                };
+                Ok(vec![Action::LaunchPlugin(
                     run_plugin,
                     floating,
                     move_to_focused_tab,

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -211,8 +211,8 @@ pub enum Action {
     MiddleClick(Position),
     LaunchOrFocusPlugin(RunPlugin, bool, bool, bool), // bools => should float,
     // move_to_focused_tab, should_open_in_place
-    LaunchPlugin(RunPlugin, bool, bool, bool), // bools => should float,
-    // move_to_focused_tab, should_open_in_place
+    LaunchPlugin(RunPlugin, bool, bool), // bools => should float,
+    // should_open_in_place
     LeftMouseRelease(Position),
     RightMouseRelease(Position),
     MiddleMouseRelease(Position),
@@ -545,7 +545,6 @@ impl Action {
                 url,
                 floating,
                 in_place,
-                move_to_focused_tab,
                 configuration,
             } => {
                 let current_dir = get_current_dir();
@@ -559,7 +558,6 @@ impl Action {
                 Ok(vec![Action::LaunchPlugin(
                     run_plugin,
                     floating,
-                    move_to_focused_tab,
                     in_place,
                 )])
             },

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -210,9 +210,9 @@ pub enum Action {
     RightClick(Position),
     MiddleClick(Position),
     LaunchOrFocusPlugin(RunPlugin, bool, bool, bool), // bools => should float,
-                                                      // move_to_focused_tab, should_open_in_place
+    // move_to_focused_tab, should_open_in_place
     LaunchPlugin(RunPlugin, bool, bool, bool), // bools => should float,
-                                               // move_to_focused_tab, should_open_in_place
+    // move_to_focused_tab, should_open_in_place
     LeftMouseRelease(Position),
     RightMouseRelease(Position),
     MiddleMouseRelease(Position),

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -953,6 +953,43 @@ impl TryFrom<(&KdlNode, &Options)> for Action {
                     should_open_in_place,
                 ))
             },
+            "LaunchPlugin" => {
+                let arguments = action_arguments.iter().copied();
+                let mut args = kdl_arguments_that_are_strings(arguments)?;
+                if args.is_empty() {
+                    return Err(ConfigError::new_kdl_error(
+                        "No plugin found to launch in LaunchPlugin".into(),
+                        kdl_action.span().offset(),
+                        kdl_action.span().len(),
+                    ));
+                }
+                let plugin_path = args.remove(0);
+
+                let command_metadata = action_children.iter().next();
+                let should_float = command_metadata
+                    .and_then(|c_m| kdl_child_bool_value_for_entry(c_m, "floating"))
+                    .unwrap_or(false);
+                let move_to_focused_tab = command_metadata
+                    .and_then(|c_m| kdl_child_bool_value_for_entry(c_m, "move_to_focused_tab"))
+                    .unwrap_or(false);
+                let should_open_in_place = command_metadata
+                    .and_then(|c_m| kdl_child_bool_value_for_entry(c_m, "in_place"))
+                    .unwrap_or(false);
+                let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+                let location = RunPluginLocation::parse(&plugin_path, Some(current_dir))?;
+                let configuration = KdlLayoutParser::parse_plugin_user_configuration(&kdl_action)?;
+                let run_plugin = RunPlugin {
+                    location,
+                    _allow_exec_host_cmd: false,
+                    configuration,
+                };
+                Ok(Action::LaunchPlugin(
+                    run_plugin,
+                    should_float,
+                    move_to_focused_tab,
+                    should_open_in_place,
+                ))
+            },
             "PreviousSwapLayout" => Ok(Action::PreviousSwapLayout),
             "NextSwapLayout" => Ok(Action::NextSwapLayout),
             "BreakPane" => Ok(Action::BreakPane),

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -969,9 +969,6 @@ impl TryFrom<(&KdlNode, &Options)> for Action {
                 let should_float = command_metadata
                     .and_then(|c_m| kdl_child_bool_value_for_entry(c_m, "floating"))
                     .unwrap_or(false);
-                let move_to_focused_tab = command_metadata
-                    .and_then(|c_m| kdl_child_bool_value_for_entry(c_m, "move_to_focused_tab"))
-                    .unwrap_or(false);
                 let should_open_in_place = command_metadata
                     .and_then(|c_m| kdl_child_bool_value_for_entry(c_m, "in_place"))
                     .unwrap_or(false);
@@ -986,7 +983,6 @@ impl TryFrom<(&KdlNode, &Options)> for Action {
                 Ok(Action::LaunchPlugin(
                     run_plugin,
                     should_float,
-                    move_to_focused_tab,
                     should_open_in_place,
                 ))
             },

--- a/zellij-utils/src/plugin_api/action.proto
+++ b/zellij-utils/src/plugin_api/action.proto
@@ -52,6 +52,7 @@ message Action {
     IdAndName rename_plugin_pane_payload = 43;
     IdAndName rename_tab_payload = 44;
     string rename_session_payload = 45;
+    LaunchOrFocusPluginPayload launch_plugin_payload = 46;
   }
 }
 
@@ -223,6 +224,7 @@ enum ActionName {
     BreakPaneRight = 78;
     BreakPaneLeft = 79;
     RenameSession = 80;
+    LaunchPlugin = 81;
 }
 
 message Position {

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -1022,11 +1022,7 @@ impl TryFrom<Action> for ProtobufAction {
                     )),
                 })
             },
-            Action::LaunchPlugin(
-                run_plugin,
-                should_float,
-                should_open_in_place,
-            ) => {
+            Action::LaunchPlugin(run_plugin, should_float, should_open_in_place) => {
                 let url: Url = Url::from(&run_plugin.location);
                 Ok(ProtobufAction {
                     name: ProtobufActionName::LaunchPlugin as i32,

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -428,12 +428,12 @@ impl TryFrom<ProtobufAction> for Action {
                         configuration,
                     };
                     let should_float = payload.should_float;
-                    let move_to_focused_tab = payload.move_to_focused_tab;
+                    let _move_to_focused_tab = payload.move_to_focused_tab; // not actually used in
+                                                                            // this action
                     let should_open_in_place = payload.should_open_in_place;
                     Ok(Action::LaunchPlugin(
                         run_plugin,
                         should_float,
-                        move_to_focused_tab,
                         should_open_in_place,
                     ))
                 },
@@ -1025,7 +1025,6 @@ impl TryFrom<Action> for ProtobufAction {
             Action::LaunchPlugin(
                 run_plugin,
                 should_float,
-                move_to_focused_tab,
                 should_open_in_place,
             ) => {
                 let url: Url = Url::from(&run_plugin.location);
@@ -1035,7 +1034,7 @@ impl TryFrom<Action> for ProtobufAction {
                         LaunchOrFocusPluginPayload {
                             plugin_url: url.into(),
                             should_float,
-                            move_to_focused_tab,
+                            move_to_focused_tab: false,
                             should_open_in_place,
                             plugin_configuration: Some(run_plugin.configuration.try_into()?),
                         },

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -413,6 +413,34 @@ impl TryFrom<ProtobufAction> for Action {
                     _ => Err("Wrong payload for Action::LaunchOrFocusPlugin"),
                 }
             },
+            Some(ProtobufActionName::LaunchPlugin) => {
+                match protobuf_action.optional_payload {
+                    Some(OptionalPayload::LaunchOrFocusPluginPayload(payload)) => {
+                        let run_plugin_location =
+                            RunPluginLocation::parse(&payload.plugin_url, None)
+                                .map_err(|_| "Malformed LaunchOrFocusPlugin payload")?;
+                        let configuration: PluginUserConfiguration = payload
+                            .plugin_configuration
+                            .and_then(|p| PluginUserConfiguration::try_from(p).ok())
+                            .unwrap_or_default();
+                        let run_plugin = RunPlugin {
+                            _allow_exec_host_cmd: false,
+                            location: run_plugin_location,
+                            configuration,
+                        };
+                        let should_float = payload.should_float;
+                        let move_to_focused_tab = payload.move_to_focused_tab;
+                        let should_open_in_place = payload.should_open_in_place;
+                        Ok(Action::LaunchPlugin(
+                            run_plugin,
+                            should_float,
+                            move_to_focused_tab,
+                            should_open_in_place,
+                        ))
+                    },
+                    _ => Err("Wrong payload for Action::LaunchOrFocusPlugin"),
+                }
+            },
             Some(ProtobufActionName::LeftMouseRelease) => match protobuf_action.optional_payload {
                 Some(OptionalPayload::LeftMouseReleasePayload(payload)) => {
                     let position = payload.try_into()?;
@@ -985,6 +1013,26 @@ impl TryFrom<Action> for ProtobufAction {
                 let url: Url = Url::from(&run_plugin.location);
                 Ok(ProtobufAction {
                     name: ProtobufActionName::LaunchOrFocusPlugin as i32,
+                    optional_payload: Some(OptionalPayload::LaunchOrFocusPluginPayload(
+                        LaunchOrFocusPluginPayload {
+                            plugin_url: url.into(),
+                            should_float,
+                            move_to_focused_tab,
+                            should_open_in_place,
+                            plugin_configuration: Some(run_plugin.configuration.try_into()?),
+                        },
+                    )),
+                })
+            },
+            Action::LaunchPlugin(
+                run_plugin,
+                should_float,
+                move_to_focused_tab,
+                should_open_in_place,
+            ) => {
+                let url: Url = Url::from(&run_plugin.location);
+                Ok(ProtobufAction {
+                    name: ProtobufActionName::LaunchPlugin as i32,
                     optional_payload: Some(OptionalPayload::LaunchOrFocusPluginPayload(
                         LaunchOrFocusPluginPayload {
                             plugin_url: url.into(),

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -413,33 +413,31 @@ impl TryFrom<ProtobufAction> for Action {
                     _ => Err("Wrong payload for Action::LaunchOrFocusPlugin"),
                 }
             },
-            Some(ProtobufActionName::LaunchPlugin) => {
-                match protobuf_action.optional_payload {
-                    Some(OptionalPayload::LaunchOrFocusPluginPayload(payload)) => {
-                        let run_plugin_location =
-                            RunPluginLocation::parse(&payload.plugin_url, None)
-                                .map_err(|_| "Malformed LaunchOrFocusPlugin payload")?;
-                        let configuration: PluginUserConfiguration = payload
-                            .plugin_configuration
-                            .and_then(|p| PluginUserConfiguration::try_from(p).ok())
-                            .unwrap_or_default();
-                        let run_plugin = RunPlugin {
-                            _allow_exec_host_cmd: false,
-                            location: run_plugin_location,
-                            configuration,
-                        };
-                        let should_float = payload.should_float;
-                        let move_to_focused_tab = payload.move_to_focused_tab;
-                        let should_open_in_place = payload.should_open_in_place;
-                        Ok(Action::LaunchPlugin(
-                            run_plugin,
-                            should_float,
-                            move_to_focused_tab,
-                            should_open_in_place,
-                        ))
-                    },
-                    _ => Err("Wrong payload for Action::LaunchOrFocusPlugin"),
-                }
+            Some(ProtobufActionName::LaunchPlugin) => match protobuf_action.optional_payload {
+                Some(OptionalPayload::LaunchOrFocusPluginPayload(payload)) => {
+                    let run_plugin_location =
+                        RunPluginLocation::parse(&payload.plugin_url, None)
+                            .map_err(|_| "Malformed LaunchOrFocusPlugin payload")?;
+                    let configuration: PluginUserConfiguration = payload
+                        .plugin_configuration
+                        .and_then(|p| PluginUserConfiguration::try_from(p).ok())
+                        .unwrap_or_default();
+                    let run_plugin = RunPlugin {
+                        _allow_exec_host_cmd: false,
+                        location: run_plugin_location,
+                        configuration,
+                    };
+                    let should_float = payload.should_float;
+                    let move_to_focused_tab = payload.move_to_focused_tab;
+                    let should_open_in_place = payload.should_open_in_place;
+                    Ok(Action::LaunchPlugin(
+                        run_plugin,
+                        should_float,
+                        move_to_focused_tab,
+                        should_open_in_place,
+                    ))
+                },
+                _ => Err("Wrong payload for Action::LaunchOrFocusPlugin"),
             },
             Some(ProtobufActionName::LeftMouseRelease) => match protobuf_action.optional_payload {
                 Some(OptionalPayload::LeftMouseReleasePayload(payload)) => {


### PR DESCRIPTION
This adds the `LaunchPlugin` keybind, which is just like the `LaunchOrFocus` one, except it always launches a new instance of the plugin.

This also fixes some issues with cwd in plugins (specifically we now do the right thing when opening files/terminals from a different cwd than the one Zellij was started in).

It also adds the plugin's cwd to its title pane for clarity.