### PR TITLE
Feature/format UI components

### DIFF
--- a/zellij-tile/src/ui_components/nested_list.rs
+++ b/zellij-tile/src/ui_components/nested_list.rs
@@ -1,4 +1,5 @@
 use super::Text;
+use std::borrow::Borrow;
 use std::ops::RangeBounds;
 
 #[derive(Debug, Default, Clone)]
@@ -44,12 +45,7 @@ impl NestedListItem {
 
 /// render a nested list with arbitrary data
 pub fn print_nested_list(items: Vec<NestedListItem>) {
-    let items = items
-        .into_iter()
-        .map(|i| i.serialize())
-        .collect::<Vec<_>>()
-        .join(";");
-    print!("\u{1b}Pznested_list;{}\u{1b}\\", items)
+    print!("{}", serialize_nested_list(&items))
 }
 
 pub fn print_nested_list_with_coordinates(
@@ -59,14 +55,44 @@ pub fn print_nested_list_with_coordinates(
     width: Option<usize>,
     height: Option<usize>,
 ) {
+    print!(
+        "{}",
+        serialize_nested_list_with_coordinates(&items, x, y, width, height)
+    )
+}
+
+pub fn serialize_nested_list<I>(items: I) -> String
+where
+    I: IntoIterator,
+    I::Item: Borrow<NestedListItem>,
+{
+    let items = items
+        .into_iter()
+        .map(|i| i.borrow().serialize())
+        .collect::<Vec<_>>()
+        .join(";");
+    format!("\u{1b}Pznested_list;{}\u{1b}\\", items)
+}
+
+pub fn serialize_nested_list_with_coordinates<I>(
+    items: I,
+    x: usize,
+    y: usize,
+    width: Option<usize>,
+    height: Option<usize>,
+) -> String
+where
+    I: IntoIterator,
+    I::Item: Borrow<NestedListItem>,
+{
     let width = width.map(|w| w.to_string()).unwrap_or_default();
     let height = height.map(|h| h.to_string()).unwrap_or_default();
     let items = items
         .into_iter()
-        .map(|i| i.serialize())
+        .map(|i| i.borrow().serialize())
         .collect::<Vec<_>>()
         .join(";");
-    print!(
+    format!(
         "\u{1b}Pznested_list;{}/{}/{}/{};{}\u{1b}\\",
         x, y, width, height, items
     )

--- a/zellij-tile/src/ui_components/nested_list.rs
+++ b/zellij-tile/src/ui_components/nested_list.rs
@@ -45,7 +45,12 @@ impl NestedListItem {
 
 /// render a nested list with arbitrary data
 pub fn print_nested_list(items: Vec<NestedListItem>) {
-    print!("{}", serialize_nested_list(&items))
+    let items = items
+        .into_iter()
+        .map(|i| i.serialize())
+        .collect::<Vec<_>>()
+        .join(";");
+    print!("\u{1b}Pznested_list;{}\u{1b}\\", items)
 }
 
 pub fn print_nested_list_with_coordinates(
@@ -55,9 +60,16 @@ pub fn print_nested_list_with_coordinates(
     width: Option<usize>,
     height: Option<usize>,
 ) {
+    let width = width.map(|w| w.to_string()).unwrap_or_default();
+    let height = height.map(|h| h.to_string()).unwrap_or_default();
+    let items = items
+        .into_iter()
+        .map(|i| i.serialize())
+        .collect::<Vec<_>>()
+        .join(";");
     print!(
-        "{}",
-        serialize_nested_list_with_coordinates(&items, x, y, width, height)
+        "\u{1b}Pznested_list;{}/{}/{}/{};{}\u{1b}\\",
+        x, y, width, height, items
     )
 }
 

--- a/zellij-tile/src/ui_components/ribbon.rs
+++ b/zellij-tile/src/ui_components/ribbon.rs
@@ -1,7 +1,8 @@
 use super::Text;
+use std::borrow::Borrow;
 
 pub fn print_ribbon(text: Text) {
-    print!("\u{1b}Pzribbon;{}\u{1b}\\", text.serialize());
+    print!("{}", serialize_ribbon(&text));
 }
 
 pub fn print_ribbon_with_coordinates(
@@ -11,14 +12,64 @@ pub fn print_ribbon_with_coordinates(
     width: Option<usize>,
     height: Option<usize>,
 ) {
+    print!(
+        "{}",
+        serialize_ribbon_with_coordinates(&text, x, y, width, height)
+    );
+}
+
+pub fn serialize_ribbon(text: &Text) -> String {
+    format!("\u{1b}Pzribbon;{}\u{1b}\\", text.serialize())
+}
+
+pub fn serialize_ribbon_with_coordinates(
+    text: &Text,
+    x: usize,
+    y: usize,
+    width: Option<usize>,
+    height: Option<usize>,
+) -> String {
     let width = width.map(|w| w.to_string()).unwrap_or_default();
     let height = height.map(|h| h.to_string()).unwrap_or_default();
-    print!(
+
+    format!(
         "\u{1b}Pzribbon;{}/{}/{}/{};{}\u{1b}\\",
         x,
         y,
         width,
         height,
         text.serialize()
-    );
+    )
+}
+
+pub fn serialize_ribbon_line<I>(ribbons: I) -> String
+where
+    I: IntoIterator,
+    I::Item: Borrow<Text>,
+{
+    ribbons
+        .into_iter()
+        .map(|r| serialize_ribbon(r.borrow()))
+        .collect()
+}
+
+pub fn serialize_ribbon_line_with_coordinates<I>(
+    ribbons: I,
+    x: usize,
+    y: usize,
+    width: Option<usize>,
+    height: Option<usize>,
+) -> String
+where
+    I: IntoIterator,
+    I::Item: Borrow<Text>,
+{
+    let mut ribbons = ribbons.into_iter();
+    let Some(first) = ribbons.next() else {
+        return String::new();
+    };
+
+    let mut result = serialize_ribbon_with_coordinates(first.borrow(), x, y, width, height);
+    result.push_str(&serialize_ribbon_line(ribbons));
+    result
 }

--- a/zellij-tile/src/ui_components/ribbon.rs
+++ b/zellij-tile/src/ui_components/ribbon.rs
@@ -2,7 +2,7 @@ use super::Text;
 use std::borrow::Borrow;
 
 pub fn print_ribbon(text: Text) {
-    print!("{}", serialize_ribbon(&text));
+    print!("\u{1b}Pzribbon;{}\u{1b}\\", text.serialize());
 }
 
 pub fn print_ribbon_with_coordinates(
@@ -12,9 +12,15 @@ pub fn print_ribbon_with_coordinates(
     width: Option<usize>,
     height: Option<usize>,
 ) {
+    let width = width.map(|w| w.to_string()).unwrap_or_default();
+    let height = height.map(|h| h.to_string()).unwrap_or_default();
     print!(
-        "{}",
-        serialize_ribbon_with_coordinates(&text, x, y, width, height)
+        "\u{1b}Pzribbon;{}/{}/{}/{};{}\u{1b}\\",
+        x,
+        y,
+        width,
+        height,
+        text.serialize()
     );
 }
 

--- a/zellij-tile/src/ui_components/table.rs
+++ b/zellij-tile/src/ui_components/table.rs
@@ -38,7 +38,7 @@ impl Table {
 }
 
 pub fn print_table(table: Table) {
-    print!("\u{1b}Pztable;{}", table.serialize())
+    print!("{}", serialize_table(&table))
 }
 
 pub fn print_table_with_coordinates(
@@ -48,9 +48,26 @@ pub fn print_table_with_coordinates(
     width: Option<usize>,
     height: Option<usize>,
 ) {
+    print!(
+        "{}",
+        serialize_table_with_coordinates(&table, x, y, width, height)
+    )
+}
+
+pub fn serialize_table(table: &Table) -> String {
+    format!("\u{1b}Pztable;{}", table.serialize())
+}
+
+pub fn serialize_table_with_coordinates(
+    table: &Table,
+    x: usize,
+    y: usize,
+    width: Option<usize>,
+    height: Option<usize>,
+) -> String {
     let width = width.map(|w| w.to_string()).unwrap_or_default();
     let height = height.map(|h| h.to_string()).unwrap_or_default();
-    print!(
+    format!(
         "\u{1b}Pztable;{}/{}/{}/{};{}\u{1b}\\",
         x,
         y,

--- a/zellij-tile/src/ui_components/table.rs
+++ b/zellij-tile/src/ui_components/table.rs
@@ -38,7 +38,7 @@ impl Table {
 }
 
 pub fn print_table(table: Table) {
-    print!("{}", serialize_table(&table))
+    print!("\u{1b}Pztable;{}", table.serialize())
 }
 
 pub fn print_table_with_coordinates(
@@ -48,9 +48,15 @@ pub fn print_table_with_coordinates(
     width: Option<usize>,
     height: Option<usize>,
 ) {
+    let width = width.map(|w| w.to_string()).unwrap_or_default();
+    let height = height.map(|h| h.to_string()).unwrap_or_default();
     print!(
-        "{}",
-        serialize_table_with_coordinates(&table, x, y, width, height)
+        "\u{1b}Pztable;{}/{}/{}/{};{}\u{1b}\\",
+        x,
+        y,
+        width,
+        height,
+        table.serialize()
     )
 }
 

--- a/zellij-tile/src/ui_components/text.rs
+++ b/zellij-tile/src/ui_components/text.rs
@@ -84,7 +84,7 @@ impl Text {
 }
 
 pub fn print_text(text: Text) {
-    print!("{}", serialize_text(&text))
+    print!("\u{1b}Pztext;{}\u{1b}\\", text.serialize())
 }
 
 pub fn print_text_with_coordinates(
@@ -94,9 +94,15 @@ pub fn print_text_with_coordinates(
     width: Option<usize>,
     height: Option<usize>,
 ) {
+    let width = width.map(|w| w.to_string()).unwrap_or_default();
+    let height = height.map(|h| h.to_string()).unwrap_or_default();
     print!(
-        "{}",
-        serialize_text_with_coordinates(&text, x, y, width, height)
+        "\u{1b}Pztext;{}/{}/{}/{};{}\u{1b}\\",
+        x,
+        y,
+        width,
+        height,
+        text.serialize()
     )
 }
 

--- a/zellij-tile/src/ui_components/text.rs
+++ b/zellij-tile/src/ui_components/text.rs
@@ -84,7 +84,7 @@ impl Text {
 }
 
 pub fn print_text(text: Text) {
-    print!("\u{1b}Pztext;{}\u{1b}\\", text.serialize())
+    print!("{}", serialize_text(&text))
 }
 
 pub fn print_text_with_coordinates(
@@ -94,9 +94,26 @@ pub fn print_text_with_coordinates(
     width: Option<usize>,
     height: Option<usize>,
 ) {
+    print!(
+        "{}",
+        serialize_text_with_coordinates(&text, x, y, width, height)
+    )
+}
+
+pub fn serialize_text(text: &Text) -> String {
+    format!("\u{1b}Pztext;{}\u{1b}\\", text.serialize())
+}
+
+pub fn serialize_text_with_coordinates(
+    text: &Text,
+    x: usize,
+    y: usize,
+    width: Option<usize>,
+    height: Option<usize>,
+) -> String {
     let width = width.map(|w| w.to_string()).unwrap_or_default();
     let height = height.map(|h| h.to_string()).unwrap_or_default();
-    print!(
+    format!(
         "\u{1b}Pztext;{}/{}/{}/{};{}\u{1b}\\",
         x,
         y,


### PR DESCRIPTION
Add ways to serialize/format ui components instead of only proposing `print` options.

I can remove the first commit if you want, but it did not work on my PC without it:
1. `rust -vV` error when using the "previous" rust toolchain.
2. `protoc` complain that `optional` is an experimental feature of the syntax3.

I also changed the interface to borrow the `Text` elements instead of owning it, so it can be reused.

I had some reflection on the `ribbon`: plugin developers will often want to have multiples of them in a row, so accepting an `into_iter` sounded nicer.
I also wanted to have a possibility to color the full line with the background color, but I’m not sure how to get the bg color from the user’s theme.

Note: I changed the session plugin as needed and others, but I did not `run` everything plugin before/after. However I did not see obvious breakage in the "after" state.