### PR TITLE
docs: Update Arch Linux package URL in THIRD_PARTY_INSTALL.md

### DIFF
--- a/docs/THIRD_PARTY_INSTALL.md
+++ b/docs/THIRD_PARTY_INSTALL.md
@@ -13,7 +13,7 @@
 [![Packaging status](https://repology.org/badge/vertical-allrepos/zellij.svg)](https://repology.org/project/zellij/versions)
 
 ### Arch Linux
-You can install the `zellij` package from the [official community repository](https://archlinux.org/packages/community/x86_64/zellij/):
+You can install the `zellij` package from the [official extra repository](https://archlinux.org/packages/extra/x86_64/zellij/):
 
 ```
 pacman -S zellij


### PR DESCRIPTION
The old URL returns 404 now.