### PR TITLE
fix: custom function should be eagerly evaluated

### DIFF
--- a/zellij-utils/assets/completions/comp.bash
+++ b/zellij-utils/assets/completions/comp.bash
@@ -1,4 +1,0 @@
-function zr () { zellij run --name "$*" -- bash -ic "$*";}
-function zrf () { zellij run --name "$*" --floating -- bash -ic "$*";}
-function ze () { zellij edit "$*";}
-function zef () { zellij edit --floating "$*";}

--- a/zellij-utils/assets/completions/comp.fish
+++ b/zellij-utils/assets/completions/comp.fish
@@ -6,15 +6,3 @@ complete -c zellij -n "__fish_seen_subcommand_from a" -f -a "(__fish_complete_se
 complete -c zellij -n "__fish_seen_subcommand_from kill-session" -f -a "(__fish_complete_sessions)" -d "Session"
 complete -c zellij -n "__fish_seen_subcommand_from k" -f -a "(__fish_complete_sessions)" -d "Session"
 complete -c zellij -n "__fish_seen_subcommand_from setup" -l "generate-completion" -x -a "bash elvish fish zsh powershell" -d "Shell"
-function zr
-  command zellij run --name "$argv" -- fish -c "$argv"
-end
-function zrf
-  command zellij run --name "$argv" --floating -- fish -c "$argv"
-end
-function ze
-  command zellij edit $argv
-end
-function zef
-  command zellij edit --floating $argv
-end

--- a/zellij-utils/assets/completions/comp.zsh
+++ b/zellij-utils/assets/completions/comp.zsh
@@ -1,4 +1,0 @@
-function zr () { zellij run --name "$*" -- zsh -ic "$*";}
-function zrf () { zellij run --name "$*" --floating -- zsh -ic "$*";}
-function ze () { zellij edit "$*";}
-function zef () { zellij edit --floating "$*";}

--- a/zellij-utils/assets/functions/functions.bash
+++ b/zellij-utils/assets/functions/functions.bash
@@ -1,0 +1,4 @@
+function zr () { zellij run --name "$*" -- bash -ic "$*";}
+function zrf () { zellij run --name "$*" --floating -- bash -ic "$*";}
+function ze () { zellij edit "$*";}
+function zef () { zellij edit --floating "$*";}

--- a/zellij-utils/assets/functions/functions.fish
+++ b/zellij-utils/assets/functions/functions.fish
@@ -1,0 +1,12 @@
+function zr
+  command zellij run --name "$argv" -- fish -c "$argv"
+end
+function zrf
+  command zellij run --name "$argv" --floating -- fish -c "$argv"
+end
+function ze
+  command zellij edit $argv
+end
+function zef
+  command zellij edit --floating $argv
+end

--- a/zellij-utils/assets/functions/functions.zsh
+++ b/zellij-utils/assets/functions/functions.zsh
@@ -1,0 +1,4 @@
+function zr () { zellij run --name "$*" -- zsh -ic "$*";}
+function zrf () { zellij run --name "$*" --floating -- zsh -ic "$*";}
+function ze () { zellij edit "$*";}
+function zef () { zellij edit --floating "$*";}

--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -166,6 +166,23 @@ pub const COMPACT_BAR_SWAP_LAYOUT: &[u8] = include_bytes!(concat!(
     "/",
     "assets/layouts/compact.swap.kdl"
 ));
+pub const FISH_FUNCTIONS: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/",
+    "assets/functions/functions.fish"
+));
+
+pub const BASH_FUNCTIONS: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/",
+    "assets/functions/functions.bash"
+));
+
+pub const ZSH_FUNCTIONS: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/",
+    "assets/functions/functions.zsh"
+));
 
 pub const FISH_EXTRA_COMPLETION: &[u8] = include_bytes!(concat!(
     env!("CARGO_MANIFEST_DIR"),
@@ -331,6 +348,10 @@ pub struct Setup {
     #[clap(long, value_name = "SHELL", value_parser)]
     pub generate_completion: Option<String>,
 
+    /// Generates functions for the specified shell
+    #[clap(long, value_name = "SHELL", value_parser)]
+    pub generate_functions: Option<String>,
+
     /// Generates auto-start script for the specified shell
     #[clap(long, value_name = "SHELL", value_parser)]
     pub generate_auto_start: Option<String>,
@@ -399,6 +420,11 @@ impl Setup {
 
         if let Some(shell) = &self.generate_completion {
             Self::generate_completion(shell);
+            std::process::exit(0);
+        }
+
+        if let Some(shell) = &self.generate_functions {
+            Self::generate_functions(shell);
             std::process::exit(0);
         }
 
@@ -564,6 +590,32 @@ impl Setup {
 
         Ok(())
     }
+
+    fn generate_functions(shell: &str) {
+        let shell: Shell = match shell.to_lowercase().parse() {
+            Ok(shell) => shell,
+            _ => {
+                eprintln!("Unsupported shell: {}", shell);
+                std::process::exit(1);
+            },
+        };
+        let mut out = std::io::stdout();
+        match shell {
+            Shell::Bash => {
+                let _ = out.write_all(BASH_FUNCTIONS);
+            },
+            Shell::Elvish => {},
+            Shell::Fish => {
+                let _ = out.write_all(FISH_FUNCTIONS);
+            },
+            Shell::PowerShell => {},
+            Shell::Zsh => {
+                let _ = out.write_all(ZSH_FUNCTIONS);
+            },
+            _ => {},
+        };
+    }
+
     fn generate_completion(shell: &str) {
         let shell: Shell = match shell.to_lowercase().parse() {
             Ok(shell) => shell,


### PR DESCRIPTION
completions are not evaluated eagerly. Custom shell functions should be in a different directory.

For example `/usr/share/fish/functions`

This should fix #1933. Package maintainer need to change their builds though.