### PR TITLE
fix: adjust duplicated cli alias

### DIFF
--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -218,7 +218,7 @@ pub enum Sessions {
         start_suspended: bool,
     },
     /// Load a plugin
-    #[clap(visible_alias = "r")]
+    #[clap(visible_alias = "p")]
     Plugin {
         /// Plugin URL, can either start with http(s), file: or zellij:
         #[clap(last(true), required(true))]


### PR DESCRIPTION
I guess that this was only a typo, and it is actually meant to be `p` for "plugin".
(With `r` being taken by "run", this would otherwise never be activated.)