### PR TITLE
refactor: get rid of strings macro duplication

### DIFF
--- a/default-plugins/status-bar/src/tip/data/compact_layout.rs
+++ b/default-plugins/status-bar/src/tip/data/compact_layout.rs
@@ -1,26 +1,10 @@
-use ansi_term::{
-    unstyled_len, ANSIString, ANSIStrings,
-    Color::{Fixed, RGB},
-    Style,
-};
+use ansi_term::Color::{Fixed, RGB};
+use ansi_term::{ANSIString, Style};
 
-use crate::LinePart;
 use crate::{action_key, style_key_with_modifier};
+use crate::{ansi_strings, LinePart};
 use zellij_tile::prelude::{actions::Action, *};
 use zellij_tile_utils::palette_match;
-
-macro_rules! strings {
-    ($ANSIStrings:expr) => {{
-        let strings: &[ANSIString] = $ANSIStrings;
-
-        let ansi_strings = ANSIStrings(strings);
-
-        LinePart {
-            part: format!("{}", ansi_strings),
-            len: unstyled_len(&ansi_strings),
-        }
-    }};
-}
 
 pub fn compact_layout_full(help: &ModeInfo) -> LinePart {
     // Tip: UI taking up too much space? Start Zellij with
@@ -37,7 +21,7 @@ pub fn compact_layout_full(help: &ModeInfo) -> LinePart {
         Style::new().paint(" or remove pane frames with "),
     ];
     bits.extend(add_keybinds(help));
-    strings!(&bits)
+    ansi_strings!(&bits)
 }
 
 pub fn compact_layout_medium(help: &ModeInfo) -> LinePart {
@@ -55,7 +39,7 @@ pub fn compact_layout_medium(help: &ModeInfo) -> LinePart {
         Style::new().paint(" or remove frames with "),
     ];
     bits.extend(add_keybinds(help));
-    strings!(&bits)
+    ansi_strings!(&bits)
 }
 
 pub fn compact_layout_short(help: &ModeInfo) -> LinePart {
@@ -72,7 +56,7 @@ pub fn compact_layout_short(help: &ModeInfo) -> LinePart {
         Style::new().paint(" or remove frames with "),
     ];
     bits.extend(add_keybinds(help));
-    strings!(&bits)
+    ansi_strings!(&bits)
 }
 
 fn add_keybinds(help: &ModeInfo) -> Vec<ANSIString> {

--- a/default-plugins/status-bar/src/tip/data/edit_scrollbuffer.rs
+++ b/default-plugins/status-bar/src/tip/data/edit_scrollbuffer.rs
@@ -1,25 +1,9 @@
-use ansi_term::{
-    unstyled_len, ANSIString, ANSIStrings,
-    Color::{Fixed, RGB},
-    Style,
-};
+use ansi_term::Color::{Fixed, RGB};
+use ansi_term::{ANSIString, Style};
 
-use crate::{action_key, style_key_with_modifier, LinePart};
+use crate::{action_key, ansi_strings, style_key_with_modifier, LinePart};
 use zellij_tile::prelude::{actions::Action, *};
 use zellij_tile_utils::palette_match;
-
-macro_rules! strings {
-    ($ANSIStrings:expr) => {{
-        let strings: &[ANSIString] = $ANSIStrings;
-
-        let ansi_strings = ANSIStrings(strings);
-
-        LinePart {
-            part: format!("{}", ansi_strings),
-            len: unstyled_len(&ansi_strings),
-        }
-    }};
-}
 
 pub fn edit_scrollbuffer_full(help: &ModeInfo) -> LinePart {
     // Tip: Search through the scrollbuffer using your default $EDITOR with
@@ -33,7 +17,7 @@ pub fn edit_scrollbuffer_full(help: &ModeInfo) -> LinePart {
         Style::new().paint(" with "),
     ];
     bits.extend(add_keybinds(help));
-    strings!(&bits)
+    ansi_strings!(&bits)
 }
 
 pub fn edit_scrollbuffer_medium(help: &ModeInfo) -> LinePart {
@@ -48,7 +32,7 @@ pub fn edit_scrollbuffer_medium(help: &ModeInfo) -> LinePart {
         Style::new().paint(" with "),
     ];
     bits.extend(add_keybinds(help));
-    strings!(&bits)
+    ansi_strings!(&bits)
 }
 
 pub fn edit_scrollbuffer_short(help: &ModeInfo) -> LinePart {
@@ -62,7 +46,7 @@ pub fn edit_scrollbuffer_short(help: &ModeInfo) -> LinePart {
         Style::new().paint(" with "),
     ];
     bits.extend(add_keybinds(help));
-    strings!(&bits)
+    ansi_strings!(&bits)
 }
 
 fn add_keybinds(help: &ModeInfo) -> Vec<ANSIString> {

--- a/default-plugins/status-bar/src/tip/data/floating_panes_mouse.rs
+++ b/default-plugins/status-bar/src/tip/data/floating_panes_mouse.rs
@@ -1,20 +1,7 @@
-use ansi_term::{unstyled_len, ANSIString, ANSIStrings, Style};
+use ansi_term::{ANSIString, Style};
 
-use crate::{action_key, style_key_with_modifier, LinePart};
+use crate::{action_key, ansi_strings, style_key_with_modifier, LinePart};
 use zellij_tile::prelude::{actions::Action, *};
-
-macro_rules! strings {
-    ($ANSIStrings:expr) => {{
-        let strings: &[ANSIString] = $ANSIStrings;
-
-        let ansi_strings = ANSIStrings(strings);
-
-        LinePart {
-            part: format!("{}", ansi_strings),
-            len: unstyled_len(&ansi_strings),
-        }
-    }};
-}
 
 pub fn floating_panes_mouse_full(help: &ModeInfo) -> LinePart {
     // Tip: Toggle floating panes with Ctrl + <p> + <w> and move them with keyboard or mouse
@@ -24,7 +11,7 @@ pub fn floating_panes_mouse_full(help: &ModeInfo) -> LinePart {
     ];
     bits.extend(add_keybinds(help));
     bits.push(Style::new().paint(" and move them with keyboard or mouse"));
-    strings!(&bits)
+    ansi_strings!(&bits)
 }
 
 pub fn floating_panes_mouse_medium(help: &ModeInfo) -> LinePart {
@@ -34,14 +21,14 @@ pub fn floating_panes_mouse_medium(help: &ModeInfo) -> LinePart {
         Style::new().paint("Toggle floating panes with "),
     ];
     bits.extend(add_keybinds(help));
-    strings!(&bits)
+    ansi_strings!(&bits)
 }
 
 pub fn floating_panes_mouse_short(help: &ModeInfo) -> LinePart {
     // Ctrl + <p> + <w> => floating panes
     let mut bits = add_keybinds(help);
     bits.push(Style::new().paint(" => floating panes"));
-    strings!(&bits)
+    ansi_strings!(&bits)
 }
 
 fn add_keybinds(help: &ModeInfo) -> Vec<ANSIString> {

--- a/default-plugins/status-bar/src/tip/data/mod.rs
+++ b/default-plugins/status-bar/src/tip/data/mod.rs
@@ -90,3 +90,15 @@ lazy_static! {
         ),
     ]);
 }
