### PR TITLE
xtask: Disable pusing during publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * perf(plugins): improve plugin download & load feature (https://github.com/zellij-org/zellij/pull/3001)
 * chore: bump Rust toolchain to 1.75.0 (https://github.com/zellij-org/zellij/pull/3039)
 * feat(plugins): introduce pipes to control data flow to plugins from the command line (https://github.com/zellij-org/zellij/pull/3066)
+* feat(xtask): allow publishing without pushing changes (https://github.com/zellij-org/zellij/pull/3040)
 
 ## [0.39.2] - 2023-11-29
 * fix(cli): typo in cli help (https://github.com/zellij-org/zellij/pull/2906)

--- a/xtask/src/flags.rs
+++ b/xtask/src/flags.rs
@@ -38,6 +38,8 @@ xflags::xflags! {
         cmd publish {
             /// Perform a dry-run (don't push/publish anything)
             optional --dry-run
+            /// Publish but don't push a commit to git (only works with '--cargo-registry')
+            optional --no-push
             /// Push commit to custom git remote
             optional --git-remote remote: OsString
             /// Publish crates to custom registry
@@ -159,6 +161,7 @@ pub struct Manpage;
 #[derive(Debug)]
 pub struct Publish {
     pub dry_run: bool,
+    pub no_push: bool,
     pub git_remote: Option<OsString>,
     pub cargo_registry: Option<OsString>,
 }

--- a/xtask/src/pipelines.rs
+++ b/xtask/src/pipelines.rs
@@ -337,7 +337,7 @@ pub fn publish(sh: &Shell, flags: flags::Publish) -> anyhow::Result<()> {
 
                 if let Err(err) = cmd!(
                     sh,
-                    "{cargo} publish {registry...} {more_args...} {dry_run...}"
+                    "{cargo} publish --locked {registry...} {more_args...} {dry_run...}"
                 )
                 .run()
                 .context(err_context)

--- a/xtask/src/pipelines.rs
+++ b/xtask/src/pipelines.rs
@@ -212,6 +212,9 @@ pub fn publish(sh: &Shell, flags: flags::Publish) -> anyhow::Result<()> {
         None
     };
     let registry = registry.as_ref();
+    if flags.no_push && flags.cargo_registry.is_none() {
+        anyhow::bail!("flag '--no-push' can only be used with '--cargo-registry'");
+    }
 
     sh.change_dir(crate::project_root());
     let cargo = crate::cargo().context(err_context)?;
@@ -304,6 +307,8 @@ pub fn publish(sh: &Shell, flags: flags::Publish) -> anyhow::Result<()> {
         // Push commit and tag
         if flags.dry_run {
             println!("Skipping push due to dry-run");
+        } else if flags.no_push {
+            println!("Skipping push due to no-push");
         } else {
             cmd!(sh, "git push --atomic {remote} main v{version}")
                 .run()

--- a/xtask/src/pipelines.rs
+++ b/xtask/src/pipelines.rs
@@ -197,10 +197,11 @@ pub fn publish(sh: &Shell, flags: flags::Publish) -> anyhow::Result<()> {
         None
     };
     let remote = flags.git_remote.unwrap_or("origin".into());
-    let registry = if let Some(registry) = flags.cargo_registry {
+    let registry = if let Some(ref registry) = flags.cargo_registry {
         Some(format!(
             "--registry={}",
             registry
+                .clone()
                 .into_string()
                 .map_err(|registry| anyhow::Error::msg(format!(
                     "failed to convert '{:?}' to valid registry name",


### PR DESCRIPTION
to allow simulated releases without having to offer a fork of the zellij repo to push the release commit to. This serves multiple purposes:

1. It saves the user from having to provide a writable repo to push the release commit to in the first place
2. When performing multiple subsequent releases, e.g. when a previous run failed near the end, there is no need to clean up said remote (remove the release commit and tags), as no commit was pushed at all

This PR is currently based on #3039 to allow simulating releases using my repo [over here][1]

[1]: https://gitlab.com/hartang/zellij/simulate-release