### PR TITLE
Remove MITM vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ cargo install --locked zellij
 
 bash/zsh:
 ```bash
-bash <(curl -L zellij.dev/launch)
+bash <(curl https://zellij.dev/launch)
 ```
 fish/xonsh:
 ```bash
-bash -c 'bash <(curl -L zellij.dev/launch)'
+bash -c 'bash <(curl https://zellij.dev/launch)'
 ```
 
 ## How do I get involved?


### PR DESCRIPTION
Use `curl https://zellij.dev/launch` rather than relying on a clear-text redirect via `curl -L zellij.dev/launch`.

Addresses: #2237