### PR TITLE
feat(config): add serialization interval configuration

### DIFF
--- a/src/tests/e2e/remote_runner.rs
+++ b/src/tests/e2e/remote_runner.rs
@@ -92,7 +92,7 @@ fn start_zellij_mirrored_session(channel: &mut ssh2::Channel) {
     channel
         .write_all(
             format!(
-                "{} {} --session {} --data-dir {} options --mirror-session true\n",
+                "{} {} --session {} --data-dir {} options --mirror-session true --serialization-interval 1\n",
                 SET_ENV_VARIABLES, ZELLIJ_EXECUTABLE_LOCATION, SESSION_NAME, ZELLIJ_DATA_DIR
             )
             .as_bytes(),

--- a/src/tests/e2e/remote_runner.rs
+++ b/src/tests/e2e/remote_runner.rs
@@ -107,7 +107,7 @@ fn start_zellij_mirrored_session_with_layout(channel: &mut ssh2::Channel, layout
     channel
         .write_all(
             format!(
-                "{} {} --session {} --data-dir {} --layout {} options --mirror-session true\n",
+                "{} {} --session {} --data-dir {} --layout {} options --mirror-session true --serialization-interval 1\n",
                 SET_ENV_VARIABLES,
                 ZELLIJ_EXECUTABLE_LOCATION,
                 SESSION_NAME,
@@ -129,7 +129,7 @@ fn start_zellij_mirrored_session_with_layout_and_viewport_serialization(
     channel
         .write_all(
             format!(
-                "{} {} --session {} --data-dir {} --layout {} options --mirror-session true --serialize-pane-viewport true\n",
+                "{} {} --session {} --data-dir {} --layout {} options --mirror-session true --serialize-pane-viewport true --serialization-interval 1\n",
                 SET_ENV_VARIABLES,
                 ZELLIJ_EXECUTABLE_LOCATION,
                 SESSION_NAME,

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -751,6 +751,8 @@ fn init_session(
         arrow_fonts: config_options.simplified_ui.unwrap_or_default(),
     };
 
+    let serialization_interval = config_options.serialization_interval;
+
     let default_shell = config_options.default_shell.clone().map(|command| {
         TerminalAction::RunCommand(RunCommand {
             command,
@@ -885,7 +887,7 @@ fn init_session(
                 None,
                 Some(os_input.clone()),
             );
-            || background_jobs_main(background_jobs_bus).fatal()
+            move || background_jobs_main(background_jobs_bus, serialization_interval).fatal()
         })
         .unwrap();
 

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -147,6 +147,10 @@ pub struct Options {
     #[clap(long, value_parser)]
     #[serde(default)]
     pub styled_underlines: Option<bool>,
+
+    /// The interval at which to serialize sessions for resurrection (in seconds)
+    #[clap(long, value_parser)]
+    pub serialization_interval: Option<u64>,
 }
 
 #[derive(ArgEnum, Deserialize, Serialize, Debug, Clone, Copy, PartialEq)]
@@ -218,6 +222,7 @@ impl Options {
             .scrollback_lines_to_serialize
             .or(self.scrollback_lines_to_serialize);
         let styled_underlines = other.styled_underlines.or(self.styled_underlines);
+        let serialization_interval = other.serialization_interval.or(self.serialization_interval);
 
         Options {
             simplified_ui,
@@ -244,6 +249,7 @@ impl Options {
             serialize_pane_viewport,
             scrollback_lines_to_serialize,
             styled_underlines,
+            serialization_interval,
         }
     }
 
@@ -295,6 +301,7 @@ impl Options {
             .scrollback_lines_to_serialize
             .or_else(|| self.scrollback_lines_to_serialize.clone());
         let styled_underlines = other.styled_underlines.or(self.styled_underlines);
+        let serialization_interval = other.serialization_interval.or(self.serialization_interval);
 
         Options {
             simplified_ui,
@@ -321,6 +328,7 @@ impl Options {
             serialize_pane_viewport,
             scrollback_lines_to_serialize,
             styled_underlines,
+            serialization_interval,
         }
     }
 
@@ -384,6 +392,7 @@ impl From<CliOptions> for Options {
             serialize_pane_viewport: opts.serialize_pane_viewport,
             scrollback_lines_to_serialize: opts.scrollback_lines_to_serialize,
             styled_underlines: opts.styled_underlines,
+            serialization_interval: opts.serialization_interval,
             ..Default::default()
         }
     }

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -1480,6 +1480,9 @@ impl Options {
         let styled_underlines =
             kdl_property_first_arg_as_bool_or_error!(kdl_options, "styled_underlines")
                 .map(|(v, _)| v);
+        let serialization_interval =
+            kdl_property_first_arg_as_i64_or_error!(kdl_options, "serialization_interval")
+                .map(|(scroll_buffer_size, _entry)| scroll_buffer_size as u64);
         Ok(Options {
             simplified_ui,
             theme,
@@ -1505,6 +1508,7 @@ impl Options {
             serialize_pane_viewport,
             scrollback_lines_to_serialize,
             styled_underlines,
+            serialization_interval,
         })
     }
 }

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 686
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -29,4 +30,5 @@ Options {
     serialize_pane_viewport: None,
     scrollback_lines_to_serialize: None,
     styled_underlines: None,
+    serialization_interval: None,
 }

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 714
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -29,4 +30,5 @@ Options {
     serialize_pane_viewport: None,
     scrollback_lines_to_serialize: None,
     styled_underlines: None,
+    serialization_interval: None,
 }

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 673
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -27,4 +28,5 @@ Options {
     serialize_pane_viewport: None,
     scrollback_lines_to_serialize: None,
     styled_underlines: None,
+    serialization_interval: None,
 }

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 671
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -3592,6 +3593,7 @@ Config {
         serialize_pane_viewport: None,
         scrollback_lines_to_serialize: None,
         styled_underlines: None,
+        serialization_interval: None,
     },
     themes: {},
     plugins: {

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 729
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -3592,6 +3593,7 @@ Config {
         serialize_pane_viewport: None,
         scrollback_lines_to_serialize: None,
         styled_underlines: None,
+        serialization_interval: None,
     },
     themes: {},
     plugins: {

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 785
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -85,6 +86,7 @@ Config {
         serialize_pane_viewport: None,
         scrollback_lines_to_serialize: None,
         styled_underlines: None,
+        serialization_interval: None,
     },
     themes: {},
     plugins: {

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 696
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -29,4 +30,5 @@ Options {
     serialize_pane_viewport: None,
     scrollback_lines_to_serialize: None,
     styled_underlines: None,
+    serialization_interval: None,
 }

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_plugins_override_config_plugins.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_plugins_override_config_plugins.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 757
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -3592,6 +3593,7 @@ Config {
         serialize_pane_viewport: None,
         scrollback_lines_to_serialize: None,
         styled_underlines: None,
+        serialization_interval: None,
     },
     themes: {},
     plugins: {

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 771
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -3592,6 +3593,7 @@ Config {
         serialize_pane_viewport: None,
         scrollback_lines_to_serialize: None,
         styled_underlines: None,
+        serialization_interval: None,
     },
     themes: {
         "other-theme-from-config": Theme {

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 743
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -3592,6 +3593,7 @@ Config {
         serialize_pane_viewport: None,
         scrollback_lines_to_serialize: None,
         styled_underlines: None,
+        serialization_interval: None,
     },
     themes: {},
     plugins: {


### PR DESCRIPTION
This adds a `serialization_interval` configuration parameter. Allowing users to set the interval in seconds in which the session serialization (if active) will happen. These serializations are then used in order to resurrect sessions.

The default interval has also been changed from 1 second to 60 seconds.