### PR TITLE
fix(stability): various crashes

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -116,7 +116,7 @@ macro_rules! active_tab_and_connected_client_id {
     ($screen:ident, $client_id:ident, $closure:expr, ?) => {
         match $screen.get_active_tab_mut($client_id) {
             Ok(active_tab) => {
-                $closure(active_tab, $client_id)?;
+                $closure(active_tab, $client_id).non_fatal();
             },
             Err(_) => {
                 if let Some(client_id) = $screen.get_first_client_id() {


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/3183 as well as quite a few other stability issues.
The code fix is small, but this finally brings our error reporting system to the same philosophical standpoint as our application business logic: state corruption is fine as long as we can fix it later.

The error we get from this previously-crashing macro happens 100% of the time when the state is corrupted (due to race conditions stemming from our actor-like architecture, and the like). We always know how to fix these state corruptions, and the worst effect that can happen by logging the error instead of crashing is losing one or two keypresses from the user. While this is not ideal and we should introduce some sort of cashing/retry mechanism, this is light years better than crashing in such cases.