### PR TITLE
fix(plugins): reloading plugin after crash

### DIFF
--- a/zellij-server/src/plugins/plugin_loader.rs
+++ b/zellij-server/src/plugins/plugin_loader.rs
@@ -507,6 +507,7 @@ impl<'a> PluginLoader<'a> {
         Ok(module)
     }
     pub fn compile_module(&mut self) -> Result<Module> {
+        self.loading_indication.override_previous_error();
         display_loading_stage!(
             indicate_loading_plugin_from_hd_cache_notfound,
             self.loading_indication,

--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -927,5 +927,4 @@ pub fn handle_plugin_crash(plugin_id: PluginId, message: String, senders: Thread
         plugin_id,
         loading_indication,
     ));
-    let _ = senders.send_to_plugin(PluginInstruction::Unload(plugin_id));
 }


### PR DESCRIPTION
This fixes an issue where if a plugin crashed, reloading while skipping cash would be impossible without restarting Zellij. This is relevant to the `start-or-reload` command and is mostly used for plugin development.