### PR TITLE
Fix styled underlines in editors

### DIFF
--- a/src/tests/e2e/remote_runner.rs
+++ b/src/tests/e2e/remote_runner.rs
@@ -236,6 +236,7 @@ fn read_from_channel(
                 let sixel_image_store = Rc::new(RefCell::new(SixelImageStore::default()));
                 let debug = false;
                 let arrow_fonts = true;
+                let styled_underlines = true;
                 let mut terminal_output = TerminalPane::new(
                     0,
                     pane_geom,
@@ -251,6 +252,7 @@ fn read_from_channel(
                     None,
                     debug,
                     arrow_fonts,
+                    styled_underlines,
                 ); // 0 is the pane index
                 loop {
                     if !should_keep_running.load(Ordering::SeqCst) {

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -374,6 +374,7 @@ pub struct Grid {
     style: Style,
     debug: bool,
     arrow_fonts: bool,
+    styled_underlines: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -464,6 +465,7 @@ impl Grid {
         style: Style, // TODO: consolidate this with terminal_emulator_colors
         debug: bool,
         arrow_fonts: bool,
+        styled_underlines: bool,
     ) -> Self {
         let sixel_grid = SixelGrid::new(character_cell_size.clone(), sixel_image_store);
         // make sure this is initialized as it is used internally
@@ -476,7 +478,7 @@ impl Grid {
             viewport: vec![Row::new().canonical()],
             lines_below: vec![],
             horizontal_tabstops: create_horizontal_tabstops(columns),
-            cursor: Cursor::new(0, 0),
+            cursor: Cursor::new(0, 0, styled_underlines),
             cursor_is_hidden: false,
             saved_cursor_position: None,
             scroll_region: None,
@@ -517,6 +519,7 @@ impl Grid {
             style,
             debug,
             arrow_fonts,
+            styled_underlines,
         }
     }
     pub fn render_full_viewport(&mut self) {
@@ -1688,7 +1691,7 @@ impl Grid {
         self.cursor_key_mode = false;
         self.scroll_region = None;
         self.clear_viewport_before_rendering = true;
-        self.cursor = Cursor::new(0, 0);
+        self.cursor = Cursor::new(0, 0, self.styled_underlines);
         self.saved_cursor_position = None;
         self.active_charset = Default::default();
         self.erasure_mode = false;
@@ -2132,7 +2135,7 @@ impl Grid {
         self.lines_below.clear();
     }
     pub fn reset_cursor_position(&mut self) {
-        self.cursor = Cursor::new(0, 0);
+        self.cursor = Cursor::new(0, 0, self.styled_underlines);
     }
 }
 
@@ -2614,8 +2617,10 @@ impl Perform for Grid {
                                 std::mem::replace(&mut self.lines_above, VecDeque::new());
                             let current_viewport =
                                 std::mem::replace(&mut self.viewport, vec![Row::new().canonical()]);
-                            let current_cursor =
-                                std::mem::replace(&mut self.cursor, Cursor::new(0, 0));
+                            let current_cursor = std::mem::replace(
+                                &mut self.cursor,
+                                Cursor::new(0, 0, self.styled_underlines),
+                            );
                             let sixel_image_store = self.sixel_grid.sixel_image_store.clone();
                             let alternate_sixelgrid = std::mem::replace(
                                 &mut self.sixel_grid,

--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -52,6 +52,7 @@ macro_rules! get_or_create_grid {
                 $self.style.clone(),
                 $self.debug,
                 $self.arrow_fonts,
+                $self.styled_underlines,
             );
             grid.hide_cursor();
             grid
@@ -88,6 +89,7 @@ pub(crate) struct PluginPane {
     requesting_permissions: Option<PluginPermission>,
     debug: bool,
     arrow_fonts: bool,
+    styled_underlines: bool,
 }
 
 impl PluginPane {
@@ -107,6 +109,7 @@ impl PluginPane {
         invoked_with: Option<Run>,
         debug: bool,
         arrow_fonts: bool,
+        styled_underlines: bool,
     ) -> Self {
         let loading_indication = LoadingIndication::new(title.clone()).with_colors(style.colors);
         let initial_loading_message = loading_indication.to_string();
@@ -139,6 +142,7 @@ impl PluginPane {
             requesting_permissions: None,
             debug,
             arrow_fonts,
+            styled_underlines,
         };
         for client_id in currently_connected_clients {
             plugin.handle_plugin_bytes(client_id, initial_loading_message.as_bytes().to_vec());

--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -231,9 +231,27 @@ impl CharacterStyles {
             return None;
         }
 
-        if *new_styles == RESET_STYLES {
-            *self = RESET_STYLES;
-            return Some(RESET_STYLES);
+        // if *new_styles == RESET_STYLES {
+        //     *self = RESET_STYLES.enable_styled_underlines(self.styled_underlines_enabled);
+        //     return Some(RESET_STYLES.enable_styled_underlines(self.styled_underlines_enabled));
+        // }
+
+        if new_styles.foreground == RESET_STYLES.foreground
+            && new_styles.background == RESET_STYLES.background
+            && new_styles.underline_color == RESET_STYLES.underline_color
+            && new_styles.strike == RESET_STYLES.strike
+            && new_styles.hidden == RESET_STYLES.hidden
+            && new_styles.reverse == RESET_STYLES.reverse
+            && new_styles.slow_blink == RESET_STYLES.slow_blink
+            && new_styles.fast_blink == RESET_STYLES.fast_blink
+            && new_styles.underline == RESET_STYLES.underline
+            && new_styles.bold == RESET_STYLES.bold
+            && new_styles.dim == RESET_STYLES.dim
+            && new_styles.italic == RESET_STYLES.italic
+            && new_styles.link_anchor == RESET_STYLES.link_anchor
+        {
+            *self = RESET_STYLES.enable_styled_underlines(self.styled_underlines_enabled);
+            return Some(RESET_STYLES.enable_styled_underlines(self.styled_underlines_enabled));
         }
 
         // create diff from all changed styles
@@ -805,7 +823,7 @@ impl Cursor {
         Cursor {
             x,
             y,
-            pending_styles: RESET_STYLES,
+            pending_styles: RESET_STYLES.enable_styled_underlines(true),
             charsets: Default::default(),
             shape: CursorShape::Initial,
         }
@@ -846,13 +864,15 @@ pub fn render_first_run_banner(
     rows: usize,
     style: &Style,
     run_command: Option<&RunCommand>,
+    enable_styled_underlines: bool,
 ) -> String {
     let middle_row = rows / 2;
     let middle_column = columns / 2;
+    let reset_styles = RESET_STYLES.enable_styled_underlines(enable_styled_underlines);
     match run_command {
         Some(run_command) => {
-            let bold_text = RESET_STYLES.bold(Some(AnsiCode::On));
-            let command_color_text = RESET_STYLES
+            let bold_text = reset_styles.bold(Some(AnsiCode::On));
+            let command_color_text = reset_styles
                 .foreground(Some(AnsiCode::from(style.colors.green)))
                 .bold(Some(AnsiCode::On));
             let waiting_to_run_text = "Waiting to run: ";
@@ -867,7 +887,7 @@ pub fn render_first_run_banner(
                 waiting_to_run_text,
                 command_color_text,
                 command_text,
-                RESET_STYLES
+                reset_styles
             );
 
             let controls_bare_text_first_part = "<";
@@ -877,7 +897,8 @@ pub fn render_first_run_banner(
             let controls_bare_text_third_part = "> drop to shell, <";
             let ctrl_c_bare_text = "Ctrl-c";
             let controls_bare_text_fourth_part = "> exit";
-            let controls_color = RESET_STYLES
+            let controls_color = reset_styles
+                .enable_styled_underlines(true)
                 .foreground(Some(AnsiCode::from(style.colors.orange)))
                 .bold(Some(AnsiCode::On));
             let controls_line_length = controls_bare_text_first_part.len()
@@ -896,30 +917,30 @@ pub fn render_first_run_banner(
                 bold_text,
                 controls_color,
                 enter_bare_text,
-                RESET_STYLES,
+                reset_styles,
                 bold_text,
                 controls_color,
                 esc_bare_text,
-                RESET_STYLES,
+                reset_styles,
                 bold_text,
                 controls_color,
                 ctrl_c_bare_text,
-                RESET_STYLES,
+                reset_styles,
                 bold_text
             );
             format!(
                 "\u{1b}[?25l{}{}{}{}",
-                RESET_STYLES, waiting_to_run_line, controls_line, RESET_STYLES
+                reset_styles, waiting_to_run_line, controls_line, reset_styles
             )
         },
         None => {
             let bare_text = format!("Waiting to start...");
             let bare_text_width = bare_text.width();
             let column_start_postion = middle_column.saturating_sub(bare_text_width / 2);
-            let bold_text = RESET_STYLES.bold(Some(AnsiCode::On));
+            let bold_text = reset_styles.bold(Some(AnsiCode::On));
             let waiting_to_run_line = format!(
                 "\u{1b}[?25l\u{1b}[{};{}H{}{}{}",
-                middle_row, column_start_postion, bold_text, bare_text, RESET_STYLES
+                middle_row, column_start_postion, bold_text, bare_text, reset_styles
             );
 
             let controls_bare_text_first_part = "<";
@@ -929,7 +950,7 @@ pub fn render_first_run_banner(
             let controls_bare_text_third_part = "> drop to shell, <";
             let ctrl_c_bare_text = "Ctrl-c";
             let controls_bare_text_fourth_part = "> exit";
-            let controls_color = RESET_STYLES
+            let controls_color = reset_styles
                 .foreground(Some(AnsiCode::from(style.colors.orange)))
                 .bold(Some(AnsiCode::On));
             let controls_line_length = controls_bare_text_first_part.len()
@@ -948,20 +969,20 @@ pub fn render_first_run_banner(
                 bold_text,
                 controls_color,
                 enter_bare_text,
-                RESET_STYLES,
+                reset_styles,
                 bold_text,
                 controls_color,
                 esc_bare_text,
-                RESET_STYLES,
+                reset_styles,
                 bold_text,
                 controls_color,
                 ctrl_c_bare_text,
-                RESET_STYLES,
+                reset_styles,
                 bold_text
             );
             format!(
                 "\u{1b}[?25l{}{}{}{}",
-                RESET_STYLES, waiting_to_run_line, controls_line, RESET_STYLES
+                reset_styles, waiting_to_run_line, controls_line, reset_styles
             )
         },
     }

--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -129,7 +129,7 @@ impl NamedColor {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct CharacterStyles {
     pub foreground: Option<AnsiCode>,
     pub background: Option<AnsiCode>,
@@ -145,6 +145,24 @@ pub struct CharacterStyles {
     pub italic: Option<AnsiCode>,
     pub link_anchor: Option<LinkAnchor>,
     pub styled_underlines_enabled: bool,
+}
+
+impl PartialEq for CharacterStyles {
+    fn eq(&self, other: &Self) -> bool {
+        self.foreground == other.foreground
+            && self.background == other.background
+            && self.underline_color == other.underline_color
+            && self.strike == other.strike
+            && self.hidden == other.hidden
+            && self.reverse == other.reverse
+            && self.slow_blink == other.slow_blink
+            && self.fast_blink == other.fast_blink
+            && self.underline == other.underline
+            && self.bold == other.bold
+            && self.dim == other.dim
+            && self.italic == other.italic
+            && self.link_anchor == other.link_anchor
+    }
 }
 
 impl CharacterStyles {
@@ -231,21 +249,7 @@ impl CharacterStyles {
             return None;
         }
 
-        // if *new_styles == RESET_STYLES {
-        if new_styles.foreground == RESET_STYLES.foreground
-            && new_styles.background == RESET_STYLES.background
-            && new_styles.underline_color == RESET_STYLES.underline_color
-            && new_styles.strike == RESET_STYLES.strike
-            && new_styles.hidden == RESET_STYLES.hidden
-            && new_styles.reverse == RESET_STYLES.reverse
-            && new_styles.slow_blink == RESET_STYLES.slow_blink
-            && new_styles.fast_blink == RESET_STYLES.fast_blink
-            && new_styles.underline == RESET_STYLES.underline
-            && new_styles.bold == RESET_STYLES.bold
-            && new_styles.dim == RESET_STYLES.dim
-            && new_styles.italic == RESET_STYLES.italic
-            && new_styles.link_anchor == RESET_STYLES.link_anchor
-        {
+        if *new_styles == RESET_STYLES {
             *self = RESET_STYLES.enable_styled_underlines(self.styled_underlines_enabled);
             return Some(RESET_STYLES.enable_styled_underlines(self.styled_underlines_enabled));
         }
@@ -860,15 +864,13 @@ pub fn render_first_run_banner(
     rows: usize,
     style: &Style,
     run_command: Option<&RunCommand>,
-    styled_underlines: bool,
 ) -> String {
     let middle_row = rows / 2;
     let middle_column = columns / 2;
-    let reset_styles = RESET_STYLES.enable_styled_underlines(styled_underlines);
     match run_command {
         Some(run_command) => {
-            let bold_text = reset_styles.bold(Some(AnsiCode::On));
-            let command_color_text = reset_styles
+            let bold_text = RESET_STYLES.bold(Some(AnsiCode::On));
+            let command_color_text = RESET_STYLES
                 .foreground(Some(AnsiCode::from(style.colors.green)))
                 .bold(Some(AnsiCode::On));
             let waiting_to_run_text = "Waiting to run: ";
@@ -883,7 +885,7 @@ pub fn render_first_run_banner(
                 waiting_to_run_text,
                 command_color_text,
                 command_text,
-                reset_styles
+                RESET_STYLES
             );
 
             let controls_bare_text_first_part = "<";
@@ -893,7 +895,7 @@ pub fn render_first_run_banner(
             let controls_bare_text_third_part = "> drop to shell, <";
             let ctrl_c_bare_text = "Ctrl-c";
             let controls_bare_text_fourth_part = "> exit";
-            let controls_color = reset_styles
+            let controls_color = RESET_STYLES
                 .foreground(Some(AnsiCode::from(style.colors.orange)))
                 .bold(Some(AnsiCode::On));
             let controls_line_length = controls_bare_text_first_part.len()
@@ -912,30 +914,30 @@ pub fn render_first_run_banner(
                 bold_text,
                 controls_color,
                 enter_bare_text,
-                reset_styles,
+                RESET_STYLES,
                 bold_text,
                 controls_color,
                 esc_bare_text,
-                reset_styles,
+                RESET_STYLES,
                 bold_text,
                 controls_color,
                 ctrl_c_bare_text,
-                reset_styles,
+                RESET_STYLES,
                 bold_text
             );
             format!(
                 "\u{1b}[?25l{}{}{}{}",
-                reset_styles, waiting_to_run_line, controls_line, reset_styles
+                RESET_STYLES, waiting_to_run_line, controls_line, RESET_STYLES
             )
         },
         None => {
             let bare_text = format!("Waiting to start...");
             let bare_text_width = bare_text.width();
             let column_start_postion = middle_column.saturating_sub(bare_text_width / 2);
-            let bold_text = reset_styles.bold(Some(AnsiCode::On));
+            let bold_text = RESET_STYLES.bold(Some(AnsiCode::On));
             let waiting_to_run_line = format!(
                 "\u{1b}[?25l\u{1b}[{};{}H{}{}{}",
-                middle_row, column_start_postion, bold_text, bare_text, reset_styles
+                middle_row, column_start_postion, bold_text, bare_text, RESET_STYLES
             );
 
             let controls_bare_text_first_part = "<";
@@ -945,7 +947,7 @@ pub fn render_first_run_banner(
             let controls_bare_text_third_part = "> drop to shell, <";
             let ctrl_c_bare_text = "Ctrl-c";
             let controls_bare_text_fourth_part = "> exit";
-            let controls_color = reset_styles
+            let controls_color = RESET_STYLES
                 .foreground(Some(AnsiCode::from(style.colors.orange)))
                 .bold(Some(AnsiCode::On));
             let controls_line_length = controls_bare_text_first_part.len()
@@ -964,20 +966,20 @@ pub fn render_first_run_banner(
                 bold_text,
                 controls_color,
                 enter_bare_text,
-                reset_styles,
+                RESET_STYLES,
                 bold_text,
                 controls_color,
                 esc_bare_text,
-                reset_styles,
+                RESET_STYLES,
                 bold_text,
                 controls_color,
                 ctrl_c_bare_text,
-                reset_styles,
+                RESET_STYLES,
                 bold_text
             );
             format!(
                 "\u{1b}[?25l{}{}{}{}",
-                reset_styles, waiting_to_run_line, controls_line, reset_styles
+                RESET_STYLES, waiting_to_run_line, controls_line, RESET_STYLES
             )
         },
     }

--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -232,10 +232,6 @@ impl CharacterStyles {
         }
 
         // if *new_styles == RESET_STYLES {
-        //     *self = RESET_STYLES.enable_styled_underlines(self.styled_underlines_enabled);
-        //     return Some(RESET_STYLES.enable_styled_underlines(self.styled_underlines_enabled));
-        // }
-
         if new_styles.foreground == RESET_STYLES.foreground
             && new_styles.background == RESET_STYLES.background
             && new_styles.underline_color == RESET_STYLES.underline_color
@@ -819,11 +815,11 @@ pub struct Cursor {
 }
 
 impl Cursor {
-    pub fn new(x: usize, y: usize) -> Self {
+    pub fn new(x: usize, y: usize, styled_underlines: bool) -> Self {
         Cursor {
             x,
             y,
-            pending_styles: RESET_STYLES.enable_styled_underlines(true),
+            pending_styles: RESET_STYLES.enable_styled_underlines(styled_underlines),
             charsets: Default::default(),
             shape: CursorShape::Initial,
         }
@@ -864,11 +860,11 @@ pub fn render_first_run_banner(
     rows: usize,
     style: &Style,
     run_command: Option<&RunCommand>,
-    enable_styled_underlines: bool,
+    styled_underlines: bool,
 ) -> String {
     let middle_row = rows / 2;
     let middle_column = columns / 2;
-    let reset_styles = RESET_STYLES.enable_styled_underlines(enable_styled_underlines);
+    let reset_styles = RESET_STYLES.enable_styled_underlines(styled_underlines);
     match run_command {
         Some(run_command) => {
             let bold_text = reset_styles.bold(Some(AnsiCode::On));
@@ -898,7 +894,6 @@ pub fn render_first_run_banner(
             let ctrl_c_bare_text = "Ctrl-c";
             let controls_bare_text_fourth_part = "> exit";
             let controls_color = reset_styles
-                .enable_styled_underlines(true)
                 .foreground(Some(AnsiCode::from(style.colors.orange)))
                 .bold(Some(AnsiCode::On));
             let controls_line_length = controls_bare_text_first_part.len()

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -805,6 +805,7 @@ impl TerminalPane {
             style.clone(),
             debug,
             arrow_fonts,
+            styled_underlines,
         );
         TerminalPane {
             frame: HashMap::new(),

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -117,6 +117,7 @@ pub struct TerminalPane {
     invoked_with: Option<Run>,
     #[allow(dead_code)]
     arrow_fonts: bool,
+    styled_underlines: bool,
 }
 
 impl Pane for TerminalPane {
@@ -789,6 +790,7 @@ impl TerminalPane {
         invoked_with: Option<Run>,
         debug: bool,
         arrow_fonts: bool,
+        styled_underlines: bool,
     ) -> TerminalPane {
         let initial_pane_title =
             initial_pane_title.unwrap_or_else(|| format!("Pane #{}", pane_index));
@@ -828,6 +830,7 @@ impl TerminalPane {
             pane_frame_color_override: None,
             invoked_with,
             arrow_fonts,
+            styled_underlines,
         }
     }
     pub fn get_x(&self) -> usize {
@@ -879,10 +882,16 @@ impl TerminalPane {
         let columns = self.get_content_columns();
         let rows = self.get_content_rows();
         let banner = match &self.is_held {
-            Some((_exit_status, _is_first_run, run_command)) => {
-                render_first_run_banner(columns, rows, &self.style, Some(run_command))
+            Some((_exit_status, _is_first_run, run_command)) => render_first_run_banner(
+                columns,
+                rows,
+                &self.style,
+                Some(run_command),
+                self.styled_underlines,
+            ),
+            None => {
+                render_first_run_banner(columns, rows, &self.style, None, self.styled_underlines)
             },
-            None => render_first_run_banner(columns, rows, &self.style, None),
         };
         self.banner = Some(banner.clone());
         self.handle_pty_bytes(banner.as_bytes().to_vec());

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -117,7 +117,6 @@ pub struct TerminalPane {
     invoked_with: Option<Run>,
     #[allow(dead_code)]
     arrow_fonts: bool,
-    styled_underlines: bool,
 }
 
 impl Pane for TerminalPane {
@@ -831,7 +830,6 @@ impl TerminalPane {
             pane_frame_color_override: None,
             invoked_with,
             arrow_fonts,
-            styled_underlines,
         }
     }
     pub fn get_x(&self) -> usize {
@@ -883,16 +881,10 @@ impl TerminalPane {
         let columns = self.get_content_columns();
         let rows = self.get_content_rows();
         let banner = match &self.is_held {
-            Some((_exit_status, _is_first_run, run_command)) => render_first_run_banner(
-                columns,
-                rows,
-                &self.style,
-                Some(run_command),
-                self.styled_underlines,
-            ),
-            None => {
-                render_first_run_banner(columns, rows, &self.style, None, self.styled_underlines)
+            Some((_exit_status, _is_first_run, run_command)) => {
+                render_first_run_banner(columns, rows, &self.style, Some(run_command))
             },
+            None => render_first_run_banner(columns, rows, &self.style, None),
         };
         self.banner = Some(banner.clone());
         self.handle_pty_bytes(banner.as_bytes().to_vec());

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -31,6 +31,7 @@ fn vttest1_0() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -42,6 +43,7 @@ fn vttest1_0() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest1-0";
     let content = read_fixture(fixture_name);
@@ -58,6 +60,7 @@ fn vttest1_1() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -69,6 +72,7 @@ fn vttest1_1() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest1-1";
     let content = read_fixture(fixture_name);
@@ -85,6 +89,7 @@ fn vttest1_2() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -96,6 +101,7 @@ fn vttest1_2() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest1-2";
     let content = read_fixture(fixture_name);
@@ -112,6 +118,7 @@ fn vttest1_3() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -123,6 +130,7 @@ fn vttest1_3() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest1-3";
     let content = read_fixture(fixture_name);
@@ -139,6 +147,7 @@ fn vttest1_4() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -150,6 +159,7 @@ fn vttest1_4() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest1-4";
     let content = read_fixture(fixture_name);
@@ -166,6 +176,7 @@ fn vttest1_5() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -177,6 +188,7 @@ fn vttest1_5() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest1-5";
     let content = read_fixture(fixture_name);
@@ -193,6 +205,7 @@ fn vttest2_0() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -204,6 +217,7 @@ fn vttest2_0() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest2-0";
     let content = read_fixture(fixture_name);
@@ -220,6 +234,7 @@ fn vttest2_1() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -231,6 +246,7 @@ fn vttest2_1() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest2-1";
     let content = read_fixture(fixture_name);
@@ -247,6 +263,7 @@ fn vttest2_2() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -258,6 +275,7 @@ fn vttest2_2() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest2-2";
     let content = read_fixture(fixture_name);
@@ -274,6 +292,7 @@ fn vttest2_3() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -285,6 +304,7 @@ fn vttest2_3() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest2-3";
     let content = read_fixture(fixture_name);
@@ -301,6 +321,7 @@ fn vttest2_4() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -312,6 +333,7 @@ fn vttest2_4() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest2-4";
     let content = read_fixture(fixture_name);
@@ -328,6 +350,7 @@ fn vttest2_5() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -339,6 +362,7 @@ fn vttest2_5() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest2-5";
     let content = read_fixture(fixture_name);
@@ -355,6 +379,7 @@ fn vttest2_6() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -366,6 +391,7 @@ fn vttest2_6() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest2-6";
     let content = read_fixture(fixture_name);
@@ -382,6 +408,7 @@ fn vttest2_7() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -393,6 +420,7 @@ fn vttest2_7() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest2-7";
     let content = read_fixture(fixture_name);
@@ -409,6 +437,7 @@ fn vttest2_8() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -420,6 +449,7 @@ fn vttest2_8() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest2-8";
     let content = read_fixture(fixture_name);
@@ -436,6 +466,7 @@ fn vttest2_9() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -447,6 +478,7 @@ fn vttest2_9() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest2-9";
     let content = read_fixture(fixture_name);
@@ -463,6 +495,7 @@ fn vttest2_10() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -474,6 +507,7 @@ fn vttest2_10() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest2-10";
     let content = read_fixture(fixture_name);
@@ -490,6 +524,7 @@ fn vttest2_11() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -501,6 +536,7 @@ fn vttest2_11() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest2-11";
     let content = read_fixture(fixture_name);
@@ -517,6 +553,7 @@ fn vttest2_12() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -528,6 +565,7 @@ fn vttest2_12() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest2-12";
     let content = read_fixture(fixture_name);
@@ -544,6 +582,7 @@ fn vttest2_13() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -555,6 +594,7 @@ fn vttest2_13() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest2-13";
     let content = read_fixture(fixture_name);
@@ -571,6 +611,7 @@ fn vttest2_14() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -582,6 +623,7 @@ fn vttest2_14() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest2-14";
     let content = read_fixture(fixture_name);
@@ -598,6 +640,7 @@ fn vttest3_0() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -609,6 +652,7 @@ fn vttest3_0() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest3-0";
     let content = read_fixture(fixture_name);
@@ -625,6 +669,7 @@ fn vttest8_0() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         97,
@@ -636,6 +681,7 @@ fn vttest8_0() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest8-0";
     let content = read_fixture(fixture_name);
@@ -652,6 +698,7 @@ fn vttest8_1() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         97,
@@ -663,6 +710,7 @@ fn vttest8_1() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest8-1";
     let content = read_fixture(fixture_name);
@@ -679,6 +727,7 @@ fn vttest8_2() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         97,
@@ -690,6 +739,7 @@ fn vttest8_2() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest8-2";
     let content = read_fixture(fixture_name);
@@ -706,6 +756,7 @@ fn vttest8_3() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         97,
@@ -717,6 +768,7 @@ fn vttest8_3() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest8-3";
     let content = read_fixture(fixture_name);
@@ -733,6 +785,7 @@ fn vttest8_4() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         97,
@@ -744,6 +797,7 @@ fn vttest8_4() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest8-4";
     let content = read_fixture(fixture_name);
@@ -760,6 +814,7 @@ fn vttest8_5() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         97,
@@ -771,6 +826,7 @@ fn vttest8_5() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vttest8-5";
     let content = read_fixture(fixture_name);
@@ -787,6 +843,7 @@ fn csi_b() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         97,
@@ -798,6 +855,7 @@ fn csi_b() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "csi-b";
     let content = read_fixture(fixture_name);
@@ -814,6 +872,7 @@ fn csi_capital_i() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         97,
@@ -825,6 +884,7 @@ fn csi_capital_i() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "csi-capital-i";
     let content = read_fixture(fixture_name);
@@ -841,6 +901,7 @@ fn csi_capital_z() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         97,
@@ -852,6 +913,7 @@ fn csi_capital_z() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "csi-capital-z";
     let content = read_fixture(fixture_name);
@@ -868,6 +930,7 @@ fn terminal_reports() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         97,
@@ -879,6 +942,7 @@ fn terminal_reports() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "terminal_reports";
     let content = read_fixture(fixture_name);
@@ -895,6 +959,7 @@ fn wide_characters() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         21,
         104,
@@ -906,6 +971,7 @@ fn wide_characters() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "wide_characters";
     let content = read_fixture(fixture_name);
@@ -922,6 +988,7 @@ fn wide_characters_line_wrap() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         21,
         104,
@@ -933,6 +1000,7 @@ fn wide_characters_line_wrap() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "wide_characters_line_wrap";
     let content = read_fixture(fixture_name);
@@ -949,6 +1017,7 @@ fn insert_character_in_line_with_wide_character() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         21,
         104,
@@ -960,6 +1029,7 @@ fn insert_character_in_line_with_wide_character() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "wide_characters_middle_line_insert";
     let content = read_fixture(fixture_name);
@@ -976,6 +1046,7 @@ fn delete_char_in_middle_of_line_with_widechar() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         21,
         104,
@@ -987,6 +1058,7 @@ fn delete_char_in_middle_of_line_with_widechar() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "wide-chars-delete-middle";
     let content = read_fixture(fixture_name);
@@ -1003,6 +1075,7 @@ fn delete_char_in_middle_of_line_with_multiple_widechars() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         21,
         104,
@@ -1014,6 +1087,7 @@ fn delete_char_in_middle_of_line_with_multiple_widechars() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "wide-chars-delete-middle-after-multi";
     let content = read_fixture(fixture_name);
@@ -1030,6 +1104,7 @@ fn fish_wide_characters_override_clock() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         21,
         104,
@@ -1041,6 +1116,7 @@ fn fish_wide_characters_override_clock() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "fish_wide_characters_override_clock";
     let content = read_fixture(fixture_name);
@@ -1057,6 +1133,7 @@ fn bash_delete_wide_characters() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         21,
         104,
@@ -1068,6 +1145,7 @@ fn bash_delete_wide_characters() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "bash_delete_wide_characters";
     let content = read_fixture(fixture_name);
@@ -1084,6 +1162,7 @@ fn delete_wide_characters_before_cursor() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         21,
         104,
@@ -1095,6 +1174,7 @@ fn delete_wide_characters_before_cursor() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "delete_wide_characters_before_cursor";
     let content = read_fixture(fixture_name);
@@ -1111,6 +1191,7 @@ fn delete_wide_characters_before_cursor_when_cursor_is_on_wide_character() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         21,
         104,
@@ -1122,6 +1203,7 @@ fn delete_wide_characters_before_cursor_when_cursor_is_on_wide_character() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "delete_wide_characters_before_cursor_when_cursor_is_on_wide_character";
     let content = read_fixture(fixture_name);
@@ -1138,6 +1220,7 @@ fn delete_wide_character_under_cursor() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         21,
         104,
@@ -1149,6 +1232,7 @@ fn delete_wide_character_under_cursor() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "delete_wide_character_under_cursor";
     let content = read_fixture(fixture_name);
@@ -1165,6 +1249,7 @@ fn replace_wide_character_under_cursor() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         21,
         104,
@@ -1176,6 +1261,7 @@ fn replace_wide_character_under_cursor() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "replace_wide_character_under_cursor";
     let content = read_fixture(fixture_name);
@@ -1192,6 +1278,7 @@ fn wrap_wide_characters() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         21,
         90,
@@ -1203,6 +1290,7 @@ fn wrap_wide_characters() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "wide_characters_full";
     let content = read_fixture(fixture_name);
@@ -1219,6 +1307,7 @@ fn wrap_wide_characters_on_size_change() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         21,
         93,
@@ -1230,6 +1319,7 @@ fn wrap_wide_characters_on_size_change() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "wide_characters_full";
     let content = read_fixture(fixture_name);
@@ -1247,6 +1337,7 @@ fn unwrap_wide_characters_on_size_change() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         21,
         93,
@@ -1258,6 +1349,7 @@ fn unwrap_wide_characters_on_size_change() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "wide_characters_full";
     let content = read_fixture(fixture_name);
@@ -1276,6 +1368,7 @@ fn wrap_wide_characters_in_the_middle_of_the_line() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         21,
         91,
@@ -1287,6 +1380,7 @@ fn wrap_wide_characters_in_the_middle_of_the_line() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "wide_characters_line_middle";
     let content = read_fixture(fixture_name);
@@ -1303,6 +1397,7 @@ fn wrap_wide_characters_at_the_end_of_the_line() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         21,
         90,
@@ -1314,6 +1409,7 @@ fn wrap_wide_characters_at_the_end_of_the_line() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "wide_characters_line_end";
     let content = read_fixture(fixture_name);
@@ -1330,6 +1426,7 @@ fn copy_selected_text_from_viewport() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         27,
         125,
@@ -1341,6 +1438,7 @@ fn copy_selected_text_from_viewport() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "grid_copy";
     let content = read_fixture(fixture_name);
@@ -1365,6 +1463,7 @@ fn copy_wrapped_selected_text_from_viewport() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         22,
         73,
@@ -1376,6 +1475,7 @@ fn copy_wrapped_selected_text_from_viewport() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "grid_copy_wrapped";
     let content = read_fixture(fixture_name);
@@ -1399,6 +1499,7 @@ fn copy_selected_text_from_lines_above() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         27,
         125,
@@ -1410,6 +1511,7 @@ fn copy_selected_text_from_lines_above() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "grid_copy";
     let content = read_fixture(fixture_name);
@@ -1434,6 +1536,7 @@ fn copy_selected_text_from_lines_below() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         27,
         125,
@@ -1445,6 +1548,7 @@ fn copy_selected_text_from_lines_below() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "grid_copy";
     let content = read_fixture(fixture_name);
@@ -1477,6 +1581,7 @@ fn run_bandwhich_from_fish_shell() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         28,
         116,
@@ -1488,6 +1593,7 @@ fn run_bandwhich_from_fish_shell() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "fish_and_bandwhich";
     let content = read_fixture(fixture_name);
@@ -1504,6 +1610,7 @@ fn fish_tab_completion_options() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         28,
         116,
@@ -1515,6 +1622,7 @@ fn fish_tab_completion_options() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "fish_tab_completion_options";
     let content = read_fixture(fixture_name);
@@ -1537,6 +1645,7 @@ pub fn fish_select_tab_completion_options() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         28,
         116,
@@ -1548,6 +1657,7 @@ pub fn fish_select_tab_completion_options() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "fish_select_tab_completion_options";
     let content = read_fixture(fixture_name);
@@ -1574,6 +1684,7 @@ pub fn vim_scroll_region_down() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         28,
         116,
@@ -1585,6 +1696,7 @@ pub fn vim_scroll_region_down() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vim_scroll_region_down";
     let content = read_fixture(fixture_name);
@@ -1608,6 +1720,7 @@ pub fn vim_ctrl_d() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         28,
         116,
@@ -1619,6 +1732,7 @@ pub fn vim_ctrl_d() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vim_ctrl_d";
     let content = read_fixture(fixture_name);
@@ -1641,6 +1755,7 @@ pub fn vim_ctrl_u() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         28,
         116,
@@ -1652,6 +1767,7 @@ pub fn vim_ctrl_u() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vim_ctrl_u";
     let content = read_fixture(fixture_name);
@@ -1668,6 +1784,7 @@ pub fn htop() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         28,
         116,
@@ -1679,6 +1796,7 @@ pub fn htop() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "htop";
     let content = read_fixture(fixture_name);
@@ -1695,6 +1813,7 @@ pub fn htop_scrolling() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         28,
         116,
@@ -1706,6 +1825,7 @@ pub fn htop_scrolling() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "htop_scrolling";
     let content = read_fixture(fixture_name);
@@ -1722,6 +1842,7 @@ pub fn htop_right_scrolling() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         28,
         116,
@@ -1733,6 +1854,7 @@ pub fn htop_right_scrolling() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "htop_right_scrolling";
     let content = read_fixture(fixture_name);
@@ -1759,6 +1881,7 @@ pub fn vim_overwrite() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         28,
         116,
@@ -1770,6 +1893,7 @@ pub fn vim_overwrite() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "vim_overwrite";
     let content = read_fixture(fixture_name);
@@ -1788,6 +1912,7 @@ pub fn clear_scroll_region() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         28,
         116,
@@ -1799,6 +1924,7 @@ pub fn clear_scroll_region() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "clear_scroll_region";
     let content = read_fixture(fixture_name);
@@ -1815,6 +1941,7 @@ pub fn display_tab_characters_properly() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         28,
         116,
@@ -1826,6 +1953,7 @@ pub fn display_tab_characters_properly() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "tab_characters";
     let content = read_fixture(fixture_name);
@@ -1842,6 +1970,7 @@ pub fn neovim_insert_mode() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         28,
         116,
@@ -1853,6 +1982,7 @@ pub fn neovim_insert_mode() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "nvim_insert";
     let content = read_fixture(fixture_name);
@@ -1869,6 +1999,7 @@ pub fn bash_cursor_linewrap() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         28,
         116,
@@ -1880,6 +2011,7 @@ pub fn bash_cursor_linewrap() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "bash_cursor_linewrap";
     let content = read_fixture(fixture_name);
@@ -1898,6 +2030,7 @@ pub fn fish_paste_multiline() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         28,
         149,
@@ -1909,6 +2042,7 @@ pub fn fish_paste_multiline() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "fish_paste_multiline";
     let content = read_fixture(fixture_name);
@@ -1925,6 +2059,7 @@ pub fn git_log() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         28,
         149,
@@ -1936,6 +2071,7 @@ pub fn git_log() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "git_log";
     let content = read_fixture(fixture_name);
@@ -1954,6 +2090,7 @@ pub fn git_diff_scrollup() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         28,
         149,
@@ -1965,6 +2102,7 @@ pub fn git_diff_scrollup() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "git_diff_scrollup";
     let content = read_fixture(fixture_name);
@@ -1981,6 +2119,7 @@ pub fn emacs_longbuf() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         60,
         284,
@@ -1992,6 +2131,7 @@ pub fn emacs_longbuf() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "emacs_longbuf_tutorial";
     let content = read_fixture(fixture_name);
@@ -2008,6 +2148,7 @@ pub fn top_and_quit() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         56,
         235,
@@ -2019,6 +2160,7 @@ pub fn top_and_quit() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "top_and_quit";
     let content = read_fixture(fixture_name);
@@ -2042,6 +2184,7 @@ pub fn exa_plus_omf_theme() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         56,
         235,
@@ -2053,6 +2196,7 @@ pub fn exa_plus_omf_theme() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "exa_plus_omf_theme";
     let content = read_fixture(fixture_name);
@@ -2069,6 +2213,7 @@ pub fn scroll_up() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         10,
         50,
@@ -2080,6 +2225,7 @@ pub fn scroll_up() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "scrolling";
     let content = read_fixture(fixture_name);
@@ -2097,6 +2243,7 @@ pub fn scroll_down() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         10,
         50,
@@ -2108,6 +2255,7 @@ pub fn scroll_down() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "scrolling";
     let content = read_fixture(fixture_name);
@@ -2126,6 +2274,7 @@ pub fn scroll_up_with_line_wraps() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         10,
         25,
@@ -2137,6 +2286,7 @@ pub fn scroll_up_with_line_wraps() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "scrolling";
     let content = read_fixture(fixture_name);
@@ -2154,6 +2304,7 @@ pub fn scroll_down_with_line_wraps() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         10,
         25,
@@ -2165,6 +2316,7 @@ pub fn scroll_down_with_line_wraps() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "scrolling";
     let content = read_fixture(fixture_name);
@@ -2183,6 +2335,7 @@ pub fn scroll_up_decrease_width_and_scroll_down() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         10,
         50,
@@ -2194,6 +2347,7 @@ pub fn scroll_up_decrease_width_and_scroll_down() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "scrolling";
     let content = read_fixture(fixture_name);
@@ -2217,6 +2371,7 @@ pub fn scroll_up_increase_width_and_scroll_down() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         10,
         25,
@@ -2228,6 +2383,7 @@ pub fn scroll_up_increase_width_and_scroll_down() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "scrolling";
     let content = read_fixture(fixture_name);
@@ -2251,6 +2407,7 @@ pub fn move_cursor_below_scroll_region() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         34,
         114,
@@ -2262,6 +2419,7 @@ pub fn move_cursor_below_scroll_region() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "move_cursor_below_scroll_region";
     let content = read_fixture(fixture_name);
@@ -2278,6 +2436,7 @@ pub fn insert_wide_characters_in_existing_line() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         21,
         86,
@@ -2289,6 +2448,7 @@ pub fn insert_wide_characters_in_existing_line() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "chinese_characters_line_middle";
     let content = read_fixture(fixture_name);
@@ -2311,6 +2471,7 @@ pub fn full_screen_scroll_region_and_scroll_up() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         54,
         80,
@@ -2322,6 +2483,7 @@ pub fn full_screen_scroll_region_and_scroll_up() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "scroll_region_full_screen";
     let content = read_fixture(fixture_name);
@@ -2341,6 +2503,7 @@ pub fn ring_bell() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         134,
         64,
@@ -2352,6 +2515,7 @@ pub fn ring_bell() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "ring_bell";
     let content = read_fixture(fixture_name);
@@ -2368,6 +2532,7 @@ pub fn alternate_screen_change_size() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         20,
         20,
@@ -2379,6 +2544,7 @@ pub fn alternate_screen_change_size() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "alternate_screen_change_size";
     let content = read_fixture(fixture_name);
@@ -2399,6 +2565,7 @@ pub fn fzf_fullscreen() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         112,
@@ -2410,6 +2577,7 @@ pub fn fzf_fullscreen() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "fzf_fullscreen";
     let content = read_fixture(fixture_name);
@@ -2430,6 +2598,7 @@ pub fn replace_multiple_wide_characters_under_cursor() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         112,
@@ -2441,6 +2610,7 @@ pub fn replace_multiple_wide_characters_under_cursor() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "replace_multiple_wide_characters";
     let content = read_fixture(fixture_name);
@@ -2461,6 +2631,7 @@ pub fn replace_non_wide_characters_with_wide_characters() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         112,
@@ -2472,6 +2643,7 @@ pub fn replace_non_wide_characters_with_wide_characters() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "replace_non_wide_characters_with_wide_characters";
     let content = read_fixture(fixture_name);
@@ -2488,6 +2660,7 @@ pub fn scroll_down_ansi() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         112,
@@ -2499,6 +2672,7 @@ pub fn scroll_down_ansi() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "scroll_down";
     let content = read_fixture(fixture_name);
@@ -2515,6 +2689,7 @@ pub fn ansi_capital_t() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         112,
@@ -2526,6 +2701,7 @@ pub fn ansi_capital_t() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let content = "foo\u{1b}[14Tbar".as_bytes();
     for byte in content {
@@ -2541,6 +2717,7 @@ pub fn ansi_capital_s() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         112,
@@ -2552,6 +2729,7 @@ pub fn ansi_capital_s() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let content = "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nfoo\u{1b}[14Sbar".as_bytes();
     for byte in content {
@@ -2567,6 +2745,7 @@ fn terminal_pixel_size_reports() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         97,
@@ -2581,6 +2760,7 @@ fn terminal_pixel_size_reports() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "terminal_pixel_size_reports";
     let content = read_fixture(fixture_name);
@@ -2603,6 +2783,7 @@ fn terminal_pixel_size_reports_in_unsupported_terminals() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         97,
@@ -2614,6 +2795,7 @@ fn terminal_pixel_size_reports_in_unsupported_terminals() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "terminal_pixel_size_reports";
     let content = read_fixture(fixture_name);
@@ -2637,6 +2819,7 @@ pub fn ansi_csi_at_sign() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         112,
@@ -2648,6 +2831,7 @@ pub fn ansi_csi_at_sign() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let content = "foo\u{1b}[2D\u{1b}[2@".as_bytes();
     for byte in content {
@@ -2667,6 +2851,7 @@ pub fn sixel_images_are_reaped_when_scrolled_off() {
     })));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         112,
@@ -2678,6 +2863,7 @@ pub fn sixel_images_are_reaped_when_scrolled_off() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let pane_content = read_fixture("sixel-image-500px.six");
     for byte in pane_content {
@@ -2706,6 +2892,7 @@ pub fn sixel_images_are_reaped_when_resetting() {
     })));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         112,
@@ -2717,6 +2904,7 @@ pub fn sixel_images_are_reaped_when_resetting() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let pane_content = read_fixture("sixel-image-500px.six");
     for byte in pane_content {
@@ -2742,6 +2930,7 @@ pub fn sixel_image_in_alternate_buffer() {
     })));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         30,
         112,
@@ -2753,6 +2942,7 @@ pub fn sixel_image_in_alternate_buffer() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
 
     let move_to_alternate_screen = "\u{1b}[?1049h";
@@ -2789,6 +2979,7 @@ pub fn sixel_with_image_scrolling_decsdm() {
     })));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         30,
         112,
@@ -2800,6 +2991,7 @@ pub fn sixel_with_image_scrolling_decsdm() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
 
     // enter DECSDM
@@ -2855,6 +3047,7 @@ pub fn osc_4_background_query() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         97,
@@ -2866,6 +3059,7 @@ pub fn osc_4_background_query() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let content = "\u{1b}]10;?\u{1b}\\";
     for byte in content.as_bytes() {
@@ -2889,6 +3083,7 @@ pub fn osc_4_foreground_query() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         97,
@@ -2900,6 +3095,7 @@ pub fn osc_4_foreground_query() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let content = "\u{1b}]11;?\u{1b}\\";
     for byte in content.as_bytes() {
@@ -2925,6 +3121,7 @@ pub fn osc_4_color_query() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(color_codes));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         97,
@@ -2936,6 +3133,7 @@ pub fn osc_4_color_query() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let content = "\u{1b}]4;222;?\u{1b}\\";
     for byte in content.as_bytes() {
@@ -2959,6 +3157,7 @@ pub fn xtsmgraphics_color_register_count() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         97,
@@ -2970,6 +3169,7 @@ pub fn xtsmgraphics_color_register_count() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let content = "\u{1b}[?1;1;S\u{1b}\\";
     for byte in content.as_bytes() {
@@ -2997,6 +3197,7 @@ pub fn xtsmgraphics_pixel_graphics_geometry() {
     })));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         51,
         97,
@@ -3008,6 +3209,7 @@ pub fn xtsmgraphics_pixel_graphics_geometry() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let content = "\u{1b}[?2;1;S\u{1b}\\";
     for byte in content.as_bytes() {
@@ -3035,6 +3237,7 @@ pub fn cursor_hide_persists_through_alternate_screen() {
     })));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         30,
         112,
@@ -3046,6 +3249,7 @@ pub fn cursor_hide_persists_through_alternate_screen() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
 
     let hide_cursor = "\u{1b}[?25l";
@@ -3087,6 +3291,7 @@ fn table_ui_component() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -3098,6 +3303,7 @@ fn table_ui_component() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "table-ui-component";
     let content = read_fixture(fixture_name);
@@ -3114,6 +3320,7 @@ fn table_ui_component_with_coordinates() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -3125,6 +3332,7 @@ fn table_ui_component_with_coordinates() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "table-ui-component-with-coordinates";
     let content = read_fixture(fixture_name);
@@ -3141,6 +3349,7 @@ fn ribbon_ui_component() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -3152,6 +3361,7 @@ fn ribbon_ui_component() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "ribbon-ui-component";
     let content = read_fixture(fixture_name);
@@ -3168,6 +3378,7 @@ fn ribbon_ui_component_with_coordinates() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         110,
@@ -3179,6 +3390,7 @@ fn ribbon_ui_component_with_coordinates() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "ribbon-ui-component-with-coordinates";
     let content = read_fixture(fixture_name);
@@ -3195,6 +3407,7 @@ fn nested_list_ui_component() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         120,
@@ -3206,6 +3419,7 @@ fn nested_list_ui_component() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "nested-list-ui-component";
     let content = read_fixture(fixture_name);
@@ -3222,6 +3436,7 @@ fn nested_list_ui_component_with_coordinates() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         120,
@@ -3233,6 +3448,7 @@ fn nested_list_ui_component_with_coordinates() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "nested-list-ui-component-with-coordinates";
     let content = read_fixture(fixture_name);
@@ -3249,6 +3465,7 @@ fn text_ui_component() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         120,
@@ -3260,6 +3477,7 @@ fn text_ui_component() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "text-ui-component";
     let content = read_fixture(fixture_name);
@@ -3276,6 +3494,7 @@ fn text_ui_component_with_coordinates() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         41,
         120,
@@ -3287,6 +3506,7 @@ fn text_ui_component_with_coordinates() {
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let fixture_name = "text-ui-component-with-coordinates";
     let content = read_fixture(fixture_name);

--- a/zellij-server/src/panes/unit/search_in_pane_tests.rs
+++ b/zellij-server/src/panes/unit/search_in_pane_tests.rs
@@ -30,6 +30,7 @@ fn create_pane() -> TerminalPane {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut terminal_pane = TerminalPane::new(
         pid,
         fake_win_size,
@@ -45,6 +46,7 @@ fn create_pane() -> TerminalPane {
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     ); // 0 is the pane index
     let content = read_fixture();
     terminal_pane.handle_pty_bytes(content);

--- a/zellij-server/src/panes/unit/terminal_pane_tests.rs
+++ b/zellij-server/src/panes/unit/terminal_pane_tests.rs
@@ -38,6 +38,7 @@ pub fn scrolling_inside_a_pane() {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut terminal_pane = TerminalPane::new(
         pid,
         fake_win_size,
@@ -53,6 +54,7 @@ pub fn scrolling_inside_a_pane() {
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     ); // 0 is the pane index
     let mut text_to_fill_pane = String::new();
     for i in 0..30 {
@@ -84,6 +86,7 @@ pub fn sixel_image_inside_terminal_pane() {
     })));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut terminal_pane = TerminalPane::new(
         pid,
         fake_win_size,
@@ -99,6 +102,7 @@ pub fn sixel_image_inside_terminal_pane() {
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     ); // 0 is the pane index
     let sixel_image_bytes = "\u{1b}Pq
         #0;2;0;0;0#1;2;100;100;0#2;2;0;100;0
@@ -130,6 +134,7 @@ pub fn partial_sixel_image_inside_terminal_pane() {
     })));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut terminal_pane = TerminalPane::new(
         pid,
         fake_win_size,
@@ -145,6 +150,7 @@ pub fn partial_sixel_image_inside_terminal_pane() {
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     ); // 0 is the pane index
     let pane_content = read_fixture("sixel-image-500px.six");
     terminal_pane.handle_pty_bytes(pane_content);
@@ -170,6 +176,7 @@ pub fn overflowing_sixel_image_inside_terminal_pane() {
     })));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut terminal_pane = TerminalPane::new(
         pid,
         fake_win_size,
@@ -185,6 +192,7 @@ pub fn overflowing_sixel_image_inside_terminal_pane() {
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     ); // 0 is the pane index
     let pane_content = read_fixture("sixel-image-500px.six");
     terminal_pane.handle_pty_bytes(pane_content);
@@ -209,6 +217,7 @@ pub fn scrolling_through_a_sixel_image() {
     })));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut terminal_pane = TerminalPane::new(
         pid,
         fake_win_size,
@@ -224,6 +233,7 @@ pub fn scrolling_through_a_sixel_image() {
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     ); // 0 is the pane index
     let mut text_to_fill_pane = String::new();
     for i in 0..30 {
@@ -259,6 +269,7 @@ pub fn multiple_sixel_images_in_pane() {
     })));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut terminal_pane = TerminalPane::new(
         pid,
         fake_win_size,
@@ -274,6 +285,7 @@ pub fn multiple_sixel_images_in_pane() {
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     ); // 0 is the pane index
     let mut text_to_fill_pane = String::new();
     for i in 0..5 {
@@ -307,6 +319,7 @@ pub fn resizing_pane_with_sixel_images() {
     })));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut terminal_pane = TerminalPane::new(
         pid,
         fake_win_size,
@@ -322,6 +335,7 @@ pub fn resizing_pane_with_sixel_images() {
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     ); // 0 is the pane index
     let mut text_to_fill_pane = String::new();
     for i in 0..5 {
@@ -358,6 +372,7 @@ pub fn changing_character_cell_size_with_sixel_images() {
     })));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut terminal_pane = TerminalPane::new(
         pid,
         fake_win_size,
@@ -373,6 +388,7 @@ pub fn changing_character_cell_size_with_sixel_images() {
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     ); // 0 is the pane index
     let mut text_to_fill_pane = String::new();
     for i in 0..5 {
@@ -414,6 +430,7 @@ pub fn keep_working_after_corrupted_sixel_image() {
     })));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut terminal_pane = TerminalPane::new(
         pid,
         fake_win_size,
@@ -429,6 +446,7 @@ pub fn keep_working_after_corrupted_sixel_image() {
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     ); // 0 is the pane index
 
     let sixel_image_bytes = "\u{1b}PI AM CORRUPTED BWAHAHAq
@@ -468,6 +486,7 @@ pub fn pane_with_frame_position_is_on_frame() {
     })));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut terminal_pane = TerminalPane::new(
         pid,
         fake_win_size,
@@ -483,6 +502,7 @@ pub fn pane_with_frame_position_is_on_frame() {
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     ); // 0 is the pane index
 
     terminal_pane.set_content_offset(Offset::frame(1));
@@ -558,6 +578,7 @@ pub fn pane_with_bottom_and_right_borders_position_is_on_frame() {
     })));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut terminal_pane = TerminalPane::new(
         pid,
         fake_win_size,
@@ -573,6 +594,7 @@ pub fn pane_with_bottom_and_right_borders_position_is_on_frame() {
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     ); // 0 is the pane index
 
     terminal_pane.set_content_offset(Offset::shift(1, 1));
@@ -648,6 +670,7 @@ pub fn frameless_pane_position_is_on_frame() {
     })));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut terminal_pane = TerminalPane::new(
         pid,
         fake_win_size,
@@ -663,6 +686,7 @@ pub fn frameless_pane_position_is_on_frame() {
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     ); // 0 is the pane index
 
     terminal_pane.set_content_offset(Offset::default());

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1171,6 +1171,7 @@ impl Screen {
             self.default_shell.clone(),
             self.debug,
             self.arrow_fonts,
+            self.styled_underlines,
         );
         self.tabs.insert(tab_index, tab);
         Ok(())

--- a/zellij-server/src/tab/layout_applier.rs
+++ b/zellij-server/src/tab/layout_applier.rs
@@ -263,6 +263,7 @@ impl<'a> LayoutApplier<'a> {
                             layout.run.clone(),
                             self.debug,
                             self.arrow_fonts,
+                            self.styled_underlines,
                         );
                         if let Some(pane_initial_contents) = &layout.pane_initial_contents {
                             new_plugin.handle_pty_bytes(pane_initial_contents.as_bytes().into());
@@ -391,6 +392,7 @@ impl<'a> LayoutApplier<'a> {
                     floating_pane_layout.run.clone(),
                     self.debug,
                     self.arrow_fonts,
+                    self.styled_underlines,
                 );
                 if let Some(pane_initial_contents) = &floating_pane_layout.pane_initial_contents {
                     new_pane.handle_pty_bytes(pane_initial_contents.as_bytes().into());

--- a/zellij-server/src/tab/layout_applier.rs
+++ b/zellij-server/src/tab/layout_applier.rs
@@ -42,6 +42,7 @@ pub struct LayoutApplier<'a> {
     os_api: Box<dyn ServerOsApi>,
     debug: bool,
     arrow_fonts: bool,
+    styled_underlines: bool,
 }
 
 impl<'a> LayoutApplier<'a> {
@@ -63,6 +64,7 @@ impl<'a> LayoutApplier<'a> {
         os_api: &Box<dyn ServerOsApi>,
         debug: bool,
         arrow_fonts: bool,
+        styled_underlines: bool,
     ) -> Self {
         let viewport = viewport.clone();
         let senders = senders.clone();
@@ -93,6 +95,7 @@ impl<'a> LayoutApplier<'a> {
             os_api,
             debug,
             arrow_fonts,
+            styled_underlines,
         }
     }
     pub fn apply_layout(
@@ -297,6 +300,7 @@ impl<'a> LayoutApplier<'a> {
                                 layout.run.clone(),
                                 self.debug,
                                 self.arrow_fonts,
+                                self.styled_underlines,
                             );
                             if let Some(pane_initial_contents) = &layout.pane_initial_contents {
                                 new_pane.handle_pty_bytes(pane_initial_contents.as_bytes().into());
@@ -427,6 +431,7 @@ impl<'a> LayoutApplier<'a> {
                     floating_pane_layout.run.clone(),
                     self.debug,
                     self.arrow_fonts,
+                    self.styled_underlines,
                 );
                 if let Some(pane_initial_contents) = &floating_pane_layout.pane_initial_contents {
                     new_pane.handle_pty_bytes(pane_initial_contents.as_bytes().into());

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1100,6 +1100,7 @@ impl Tab {
                     invoked_with,
                     self.debug,
                     self.arrow_fonts,
+                    self.styled_underlines,
                 )) as Box<dyn Pane>
             },
         };
@@ -1265,6 +1266,7 @@ impl Tab {
                     run,
                     self.debug,
                     self.arrow_fonts,
+                    self.styled_underlines,
                 );
                 let replaced_pane = if self.floating_panes.panes_contain(&old_pane_id) {
                     self.floating_panes

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -186,6 +186,7 @@ pub(crate) struct Tab {
     default_shell: Option<PathBuf>,
     debug: bool,
     arrow_fonts: bool,
+    styled_underlines: bool,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -535,6 +536,7 @@ impl Tab {
         default_shell: Option<PathBuf>,
         debug: bool,
         arrow_fonts: bool,
+        styled_underlines: bool,
     ) -> Self {
         let name = if name.is_empty() {
             format!("Tab #{}", index + 1)
@@ -624,6 +626,7 @@ impl Tab {
             default_shell,
             debug,
             arrow_fonts,
+            styled_underlines,
         }
     }
 
@@ -656,6 +659,7 @@ impl Tab {
             &self.os_api,
             self.debug,
             self.arrow_fonts,
+            self.styled_underlines,
         )
         .apply_layout(
             layout,
@@ -718,6 +722,7 @@ impl Tab {
                 &self.os_api,
                 self.debug,
                 self.arrow_fonts,
+                self.styled_underlines,
             )
             .apply_floating_panes_layout_to_existing_panes(
                 &layout_candidate,
@@ -773,6 +778,7 @@ impl Tab {
                 &self.os_api,
                 self.debug,
                 self.arrow_fonts,
+                self.styled_underlines,
             )
             .apply_tiled_panes_layout_to_existing_panes(
                 &layout_candidate,
@@ -1070,6 +1076,7 @@ impl Tab {
                     invoked_with,
                     self.debug,
                     self.arrow_fonts,
+                    self.styled_underlines,
                 )) as Box<dyn Pane>
             },
             PaneId::Plugin(plugin_pid) => {
@@ -1130,6 +1137,7 @@ impl Tab {
                     None,
                     self.debug,
                     self.arrow_fonts,
+                    self.styled_underlines,
                 );
                 new_pane.update_name("EDITING SCROLLBACK"); // we do this here and not in the
                                                             // constructor so it won't be overrided
@@ -1203,6 +1211,7 @@ impl Tab {
                     run,
                     self.debug,
                     self.arrow_fonts,
+                    self.styled_underlines,
                 );
                 let replaced_pane = if self.floating_panes.panes_contain(&old_pane_id) {
                     self.floating_panes
@@ -1325,6 +1334,7 @@ impl Tab {
                     None,
                     self.debug,
                     self.arrow_fonts,
+                    self.styled_underlines,
                 );
                 self.tiled_panes
                     .split_pane_horizontally(pid, Box::new(new_terminal), client_id);
@@ -1383,6 +1393,7 @@ impl Tab {
                     None,
                     self.debug,
                     self.arrow_fonts,
+                    self.styled_underlines,
                 );
                 self.tiled_panes
                     .split_pane_vertically(pid, Box::new(new_terminal), client_id);

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -225,6 +225,7 @@ fn create_new_tab(size: Size, default_mode: ModeInfo) -> Tab {
     let sixel_image_store = Rc::new(RefCell::new(SixelImageStore::default()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut tab = Tab::new(
         index,
         position,
@@ -249,6 +250,7 @@ fn create_new_tab(size: Size, default_mode: ModeInfo) -> Tab {
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     tab.apply_layout(
         TiledPaneLayout::default(),
@@ -300,6 +302,7 @@ fn create_new_tab_with_swap_layouts(
     let sixel_image_store = Rc::new(RefCell::new(SixelImageStore::default()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut tab = Tab::new(
         index,
         position,
@@ -324,6 +327,7 @@ fn create_new_tab_with_swap_layouts(
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let (
         base_layout,
@@ -377,6 +381,7 @@ fn create_new_tab_with_os_api(
     let sixel_image_store = Rc::new(RefCell::new(SixelImageStore::default()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut tab = Tab::new(
         index,
         position,
@@ -401,6 +406,7 @@ fn create_new_tab_with_os_api(
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     tab.apply_layout(
         TiledPaneLayout::default(),
@@ -440,6 +446,7 @@ fn create_new_tab_with_layout(size: Size, default_mode: ModeInfo, layout: &str) 
     let (tab_layout, floating_panes_layout) = layout.new_tab();
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut tab = Tab::new(
         index,
         position,
@@ -464,6 +471,7 @@ fn create_new_tab_with_layout(size: Size, default_mode: ModeInfo, layout: &str) 
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let pane_ids = tab_layout
         .extract_run_instructions()
@@ -517,6 +525,7 @@ fn create_new_tab_with_mock_pty_writer(
     let sixel_image_store = Rc::new(RefCell::new(SixelImageStore::default()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut tab = Tab::new(
         index,
         position,
@@ -541,6 +550,7 @@ fn create_new_tab_with_mock_pty_writer(
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     tab.apply_layout(
         TiledPaneLayout::default(),
@@ -585,6 +595,7 @@ fn create_new_tab_with_sixel_support(
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut tab = Tab::new(
         index,
         position,
@@ -609,6 +620,7 @@ fn create_new_tab_with_sixel_support(
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     tab.apply_layout(
         TiledPaneLayout::default(),

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -658,6 +658,7 @@ fn take_snapshot(ansi_instructions: &str, rows: usize, columns: usize, palette: 
     })));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         rows,
         columns,
@@ -669,6 +670,7 @@ fn take_snapshot(ansi_instructions: &str, rows: usize, columns: usize, palette: 
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let mut vte_parser = vte::Parser::new();
     for &byte in ansi_instructions.as_bytes() {
@@ -691,6 +693,7 @@ fn take_snapshot_with_sixel(
     })));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         rows,
         columns,
@@ -702,6 +705,7 @@ fn take_snapshot_with_sixel(
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let mut vte_parser = vte::Parser::new();
     for &byte in ansi_instructions.as_bytes() {
@@ -721,6 +725,7 @@ fn take_snapshot_and_cursor_position(
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         rows,
         columns,
@@ -732,6 +737,7 @@ fn take_snapshot_and_cursor_position(
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let mut vte_parser = vte::Parser::new();
     for &byte in ansi_instructions.as_bytes() {

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -166,6 +166,7 @@ fn create_new_tab(size: Size) -> Tab {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut tab = Tab::new(
         index,
         position,
@@ -190,6 +191,7 @@ fn create_new_tab(size: Size) -> Tab {
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     tab.apply_layout(
         TiledPaneLayout::default(),
@@ -226,6 +228,7 @@ fn create_new_tab_with_layout(size: Size, layout: TiledPaneLayout) -> Tab {
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut tab = Tab::new(
         index,
         position,
@@ -250,6 +253,7 @@ fn create_new_tab_with_layout(size: Size, layout: TiledPaneLayout) -> Tab {
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let mut new_terminal_ids = vec![];
     for i in 0..layout.extract_run_instructions().len() {
@@ -292,6 +296,7 @@ fn create_new_tab_with_cell_size(
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut tab = Tab::new(
         index,
         position,
@@ -316,6 +321,7 @@ fn create_new_tab_with_cell_size(
         None,
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     tab.apply_layout(
         TiledPaneLayout::default(),

--- a/zellij-server/src/ui/boundaries.rs
+++ b/zellij-server/src/ui/boundaries.rs
@@ -67,6 +67,7 @@ impl BoundarySymbol {
                 character,
                 width: 1,
                 styles: RESET_STYLES
+                    .enable_styled_underlines(true)
                     .foreground(self.color.map(|palette_color| palette_color.into())),
             }
         };

--- a/zellij-server/src/ui/boundaries.rs
+++ b/zellij-server/src/ui/boundaries.rs
@@ -67,7 +67,6 @@ impl BoundarySymbol {
                 character,
                 width: 1,
                 styles: RESET_STYLES
-                    .enable_styled_underlines(true)
                     .foreground(self.color.map(|palette_color| palette_color.into())),
             }
         };

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -68,6 +68,7 @@ fn take_snapshots_and_cursor_coordinates_from_render_events<'a>(
     })));
     let debug = false;
     let arrow_fonts = true;
+    let styled_underlines = true;
     let mut grid = Grid::new(
         screen_size.rows,
         screen_size.cols,
@@ -79,6 +80,7 @@ fn take_snapshots_and_cursor_coordinates_from_render_events<'a>(
         Style::default(),
         debug,
         arrow_fonts,
+        styled_underlines,
     );
     let snapshots: Vec<(Option<(usize, usize)>, String)> = all_events
         .filter_map(|server_instruction| {


### PR DESCRIPTION
Styled underlines fail to render in text editors like neovim and helix while in a Zellij session. 

This is because `RESET_STYLES` in `terminal_character.rs` sets `styled_underlines` to false. In order to address this, a new parameter is added on `Cursor::new` to read the `styled_underlines` config variable as it's passed down the stack from `Screen` > `Tab` > `TerminalPane` > `Grid`.

I've tried to make this as minimal of a change as possible but some significant boilerplate had to be added.

Finally, I was only able to test this in Neovim. Helix, for whatever reason, ws not rendering styled underlines inside or outside of Zellij. Probably an issue with my config. But if someone else can confirm this works, that would be greatly appreciated.
