### PR TITLE
fix(startup): recover from race condition that causes Zellij to start in the wrong size

### DIFF
--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -51,6 +51,7 @@ pub(crate) enum ClientInstruction {
     SetSynchronizedOutput(Option<SyncOutput>),
     UnblockCliPipeInput(String),   // String -> pipe name
     CliPipeOutput(String, String), // String -> pipe name, String -> output
+    QueryTerminalSize,
 }
 
 impl From<ServerToClientMsg> for ClientInstruction {
@@ -75,6 +76,7 @@ impl From<ServerToClientMsg> for ClientInstruction {
             ServerToClientMsg::CliPipeOutput(pipe_name, output) => {
                 ClientInstruction::CliPipeOutput(pipe_name, output)
             },
+            ServerToClientMsg::QueryTerminalSize => ClientInstruction::QueryTerminalSize,
         }
     }
 }
@@ -97,6 +99,7 @@ impl From<&ClientInstruction> for ClientContext {
             ClientInstruction::SetSynchronizedOutput(..) => ClientContext::SetSynchronisedOutput,
             ClientInstruction::UnblockCliPipeInput(..) => ClientContext::UnblockCliPipeInput,
             ClientInstruction::CliPipeOutput(..) => ClientContext::CliPipeOutput,
+            ClientInstruction::QueryTerminalSize => ClientContext::QueryTerminalSize,
         }
     }
 }
@@ -499,6 +502,11 @@ pub fn start_client(
             ClientInstruction::SetSynchronizedOutput(enabled) => {
                 synchronised_output = enabled;
             },
+            ClientInstruction::QueryTerminalSize => {
+                os_input.send_to_server(ClientToServerMsg::TerminalResize(
+                    os_input.get_terminal_size_using_fd(0),
+                ));
+            }
             _ => {},
         }
     }

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -506,7 +506,7 @@ pub fn start_client(
                 os_input.send_to_server(ClientToServerMsg::TerminalResize(
                     os_input.get_terminal_size_using_fd(0),
                 ));
-            }
+            },
             _ => {},
         }
     }

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -3008,10 +3008,8 @@ pub(crate) fn screen_thread_main(
                 // very short and cheap and shouldn't cause any trouble
                 if let Some(os_input) = &mut screen.bus.os_input {
                     for client_id in screen.connected_clients.borrow().iter() {
-                        let _ = os_input.send_to_client(
-                            *client_id,
-                            ServerToClientMsg::QueryTerminalSize
-                        );
+                        let _ = os_input
+                            .send_to_client(*client_id, ServerToClientMsg::QueryTerminalSize);
                     }
                 }
             },

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -424,6 +424,7 @@ pub enum ClientContext {
     SetSynchronisedOutput,
     UnblockCliPipeInput,
     CliPipeOutput,
+    QueryTerminalSize,
 }
 
 /// Stack call representations corresponding to the different types of [`ServerInstruction`]s.

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -105,6 +105,7 @@ pub enum ServerToClientMsg {
     SwitchSession(ConnectToSession),
     UnblockCliPipeInput(String),   // String -> pipe name
     CliPipeOutput(String, String), // String -> pipe name, String -> Output
+    QueryTerminalSize,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
This fixes several issues in which Zellij starts up without filling up the whole terminal window.

While the race condition is arguably the responsibility of the terminal emulator (starting the program on the secondary side of the PTY without first setting the size of the STDOUT fd - essentially passing it to termios if in the context of *nix systems), we should definitely be able to recover from this - which is what this PR does.