### PR TITLE
feat(plugins): add api to dump the current session layout to a plugin

### DIFF
--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -2,7 +2,7 @@ use crate::background_jobs::BackgroundJob;
 use crate::terminal_bytes::TerminalBytes;
 use crate::{
     panes::PaneId,
-    plugins::PluginInstruction,
+    plugins::{PluginId, PluginInstruction},
     screen::ScreenInstruction,
     session_layout_metadata::SessionLayoutMetadata,
     thread_bus::{Bus, ThreadSenders},
@@ -77,6 +77,7 @@ pub enum PtyInstruction {
         ClientTabIndexOrPaneId,
     ), // String is an optional pane name
     DumpLayout(SessionLayoutMetadata, ClientId),
+    DumpLayoutToPlugin(SessionLayoutMetadata, PluginId),
     LogLayoutToHd(SessionLayoutMetadata),
     FillPluginCwd(
         Option<bool>,   // should float
@@ -110,6 +111,7 @@ impl From<&PtyInstruction> for PtyContext {
             PtyInstruction::DropToShellInPane { .. } => PtyContext::DropToShellInPane,
             PtyInstruction::SpawnInPlaceTerminal(..) => PtyContext::SpawnInPlaceTerminal,
             PtyInstruction::DumpLayout(..) => PtyContext::DumpLayout,
+            PtyInstruction::DumpLayoutToPlugin(..) => PtyContext::DumpLayoutToPlugin,
             PtyInstruction::LogLayoutToHd(..) => PtyContext::LogLayoutToHd,
             PtyInstruction::FillPluginCwd(..) => PtyContext::FillPluginCwd,
             PtyInstruction::Exit => PtyContext::Exit,
@@ -629,6 +631,18 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                             .non_fatal();
                     },
                 }
+            },
+            PtyInstruction::DumpLayoutToPlugin(mut session_layout_metadata, plugin_id) => {
+                let err_context = || format!("Failed to dump layout");
+                pty.populate_session_layout_metadata(&mut session_layout_metadata);
+                pty.bus
+                    .senders
+                    .send_to_plugin(PluginInstruction::DumpLayoutToPlugin(
+                        session_layout_metadata,
+                        plugin_id,
+                    ))
+                    .with_context(err_context)
+                    .non_fatal();
             },
             PtyInstruction::LogLayoutToHd(mut session_layout_metadata) => {
                 let err_context = || format!("Failed to dump layout");

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -784,6 +784,14 @@ pub fn watch_filesystem() {
     unsafe { host_run_plugin_command() };
 }
 
+/// Get the serialized session layout in KDL format as a CustomMessage Event
+pub fn dump_session_layout() {
+    let plugin_command = PluginCommand::DumpSessionLayout;
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
 // Utility Functions
 
 #[allow(unused)]

--- a/zellij-utils/assets/prost/api.plugin_command.rs
+++ b/zellij-utils/assets/prost/api.plugin_command.rs
@@ -420,6 +420,7 @@ pub enum CommandName {
     KillSessions = 81,
     ScanHostFolder = 82,
     WatchFilesystem = 83,
+    DumpSessionLayout = 84,
 }
 impl CommandName {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -512,6 +513,7 @@ impl CommandName {
             CommandName::KillSessions => "KillSessions",
             CommandName::ScanHostFolder => "ScanHostFolder",
             CommandName::WatchFilesystem => "WatchFilesystem",
+            CommandName::DumpSessionLayout => "DumpSessionLayout",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -601,6 +603,7 @@ impl CommandName {
             "KillSessions" => Some(Self::KillSessions),
             "ScanHostFolder" => Some(Self::ScanHostFolder),
             "WatchFilesystem" => Some(Self::WatchFilesystem),
+            "DumpSessionLayout" => Some(Self::DumpSessionLayout),
             _ => None,
         }
     }

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -1378,4 +1378,5 @@ pub enum PluginCommand {
     KillSessions(Vec<String>), // one or more session names
     ScanHostFolder(PathBuf),   // TODO: rename to ScanHostFolder
     WatchFilesystem,
+    DumpSessionLayout,
 }

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -351,6 +351,7 @@ pub enum ScreenContext {
     NewInPlacePluginPane,
     DumpLayoutToHd,
     RenameSession,
+    DumpLayoutToPlugin,
 }
 
 /// Stack call representations corresponding to the different types of [`PtyInstruction`]s.
@@ -371,6 +372,7 @@ pub enum PtyContext {
     DumpLayout,
     LogLayoutToHd,
     FillPluginCwd,
+    DumpLayoutToPlugin,
     Exit,
 }
 
@@ -402,6 +404,7 @@ pub enum PluginContext {
     UnblockCliPipes,
     WatchFilesystem,
     KeybindPipe,
+    DumpLayoutToPlugin,
 }
 
 /// Stack call representations corresponding to the different types of [`ClientInstruction`]s.

--- a/zellij-utils/src/plugin_api/plugin_command.proto
+++ b/zellij-utils/src/plugin_api/plugin_command.proto
@@ -95,6 +95,7 @@ enum CommandName {
   KillSessions = 81;
   ScanHostFolder = 82;
   WatchFilesystem = 83;
+  DumpSessionLayout = 84;
 }
 
 message PluginCommand {

--- a/zellij-utils/src/plugin_api/plugin_command.rs
+++ b/zellij-utils/src/plugin_api/plugin_command.rs
@@ -867,6 +867,10 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
                 Some(_) => Err("WatchFilesystem should have no payload, found a payload"),
                 None => Ok(PluginCommand::WatchFilesystem),
             },
+            Some(CommandName::DumpSessionLayout) => match protobuf_plugin_command.payload {
+                Some(_) => Err("DumpSessionLayout should have no payload, found a payload"),
+                None => Ok(PluginCommand::DumpSessionLayout),
+            },
             None => Err("Unrecognized plugin command"),
         }
     }
@@ -1379,6 +1383,10 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
             }),
             PluginCommand::WatchFilesystem => Ok(ProtobufPluginCommand {
                 name: CommandName::WatchFilesystem as i32,
+                payload: None,
+            }),
+            PluginCommand::DumpSessionLayout => Ok(ProtobufPluginCommand {
+                name: CommandName::DumpSessionLayout as i32,
                 payload: None,
             }),
         }


### PR DESCRIPTION
This adds a plugin API that allows plugins to request the serialized layout of the current session. The serialized KDL layout will be returned as a `CustomMessage` API `Event` with the `session_layout` key. If there's an error, a `CustomMessage` API `Event` will be returned with the `session_layout_error` key. Either way, the plugin needs to subscribe to the `CustomMessage` `Event`.

This requires the `ReadApplicationState` permissions.