### PR TITLE
fix: resurrection by prefix

### DIFF
--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -329,17 +329,24 @@ pub(crate) fn session_exists(name: &str) -> Result<bool, io::ErrorKind> {
 }
 
 // if the session is resurrecable, the returned layout is the one to be used to resurrect it
-pub(crate) fn resurrection_layout(session_name_to_resurrect: &str) -> Option<Layout> {
+pub(crate) fn resurrection_layout(session_name_to_resurrect: &str) -> Option<(String, Layout)> {
     let resurrectable_sessions = get_resurrectable_sessions();
-    resurrectable_sessions
-        .iter()
-        .find_map(|(name, _timestamp, layout)| {
-            if name == session_name_to_resurrect {
-                Some(layout.clone())
-            } else {
-                None
-            }
-        })
+    let filtered_layouts: Vec<(String, Duration, Layout)> = resurrectable_sessions
+        .into_iter()
+        .filter(|e| e.0.starts_with(session_name_to_resurrect))
+        .collect();
+
+    for item in &filtered_layouts {
+        if item.0 == session_name_to_resurrect {
+            return Some((item.0.clone(), item.2.clone()));
+        }
+    }
+
+    match &filtered_layouts[..] {
+        [] => None,
+        [s] => Some((s.0.clone(), s.2.clone())),
+        _ => None,
+    }
 }
 
 pub(crate) fn assert_session(name: &str) {

--- a/src/tests/e2e/cases.rs
+++ b/src/tests/e2e/cases.rs
@@ -1050,6 +1050,70 @@ pub fn quit_and_resurrect_session() {
 
 #[test]
 #[ignore]
+pub fn quit_and_resurrect_session_by_prefix() {
+    let fake_win_size = Size {
+        cols: 120,
+        rows: 24,
+    };
+    let mut test_attempts = 10;
+    let layout_name = "layout_for_resurrection.kdl";
+    let session_name = "resurrection-by-prefix";
+    let last_snapshot = loop {
+        RemoteRunner::kill_running_sessions(fake_win_size);
+        let mut runner = RemoteRunner::new_mirrored_session_with_name_and_layout(
+            fake_win_size,
+            session_name,
+            layout_name,
+        )
+        .add_step(Step {
+            name: "Wait for session to be serialized",
+            instruction: |mut remote_terminal: RemoteTerminal| -> bool {
+                let mut step_is_complete = false;
+                if remote_terminal.snapshot_contains("Waiting to run: top") {
+                    std::thread::sleep(std::time::Duration::from_millis(5000)); // wait for
+                                                                                // serialization
+                    remote_terminal.send_key(&QUIT);
+                    step_is_complete = true;
+                }
+                step_is_complete
+            },
+        })
+        .add_step(Step {
+            name: "Resurrect session by attaching",
+            instruction: |mut remote_terminal: RemoteTerminal| -> bool {
+                let mut step_is_complete = false;
+                if remote_terminal.snapshot_contains("Bye from Zellij!") {
+                    let session_name_prefix = "resurrection-by";
+                    remote_terminal.attach_to_session_by_name(session_name_prefix);
+                    step_is_complete = true;
+                }
+                step_is_complete
+            },
+        });
+        runner.run_all_steps();
+        let last_snapshot = runner.take_snapshot_after(Step {
+            name: "Wait for session to be resurrected",
+            instruction: |remote_terminal: RemoteTerminal| -> bool {
+                let mut step_is_complete = false;
+                if remote_terminal.snapshot_contains("(FLOATING PANES VISIBLE)") {
+                    step_is_complete = true;
+                }
+                step_is_complete
+            },
+        });
+        if runner.test_timed_out && test_attempts > 0 {
+            test_attempts -= 1;
+            continue;
+        } else {
+            break last_snapshot;
+        }
+    };
+    let last_snapshot = account_for_races_in_snapshot(last_snapshot);
+    assert_snapshot!(last_snapshot);
+}
+
+#[test]
+#[ignore]
 pub fn quit_and_resurrect_session_with_viewport_serialization() {
     let fake_win_size = Size {
         cols: 120,

--- a/src/tests/e2e/remote_runner.rs
+++ b/src/tests/e2e/remote_runner.rs
@@ -102,6 +102,21 @@ fn start_zellij_mirrored_session(channel: &mut ssh2::Channel) {
     std::thread::sleep(std::time::Duration::from_secs(1)); // wait until Zellij stops parsing startup ANSI codes from the terminal STDIN
 }
 
+fn start_zellij_mirrored_session_with_name(channel: &mut ssh2::Channel, session_name: &str) {
+    stop_zellij(channel);
+    channel
+        .write_all(
+            format!(
+                "{} {} --session {} --data-dir {} options --mirror-session true --serialization-interval 1\n",
+                SET_ENV_VARIABLES, ZELLIJ_EXECUTABLE_LOCATION, session_name, ZELLIJ_DATA_DIR
+            )
+            .as_bytes(),
+        )
+        .unwrap();
+    channel.flush().unwrap();
+    std::thread::sleep(std::time::Duration::from_secs(1)); // wait until Zellij stops parsing startup ANSI codes from the terminal STDIN
+}
+
 fn start_zellij_mirrored_session_with_layout(channel: &mut ssh2::Channel, layout_file_name: &str) {
     stop_zellij(channel);
     channel
@@ -111,6 +126,29 @@ fn start_zellij_mirrored_session_with_layout(channel: &mut ssh2::Channel, layout
                 SET_ENV_VARIABLES,
                 ZELLIJ_EXECUTABLE_LOCATION,
                 SESSION_NAME,
+                ZELLIJ_DATA_DIR,
+                format!("{}/{}", ZELLIJ_FIXTURE_PATH, layout_file_name)
+            )
+            .as_bytes(),
+        )
+        .unwrap();
+    channel.flush().unwrap();
+    std::thread::sleep(std::time::Duration::from_secs(1)); // wait until Zellij stops parsing startup ANSI codes from the terminal STDIN
+}
+
+fn start_zellij_mirrored_session_with_name_and_layout(
+    channel: &mut ssh2::Channel,
+    session_name: &str,
+    layout_file_name: &str,
+) {
+    stop_zellij(channel);
+    channel
+        .write_all(
+            format!(
+                "{} {} --session {} --data-dir {} --layout {} options --mirror-session true --serialization-interval 1\n",
+                SET_ENV_VARIABLES,
+                ZELLIJ_EXECUTABLE_LOCATION,
+                session_name,
                 ZELLIJ_DATA_DIR,
                 format!("{}/{}", ZELLIJ_FIXTURE_PATH, layout_file_name)
             )
@@ -496,6 +534,86 @@ impl RemoteRunner {
         };
         setup_remote_environment(&mut channel, win_size);
         start_zellij_mirrored_session(&mut channel);
+        let channel = Arc::new(Mutex::new(channel));
+        let last_snapshot = Arc::new(Mutex::new(String::new()));
+        let cursor_coordinates = Arc::new(Mutex::new((0, 0)));
+        sess.set_blocking(false);
+        let reader_thread =
+            read_from_channel(&channel, &last_snapshot, &cursor_coordinates, &pane_geom);
+        RemoteRunner {
+            steps: vec![],
+            channel,
+            currently_running_step: None,
+            current_step_index: 0,
+            retries_left: RETRIES,
+            retry_pause_ms: 100,
+            test_timed_out: false,
+            panic_on_no_retries_left: true,
+            last_snapshot,
+            cursor_coordinates,
+            reader_thread,
+        }
+    }
+    pub fn new_mirrored_session_with_name(win_size: Size, session_name: &str) -> Self {
+        let sess = ssh_connect();
+        let mut channel = sess.channel_session().unwrap();
+        let mut rows = Dimension::fixed(win_size.rows);
+        let mut cols = Dimension::fixed(win_size.cols);
+        rows.set_inner(win_size.rows);
+        cols.set_inner(win_size.cols);
+        let pane_geom = PaneGeom {
+            x: 0,
+            y: 0,
+            rows,
+            cols,
+            is_stacked: false,
+        };
+        setup_remote_environment(&mut channel, win_size);
+        start_zellij_mirrored_session_with_name(&mut channel, session_name);
+        let channel = Arc::new(Mutex::new(channel));
+        let last_snapshot = Arc::new(Mutex::new(String::new()));
+        let cursor_coordinates = Arc::new(Mutex::new((0, 0)));
+        sess.set_blocking(false);
+        let reader_thread =
+            read_from_channel(&channel, &last_snapshot, &cursor_coordinates, &pane_geom);
+        RemoteRunner {
+            steps: vec![],
+            channel,
+            currently_running_step: None,
+            current_step_index: 0,
+            retries_left: RETRIES,
+            retry_pause_ms: 100,
+            test_timed_out: false,
+            panic_on_no_retries_left: true,
+            last_snapshot,
+            cursor_coordinates,
+            reader_thread,
+        }
+    }
+    pub fn new_mirrored_session_with_name_and_layout(
+        win_size: Size,
+        session_name: &str,
+        layout_file_name: &str,
+    ) -> Self {
+        let sess = ssh_connect();
+        let mut channel = sess.channel_session().unwrap();
+        let mut rows = Dimension::fixed(win_size.rows);
+        let mut cols = Dimension::fixed(win_size.cols);
+        rows.set_inner(win_size.rows);
+        cols.set_inner(win_size.cols);
+        let pane_geom = PaneGeom {
+            x: 0,
+            y: 0,
+            rows,
+            cols,
+            is_stacked: false,
+        };
+        setup_remote_environment(&mut channel, win_size);
+        start_zellij_mirrored_session_with_name_and_layout(
+            &mut channel,
+            session_name,
+            layout_file_name,
+        );
         let channel = Arc::new(Mutex::new(channel));
         let last_snapshot = Arc::new(Mutex::new(String::new()));
         let cursor_coordinates = Arc::new(Mutex::new((0, 0)));

--- a/src/tests/e2e/remote_runner.rs
+++ b/src/tests/e2e/remote_runner.rs
@@ -388,15 +388,18 @@ impl RemoteTerminal {
             .request_pty_size(cols, rows, Some(cols), Some(rows))
             .unwrap();
     }
-    pub fn attach_to_original_session(&mut self) {
+    pub fn attach_to_session_by_name(&mut self, session_name: &str) {
         let mut channel = self.channel.lock().unwrap();
         channel
             .write_all(
-                format!("{} attach {}\n", ZELLIJ_EXECUTABLE_LOCATION, SESSION_NAME).as_bytes(),
+                format!("{} attach {}\n", ZELLIJ_EXECUTABLE_LOCATION, session_name).as_bytes(),
             )
             .unwrap();
         channel.flush().unwrap();
         std::thread::sleep(std::time::Duration::from_secs(1)); // wait until Zellij stops parsing startup ANSI codes from the terminal STDIN
+    }
+    pub fn attach_to_original_session(&mut self) {
+        self.attach_to_session_by_name(SESSION_NAME)
     }
     pub fn send_command_through_the_cli(&mut self, command: &str) {
         let mut channel = self.channel.lock().unwrap();


### PR DESCRIPTION
Dead sessions could only be resurrected with their full name.
This patch mirrors the _attach if unique prefix found_ logic for running sessions.

In short:
Before this dead session `foo` could be resurrected by `zellij attach foo`.
But if `f` uniquely matches `foo` then `zellij attach f` will work as well.