### PR TITLE
fix(session): dead sessions without layout shouldn't be resurrectable

### DIFF
--- a/zellij-server/src/background_jobs.rs
+++ b/zellij-server/src/background_jobs.rs
@@ -432,16 +432,10 @@ fn find_resurrectable_sessions(
                         .and_then(|metadata| metadata.created())
                     {
                         Ok(created) => Some(created),
+                        // let's not spam the logs if serialization is disabled
+                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
                         Err(e) => {
-                            if e.kind() != std::io::ErrorKind::NotFound {
-                                // let's not spam the
-                                // logs if serialization
-                                // is disabled
-                                log::error!(
-                                    "Failed to read created stamp of resurrection file: {:?}",
-                                    e
-                                );
-                            }
+                            log::error!("Failed to read created stamp of resurrection file: {e:?}");
                             None
                         },
                     };


### PR DESCRIPTION
It is possible for a dead session to not have a committed **session-layout.kdl** file, either because serialization is turned off, or because the session was killed before being flushed into disc. Since there isn't a file to load from, the session shouldn't be marked as resurrectable (for example, by the session-manager plugin), because its state is lost. As an example, the session-manager plugin will simply load the default layout for the dead session if selected, so it is just better to not list it at all.