### PR TITLE
Improve zellij exit to reduce error

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -24,7 +24,6 @@ use std::{
     sync::{Arc, RwLock},
     thread,
 };
-use zellij_utils::channels::{bounded, unbounded};
 use zellij_utils::envs;
 use zellij_utils::nix::sys::stat::{umask, Mode};
 use zellij_utils::pane_size::Size;

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -18,13 +18,13 @@ mod ui;
 use background_jobs::{background_jobs_main, BackgroundJob};
 use log::info;
 use pty_writer::{pty_writer_main, PtyWriteInstruction};
-use zellij_utils::channels::{unbounded, bounded};
 use std::collections::{HashMap, HashSet};
 use std::{
     path::PathBuf,
     sync::{Arc, RwLock},
     thread,
 };
+use zellij_utils::channels::{bounded, unbounded};
 use zellij_utils::envs;
 use zellij_utils::nix::sys::stat::{umask, Mode};
 use zellij_utils::pane_size::Size;
@@ -134,7 +134,7 @@ impl Drop for SessionMetaData {
         if let Some(pty_thread) = self.pty_thread.take() {
             let _ = pty_thread.join();
         }
-        
+
         let _ = self.senders.send_to_pty_writer(PtyWriteInstruction::Exit);
         if let Some(pty_writer_thread) = self.pty_writer_thread.take() {
             let _ = pty_writer_thread.join();
@@ -144,8 +144,7 @@ impl Drop for SessionMetaData {
         if let Some(plugin_thread) = self.plugin_thread.take() {
             let _ = plugin_thread.is_finished();
         }
-        
-        
+
         let _ = self.senders.send_to_background_jobs(BackgroundJob::Exit);
         let _ = self.senders.send_to_screen(ScreenInstruction::Exit);
         if let Some(background_jobs_thread) = self.background_jobs_thread.take() {
@@ -155,7 +154,6 @@ impl Drop for SessionMetaData {
         if let Some(screen_thread) = self.screen_thread.take() {
             let _ = screen_thread.join();
         }
-        
     }
 }
 

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -930,12 +930,10 @@ impl Screen {
         // below we don't check the result of sending the CloseTab instruction to the pty thread
         // because this might be happening when the app is closing, at which point the pty thread
         // has already closed and this would result in an error
-        info!("close tab idx1 {:?}", self.connected_clients);
         self.bus
             .senders
             .send_to_pty(PtyInstruction::CloseTab(pane_ids))
             .with_context(err_context)?;
-        info!("close tab idx2");
         if self.tabs.is_empty() {
             self.active_tab_indices.clear();
             self.bus
@@ -2150,7 +2148,6 @@ pub(crate) fn screen_thread_main(
             .bus
             .recv()
             .context("failed to receive event on channel")?;
-
         err_ctx.add_call(ContextType::Screen((&event).into()));
         // here we start caching resizes, so that we'll send them in bulk at the end of each event
         // when this cache is Dropped, for more information, see the comments in PtyWriter
@@ -2562,7 +2559,7 @@ pub(crate) fn screen_thread_main(
                     screen,
                     client_id,
                     |tab: &mut Tab, client_id: ClientId| tab
-                        .handle_scrollwheel_up(&point, 1, client_id), ?
+                        .handle_scrollwheel_up(&point, 3, client_id), ?
                 );
                 screen.render()?;
                 screen.unblock_input()?;
@@ -2699,7 +2696,6 @@ pub(crate) fn screen_thread_main(
                         }
                     },
                 }
-
                 screen.unblock_input()?;
                 screen.log_and_report_session_state()?;
             },
@@ -3023,7 +3019,6 @@ pub(crate) fn screen_thread_main(
                 screen.render()?;
             },
             ScreenInstruction::Exit => {
-                info!("exit");
                 break;
             },
             ScreenInstruction::ToggleTab(client_id) => {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -7,7 +7,6 @@ use std::rc::Rc;
 use std::str;
 use std::time::Duration;
 
-use log::info;
 use zellij_utils::data::{
     Direction, PaneManifest, PluginPermission, Resize, ResizeStrategy, SessionInfo,
 };

--- a/zellij-server/src/terminal_bytes.rs
+++ b/zellij-server/src/terminal_bytes.rs
@@ -4,6 +4,7 @@ use crate::{
     thread_bus::ThreadSenders,
 };
 use async_std::{future::timeout as async_timeout, task};
+use log::info;
 use std::{
     os::unix::io::RawFd,
     time::{Duration, Instant},
@@ -82,7 +83,10 @@ impl TerminalBytes {
         let mut buf = [0u8; 65536];
         loop {
             match self.deadline_read(&mut buf).await {
-                ReadResult::Ok(0) | ReadResult::Err(_) => break, // EOF or error
+                ReadResult::Ok(0) | ReadResult::Err(_) => {
+                    info!("deadline read");
+                    break // EOF or error
+                }
                 ReadResult::Timeout => {
                     let time_to_send_render = self
                         .async_send_to_screen(ScreenInstruction::Render)

--- a/zellij-server/src/terminal_bytes.rs
+++ b/zellij-server/src/terminal_bytes.rs
@@ -83,10 +83,7 @@ impl TerminalBytes {
         let mut buf = [0u8; 65536];
         loop {
             match self.deadline_read(&mut buf).await {
-                ReadResult::Ok(0) | ReadResult::Err(_) => {
-                    info!("deadline read");
-                    break // EOF or error
-                }
+                ReadResult::Ok(0) | ReadResult::Err(_) => break, // EOF or error
                 ReadResult::Timeout => {
                     let time_to_send_render = self
                         .async_send_to_screen(ScreenInstruction::Render)

--- a/zellij-server/src/terminal_bytes.rs
+++ b/zellij-server/src/terminal_bytes.rs
@@ -4,7 +4,6 @@ use crate::{
     thread_bus::ThreadSenders,
 };
 use async_std::{future::timeout as async_timeout, task};
-use log::info;
 use std::{
     os::unix::io::RawFd,
     time::{Duration, Instant},


### PR DESCRIPTION
Currently, when zellij exits, a number of errors are printed in the logs, such as the following error. 
```bash
rors.tuna.tsinghua.edu.cn-df7c3c540f42cdbd/zellij-utils-0.39.1/src/errors.rs:632]: Panic occured:
             thread: screen
             location: At /home/wjd/.cargo/registry/src/mirrors.tuna.tsinghua.edu.cn-df7c3c540f42cdbd/zellij-server-0.39.1/src/lib.rs:817:18
             message: Program terminates: a fatal error occured

Caused by:
    0: failed to remove client 1
    1: Failed to log and report session state
    2: failed to send message to background jobs
    3: Originating Thread(s)
       	1. stdin_handler_thread: AcceptInput
       	2. ipc_server: ClientExit
       	3. screen_thread: RemoveClient
       
    4: failed to send message to channel 

```

This may lead the user to believe that a panic has occurred, but it does not actually affect usage.
Since there are multiple loops in zellij (server, screen, pty, plugin) and they communicate through channels, the order in which the loops are closed may affect the errors.
This PR optimizes the startup logic of zellij to minimize the occurrence of errors.

