### PR TITLE
fix(plugins): session layouts are still serialized using the legacy plugin syntax (remote:)

### DIFF
--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -571,7 +571,7 @@ impl RunPluginLocation {
         match self {
             RunPluginLocation::File(pathbuf) => format!("file:{}", pathbuf.display()),
             RunPluginLocation::Zellij(plugin_tag) => format!("zellij:{}", plugin_tag),
-            RunPluginLocation::Remote(url) => format!("remote:{}", url),
+            RunPluginLocation::Remote(url) => String::from(url),
         }
     }
 }
@@ -584,7 +584,7 @@ impl From<&RunPluginLocation> for Url {
                 path.clone().into_os_string().into_string().unwrap()
             ),
             RunPluginLocation::Zellij(tag) => format!("zellij:{}", tag),
-            RunPluginLocation::Remote(url) => format!("remote:{}", url),
+            RunPluginLocation::Remote(url) => String::from(url),
         };
         Self::parse(&url).unwrap()
     }

--- a/zellij-utils/src/input/unit/layout_test.rs
+++ b/zellij-utils/src/input/unit/layout_test.rs
@@ -2085,6 +2085,9 @@ fn run_plugin_location_parsing() {
             pane {
                 plugin location="filepicker"
             }
+            pane {
+                plugin location="https://somewhere.com/plugin.wasm"
+            }
         }
     "#;
     let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
@@ -2158,6 +2161,15 @@ fn run_plugin_location_parsing() {
                         run: Some(Run::Plugin(RunPluginOrAlias::Alias(PluginAlias {
                             name: "filepicker".to_owned(),
                             configuration: Some(PluginUserConfiguration::default()),
+                            ..Default::default()
+                        }))),
+                        ..Default::default()
+                    },
+                    TiledPaneLayout {
+                        run: Some(Run::Plugin(RunPluginOrAlias::RunPlugin(RunPlugin {
+                            _allow_exec_host_cmd: false,
+                            location: RunPluginLocation::Remote(String::from("https://somewhere.com/plugin.wasm")),
+                            configuration: Default::default(),
                             ..Default::default()
                         }))),
                         ..Default::default()

--- a/zellij-utils/src/input/unit/layout_test.rs
+++ b/zellij-utils/src/input/unit/layout_test.rs
@@ -2086,7 +2086,7 @@ fn run_plugin_location_parsing() {
                 plugin location="filepicker"
             }
             pane {
-                plugin location="https://somewhere.com/plugin.wasm"
+                plugin location="https://example.com/plugin.wasm"
             }
         }
     "#;
@@ -2168,7 +2168,7 @@ fn run_plugin_location_parsing() {
                     TiledPaneLayout {
                         run: Some(Run::Plugin(RunPluginOrAlias::RunPlugin(RunPlugin {
                             _allow_exec_host_cmd: false,
-                            location: RunPluginLocation::Remote(String::from("https://somewhere.com/plugin.wasm")),
+                            location: RunPluginLocation::Remote(String::from("https://example.com/plugin.wasm")),
                             configuration: Default::default(),
                             ..Default::default()
                         }))),

--- a/zellij-utils/src/input/unit/layout_test.rs
+++ b/zellij-utils/src/input/unit/layout_test.rs
@@ -2168,7 +2168,9 @@ fn run_plugin_location_parsing() {
                     TiledPaneLayout {
                         run: Some(Run::Plugin(RunPluginOrAlias::RunPlugin(RunPlugin {
                             _allow_exec_host_cmd: false,
-                            location: RunPluginLocation::Remote(String::from("https://example.com/plugin.wasm")),
+                            location: RunPluginLocation::Remote(String::from(
+                                "https://example.com/plugin.wasm",
+                            )),
                             configuration: Default::default(),
                             ..Default::default()
                         }))),


### PR DESCRIPTION
In #2863 and #3157, remote plugins are now designed with their raw URL directly, without the `remote:` prefix but they were still serialized using the `remote:` prefix in session layouts.
As a result, session using remote plugins were not able to restore remote plugins (like `zjstatus`).
This PR just apply the same serialization everywhere to ensure no more `remote:` prefix is used.