### PR TITLE
feat(tab-bar): Display index number of tab before name (#2583)

### DIFF
--- a/default-plugins/compact-bar/src/tab.rs
+++ b/default-plugins/compact-bar/src/tab.rs
@@ -49,6 +49,9 @@ pub fn render_tab(
         .bold()
         .paint(format!(" {} ", text));
 
+    let position_text = style!(foreground_color, background_color)
+        .bold()
+        .paint(format!(" {}", tab.position + 1));
     let right_separator = style!(background_color, foreground_color).paint(separator);
     let tab_styled_text = if !focused_clients.is_empty() {
         let (cursor_section, extra_length) = cursors(focused_clients, palette);
@@ -71,7 +74,13 @@ pub fn render_tab(
         s.push_str(&right_separator.to_string());
         s
     } else {
-        ANSIStrings(&[left_separator, tab_styled_text, right_separator]).to_string()
+        ANSIStrings(&[
+            left_separator,
+            position_text,
+            tab_styled_text,
+            right_separator,
+        ])
+        .to_string()
     };
 
     LinePart {

--- a/default-plugins/tab-bar/src/tab.rs
+++ b/default-plugins/tab-bar/src/tab.rs
@@ -44,6 +44,9 @@ pub fn render_tab(
     };
     let left_separator = style!(foreground_color, background_color).paint(separator);
     let mut tab_text_len = text.width() + (separator_width * 2) + 2; // +2 for padding
+    let position_text = style!(foreground_color, background_color)
+        .bold()
+        .paint(format!(" {}", tab.position + 1));
     let tab_styled_text = style!(foreground_color, background_color)
         .bold()
         .paint(format!(" {} ", text));
@@ -70,7 +73,13 @@ pub fn render_tab(
         s.push_str(&right_separator.to_string());
         s
     } else {
-        ANSIStrings(&[left_separator, tab_styled_text, right_separator]).to_string()
+        ANSIStrings(&[
+            left_separator,
+            position_text,
+            tab_styled_text,
+            right_separator,
+        ])
+        .to_string()
     };
 
     LinePart {


### PR DESCRIPTION
The index of the tab bar (the number that the user can use to switch to the tab) in both default and compact view is now visible before the tab name.

I decided on just a single space as a separator, which matches GNU screen's default behaviour.