### PR TITLE
fix(terminal): curly underlines mid-chunk

### DIFF
--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -375,7 +375,7 @@ impl CharacterStyles {
         }
 
         // apply new styles
-        *self = *new_styles;
+        *self = new_styles.enable_styled_underlines(self.styled_underlines_enabled);
 
         if let Some(changed_colors) = changed_colors {
             if let Some(AnsiCode::ColorIndex(color_index)) = diff.foreground {


### PR DESCRIPTION
This is a small fix for a recent regression in main (that was not released yet) in which curly underlines were not rendered mid line.

@aidanhs - any chance you could briefly take a look to make sure I didn't ruin any of your improvements?