### PR TITLE
chore(integrations): zpipe alias

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -667,3 +667,23 @@ fn generate_unique_session_name() -> String {
         process::exit(1);
     }
 }
+
+pub(crate) fn list_aliases(opts: CliArgs) {
+    let (config, _layout, _config_options, _config_without_layout, _config_options_without_layout) =
+        match Setup::from_cli_args(&opts) {
+            Ok(results) => results,
+            Err(e) => {
+                if let ConfigError::KdlError(error) = e {
+                    let report: Report = error.into();
+                    eprintln!("{:?}", report);
+                } else {
+                    eprintln!("{}", e);
+                }
+                process::exit(1);
+            },
+        };
+    for alias in config.plugins.list() {
+        println!("{}", alias);
+    }
+    process::exit(0);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,6 +170,8 @@ fn main() {
     })) = opts.command
     {
         commands::list_sessions(no_formatting, short);
+    } else if let Some(Command::Sessions(Sessions::ListAliases)) = opts.command {
+        commands::list_aliases(opts);
     } else if let Some(Command::Sessions(Sessions::KillAllSessions { yes })) = opts.command {
         commands::kill_all_sessions(yes);
     } else if let Some(Command::Sessions(Sessions::KillSession { ref target_session })) =

--- a/zellij-utils/assets/completions/comp.bash
+++ b/zellij-utils/assets/completions/comp.bash
@@ -2,3 +2,10 @@ function zr () { zellij run --name "$*" -- bash -ic "$*";}
 function zrf () { zellij run --name "$*" --floating -- bash -ic "$*";}
 function ze () { zellij edit "$*";}
 function zef () { zellij edit --floating "$*";}
+function zpipe () { 
+  if [ -z "$1" ]; then
+    zellij pipe;
+  else 
+    zellij pipe -p $1;
+  fi
+}

--- a/zellij-utils/assets/completions/comp.fish
+++ b/zellij-utils/assets/completions/comp.fish
@@ -18,6 +18,11 @@ end
 function zef
   command zellij edit --floating $argv
 end
+
+# the zpipe alias and its completions
+function __fish_complete_aliases
+  zellij list-aliases 2>/dev/null
+end
 function zpipe
   if count $argv > /dev/null
     command zellij pipe -p $argv
@@ -25,3 +30,4 @@ function zpipe
     command zellij pipe
   end
 end
+complete -c zpipe -f -a "(__fish_complete_aliases)" -d "Zpipes"

--- a/zellij-utils/assets/completions/comp.fish
+++ b/zellij-utils/assets/completions/comp.fish
@@ -18,3 +18,10 @@ end
 function zef
   command zellij edit --floating $argv
 end
+function zpipe
+  if count $argv > /dev/null
+    command zellij pipe -p $argv
+  else
+    command zellij pipe
+  end
+end

--- a/zellij-utils/assets/completions/comp.zsh
+++ b/zellij-utils/assets/completions/comp.zsh
@@ -2,3 +2,10 @@ function zr () { zellij run --name "$*" -- zsh -ic "$*";}
 function zrf () { zellij run --name "$*" --floating -- zsh -ic "$*";}
 function ze () { zellij edit "$*";}
 function zef () { zellij edit --floating "$*";}
+function zpipe () { 
+  if [ -z "$1" ]; then
+    /home/aram/code/zellij/target/dev-opt/zellij pipe;
+  else 
+    /home/aram/code/zellij/target/dev-opt/zellij pipe -p $1;
+  fi
+}

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -231,7 +231,7 @@ pub enum Sessions {
         height: Option<String>,
     },
     /// Load a plugin
-    #[clap(visible_alias = "r")]
+    #[clap(visible_alias = "p")]
     Plugin {
         /// Plugin URL, can either start with http(s), file: or zellij:
         #[clap(last(true), required(true))]

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -107,7 +107,9 @@ pub enum Sessions {
         #[clap(short, long, value_parser, takes_value(false), default_value("false"))]
         short: bool,
     },
-
+    /// List existing plugin aliases
+    #[clap(visible_alias = "la")]
+    ListAliases,
     /// Attach to a session
     #[clap(visible_alias = "a")]
     Attach {

--- a/zellij-utils/src/input/plugins.rs
+++ b/zellij-utils/src/input/plugins.rs
@@ -25,6 +25,9 @@ impl PluginAliases {
     pub fn from_data(aliases: BTreeMap<String, RunPlugin>) -> Self {
         PluginAliases { aliases }
     }
+    pub fn list(&self) -> Vec<String> {
+        self.aliases.keys().cloned().collect()
+    }
 }
 
 /// Plugin metadata


### PR DESCRIPTION
This adds the `zpipe` alias, which is an alias to `zellij pipe`. If arguments are provided, they will be treated as the plugin alias/path (eg. `zpipe filepicker` or `zpipe https://example.com/my-plugin.wasm`).

This PR also adds the `zellij list-aliases` command which can be used to list all the configured aliases. This is in order to facilitate fast typing and completions when using zpipe.