### PR TITLE
Update `mio` to the latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,36 +2181,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.14"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
-dependencies = [
- "libc",
- "log",
- "miow",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2292,7 +2270,7 @@ dependencies = [
  "inotify",
  "kqueue",
  "libc",
- "mio 0.8.6",
+ "mio",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -5070,7 +5048,7 @@ version = "0.40.0"
 dependencies = [
  "insta",
  "log",
- "mio 0.7.14",
+ "mio",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/zellij-client/Cargo.toml
+++ b/zellij-client/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-mio = { version = "0.7.11", features = ['os-ext'] }
+mio = { version = "0.8.11", features = ['os-ext'] }
 serde = { version = "1.0", features = ["derive"] }
 url = { version = "2.2.2", features = ["serde"] }
 serde_yaml = "0.8"


### PR DESCRIPTION
This is one package that previously depended on an outdated version of `ntapi`, which is causing build issues at
<https://github.com/zellij-org/zellij/issues/2760>.