### PR TITLE
Bump rust version to 1.75.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix(plugins): display errors properly (https://github.com/zellij-org/zellij/pull/2975)
 * feat(terminal): implement synchronized renders (https://github.com/zellij-org/zellij/pull/2977)
 * perf(plugins): improve plugin download & load feature (https://github.com/zellij-org/zellij/pull/3001)
+* chore: bump Rust toolchain to 1.75.0 (https://github.com/zellij-org/zellij/pull/3039)
 
 ## [0.39.2] - 2023-11-29
 * fix(cli): typo in cli help (https://github.com/zellij-org/zellij/pull/2906)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # This file is updated by `update-toolchain.sh`
 [toolchain]
-channel = "1.67.0"
+channel = "1.69.0"
 components = ["rustfmt", "clippy", "rust-analysis"]
 targets = ["wasm32-wasi", "x86_64-unknown-linux-musl"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # This file is updated by `update-toolchain.sh`
 [toolchain]
-channel = "1.69.0"
+channel = "1.70.0"
 components = ["rustfmt", "clippy", "rust-analysis"]
 targets = ["wasm32-wasi", "x86_64-unknown-linux-musl"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # This file is updated by `update-toolchain.sh`
 [toolchain]
-channel = "1.70.0"
+channel = "1.75.0"
 components = ["rustfmt", "clippy", "rust-analysis"]
 targets = ["wasm32-wasi", "x86_64-unknown-linux-musl"]

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -883,7 +883,7 @@ impl Layout {
             None => {
                 let home = find_default_config_dir();
                 let Some(home) = home else {
-                    return Layout::stringified_from_default_assets(layout)
+                    return Layout::stringified_from_default_assets(layout);
                 };
 
                 let layout_path = &home.join(layout);


### PR DESCRIPTION
Rust 1.75.0 is the current latest release of the Rust language and toolchains. This change is necessary since I have discovered that with the previously used version, 1.67.0, future releases will no longer be possible. The reason is that `cargo publish`, even when using the `--locked` flag, seems to perform its' own package version resolution. During this process it hits an issue with one of our dependencies that has bumped its' MSRV to 1.70.0.

While I think technically this is a bug in the Rust tooling, it's still a nice idea to do the upgrade. The commits in this PR perform the upgrade in "three" steps with Rust versions 1.69, 1.70 and 1.75. I have picked these versions as I think that each of these mentioned something in their `CHANGELOG` that offers a potential benefit or risk to zellij. For more information, refer to the individual commits.

The quick upshot is: When going from 1.67.0 to 1.75.0, build time (in Debug) drops from ~240 s to ~190 s on my PC (for a clean build), and initial package resolution (from an empty cargo cache) goes down from ~75 s to ~10 s. There are other benefits (e.g. cross-crate inlining) that promise performance improvements, but I do not know how to measure performance at this point. One particular feature that may be of interest is the introduction of [native WASM exceptions][1] in Rust 1.72.0 for our plugins, but I have not looked into this any futher so far.

I compiled zellij with each of the new toolchains and made sure they all execute with current `main`, running on an x86_64-unknown-linux host. Finally, I performed a simulated release with the version compiled with 1.75.0. I can upload the bins if there is interest.


[1]: https://github.com/rust-lang/rust/pull/111322/