### PR TITLE
feat(plugins): skip plugin cache flag

### DIFF
--- a/default-plugins/status-bar/src/second_line.rs
+++ b/default-plugins/status-bar/src/second_line.rs
@@ -245,7 +245,7 @@ fn get_keys_and_hints(mi: &ModeInfo) -> Vec<(String, String, Vec<Key>)> {
             action_key(&km, &[A::SearchToggleOption(SOpt::WholeWord)])),
     ]} else if mi.mode == IM::Session { vec![
         (s("Detach"), s("Detach"), action_key(&km, &[Action::Detach])),
-        (s("Session Manager"), s("Manager"), action_key(&km, &[A::LaunchOrFocusPlugin(Default::default(), true, true, false), TO_NORMAL])), // not entirely accurate
+        (s("Session Manager"), s("Manager"), action_key(&km, &[A::LaunchOrFocusPlugin(Default::default(), true, true, false, false), TO_NORMAL])), // not entirely accurate
         (s("Select pane"), s("Select"), to_normal_key),
     ]} else if mi.mode == IM::Tmux { vec![
         (s("Move focus"), s("Move"), action_key_group(&km, &[

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ fn main() {
             start_suspended,
         })) = opts.command
         {
+            let skip_plugin_cache = false; // N/A for this action
             let command_cli_action = CliAction::NewPane {
                 command,
                 plugin: None,
@@ -42,6 +43,7 @@ fn main() {
                 close_on_exit,
                 start_suspended,
                 configuration: None,
+                skip_plugin_cache,
             };
             commands::send_action_to_session(command_cli_action, opts.session, config);
             std::process::exit(0);
@@ -51,6 +53,7 @@ fn main() {
             floating,
             in_place,
             configuration,
+            skip_plugin_cache,
         })) = opts.command
         {
             let command_cli_action = CliAction::NewPane {
@@ -64,6 +67,7 @@ fn main() {
                 close_on_exit: false,
                 start_suspended: false,
                 configuration,
+                skip_plugin_cache,
             };
             commands::send_action_to_session(command_cli_action, opts.session, config);
             std::process::exit(0);

--- a/zellij-server/src/plugins/mod.rs
+++ b/zellij-server/src/plugins/mod.rs
@@ -51,7 +51,7 @@ pub enum PluginInstruction {
         ClientId,
         Size,
         Option<PathBuf>, // cwd
-        bool, // skip cache
+        bool,            // skip cache
     ),
     Update(Vec<(Option<PluginId>, Option<ClientId>, Event)>), // Focused plugin / broadcast, client_id, event data
     Unload(PluginId),                                         // plugin_id
@@ -186,8 +186,14 @@ pub(crate) fn plugin_thread_main(
                 size,
                 cwd,
                 skip_cache,
-            ) => match wasm_bridge.load_plugin(&run, tab_index, size, cwd.clone(), skip_cache, Some(client_id))
-            {
+            ) => match wasm_bridge.load_plugin(
+                &run,
+                tab_index,
+                size,
+                cwd.clone(),
+                skip_cache,
+                Some(client_id),
+            ) {
                 Ok(plugin_id) => {
                     drop(bus.senders.send_to_screen(ScreenInstruction::AddPlugin(
                         should_float,
@@ -224,7 +230,9 @@ pub(crate) fn plugin_thread_main(
                             // we intentionally do not provide the client_id here because it belongs to
                             // the cli who spawned the command and is not an existing client_id
                             let skip_cache = true; // when reloading we always skip cache
-                            match wasm_bridge.load_plugin(&run, tab_index, size, None, skip_cache, None) {
+                            match wasm_bridge
+                                .load_plugin(&run, tab_index, size, None, skip_cache, None)
+                            {
                                 Ok(plugin_id) => {
                                     let should_be_open_in_place = false;
                                     drop(bus.senders.send_to_screen(ScreenInstruction::AddPlugin(

--- a/zellij-server/src/plugins/plugin_loader.rs
+++ b/zellij-server/src/plugins/plugin_loader.rs
@@ -170,46 +170,47 @@ impl<'a> PluginLoader<'a> {
             default_layout,
         )?;
         if skip_cache {
-            plugin_loader.compile_module()
-            .and_then(|module| plugin_loader.create_plugin_environment(module))
-            .and_then(|(store, instance, plugin_env, subscriptions)| {
-                plugin_loader.load_plugin_instance(
-                    store,
-                    &instance,
-                    &plugin_env,
-                    &plugin_map,
-                    &subscriptions,
-                )
-            })
-            .and_then(|_| {
-                plugin_loader.clone_instance_for_other_clients(
-                    &connected_clients.lock().unwrap(),
-                    &plugin_map,
-                )
-            })
-            .with_context(err_context)?;
+            plugin_loader
+                .compile_module()
+                .and_then(|module| plugin_loader.create_plugin_environment(module))
+                .and_then(|(store, instance, plugin_env, subscriptions)| {
+                    plugin_loader.load_plugin_instance(
+                        store,
+                        &instance,
+                        &plugin_env,
+                        &plugin_map,
+                        &subscriptions,
+                    )
+                })
+                .and_then(|_| {
+                    plugin_loader.clone_instance_for_other_clients(
+                        &connected_clients.lock().unwrap(),
+                        &plugin_map,
+                    )
+                })
+                .with_context(err_context)?;
         } else {
             plugin_loader
                 .load_module_from_memory()
                 .or_else(|_e| plugin_loader.load_module_from_hd_cache())
                 .or_else(|_e| plugin_loader.compile_module())
-            .and_then(|module| plugin_loader.create_plugin_environment(module))
-            .and_then(|(store, instance, plugin_env, subscriptions)| {
-                plugin_loader.load_plugin_instance(
-                    store,
-                    &instance,
-                    &plugin_env,
-                    &plugin_map,
-                    &subscriptions,
-                )
-            })
-            .and_then(|_| {
-                plugin_loader.clone_instance_for_other_clients(
-                    &connected_clients.lock().unwrap(),
-                    &plugin_map,
-                )
-            })
-            .with_context(err_context)?;
+                .and_then(|module| plugin_loader.create_plugin_environment(module))
+                .and_then(|(store, instance, plugin_env, subscriptions)| {
+                    plugin_loader.load_plugin_instance(
+                        store,
+                        &instance,
+                        &plugin_env,
+                        &plugin_map,
+                        &subscriptions,
+                    )
+                })
+                .and_then(|_| {
+                    plugin_loader.clone_instance_for_other_clients(
+                        &connected_clients.lock().unwrap(),
+                        &plugin_map,
+                    )
+                })
+                .with_context(err_context)?;
         };
         display_loading_stage!(end, loading_indication, senders, plugin_id);
         Ok(())

--- a/zellij-server/src/plugins/plugin_loader.rs
+++ b/zellij-server/src/plugins/plugin_loader.rs
@@ -148,6 +148,7 @@ impl<'a> PluginLoader<'a> {
         client_attributes: ClientAttributes,
         default_shell: Option<TerminalAction>,
         default_layout: Box<Layout>,
+        skip_cache: bool,
     ) -> Result<()> {
         let err_context = || format!("failed to start plugin {plugin_id} for client {client_id}");
         let mut plugin_loader = PluginLoader::new(
@@ -168,10 +169,8 @@ impl<'a> PluginLoader<'a> {
             default_shell,
             default_layout,
         )?;
-        plugin_loader
-            .load_module_from_memory()
-            .or_else(|_e| plugin_loader.load_module_from_hd_cache())
-            .or_else(|_e| plugin_loader.compile_module())
+        if skip_cache {
+            plugin_loader.compile_module()
             .and_then(|module| plugin_loader.create_plugin_environment(module))
             .and_then(|(store, instance, plugin_env, subscriptions)| {
                 plugin_loader.load_plugin_instance(
@@ -189,6 +188,29 @@ impl<'a> PluginLoader<'a> {
                 )
             })
             .with_context(err_context)?;
+        } else {
+            plugin_loader
+                .load_module_from_memory()
+                .or_else(|_e| plugin_loader.load_module_from_hd_cache())
+                .or_else(|_e| plugin_loader.compile_module())
+            .and_then(|module| plugin_loader.create_plugin_environment(module))
+            .and_then(|(store, instance, plugin_env, subscriptions)| {
+                plugin_loader.load_plugin_instance(
+                    store,
+                    &instance,
+                    &plugin_env,
+                    &plugin_map,
+                    &subscriptions,
+                )
+            })
+            .and_then(|_| {
+                plugin_loader.clone_instance_for_other_clients(
+                    &connected_clients.lock().unwrap(),
+                    &plugin_map,
+                )
+            })
+            .with_context(err_context)?;
+        };
         display_loading_stage!(end, loading_indication, senders, plugin_id);
         Ok(())
     }

--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -114,6 +114,7 @@ impl WasmBridge {
         tab_index: usize,
         size: Size,
         cwd: Option<PathBuf>,
+        skip_cache: bool,
         client_id: Option<ClientId>,
     ) -> Result<PluginId> {
         // returns the plugin id
@@ -209,6 +210,7 @@ impl WasmBridge {
                     client_attributes,
                     default_shell,
                     default_layout,
+                    skip_cache,
                 ) {
                     Ok(_) => handle_plugin_successful_loading(&senders, plugin_id),
                     Err(e) => handle_plugin_loading_failure(

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -88,6 +88,7 @@ pub enum PtyInstruction {
         Option<PaneId>, // pane id to replace if this is to be opened "in-place"
         ClientId,
         Size,
+        bool, // skip cache
     ),
     Exit,
 }
@@ -653,6 +654,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                 pane_id_to_replace,
                 client_id,
                 size,
+                skip_cache,
             ) => {
                 pty.fill_plugin_cwd(
                     should_float,
@@ -663,6 +665,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                     pane_id_to_replace,
                     client_id,
                     size,
+                    skip_cache,
                 )?;
             },
             PtyInstruction::Exit => break,
@@ -1328,6 +1331,7 @@ impl Pty {
         pane_id_to_replace: Option<PaneId>, // pane id to replace if this is to be opened "in-place"
         client_id: ClientId,
         size: Size,
+        skip_cache: bool,
     ) -> Result<()> {
         let cwd = self
             .active_panes
@@ -1353,6 +1357,7 @@ impl Pty {
             client_id,
             size,
             cwd,
+            skip_cache,
         ))?;
         Ok(())
     }

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -658,25 +658,25 @@ pub(crate) fn route_action(
                 .send_to_screen(ScreenInstruction::QueryTabNames(client_id))
                 .with_context(err_context)?;
         },
-        Action::NewTiledPluginPane(run_plugin, name) => {
+        Action::NewTiledPluginPane(run_plugin, name, skip_cache) => {
             senders
                 .send_to_screen(ScreenInstruction::NewTiledPluginPane(
-                    run_plugin, name, client_id,
+                    run_plugin, name, skip_cache, client_id,
                 ))
                 .with_context(err_context)?;
         },
-        Action::NewFloatingPluginPane(run_plugin, name) => {
+        Action::NewFloatingPluginPane(run_plugin, name, skip_cache) => {
             senders
                 .send_to_screen(ScreenInstruction::NewFloatingPluginPane(
-                    run_plugin, name, client_id,
+                    run_plugin, name, skip_cache, client_id,
                 ))
                 .with_context(err_context)?;
         },
-        Action::NewInPlacePluginPane(run_plugin, name) => {
+        Action::NewInPlacePluginPane(run_plugin, name, skip_cache) => {
             if let Some(pane_id) = pane_id {
                 senders
                     .send_to_screen(ScreenInstruction::NewInPlacePluginPane(
-                        run_plugin, name, pane_id, client_id,
+                        run_plugin, name, pane_id, skip_cache, client_id,
                     ))
                     .with_context(err_context)?;
             } else {
@@ -693,6 +693,7 @@ pub(crate) fn route_action(
             should_float,
             move_to_focused_tab,
             should_open_in_place,
+            skip_cache,
         ) => {
             senders
                 .send_to_screen(ScreenInstruction::LaunchOrFocusPlugin(
@@ -701,17 +702,19 @@ pub(crate) fn route_action(
                     move_to_focused_tab,
                     should_open_in_place,
                     pane_id,
+                    skip_cache,
                     client_id,
                 ))
                 .with_context(err_context)?;
         },
-        Action::LaunchPlugin(run_plugin, should_float, should_open_in_place) => {
+        Action::LaunchPlugin(run_plugin, should_float, should_open_in_place, skip_cache) => {
             senders
                 .send_to_screen(ScreenInstruction::LaunchPlugin(
                     run_plugin,
                     should_float,
                     should_open_in_place,
                     pane_id,
+                    skip_cache,
                     client_id,
                 ))
                 .with_context(err_context)?;

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -272,11 +272,13 @@ pub enum ScreenInstruction {
     PreviousSwapLayout(ClientId),
     NextSwapLayout(ClientId),
     QueryTabNames(ClientId),
-    NewTiledPluginPane(RunPlugin, Option<String>, ClientId), // Option<String> is
-    // optional pane title
-    NewFloatingPluginPane(RunPlugin, Option<String>, ClientId), // Option<String> is an
-    NewInPlacePluginPane(RunPlugin, Option<String>, PaneId, ClientId), // Option<String> is an
-    // optional pane title
+    NewTiledPluginPane(RunPlugin, Option<String>, bool, ClientId), // Option<String> is
+    // optional pane title, bool is skip cache
+    NewFloatingPluginPane(RunPlugin, Option<String>, bool, ClientId), // Option<String> is an
+                                                                      // optional pane title, bool
+                                                                      // is skip cache
+    NewInPlacePluginPane(RunPlugin, Option<String>, PaneId, bool, ClientId), // Option<String> is an
+    // optional pane title, bool is skip cache
     StartOrReloadPluginPane(RunPlugin, Option<String>),
     AddPlugin(
         Option<bool>, // should_float
@@ -293,8 +295,8 @@ pub enum ScreenInstruction {
     StartPluginLoadingIndication(u32, LoadingIndication), // u32 - plugin_id
     ProgressPluginLoadingOffset(u32),                 // u32 - plugin id
     RequestStateUpdateForPlugins,
-    LaunchOrFocusPlugin(RunPlugin, bool, bool, bool, Option<PaneId>, ClientId), // bools are: should_float, move_to_focused_tab, should_open_in_place Option<PaneId> is the pane id to replace
-    LaunchPlugin(RunPlugin, bool, bool, Option<PaneId>, ClientId), // bools are: should_float, should_open_in_place Option<PaneId> is the pane id to replace
+    LaunchOrFocusPlugin(RunPlugin, bool, bool, bool, Option<PaneId>, bool, ClientId), // bools are: should_float, move_to_focused_tab, should_open_in_place, Option<PaneId> is the pane id to replace, bool following it is skip_cache
+    LaunchPlugin(RunPlugin, bool, bool, Option<PaneId>, bool, ClientId), // bools are: should_float, should_open_in_place Option<PaneId> is the pane id to replace, bool after is skip_cache
     SuppressPane(PaneId, ClientId),                                // bool is should_float
     FocusPaneWithId(PaneId, bool, ClientId),                       // bool is should_float
     RenamePane(PaneId, Vec<u8>),
@@ -3145,7 +3147,7 @@ pub(crate) fn screen_thread_main(
                     .senders
                     .send_to_server(ServerInstruction::Log(tab_names, client_id))?;
             },
-            ScreenInstruction::NewTiledPluginPane(run_plugin, pane_title, client_id) => {
+            ScreenInstruction::NewTiledPluginPane(run_plugin, pane_title, skip_cache, client_id) => {
                 let tab_index = screen.active_tab_indices.values().next().unwrap_or(&1);
                 let size = Size::default();
                 let should_float = Some(false);
@@ -3162,9 +3164,10 @@ pub(crate) fn screen_thread_main(
                         None,
                         client_id,
                         size,
+                        skip_cache,
                     ))?;
             },
-            ScreenInstruction::NewFloatingPluginPane(run_plugin, pane_title, client_id) => {
+            ScreenInstruction::NewFloatingPluginPane(run_plugin, pane_title, skip_cache, client_id) => {
                 match screen.active_tab_indices.values().next() {
                     Some(tab_index) => {
                         let size = Size::default();
@@ -3182,6 +3185,7 @@ pub(crate) fn screen_thread_main(
                                 None,
                                 client_id,
                                 size,
+                                skip_cache,
                             ))?;
                     },
                     None => {
@@ -3195,6 +3199,7 @@ pub(crate) fn screen_thread_main(
                 run_plugin,
                 pane_title,
                 pane_id_to_replace,
+                skip_cache,
                 client_id,
             ) => match screen.active_tab_indices.values().next() {
                 Some(tab_index) => {
@@ -3213,6 +3218,7 @@ pub(crate) fn screen_thread_main(
                             Some(pane_id_to_replace),
                             client_id,
                             size,
+                            skip_cache,
                         ))?;
                 },
                 None => {
@@ -3340,6 +3346,7 @@ pub(crate) fn screen_thread_main(
                 move_to_focused_tab,
                 should_open_in_place,
                 pane_id_to_replace,
+                skip_cache,
                 client_id,
             ) => match pane_id_to_replace {
                 Some(pane_id_to_replace) => match screen.active_tab_indices.values().next() {
@@ -3357,6 +3364,7 @@ pub(crate) fn screen_thread_main(
                                 Some(pane_id_to_replace),
                                 client_id,
                                 size,
+                                skip_cache,
                             ))?;
                     },
                     None => {
@@ -3400,6 +3408,7 @@ pub(crate) fn screen_thread_main(
                                         None,
                                         client_id,
                                         Size::default(),
+                                        skip_cache,
                                     ))?;
                             }
                         },
@@ -3414,6 +3423,7 @@ pub(crate) fn screen_thread_main(
                 should_float,
                 should_open_in_place,
                 pane_id_to_replace,
+                skip_cache,
                 client_id,
             ) => match pane_id_to_replace {
                 Some(pane_id_to_replace) => match screen.active_tab_indices.values().next() {
@@ -3431,6 +3441,7 @@ pub(crate) fn screen_thread_main(
                                 Some(pane_id_to_replace),
                                 client_id,
                                 size,
+                                skip_cache,
                             ))?;
                     },
                     None => {
@@ -3465,6 +3476,7 @@ pub(crate) fn screen_thread_main(
                                     None,
                                     client_id,
                                     Size::default(),
+                                    skip_cache,
                                 ))?;
                         },
                         None => {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -275,8 +275,8 @@ pub enum ScreenInstruction {
     NewTiledPluginPane(RunPlugin, Option<String>, bool, ClientId), // Option<String> is
     // optional pane title, bool is skip cache
     NewFloatingPluginPane(RunPlugin, Option<String>, bool, ClientId), // Option<String> is an
-                                                                      // optional pane title, bool
-                                                                      // is skip cache
+    // optional pane title, bool
+    // is skip cache
     NewInPlacePluginPane(RunPlugin, Option<String>, PaneId, bool, ClientId), // Option<String> is an
     // optional pane title, bool is skip cache
     StartOrReloadPluginPane(RunPlugin, Option<String>),
@@ -297,8 +297,8 @@ pub enum ScreenInstruction {
     RequestStateUpdateForPlugins,
     LaunchOrFocusPlugin(RunPlugin, bool, bool, bool, Option<PaneId>, bool, ClientId), // bools are: should_float, move_to_focused_tab, should_open_in_place, Option<PaneId> is the pane id to replace, bool following it is skip_cache
     LaunchPlugin(RunPlugin, bool, bool, Option<PaneId>, bool, ClientId), // bools are: should_float, should_open_in_place Option<PaneId> is the pane id to replace, bool after is skip_cache
-    SuppressPane(PaneId, ClientId),                                // bool is should_float
-    FocusPaneWithId(PaneId, bool, ClientId),                       // bool is should_float
+    SuppressPane(PaneId, ClientId),                                      // bool is should_float
+    FocusPaneWithId(PaneId, bool, ClientId),                             // bool is should_float
     RenamePane(PaneId, Vec<u8>),
     RenameTab(usize, Vec<u8>),
     RequestPluginPermissions(
@@ -3147,7 +3147,12 @@ pub(crate) fn screen_thread_main(
                     .senders
                     .send_to_server(ServerInstruction::Log(tab_names, client_id))?;
             },
-            ScreenInstruction::NewTiledPluginPane(run_plugin, pane_title, skip_cache, client_id) => {
+            ScreenInstruction::NewTiledPluginPane(
+                run_plugin,
+                pane_title,
+                skip_cache,
+                client_id,
+            ) => {
                 let tab_index = screen.active_tab_indices.values().next().unwrap_or(&1);
                 let size = Size::default();
                 let should_float = Some(false);
@@ -3167,33 +3172,36 @@ pub(crate) fn screen_thread_main(
                         skip_cache,
                     ))?;
             },
-            ScreenInstruction::NewFloatingPluginPane(run_plugin, pane_title, skip_cache, client_id) => {
-                match screen.active_tab_indices.values().next() {
-                    Some(tab_index) => {
-                        let size = Size::default();
-                        let should_float = Some(true);
-                        let should_be_opened_in_place = false;
-                        screen
-                            .bus
-                            .senders
-                            .send_to_pty(PtyInstruction::FillPluginCwd(
-                                should_float,
-                                should_be_opened_in_place,
-                                pane_title,
-                                run_plugin,
-                                *tab_index,
-                                None,
-                                client_id,
-                                size,
-                                skip_cache,
-                            ))?;
-                    },
-                    None => {
-                        log::error!(
-                            "Could not find an active tab - is there at least 1 connected user?"
-                        );
-                    },
-                }
+            ScreenInstruction::NewFloatingPluginPane(
+                run_plugin,
+                pane_title,
+                skip_cache,
+                client_id,
+            ) => match screen.active_tab_indices.values().next() {
+                Some(tab_index) => {
+                    let size = Size::default();
+                    let should_float = Some(true);
+                    let should_be_opened_in_place = false;
+                    screen
+                        .bus
+                        .senders
+                        .send_to_pty(PtyInstruction::FillPluginCwd(
+                            should_float,
+                            should_be_opened_in_place,
+                            pane_title,
+                            run_plugin,
+                            *tab_index,
+                            None,
+                            client_id,
+                            size,
+                            skip_cache,
+                        ))?;
+                },
+                None => {
+                    log::error!(
+                        "Could not find an active tab - is there at least 1 connected user?"
+                    );
+                },
             },
             ScreenInstruction::NewInPlacePluginPane(
                 run_plugin,

--- a/zellij-utils/assets/prost/api.action.rs
+++ b/zellij-utils/assets/prost/api.action.rs
@@ -129,6 +129,8 @@ pub struct NewPluginPanePayload {
     pub plugin_url: ::prost::alloc::string::String,
     #[prost(string, optional, tag = "2")]
     pub pane_name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(bool, tag = "3")]
+    pub skip_plugin_cache: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -143,6 +145,8 @@ pub struct LaunchOrFocusPluginPayload {
     pub move_to_focused_tab: bool,
     #[prost(bool, tag = "5")]
     pub should_open_in_place: bool,
+    #[prost(bool, tag = "6")]
+    pub skip_plugin_cache: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -242,6 +242,11 @@ pub enum Sessions {
             conflicts_with("floating")
         )]
         in_place: bool,
+
+        /// Skip the memory and HD cache and force recompile of the plugin (good for development)
+        #[clap(short, long, value_parser, default_value("false"), takes_value(false))]
+        skip_plugin_cache: bool,
+
     },
     /// Edit file with default $EDITOR / $VISUAL
     #[clap(visible_alias = "e")]
@@ -417,6 +422,8 @@ pub enum CliAction {
         start_suspended: bool,
         #[clap(long, value_parser)]
         configuration: Option<PluginUserConfiguration>,
+        #[clap(short, long, value_parser)]
+        skip_plugin_cache: bool,
     },
     /// Open the specified file in a new zellij pane with your default EDITOR
     Edit {
@@ -526,6 +533,8 @@ pub enum CliAction {
         url: Url,
         #[clap(short, long, value_parser)]
         configuration: Option<PluginUserConfiguration>,
+        #[clap(short, long, value_parser)]
+        skip_plugin_cache: bool,
     },
     LaunchPlugin {
         #[clap(short, long, value_parser)]
@@ -535,6 +544,8 @@ pub enum CliAction {
         url: Url,
         #[clap(short, long, value_parser)]
         configuration: Option<PluginUserConfiguration>,
+        #[clap(short, long, value_parser)]
+        skip_plugin_cache: bool,
     },
     RenameSession {
         name: String,

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -246,7 +246,6 @@ pub enum Sessions {
         /// Skip the memory and HD cache and force recompile of the plugin (good for development)
         #[clap(short, long, value_parser, default_value("false"), takes_value(false))]
         skip_plugin_cache: bool,
-
     },
     /// Edit file with default $EDITOR / $VISUAL
     #[clap(visible_alias = "e")]

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -239,11 +239,11 @@ pub enum Action {
     QueryTabNames,
     /// Open a new tiled (embedded, non-floating) plugin pane
     NewTiledPluginPane(RunPlugin, Option<String>, bool), // String is an optional name, bool is
-                                                         // skip_cache
+    // skip_cache
     NewFloatingPluginPane(RunPlugin, Option<String>, bool), // String is an optional name, bool is
-                                                            // skip_cache
-    NewInPlacePluginPane(RunPlugin, Option<String>, bool),  // String is an optional name, bool is
-                                                            // skip_cache
+    // skip_cache
+    NewInPlacePluginPane(RunPlugin, Option<String>, bool), // String is an optional name, bool is
+    // skip_cache
     StartOrReloadPlugin(RunPlugin),
     CloseTerminalPane(u32),
     ClosePluginPane(u32),
@@ -329,9 +329,17 @@ impl Action {
                         configuration: user_configuration,
                     };
                     if floating {
-                        Ok(vec![Action::NewFloatingPluginPane(plugin, name, skip_plugin_cache)])
+                        Ok(vec![Action::NewFloatingPluginPane(
+                            plugin,
+                            name,
+                            skip_plugin_cache,
+                        )])
                     } else if in_place {
-                        Ok(vec![Action::NewInPlacePluginPane(plugin, name, skip_plugin_cache)])
+                        Ok(vec![Action::NewInPlacePluginPane(
+                            plugin,
+                            name,
+                            skip_plugin_cache,
+                        )])
                     } else {
                         // it is intentional that a new tiled plugin pane cannot include a
                         // direction
@@ -341,7 +349,11 @@ impl Action {
                         // is being loaded
                         // this is not the case with terminal panes for historical reasons of
                         // backwards compatibility to a time before we had auto layouts
-                        Ok(vec![Action::NewTiledPluginPane(plugin, name, skip_plugin_cache)])
+                        Ok(vec![Action::NewTiledPluginPane(
+                            plugin,
+                            name,
+                            skip_plugin_cache,
+                        )])
                     }
                 } else if !command.is_empty() {
                     let mut command = command.clone();
@@ -562,7 +574,12 @@ impl Action {
                     _allow_exec_host_cmd: false,
                     configuration: configuration.unwrap_or_default(),
                 };
-                Ok(vec![Action::LaunchPlugin(run_plugin, floating, in_place, skip_plugin_cache)])
+                Ok(vec![Action::LaunchPlugin(
+                    run_plugin,
+                    floating,
+                    in_place,
+                    skip_plugin_cache,
+                )])
             },
             CliAction::RenameSession { name } => Ok(vec![Action::RenameSession(name)]),
         }

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -938,6 +938,9 @@ impl TryFrom<(&KdlNode, &Options)> for Action {
                 let should_open_in_place = command_metadata
                     .and_then(|c_m| kdl_child_bool_value_for_entry(c_m, "in_place"))
                     .unwrap_or(false);
+                let skip_plugin_cache = command_metadata
+                    .and_then(|c_m| kdl_child_bool_value_for_entry(c_m, "skip_plugin_cache"))
+                    .unwrap_or(false);
                 let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
                 let location = RunPluginLocation::parse(&plugin_path, Some(current_dir))?;
                 let configuration = KdlLayoutParser::parse_plugin_user_configuration(&kdl_action)?;
@@ -951,6 +954,7 @@ impl TryFrom<(&KdlNode, &Options)> for Action {
                     should_float,
                     move_to_focused_tab,
                     should_open_in_place,
+                    skip_plugin_cache,
                 ))
             },
             "LaunchPlugin" => {
@@ -972,6 +976,9 @@ impl TryFrom<(&KdlNode, &Options)> for Action {
                 let should_open_in_place = command_metadata
                     .and_then(|c_m| kdl_child_bool_value_for_entry(c_m, "in_place"))
                     .unwrap_or(false);
+                let skip_plugin_cache = command_metadata
+                    .and_then(|c_m| kdl_child_bool_value_for_entry(c_m, "skip_plugin_cache"))
+                    .unwrap_or(false);
                 let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
                 let location = RunPluginLocation::parse(&plugin_path, Some(current_dir))?;
                 let configuration = KdlLayoutParser::parse_plugin_user_configuration(&kdl_action)?;
@@ -984,6 +991,7 @@ impl TryFrom<(&KdlNode, &Options)> for Action {
                     run_plugin,
                     should_float,
                     should_open_in_place,
+                    skip_plugin_cache,
                 ))
             },
             "PreviousSwapLayout" => Ok(Action::PreviousSwapLayout),

--- a/zellij-utils/src/plugin_api/action.proto
+++ b/zellij-utils/src/plugin_api/action.proto
@@ -69,6 +69,7 @@ message PaneIdAndShouldFloat {
 message NewPluginPanePayload {
   string plugin_url = 1;
   optional string pane_name = 2;
+  bool skip_plugin_cache = 3;
 }
 
 enum SearchDirection {
@@ -88,6 +89,7 @@ message LaunchOrFocusPluginPayload {
   optional PluginConfiguration plugin_configuration = 3;
   bool move_to_focused_tab = 4;
   bool should_open_in_place = 5;
+  bool skip_plugin_cache = 6;
 }
 
 message GoToTabNamePayload {

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -544,7 +544,11 @@ impl TryFrom<ProtobufAction> for Action {
                         };
                         let pane_name = payload.pane_name;
                         let skip_plugin_cache = payload.skip_plugin_cache;
-                        Ok(Action::NewTiledPluginPane(run_plugin, pane_name, skip_plugin_cache))
+                        Ok(Action::NewTiledPluginPane(
+                            run_plugin,
+                            pane_name,
+                            skip_plugin_cache,
+                        ))
                     },
                     _ => Err("Wrong payload for Action::NewTiledPluginPane"),
                 }
@@ -562,7 +566,11 @@ impl TryFrom<ProtobufAction> for Action {
                         };
                         let pane_name = payload.pane_name;
                         let skip_plugin_cache = payload.skip_plugin_cache;
-                        Ok(Action::NewFloatingPluginPane(run_plugin, pane_name, skip_plugin_cache))
+                        Ok(Action::NewFloatingPluginPane(
+                            run_plugin,
+                            pane_name,
+                            skip_plugin_cache,
+                        ))
                     },
                     _ => Err("Wrong payload for Action::MiddleClick"),
                 }
@@ -1030,7 +1038,12 @@ impl TryFrom<Action> for ProtobufAction {
                     )),
                 })
             },
-            Action::LaunchPlugin(run_plugin, should_float, should_open_in_place, skip_plugin_cache) => {
+            Action::LaunchPlugin(
+                run_plugin,
+                should_float,
+                should_open_in_place,
+                skip_plugin_cache,
+            ) => {
                 let url: Url = Url::from(&run_plugin.location);
                 Ok(ProtobufAction {
                     name: ProtobufActionName::LaunchPlugin as i32,

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -403,11 +403,13 @@ impl TryFrom<ProtobufAction> for Action {
                         let should_float = payload.should_float;
                         let move_to_focused_tab = payload.move_to_focused_tab;
                         let should_open_in_place = payload.should_open_in_place;
+                        let skip_plugin_cache = payload.skip_plugin_cache;
                         Ok(Action::LaunchOrFocusPlugin(
                             run_plugin,
                             should_float,
                             move_to_focused_tab,
                             should_open_in_place,
+                            skip_plugin_cache,
                         ))
                     },
                     _ => Err("Wrong payload for Action::LaunchOrFocusPlugin"),
@@ -431,10 +433,12 @@ impl TryFrom<ProtobufAction> for Action {
                     let _move_to_focused_tab = payload.move_to_focused_tab; // not actually used in
                                                                             // this action
                     let should_open_in_place = payload.should_open_in_place;
+                    let skip_plugin_cache = payload.skip_plugin_cache;
                     Ok(Action::LaunchPlugin(
                         run_plugin,
                         should_float,
                         should_open_in_place,
+                        skip_plugin_cache,
                     ))
                 },
                 _ => Err("Wrong payload for Action::LaunchOrFocusPlugin"),
@@ -539,7 +543,8 @@ impl TryFrom<ProtobufAction> for Action {
                             configuration: PluginUserConfiguration::default(),
                         };
                         let pane_name = payload.pane_name;
-                        Ok(Action::NewTiledPluginPane(run_plugin, pane_name))
+                        let skip_plugin_cache = payload.skip_plugin_cache;
+                        Ok(Action::NewTiledPluginPane(run_plugin, pane_name, skip_plugin_cache))
                     },
                     _ => Err("Wrong payload for Action::NewTiledPluginPane"),
                 }
@@ -556,7 +561,8 @@ impl TryFrom<ProtobufAction> for Action {
                             configuration: PluginUserConfiguration::default(),
                         };
                         let pane_name = payload.pane_name;
-                        Ok(Action::NewFloatingPluginPane(run_plugin, pane_name))
+                        let skip_plugin_cache = payload.skip_plugin_cache;
+                        Ok(Action::NewFloatingPluginPane(run_plugin, pane_name, skip_plugin_cache))
                     },
                     _ => Err("Wrong payload for Action::MiddleClick"),
                 }
@@ -1007,6 +1013,7 @@ impl TryFrom<Action> for ProtobufAction {
                 should_float,
                 move_to_focused_tab,
                 should_open_in_place,
+                skip_plugin_cache,
             ) => {
                 let url: Url = Url::from(&run_plugin.location);
                 Ok(ProtobufAction {
@@ -1018,11 +1025,12 @@ impl TryFrom<Action> for ProtobufAction {
                             move_to_focused_tab,
                             should_open_in_place,
                             plugin_configuration: Some(run_plugin.configuration.try_into()?),
+                            skip_plugin_cache,
                         },
                     )),
                 })
             },
-            Action::LaunchPlugin(run_plugin, should_float, should_open_in_place) => {
+            Action::LaunchPlugin(run_plugin, should_float, should_open_in_place, skip_plugin_cache) => {
                 let url: Url = Url::from(&run_plugin.location);
                 Ok(ProtobufAction {
                     name: ProtobufActionName::LaunchPlugin as i32,
@@ -1033,6 +1041,7 @@ impl TryFrom<Action> for ProtobufAction {
                             move_to_focused_tab: false,
                             should_open_in_place,
                             plugin_configuration: Some(run_plugin.configuration.try_into()?),
+                            skip_plugin_cache,
                         },
                     )),
                 })
@@ -1115,7 +1124,7 @@ impl TryFrom<Action> for ProtobufAction {
                 name: ProtobufActionName::QueryTabNames as i32,
                 optional_payload: None,
             }),
-            Action::NewTiledPluginPane(run_plugin, pane_name) => {
+            Action::NewTiledPluginPane(run_plugin, pane_name, skip_plugin_cache) => {
                 let plugin_url: Url = Url::from(&run_plugin.location);
                 Ok(ProtobufAction {
                     name: ProtobufActionName::NewTiledPluginPane as i32,
@@ -1123,11 +1132,12 @@ impl TryFrom<Action> for ProtobufAction {
                         NewPluginPanePayload {
                             plugin_url: plugin_url.into(),
                             pane_name,
+                            skip_plugin_cache,
                         },
                     )),
                 })
             },
-            Action::NewFloatingPluginPane(run_plugin, pane_name) => {
+            Action::NewFloatingPluginPane(run_plugin, pane_name, skip_plugin_cache) => {
                 let plugin_url: Url = Url::from(&run_plugin.location);
                 Ok(ProtobufAction {
                     name: ProtobufActionName::NewFloatingPluginPane as i32,
@@ -1135,6 +1145,7 @@ impl TryFrom<Action> for ProtobufAction {
                         NewPluginPanePayload {
                             plugin_url: plugin_url.into(),
                             pane_name,
+                            skip_plugin_cache,
                         },
                     )),
                 })


### PR DESCRIPTION
This adds a flag to the various plugin loading commands (eg. `zellij plugin --skip-plugin-cache -- file:/path/to/my/plugin.wasm`). This `--skip-plugin-cache` flag will force-recompile the plugin even if it is in the memory/hd cache.

This is useful for development, when we would want to recompile the plugin every time.