### PR TITLE
feat(plugins): allow piping messages to a specific plugin id

### DIFF
--- a/zellij-server/src/plugins/mod.rs
+++ b/zellij-server/src/plugins/mod.rs
@@ -592,7 +592,7 @@ pub(crate) fn plugin_thread_main(
                                 message.message_name,
                                 &message.message_payload,
                                 &Some(message.message_args),
-                                is_private
+                                is_private,
                             ),
                         ));
                     },
@@ -607,7 +607,7 @@ pub(crate) fn plugin_thread_main(
                                 message.message_name,
                                 &message.message_payload,
                                 &Some(message.message_args),
-                                is_private
+                                is_private,
                             ),
                         ));
                     },

--- a/zellij-server/src/plugins/mod.rs
+++ b/zellij-server/src/plugins/mod.rs
@@ -560,8 +560,8 @@ pub(crate) fn plugin_thread_main(
                     .new_plugin_args
                     .as_ref()
                     .and_then(|n| n.pane_id_to_replace);
-                match message.plugin_url {
-                    Some(plugin_url) => {
+                match (message.plugin_url, message.destination_plugin_id) {
+                    (Some(plugin_url), None) => {
                         // send to specific plugin(s)
                         pipe_to_specific_plugins(
                             PipeSource::Plugin(source_plugin_id),
@@ -582,7 +582,36 @@ pub(crate) fn plugin_thread_main(
                             &plugin_aliases,
                         );
                     },
-                    None => {
+                    (None, Some(destination_plugin_id)) => {
+                        let is_private = true;
+                        pipe_messages.push((
+                            Some(destination_plugin_id),
+                            None,
+                            PipeMessage::new(
+                                PipeSource::Plugin(source_plugin_id),
+                                message.message_name,
+                                &message.message_payload,
+                                &Some(message.message_args),
+                                is_private
+                            ),
+                        ));
+                    },
+                    (Some(plugin_url), Some(destination_plugin_id)) => {
+                        log::warn!("Message contains both a destination plugin url: {plugin_url} and a destination plugin id: {destination_plugin_id}, ignoring the url and prioritizing the id");
+                        let is_private = true;
+                        pipe_messages.push((
+                            Some(destination_plugin_id),
+                            None,
+                            PipeMessage::new(
+                                PipeSource::Plugin(source_plugin_id),
+                                message.message_name,
+                                &message.message_payload,
+                                &Some(message.message_args),
+                                is_private
+                            ),
+                        ));
+                    },
+                    (None, None) => {
                         // send to all plugins
                         pipe_to_all_plugins(
                             PipeSource::Plugin(source_plugin_id),

--- a/zellij-utils/assets/prost/api.plugin_command.rs
+++ b/zellij-utils/assets/prost/api.plugin_command.rs
@@ -145,6 +145,8 @@ pub struct MessageToPluginPayload {
     pub message_args: ::prost::alloc::vec::Vec<ContextItem>,
     #[prost(message, optional, tag = "6")]
     pub new_plugin_args: ::core::option::Option<NewPluginArgs>,
+    #[prost(uint32, optional, tag = "7")]
+    pub destination_plugin_id: ::core::option::Option<u32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -1007,6 +1007,7 @@ impl CommandToRun {
 #[derive(Debug, Default, Clone)]
 pub struct MessageToPlugin {
     pub plugin_url: Option<String>,
+    pub destination_plugin_id: Option<u32>,
     pub plugin_config: BTreeMap<String, String>,
     pub message_name: String,
     pub message_payload: Option<String>,
@@ -1040,6 +1041,10 @@ impl MessageToPlugin {
     }
     pub fn with_plugin_url(mut self, url: impl Into<String>) -> Self {
         self.plugin_url = Some(url.into());
+        self
+    }
+    pub fn with_destination_plugin_id(mut self, destination_plugin_id: u32) -> Self {
+        self.destination_plugin_id = Some(destination_plugin_id);
         self
     }
     pub fn with_plugin_config(mut self, plugin_config: BTreeMap<String, String>) -> Self {

--- a/zellij-utils/src/plugin_api/plugin_command.proto
+++ b/zellij-utils/src/plugin_api/plugin_command.proto
@@ -167,6 +167,7 @@ message MessageToPluginPayload {
   optional string message_payload = 4;
   repeated ContextItem message_args = 5;
   optional NewPluginArgs new_plugin_args = 6;
+  optional uint32 destination_plugin_id = 7;
 }
 
 message NewPluginArgs {

--- a/zellij-utils/src/plugin_api/plugin_command.rs
+++ b/zellij-utils/src/plugin_api/plugin_command.rs
@@ -814,6 +814,7 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
                     message_payload,
                     message_args,
                     new_plugin_args,
+                    destination_plugin_id,
                 })) => {
                     let plugin_config: BTreeMap<String, String> = plugin_config
                         .into_iter()
@@ -840,6 +841,7 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
                                 skip_cache: protobuf_new_plugin_args.skip_cache,
                             })
                         }),
+                        destination_plugin_id,
                     }))
                 },
                 _ => Err("Mismatched payload for MessageToPlugin"),
@@ -1343,6 +1345,7 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
                                 skip_cache: m_t_p.skip_cache,
                             }
                         }),
+                        destination_plugin_id: message_to_plugin.destination_plugin_id,
                     })),
                 })
             },


### PR DESCRIPTION
This is mainly so that plugins can send queries and replies to one another.