### PR TITLE
optimize: update refresh prorcess for sysinfo to reduce cpu usage

### DIFF
--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -761,7 +761,8 @@ impl ServerOsApi for ServerOsInputOutput {
         for pid in pids {
             // Update by minimizing information.
             // See https://docs.rs/sysinfo/0.22.5/sysinfo/struct.ProcessRefreshKind.html#
-            let is_found = system_info.refresh_process_specifics(pid.into(), ProcessRefreshKind::default());
+            let is_found =
+                system_info.refresh_process_specifics(pid.into(), ProcessRefreshKind::default());
             if is_found {
                 if let Some(process) = system_info.process(pid.into()) {
                     let cwd = process.cwd();

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -756,20 +756,23 @@ impl ServerOsApi for ServerOsInputOutput {
 
     fn get_cwds(&self, pids: Vec<Pid>) -> HashMap<Pid, PathBuf> {
         let mut system_info = System::new();
-        // Update by minimizing information.
-        // See https://docs.rs/sysinfo/0.22.5/sysinfo/struct.ProcessRefreshKind.html#
-        system_info.refresh_processes_specifics(ProcessRefreshKind::default());
-
         let mut cwds = HashMap::new();
+
         for pid in pids {
-            if let Some(process) = system_info.process(pid.into()) {
-                let cwd = process.cwd();
-                let cwd_is_empty = cwd.iter().next().is_none();
-                if !cwd_is_empty {
-                    cwds.insert(pid, process.cwd().to_path_buf());
+            // Update by minimizing information.
+            // See https://docs.rs/sysinfo/0.22.5/sysinfo/struct.ProcessRefreshKind.html#
+            let is_found = system_info.refresh_process_specifics(pid.into(), ProcessRefreshKind::default());
+            if is_found {
+                if let Some(process) = system_info.process(pid.into()) {
+                    let cwd = process.cwd();
+                    let cwd_is_empty = cwd.iter().next().is_none();
+                    if !cwd_is_empty {
+                        cwds.insert(pid, process.cwd().to_path_buf());
+                    }
                 }
             }
         }
+
         cwds
     }
     fn get_all_cmds_by_ppid(&self) -> HashMap<String, Vec<String>> {


### PR DESCRIPTION
Use `refresh_processes_specifics`   will use more cpu. Use refresh_process_specifics instead of refresh_processes_specifics to reduce cpu usage.