+
+#[macro_export]
+macro_rules! ansi_strings {
+    ($ANSIStrings:expr) => {{
+        let strings: &[::ansi_term::ANSIString] = $ANSIStrings;
+        let ansi_strings = ::ansi_term::ANSIStrings(strings);
+        LinePart {
+            part: format!("{}", ansi_strings),
+            len: ::ansi_term::unstyled_len(&ansi_strings),
+        }
+    }};
+}

--- a/default-plugins/status-bar/src/tip/data/move_focus_hjkl_tab_switch.rs
+++ b/default-plugins/status-bar/src/tip/data/move_focus_hjkl_tab_switch.rs
@@ -1,20 +1,7 @@
-use ansi_term::{unstyled_len, ANSIString, ANSIStrings, Style};
+use ansi_term::{ANSIString, Style};
 
-use crate::{action_key_group, style_key_with_modifier, LinePart};
+use crate::{action_key_group, ansi_strings, style_key_with_modifier, LinePart};
 use zellij_tile::prelude::{actions::Action, *};
-
-macro_rules! strings {
-    ($ANSIStrings:expr) => {{
-        let strings: &[ANSIString] = $ANSIStrings;
-
-        let ansi_strings = ANSIStrings(strings);
-
-        LinePart {
-            part: format!("{}", ansi_strings),
-            len: unstyled_len(&ansi_strings),
-        }
-    }};
-}
 
 pub fn move_focus_hjkl_tab_switch_full(help: &ModeInfo) -> LinePart {
     // Tip: When changing focus with Alt + <←↓↑→> moving off screen left/right focuses the next tab.
@@ -24,7 +11,7 @@ pub fn move_focus_hjkl_tab_switch_full(help: &ModeInfo) -> LinePart {
     ];
     bits.extend(add_keybinds(help));
     bits.push(Style::new().paint(" moving off screen left/right focuses the next tab."));
-    strings!(&bits)
+    ansi_strings!(&bits)
 }
 
 pub fn move_focus_hjkl_tab_switch_medium(help: &ModeInfo) -> LinePart {
@@ -35,14 +22,14 @@ pub fn move_focus_hjkl_tab_switch_medium(help: &ModeInfo) -> LinePart {
     ];
     bits.extend(add_keybinds(help));
     bits.push(Style::new().paint(" off screen focuses the next tab."));
-    strings!(&bits)
+    ansi_strings!(&bits)
 }
 
 pub fn move_focus_hjkl_tab_switch_short(help: &ModeInfo) -> LinePart {
     // Alt + <←↓↑→> off screen edge focuses next tab.
     let mut bits = add_keybinds(help);
     bits.push(Style::new().paint(" off screen edge focuses next tab."));
-    strings!(&bits)
+    ansi_strings!(&bits)
 }
 
 fn add_keybinds(help: &ModeInfo) -> Vec<ANSIString> {

--- a/default-plugins/status-bar/src/tip/data/quicknav.rs
+++ b/default-plugins/status-bar/src/tip/data/quicknav.rs
@@ -1,20 +1,7 @@
-use ansi_term::{unstyled_len, ANSIString, ANSIStrings, Style};
+use ansi_term::{ANSIString, Style};
 
-use crate::{action_key, action_key_group, style_key_with_modifier, LinePart};
+use crate::{action_key, action_key_group, ansi_strings, style_key_with_modifier, LinePart};
 use zellij_tile::prelude::{actions::Action, *};
-
-macro_rules! strings {
-    ($ANSIStrings:expr) => {{
-        let strings: &[ANSIString] = $ANSIStrings;
-
-        let ansi_strings = ANSIStrings(strings);
-
-        LinePart {
-            part: format!("{}", ansi_strings),
-            len: unstyled_len(&ansi_strings),
-        }
-    }};
-}
 
 pub fn quicknav_full(help: &ModeInfo) -> LinePart {
     let groups = add_keybinds(help);
@@ -26,7 +13,7 @@ pub fn quicknav_full(help: &ModeInfo) -> LinePart {
     bits.push(Style::new().paint(" => navigate between panes. "));
     bits.extend(groups.resize);
     bits.push(Style::new().paint(" => increase/decrease pane size."));
-    strings!(&bits)
+    ansi_strings!(&bits)
 }
 
 pub fn quicknav_medium(help: &ModeInfo) -> LinePart {
@@ -39,7 +26,7 @@ pub fn quicknav_medium(help: &ModeInfo) -> LinePart {
     bits.push(Style::new().paint(" => navigate. "));
     bits.extend(groups.resize);
     bits.push(Style::new().paint(" => resize pane."));
-    strings!(&bits)
+    ansi_strings!(&bits)
 }
 
 pub fn quicknav_short(help: &ModeInfo) -> LinePart {
@@ -51,7 +38,7 @@ pub fn quicknav_short(help: &ModeInfo) -> LinePart {
     bits.extend(groups.move_focus);
     bits.push(Style::new().paint(" / "));
     bits.extend(groups.resize);
-    strings!(&bits)
+    ansi_strings!(&bits)
 }
 
 struct Keygroups<'a> {

--- a/default-plugins/status-bar/src/tip/data/send_mouse_click_to_terminal.rs
+++ b/default-plugins/status-bar/src/tip/data/send_mouse_click_to_terminal.rs
@@ -1,32 +1,16 @@
-use ansi_term::{
-    unstyled_len, ANSIString, ANSIStrings,
-    Color::{Fixed, RGB},
-    Style,
-};
+use ansi_term::Color::{Fixed, RGB};
+use ansi_term::Style;
 
-use crate::LinePart;
+use crate::{ansi_strings, LinePart};
 use zellij_tile::prelude::*;
 use zellij_tile_utils::palette_match;
-
-macro_rules! strings {
-    ($ANSIStrings:expr) => {{
-        let strings: &[ANSIString] = $ANSIStrings;
-
-        let ansi_strings = ANSIStrings(strings);
-
-        LinePart {
-            part: format!("{}", ansi_strings),
-            len: unstyled_len(&ansi_strings),
-        }
-    }};
-}
 
 pub fn mouse_click_to_terminal_full(help: &ModeInfo) -> LinePart {
     // Tip: SHIFT + <mouse-click> bypasses Zellij and sends the mouse click directly to the terminal
     let green_color = palette_match!(help.style.colors.green);
     let orange_color = palette_match!(help.style.colors.orange);
 
-    strings!(&[
+    ansi_strings!(&[
         Style::new().paint(" Tip: "),
         Style::new().fg(orange_color).bold().paint("Shift"),
         Style::new().paint(" + <"),
@@ -39,7 +23,7 @@ pub fn mouse_click_to_terminal_medium(help: &ModeInfo) -> LinePart {
     // Tip: SHIFT + <mouse-click> sends the click directly to the terminal
     let green_color = palette_match!(help.style.colors.green);
     let orange_color = palette_match!(help.style.colors.orange);
-    strings!(&[
+    ansi_strings!(&[
         Style::new().paint(" Tip: "),
         Style::new().fg(orange_color).bold().paint("Shift"),
         Style::new().paint(" + <"),
@@ -53,7 +37,7 @@ pub fn mouse_click_to_terminal_short(help: &ModeInfo) -> LinePart {
     let green_color = palette_match!(help.style.colors.green);
     let orange_color = palette_match!(help.style.colors.orange);
 
-    strings!(&[
+    ansi_strings!(&[
         Style::new().paint(" Tip: "),
         Style::new().fg(orange_color).bold().paint("Shift"),
         Style::new().paint(" + <"),

--- a/default-plugins/status-bar/src/tip/data/sync_tab.rs
+++ b/default-plugins/status-bar/src/tip/data/sync_tab.rs
@@ -1,20 +1,7 @@
-use ansi_term::{unstyled_len, ANSIString, ANSIStrings, Style};
+use ansi_term::{ANSIString, Style};
 
-use crate::{action_key, style_key_with_modifier, LinePart};
+use crate::{action_key, ansi_strings, style_key_with_modifier, LinePart};
 use zellij_tile::prelude::{actions::Action, *};
-
-macro_rules! strings {
-    ($ANSIStrings:expr) => {{
-        let strings: &[ANSIString] = $ANSIStrings;
-
-        let ansi_strings = ANSIStrings(strings);
-
-        LinePart {
-            part: format!("{}", ansi_strings),
-            len: unstyled_len(&ansi_strings),
-        }
-    }};
-}
 
 pub fn sync_tab_full(help: &ModeInfo) -> LinePart {
     // Tip: Sync a tab and write keyboard input to all panes with Ctrl + <t> + <s>
@@ -23,7 +10,7 @@ pub fn sync_tab_full(help: &ModeInfo) -> LinePart {
         Style::new().paint("Sync a tab and write keyboard input to all its panes with "),
     ];
     bits.extend(add_keybinds(help));
-    strings!(&bits)
+    ansi_strings!(&bits)
 }
 
 pub fn sync_tab_medium(help: &ModeInfo) -> LinePart {
@@ -33,14 +20,14 @@ pub fn sync_tab_medium(help: &ModeInfo) -> LinePart {
         Style::new().paint("Sync input to panes in a tab with "),
     ];
     bits.extend(add_keybinds(help));
-    strings!(&bits)
+    ansi_strings!(&bits)
 }
 
 pub fn sync_tab_short(help: &ModeInfo) -> LinePart {
     // Sync input in a tab with Ctrl + <t> + <s>
     let mut bits = vec![Style::new().paint(" Sync input in a tab with ")];
     bits.extend(add_keybinds(help));
-    strings!(&bits)
+    ansi_strings!(&bits)
 }
 
 fn add_keybinds(help: &ModeInfo) -> Vec<ANSIString> {

--- a/default-plugins/status-bar/src/tip/data/use_mouse.rs
+++ b/default-plugins/status-bar/src/tip/data/use_mouse.rs
@@ -1,32 +1,16 @@
-use ansi_term::{
-    unstyled_len, ANSIString, ANSIStrings,
-    Color::{Fixed, RGB},
-    Style,
-};
+use ansi_term::Color::{Fixed, RGB};
+use ansi_term::Style;
 
-use crate::LinePart;
+use crate::{ansi_strings, LinePart};
 use zellij_tile::prelude::*;
 use zellij_tile_utils::palette_match;
-
-macro_rules! strings {
-    ($ANSIStrings:expr) => {{
-        let strings: &[ANSIString] = $ANSIStrings;
-
-        let ansi_strings = ANSIStrings(strings);
-
-        LinePart {
-            part: format!("{}", ansi_strings),
-            len: unstyled_len(&ansi_strings),
-        }
-    }};
-}
 
 pub fn use_mouse_full(help: &ModeInfo) -> LinePart {
     // Tip: Use the mouse to switch pane focus, scroll through the pane
     // scrollbuffer, switch or scroll through tabs
     let green_color = palette_match!(help.style.colors.green);
 
-    strings!(&[
+    ansi_strings!(&[
         Style::new().paint(" Tip: "),
         Style::new().fg(green_color).bold().paint("Use the mouse"),
         Style::new().paint(" to switch pane focus, scroll through the pane scrollbuffer, switch or scroll through the tabs."),
@@ -38,7 +22,7 @@ pub fn use_mouse_medium(help: &ModeInfo) -> LinePart {
     // scrollbuffer
     let green_color = palette_match!(help.style.colors.green);
 
-    strings!(&[
+    ansi_strings!(&[
         Style::new().paint(" Tip: "),
         Style::new().fg(green_color).bold().paint("Use the mouse"),
         Style::new().paint(" to switch pane/tabs or scroll through the pane scrollbuffer."),
@@ -49,7 +33,7 @@ pub fn use_mouse_short(help: &ModeInfo) -> LinePart {
     // Tip: Use the mouse to switch panes/tabs or scroll
     let green_color = palette_match!(help.style.colors.green);
 
-    strings!(&[
+    ansi_strings!(&[
         Style::new().fg(green_color).bold().paint(" Use the mouse"),
         Style::new().paint(" to switch pane/tabs or scroll."),
     ])

--- a/default-plugins/status-bar/src/tip/data/zellij_setup_check.rs
+++ b/default-plugins/status-bar/src/tip/data/zellij_setup_check.rs
@@ -1,31 +1,15 @@
-use ansi_term::{
-    unstyled_len, ANSIString, ANSIStrings,
-    Color::{Fixed, RGB},
-    Style,
-};
+use ansi_term::Color::{Fixed, RGB};
+use ansi_term::Style;
 
-use crate::LinePart;
+use crate::{ansi_strings, LinePart};
 use zellij_tile::prelude::*;
 use zellij_tile_utils::palette_match;
-
-macro_rules! strings {
-    ($ANSIStrings:expr) => {{
-        let strings: &[ANSIString] = $ANSIStrings;
-
-        let ansi_strings = ANSIStrings(strings);
-
-        LinePart {
-            part: format!("{}", ansi_strings),
-            len: unstyled_len(&ansi_strings),
-        }
-    }};
-}
 
 pub fn zellij_setup_check_full(help: &ModeInfo) -> LinePart {
     // Tip: Having issues with Zellij? Try running "zellij setup --check"
     let orange_color = palette_match!(help.style.colors.orange);
 
-    strings!(&[
+    ansi_strings!(&[
         Style::new().paint(" Tip: "),
         Style::new().paint("Having issues with Zellij? Try running "),
         Style::new()
@@ -39,7 +23,7 @@ pub fn zellij_setup_check_medium(help: &ModeInfo) -> LinePart {
     // Tip: Run "zellij setup --check" to find issues
     let orange_color = palette_match!(help.style.colors.orange);
 
-    strings!(&[
+    ansi_strings!(&[
         Style::new().paint(" Tip: "),
         Style::new().paint("Run "),
         Style::new()
@@ -54,7 +38,7 @@ pub fn zellij_setup_check_short(help: &ModeInfo) -> LinePart {
     // Run "zellij setup --check" to find issues
     let orange_color = palette_match!(help.style.colors.orange);
 
-    strings!(&[
+    ansi_strings!(&[
         Style::new().paint(" Run "),
         Style::new()
             .fg(orange_color)


### PR DESCRIPTION
This PR moves duplicated `strings` macro from each tip file to `tip/data/mod.rs` after discussion [here](https://github.com/zellij-org/zellij/pull/3047#discussion_r1463569555)

cc @jaeheonji 