### PR TITLE
Add support for Ctrl and Alt modifiers on function keys in keybindings.

### DIFF
--- a/default-plugins/status-bar/src/first_line.rs
+++ b/default-plugins/status-bar/src/first_line.rs
@@ -62,6 +62,8 @@ impl KeyShortcut {
         } else {
             match key {
                 Key::F(c) => format!("{}", c),
+                Key::CtrlF(n) => format!("F{}", n),
+                Key::AltF(n) => format!("F{}", n),
                 Key::Ctrl(c) => format!("{}", c),
                 Key::Char(_) => format!("{}", key),
                 Key::Alt(c) => format!("{}", c),

--- a/default-plugins/status-bar/src/main.rs
+++ b/default-plugins/status-bar/src/main.rs
@@ -333,8 +333,8 @@ pub fn get_common_modifier(keyvec: Vec<&Key>) -> Option<String> {
     let mut new_modifier;
     for key in keyvec.iter() {
         match key {
-            Key::Ctrl(_) => new_modifier = "Ctrl",
-            Key::Alt(_) => new_modifier = "Alt",
+            Key::Ctrl(_) | Key::CtrlF(_) => new_modifier = "Ctrl",
+            Key::Alt(_) | Key::AltF(_) => new_modifier = "Alt",
             _ => return None,
         }
         if modifier.is_empty() {
@@ -468,7 +468,9 @@ pub fn style_key_with_modifier(
             } else {
                 match key {
                     Key::Ctrl(c) => format!("{}", Key::Char(*c)),
+                    Key::CtrlF(n) => format!("{}", Key::F(*n)),
                     Key::Alt(c) => format!("{}", c),
+                    Key::AltF(n) => format!("{}", Key::F(*n)),
                     _ => format!("{}", key),
                 }
             }

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__status_bar_loads_custom_keybindings.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__status_bar_loads_custom_keybindings.snap
@@ -25,5 +25,5 @@ expression: last_snapshot
 │                                                                                                                      │
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- <F1> LOCK  <F2> PANE  <F3> TAB  <F4> RESIZE  <F5> MOVE  <F6> SEARCH  <F7> SESSION  <F8> QUIT 
+ <F1> LOCK  <F2> PANE  <F3> TAB  <F4> RESIZE  <F5> MOVE  <F6> SEARCH  <Alt+F7> SESSION  <Ctrl+F8> QUIT 
  Tip: UNBOUND => open new pane. UNBOUND => navigate between panes. UNBOUND => increase/decrease pane size.              

--- a/src/tests/fixtures/configs/changed_keys.kdl
+++ b/src/tests/fixtures/configs/changed_keys.kdl
@@ -6,7 +6,7 @@ keybinds clear-defaults=true {
         bind "F4" { SwitchToMode "Resize"; }
         bind "F5" { SwitchToMode "Move"; }
         bind "F6" { SwitchToMode "Scroll"; }
-        bind "F7" { SwitchToMode "Session"; }
-        bind "F8" { Quit; }
+        bind "Alt F7" { SwitchToMode "Session"; }
+        bind "Ctrl F8" { Quit; }
     }
 }

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -61,6 +61,8 @@ pub enum Key {
     BackTab,
     Null,
     Esc,
+    AltF(u8),
+    CtrlF(u8),
 }
 
 impl FromStr for Key {
@@ -77,14 +79,7 @@ impl FromStr for Key {
         }
         match (modifier, main_key) {
             (Some("Ctrl"), Some(main_key)) => {
-                let mut key_chars = main_key.chars();
-                let key_count = main_key.chars().count();
-                if key_count == 1 {
-                    let key_char = key_chars.next().unwrap();
-                    Ok(Key::Ctrl(key_char))
-                } else {
-                    Err(format!("Failed to parse key: {}", key_str).into())
-                }
+                parse_main_key(main_key, key_str, Key::Ctrl, Key::CtrlF)
             },
             (Some("Alt"), Some(main_key)) => {
                 match main_key {
@@ -95,16 +90,12 @@ impl FromStr for Key {
                     "Right" => Ok(Key::Alt(CharOrArrow::Direction(Direction::Right))),
                     "Up" => Ok(Key::Alt(CharOrArrow::Direction(Direction::Up))),
                     "Down" => Ok(Key::Alt(CharOrArrow::Direction(Direction::Down))),
-                    _ => {
-                        let mut key_chars = main_key.chars();
-                        let key_count = main_key.chars().count();
-                        if key_count == 1 {
-                            let key_char = key_chars.next().unwrap();
-                            Ok(Key::Alt(CharOrArrow::Char(key_char)))
-                        } else {
-                            Err(format!("Failed to parse key: {}", key_str).into())
-                        }
-                    },
+                    _ => parse_main_key(
+                        main_key,
+                        key_str,
+                        |c| Key::Alt(CharOrArrow::Char(c)),
+                        Key::AltF,
+                    ),
                 }
             },
             (None, Some(main_key)) => match main_key {
@@ -123,32 +114,39 @@ impl FromStr for Key {
                 "Space" => Ok(Key::Char(' ')),
                 "Enter" => Ok(Key::Char('\n')),
                 "Esc" => Ok(Key::Esc),
-                _ => {
-                    let mut key_chars = main_key.chars();
-                    let key_count = main_key.chars().count();
-                    if key_count == 1 {
-                        let key_char = key_chars.next().unwrap();
-                        Ok(Key::Char(key_char))
-                    } else if key_count > 1 {
-                        if let Some(first_char) = key_chars.next() {
-                            if first_char == 'F' {
-                                let f_index: String = key_chars.collect();
-                                let f_index: u8 = f_index
-                                    .parse()
-                                    .map_err(|e| format!("Failed to parse F index: {}", e))?;
-                                if f_index >= 1 && f_index <= 12 {
-                                    return Ok(Key::F(f_index));
-                                }
-                            }
-                        }
-                        Err(format!("Failed to parse key: {}", key_str).into())
-                    } else {
-                        Err(format!("Failed to parse key: {}", key_str).into())
-                    }
-                },
+                _ => parse_main_key(main_key, key_str, Key::Char, Key::F),
             },
             _ => Err(format!("Failed to parse key: {}", key_str).into()),
         }
+    }
+}
+
+fn parse_main_key(
+    main_key: &str,
+    key_str: &str,
+    to_char_key: impl FnOnce(char) -> Key,
+    to_fn_key: impl FnOnce(u8) -> Key,
+) -> Result<Key, Box<dyn std::error::Error>> {
+    let mut key_chars = main_key.chars();
+    let key_count = main_key.chars().count();
+    if key_count == 1 {
+        let key_char = key_chars.next().unwrap();
+        Ok(to_char_key(key_char))
+    } else if key_count > 1 {
+        if let Some(first_char) = key_chars.next() {
+            if first_char == 'F' {
+                let f_index: String = key_chars.collect();
+                let f_index: u8 = f_index
+                    .parse()
+                    .map_err(|e| format!("Failed to parse F index: {}", e))?;
+                if f_index >= 1 && f_index <= 12 {
+                    return Ok(to_fn_key(f_index));
+                }
+            }
+        }
+        Err(format!("Failed to parse key: {}", key_str).into())
+    } else {
+        Err(format!("Failed to parse key: {}", key_str).into())
     }
 }
 
@@ -176,6 +174,8 @@ impl fmt::Display for Key {
             },
             Key::Alt(c) => write!(f, "Alt+{}", c),
             Key::Ctrl(c) => write!(f, "Ctrl+{}", Key::Char(*c)),
+            Key::AltF(n) => write!(f, "Alt+F{}", n),
+            Key::CtrlF(n) => write!(f, "Ctrl+F{}", n),
             Key::Null => write!(f, "NULL"),
             Key::Esc => write!(f, "ESC"),
         }

--- a/zellij-utils/src/input/mod.rs
+++ b/zellij-utils/src/input/mod.rs
@@ -113,7 +113,15 @@ mod not_wasm {
             KeyCode::Tab => Key::BackTab, // TODO: ???
             KeyCode::Delete => Key::Delete,
             KeyCode::Insert => Key::Insert,
-            KeyCode::Function(n) => Key::F(n),
+            KeyCode::Function(n) => {
+                if modifiers.contains(Modifiers::ALT) {
+                    Key::AltF(n)
+                } else if modifiers.contains(Modifiers::CTRL) {
+                    Key::CtrlF(n)
+                } else {
+                    Key::F(n)
+                }
+            },
             KeyCode::Escape => Key::Esc,
             KeyCode::Enter => Key::Char('\n'),
             _ => Key::Esc, // there are other keys we can implement here, but we might need additional terminal support to implement them, not just exhausting this enum


### PR DESCRIPTION
Previously, it was not possible to define keybindings with a modifier and a function key. The `Key` enum only supported combinging the Ctrl and Alt modifiers with letters. This is somewhat limiting: I would like to make the Zellij keybindings more "distant" than those used in the programs I use from within Zelilj, so that Zellij does not intefere with those programs. Thus I would like to move some of the keybindings from Ctrl+_character_ to Ctrl+_function key_.

This change adds:

  * support for function keys with the Ctrl and Alt modifiers in the `Key` enum,
  * support for parsing such keybindings from the configuration file,
  * support for such keybindings in the protobuf which communicates the keybindings to plugins, and
  * support for these keybindings in the plugin API.

This is tested by modifying one of the e2e tests to include an example of such keybindings. This verifies that the configuration is correctly parsed, communicated with the plugin, and rendered.