### PR TITLE
feat(pipes): allow piping messages to plugins from keybindings

### DIFF
--- a/default-plugins/fixture-plugin-for-tests/src/main.rs
+++ b/default-plugins/fixture-plugin-for-tests/src/main.rs
@@ -339,6 +339,7 @@ impl ZellijPlugin for State {
         let input_pipe_id = match pipe_message.source {
             PipeSource::Cli(id) => id.clone(),
             PipeSource::Plugin(id) => format!("{}", id),
+            PipeSource::Keybind => format!("keybind"),
         };
         let name = pipe_message.name;
         let payload = pipe_message.payload;

--- a/zellij-utils/assets/prost/api.action.rs
+++ b/zellij-utils/assets/prost/api.action.rs
@@ -454,6 +454,7 @@ pub enum ActionName {
     LaunchPlugin = 81,
     CliPipe = 82,
     MoveTab = 83,
+    KeybindPipe = 84,
 }
 impl ActionName {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -546,6 +547,7 @@ impl ActionName {
             ActionName::LaunchPlugin => "LaunchPlugin",
             ActionName::CliPipe => "CliPipe",
             ActionName::MoveTab => "MoveTab",
+            ActionName::KeybindPipe => "KeybindPipe",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -635,6 +637,7 @@ impl ActionName {
             "LaunchPlugin" => Some(Self::LaunchPlugin),
             "CliPipe" => Some(Self::CliPipe),
             "MoveTab" => Some(Self::MoveTab),
+            "KeybindPipe" => Some(Self::KeybindPipe),
             _ => None,
         }
     }

--- a/zellij-utils/assets/prost/api.pipe_message.rs
+++ b/zellij-utils/assets/prost/api.pipe_message.rs
@@ -29,6 +29,7 @@ pub struct Arg {
 pub enum PipeSource {
     Cli = 0,
     Plugin = 1,
+    Keybind = 2,
 }
 impl PipeSource {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -39,6 +40,7 @@ impl PipeSource {
         match self {
             PipeSource::Cli => "Cli",
             PipeSource::Plugin => "Plugin",
+            PipeSource::Keybind => "Keybind",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -46,6 +48,7 @@ impl PipeSource {
         match value {
             "Cli" => Some(Self::Cli),
             "Plugin" => Some(Self::Plugin),
+            "Keybind" => Some(Self::Keybind),
             _ => None,
         }
     }

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -1165,6 +1165,7 @@ pub enum HttpVerb {
 pub enum PipeSource {
     Cli(String), // String is the pipe_id of the CLI pipe (used for blocking/unblocking)
     Plugin(u32), // u32 is the lugin id
+    Keybind,     // TODO: consider including the actual keybind here?
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -401,6 +401,7 @@ pub enum PluginContext {
     MessageFromPlugin,
     UnblockCliPipes,
     WatchFilesystem,
+    KeybindPipe,
 }
 
 /// Stack call representations corresponding to the different types of [`ClientInstruction`]s.

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -284,6 +284,19 @@ pub enum Action {
         cwd: Option<PathBuf>,
         pane_title: Option<String>,
     },
+    KeybindPipe {
+        name: Option<String>,
+        payload: Option<String>,
+        args: Option<BTreeMap<String, String>>,
+        plugin: Option<String>,
+        configuration: Option<BTreeMap<String, String>>,
+        launch_new: bool,
+        skip_cache: bool,
+        floating: Option<bool>,
+        in_place: Option<bool>,
+        cwd: Option<PathBuf>,
+        pane_title: Option<String>,
+    },
 }
 
 impl Action {

--- a/zellij-utils/src/plugin_api/action.proto
+++ b/zellij-utils/src/plugin_api/action.proto
@@ -243,6 +243,7 @@ enum ActionName {
     LaunchPlugin = 81;
     CliPipe = 82;
     MoveTab = 83;
+    KeybindPipe = 84;
 }
 
 message Position {

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -689,6 +689,23 @@ impl TryFrom<ProtobufAction> for Action {
                 },
                 _ => Err("Wrong payload for Action::RenameSession"),
             },
+            Some(ProtobufActionName::KeybindPipe) => match protobuf_action.optional_payload {
+                Some(_) => Err("KeybindPipe should not have a payload"),
+                // TODO: at some point we might want to support a payload here
+                None => Ok(Action::KeybindPipe {
+                    name: None,
+                    payload: None,
+                    args: None,
+                    plugin: None,
+                    configuration: None,
+                    launch_new: false,
+                    skip_cache: false,
+                    floating: None,
+                    in_place: None,
+                    cwd: None,
+                    pane_title: None,
+                }),
+            },
             _ => Err("Unknown Action"),
         }
     }
@@ -1181,25 +1198,16 @@ impl TryFrom<Action> for ProtobufAction {
                 skip_plugin_cache,
                 _cwd,
                 _coordinates,
-            ) => {
-                //                 let plugin_url: Url = match run_plugin {
-                //                     RunPluginOrAlias::RunPlugin(run_plugin) => Url::from(&run_plugin.location),
-                //                     RunPluginOrAlias::Alias(plugin_alias) => {
-                //                         // TODO: support plugin alias
-                //                         unimplemented!()
-                //                     }
-                //                 };
-                Ok(ProtobufAction {
-                    name: ProtobufActionName::NewFloatingPluginPane as i32,
-                    optional_payload: Some(OptionalPayload::NewFloatingPluginPanePayload(
-                        NewPluginPanePayload {
-                            plugin_url: run_plugin.location_string(),
-                            pane_name,
-                            skip_plugin_cache,
-                        },
-                    )),
-                })
-            },
+            ) => Ok(ProtobufAction {
+                name: ProtobufActionName::NewFloatingPluginPane as i32,
+                optional_payload: Some(OptionalPayload::NewFloatingPluginPanePayload(
+                    NewPluginPanePayload {
+                        plugin_url: run_plugin.location_string(),
+                        pane_name,
+                        skip_plugin_cache,
+                    },
+                )),
+            }),
             Action::StartOrReloadPlugin(run_plugin) => Ok(ProtobufAction {
                 name: ProtobufActionName::StartOrReloadPlugin as i32,
                 optional_payload: Some(OptionalPayload::StartOrReloadPluginPayload(
@@ -1272,6 +1280,10 @@ impl TryFrom<Action> for ProtobufAction {
             Action::RenameSession(session_name) => Ok(ProtobufAction {
                 name: ProtobufActionName::RenameSession as i32,
                 optional_payload: Some(OptionalPayload::RenameSessionPayload(session_name)),
+            }),
+            Action::KeybindPipe { .. } => Ok(ProtobufAction {
+                name: ProtobufActionName::KeybindPipe as i32,
+                optional_payload: None,
             }),
             Action::NoOp
             | Action::Confirm

--- a/zellij-utils/src/plugin_api/pipe_message.proto
+++ b/zellij-utils/src/plugin_api/pipe_message.proto
@@ -15,6 +15,7 @@ message PipeMessage {
 enum PipeSource {
   Cli = 0;
   Plugin = 1;
+  Keybind = 2;
 }
 
 message Arg {

--- a/zellij-utils/src/plugin_api/pipe_message.rs
+++ b/zellij-utils/src/plugin_api/pipe_message.rs
@@ -19,6 +19,7 @@ impl TryFrom<ProtobufPipeMessage> for PipeMessage {
             (Some(ProtobufPipeSource::Plugin), _, Some(plugin_source_id)) => {
                 PipeSource::Plugin(plugin_source_id)
             },
+            (Some(ProtobufPipeSource::Keybind), _, _) => PipeSource::Keybind,
             _ => return Err("Invalid PipeSource or payload"),
         };
         let name = protobuf_pipe_message.name;
@@ -49,6 +50,7 @@ impl TryFrom<PipeMessage> for ProtobufPipeMessage {
             PipeSource::Plugin(plugin_id) => {
                 (ProtobufPipeSource::Plugin as i32, None, Some(plugin_id))
             },
+            PipeSource::Keybind => (ProtobufPipeSource::Keybind as i32, None, None),
         };
         let name = pipe_message.name;
         let payload = pipe_message.payload;


### PR DESCRIPTION
This adds a pipe interface, similar to the one already existing in the command line, to keybindings.

This allows users to bind a `MessagePlugin` action in the keybindings configuration.

eg.
```kdl
        bind "Alt w" {
             // filepicker is the built-in alias, but any plugin url can be used (eg. https://example.com/my-plugin.wasm)
            MessagePlugin "filepicker" {
                name "optional_message_name"
                payload "optional_message_payload"
                should_float true // if this message results in loading a new plugin, should it float
                launch_new true // force a new plugin to be launched even if an existing one with this destination/config is running
                skip_cache true // if launching a new plugin, skip the plugin cache and force recompiling it (good for development)
                title "this will be the pane title if launching a new plugin"
                arbitrary_key "arbitrary_value" // will be considered plugin configuration
            }
        }
```