### PR TITLE
style(fmt): fix warnings

### DIFF
--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -443,7 +443,7 @@ struct RawFdAsyncReader {
 impl RawFdAsyncReader {
     fn new(fd: RawFd) -> RawFdAsyncReader {
         RawFdAsyncReader {
-            /// The supplied `RawFd` is consumed by the created `RawFdAsyncReader`, closing it when dropped
+            // The supplied `RawFd` is consumed by the created `RawFdAsyncReader`, closing it when dropped
             fd: unsafe { AsyncFile::from_raw_fd(fd) },
         }
     }

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -25,7 +25,7 @@ use zellij_utils::{
     data::{ModeInfo, Style},
     errors::prelude::*,
     input::command::RunCommand,
-    input::layout::{FloatingPaneLayout, Run, RunPlugin, RunPluginOrAlias},
+    input::layout::{FloatingPaneLayout, Run, RunPluginOrAlias},
     pane_size::{Dimension, Offset, PaneGeom, Size, SizeInPixels, Viewport},
 };
 

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -22,7 +22,7 @@ use zellij_utils::{
     errors::prelude::*,
     input::{
         command::RunCommand,
-        layout::{Run, RunPlugin, RunPluginOrAlias, SplitDirection},
+        layout::{Run, RunPluginOrAlias, SplitDirection},
     },
     pane_size::{Offset, PaneGeom, Size, SizeInPixels, Viewport},
 };

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -18,10 +18,7 @@ use zellij_utils::{
     errors::{ContextType, PtyContext},
     input::{
         command::{RunCommand, TerminalAction},
-        layout::{
-            FloatingPaneLayout, Layout, Run,
-            RunPluginOrAlias, TiledPaneLayout,
-        },
+        layout::{FloatingPaneLayout, Layout, Run, RunPluginOrAlias, TiledPaneLayout},
     },
     pane_size::Size,
     session_serialization,

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -19,7 +19,7 @@ use zellij_utils::{
     input::{
         command::{RunCommand, TerminalAction},
         layout::{
-            FloatingPaneLayout, Layout, PluginUserConfiguration, Run, RunPluginLocation,
+            FloatingPaneLayout, Layout, Run,
             RunPluginOrAlias, TiledPaneLayout,
         },
     },
@@ -1344,7 +1344,9 @@ impl Pty {
         size: Size,
         skip_cache: bool,
         cwd: Option<PathBuf>,
-        floating_pane_coordinates: Option<FloatingPaneCoordinates>,
+        // left here for historical and potential future reasons since we might change the ordering
+        // of the pipeline between threads and end up needing to forward this
+        _floating_pane_coordinates: Option<FloatingPaneCoordinates>,
     ) -> Result<()> {
         let cwd = cwd.or_else(|| {
             self.active_panes

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -20,8 +20,8 @@ use zellij_utils::{
     envs::set_session_name,
     input::command::TerminalAction,
     input::layout::{
-        FloatingPaneLayout, Layout, Run, RunPluginOrAlias,
-        SwapFloatingLayout, SwapTiledLayout, TiledPaneLayout,
+        FloatingPaneLayout, Layout, Run, RunPluginOrAlias, SwapFloatingLayout, SwapTiledLayout,
+        TiledPaneLayout,
     },
     position::Position,
 };

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -20,7 +20,7 @@ use zellij_utils::{
     envs::set_session_name,
     input::command::TerminalAction,
     input::layout::{
-        FloatingPaneLayout, Layout, Run, RunPlugin, RunPluginLocation, RunPluginOrAlias,
+        FloatingPaneLayout, Layout, Run, RunPluginOrAlias,
         SwapFloatingLayout, SwapTiledLayout, TiledPaneLayout,
     },
     position::Position,
@@ -3865,7 +3865,7 @@ pub(crate) fn screen_thread_main(
                     // update state
                     screen.session_name = name.clone();
                     screen.default_mode_info.session_name = Some(name.clone());
-                    for (_client_id, mut mode_info) in screen.mode_info.iter_mut() {
+                    for (_client_id, mode_info) in screen.mode_info.iter_mut() {
                         mode_info.session_name = Some(name.clone());
                     }
                     for (_, tab) in screen.tabs.iter_mut() {

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -50,7 +50,7 @@ use zellij_utils::{
     input::{
         command::TerminalAction,
         layout::{
-            FloatingPaneLayout, PluginUserConfiguration, Run, RunPlugin, RunPluginLocation,
+            FloatingPaneLayout, Run,
             RunPluginOrAlias, SwapFloatingLayout, SwapTiledLayout, TiledPaneLayout,
         },
         parse_keys,

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -50,8 +50,8 @@ use zellij_utils::{
     input::{
         command::TerminalAction,
         layout::{
-            FloatingPaneLayout, Run,
-            RunPluginOrAlias, SwapFloatingLayout, SwapTiledLayout, TiledPaneLayout,
+            FloatingPaneLayout, Run, RunPluginOrAlias, SwapFloatingLayout, SwapTiledLayout,
+            TiledPaneLayout,
         },
         parse_keys,
     },

--- a/zellij-utils/src/plugin_api/event.rs
+++ b/zellij-utils/src/plugin_api/event.rs
@@ -14,6 +14,7 @@ pub use super::generated_api::api::{
     key::Key as ProtobufKey,
     style::Style as ProtobufStyle,
 };
+#[allow(hidden_glob_reexports)]
 use crate::data::{
     CopyDestination, Event, EventType, FileMetadata, InputMode, Key, LayoutInfo, ModeInfo, Mouse,
     PaneInfo, PaneManifest, PermissionStatus, PluginCapabilities, SessionInfo, Style, TabInfo,


### PR DESCRIPTION
Removes some warnings added when we upgraded our Rust version.