### PR TITLE
fix(ui): session manager UI fixes

### DIFF
--- a/default-plugins/session-manager/src/main.rs
+++ b/default-plugins/session-manager/src/main.rs
@@ -383,6 +383,14 @@ impl State {
     fn handle_selection(&mut self) {
         match self.active_screen {
             ActiveScreen::NewSession => {
+                if self.new_session_info.name().len() >= 108 {
+                    // this is due to socket path limitations
+                    // TODO: get this from Zellij (for reference: this is part of the interprocess
+                    // package, we should get if from there if possible because it's configurable
+                    // through the package)
+                    self.show_error("Session name must be shorter than 108 bytes");
+                    return;
+                }
                 self.new_session_info.handle_selection(&self.session_name);
             },
             ActiveScreen::AttachToSession => {

--- a/default-plugins/session-manager/src/new_session_info.rs
+++ b/default-plugins/session-manager/src/new_session_info.rs
@@ -128,7 +128,11 @@ impl NewSessionInfo {
     }
     pub fn layout_list(&self, max_rows: usize) -> Vec<(LayoutInfo, bool)> {
         // bool - is_selected
-        let range_to_render = self.range_to_render(max_rows, self.layout_count(), Some(self.layout_list.selected_layout_index));
+        let range_to_render = self.range_to_render(
+            max_rows,
+            self.layout_count(),
+            Some(self.layout_list.selected_layout_index),
+        );
         self.layout_list
             .layout_list
             .iter()
@@ -162,7 +166,11 @@ impl NewSessionInfo {
     }
     pub fn layout_search_results(&self, max_rows: usize) -> Vec<(LayoutSearchResult, bool)> {
         // bool - is_selected
-        let range_to_render = self.range_to_render(max_rows, self.layout_list.layout_search_results.len(), Some(self.layout_list.selected_layout_index));
+        let range_to_render = self.range_to_render(
+            max_rows,
+            self.layout_list.layout_search_results.len(),
+            Some(self.layout_list.selected_layout_index),
+        );
         self.layout_list
             .layout_search_results
             .iter()

--- a/default-plugins/session-manager/src/ui/components.rs
+++ b/default-plugins/session-manager/src/ui/components.rs
@@ -709,11 +709,14 @@ pub fn render_new_session_block(
                 long_instruction,
             );
         } else {
-            let space_for_new_session_name = max_cols_of_new_session_block.saturating_sub(prompt.width() + 18);
+            let space_for_new_session_name =
+                max_cols_of_new_session_block.saturating_sub(prompt.width() + 18);
             let new_session_name = if new_session_name.width() > space_for_new_session_name {
                 let mut truncated = String::new();
                 for character in new_session_name.chars().rev() {
-                    if truncated.width() + character.width().unwrap_or(0) < space_for_new_session_name {
+                    if truncated.width() + character.width().unwrap_or(0)
+                        < space_for_new_session_name
+                    {
                         truncated.push(character);
                     } else {
                         break;
@@ -805,8 +808,10 @@ pub fn render_layout_selection_list(
     print_text_with_coordinates(layout_indication_line, x, y + 1, None, None);
     println!();
     let mut table = Table::new();
-    for (i, (layout_info, indices, is_selected)) in
-        new_session_info.layouts_to_render(max_rows_of_new_session_block).into_iter().enumerate()
+    for (i, (layout_info, indices, is_selected)) in new_session_info
+        .layouts_to_render(max_rows_of_new_session_block)
+        .into_iter()
+        .enumerate()
     {
         let layout_name = layout_info.name();
         let layout_name_len = layout_name.width();

--- a/default-plugins/session-manager/src/ui/components.rs
+++ b/default-plugins/session-manager/src/ui/components.rs
@@ -747,18 +747,23 @@ pub fn render_new_session_block(
         }
         render_layout_selection_list(
             new_session_info,
-            colors,
             max_rows_of_new_session_block.saturating_sub(1),
             max_cols_of_new_session_block,
             x,
             y + 1,
         );
     }
+    render_new_session_folder_prompt(
+        new_session_info,
+        colors,
+        x,
+        (y + max_rows_of_new_session_block).saturating_sub(3),
+        max_cols_of_new_session_block,
+    );
 }
 
 pub fn render_layout_selection_list(
     new_session_info: &NewSessionInfo,
-    colors: Colors,
     max_rows_of_new_session_block: usize,
     max_cols_of_new_session_block: usize,
     x: usize,
@@ -818,13 +823,6 @@ pub fn render_layout_selection_list(
     }
     let table_y = y + 3;
     print_table_with_coordinates(table, x, table_y, None, None);
-    render_new_session_folder_prompt(
-        new_session_info,
-        colors,
-        x,
-        (y + max_rows_of_new_session_block).saturating_sub(3),
-        max_cols_of_new_session_block,
-    );
 }
 
 pub fn render_error(error_text: &str, rows: usize, columns: usize, x: usize, y: usize) {

--- a/default-plugins/session-manager/src/ui/components.rs
+++ b/default-plugins/session-manager/src/ui/components.rs
@@ -761,7 +761,7 @@ pub fn render_new_session_block(
         }
         render_layout_selection_list(
             new_session_info,
-            max_rows_of_new_session_block.saturating_sub(1),
+            max_rows_of_new_session_block.saturating_sub(8),
             max_cols_of_new_session_block,
             x,
             y + 1,
@@ -806,7 +806,7 @@ pub fn render_layout_selection_list(
     println!();
     let mut table = Table::new();
     for (i, (layout_info, indices, is_selected)) in
-        new_session_info.layouts_to_render().into_iter().enumerate()
+        new_session_info.layouts_to_render(max_rows_of_new_session_block).into_iter().enumerate()
     {
         let layout_name = layout_info.name();
         let layout_name_len = layout_name.width();

--- a/default-plugins/session-manager/src/ui/components.rs
+++ b/default-plugins/session-manager/src/ui/components.rs
@@ -709,6 +709,20 @@ pub fn render_new_session_block(
                 long_instruction,
             );
         } else {
+            let space_for_new_session_name = max_cols_of_new_session_block.saturating_sub(prompt.width() + 18);
+            let new_session_name = if new_session_name.width() > space_for_new_session_name {
+                let mut truncated = String::new();
+                for character in new_session_name.chars().rev() {
+                    if truncated.width() + character.width().unwrap_or(0) < space_for_new_session_name {
+                        truncated.push(character);
+                    } else {
+                        break;
+                    }
+                }
+                format!("...{}", truncated.chars().rev().collect::<String>())
+            } else {
+                new_session_name.to_owned()
+            };
             println!(
                 "\u{1b}[m{}{} {}_ {}",
                 format!("\u{1b}[{};{}H", y + 1, x + 1),


### PR DESCRIPTION
This fixes three issues with the session manager/welcome screen when starting a new session:
1. The "New session folder:" prompt now always appears in the UI, whether actively selecting a layout or not
2. The session-name is now truncated properly if it's too long to fit on screen
3. Scrolling through the layout list and the layout search results now works as intended