### PR TITLE
fix(swap-layouts): properly identify plugin aliases

### DIFF
--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -425,12 +425,20 @@ impl RunPlugin {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Hash, Default, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, Clone, Hash, Default, Eq)]
 pub struct PluginAlias {
     pub name: String,
     pub configuration: Option<PluginUserConfiguration>,
     pub initial_cwd: Option<PathBuf>,
     pub run_plugin: Option<RunPlugin>,
+}
+
+impl PartialEq for PluginAlias {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.configuration == other.configuration
+            && self.initial_cwd == other.initial_cwd
+    }
 }
 
 impl PluginAlias {


### PR DESCRIPTION
This fixes an issue introduced with plugin aliases recently. The issue was that when swapping layouts, we would not identify the plugin aliases properly and instead just place them randomly around the tab (sometimes in a very bad manner like swapping UI panes such as the status-bar with other plugins). This fixes it by properly comparing aliases regardless of whether we've interpreted them yet or not.