### PR TITLE
feat(plugins): add api to close current plugin instance

### DIFF
--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -249,6 +249,14 @@ pub fn show_self(should_float_if_hidden: bool) {
     unsafe { host_run_plugin_command() };
 }
 
+/// Close this plugin pane
+pub fn close_self() {
+    let plugin_command = PluginCommand::CloseSelf;
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
 /// Switch to the specified Input Mode (eg. `Normal`, `Tab`, `Pane`)
 pub fn switch_to_input_mode(mode: &InputMode) {
     let plugin_command = PluginCommand::SwitchToMode(*mode);

--- a/zellij-utils/assets/prost/api.plugin_command.rs
+++ b/zellij-utils/assets/prost/api.plugin_command.rs
@@ -421,6 +421,7 @@ pub enum CommandName {
     ScanHostFolder = 82,
     WatchFilesystem = 83,
     DumpSessionLayout = 84,
+    CloseSelf = 85,
 }
 impl CommandName {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -514,6 +515,7 @@ impl CommandName {
             CommandName::ScanHostFolder => "ScanHostFolder",
             CommandName::WatchFilesystem => "WatchFilesystem",
             CommandName::DumpSessionLayout => "DumpSessionLayout",
+            CommandName::CloseSelf => "CloseSelf",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -604,6 +606,7 @@ impl CommandName {
             "ScanHostFolder" => Some(Self::ScanHostFolder),
             "WatchFilesystem" => Some(Self::WatchFilesystem),
             "DumpSessionLayout" => Some(Self::DumpSessionLayout),
+            "CloseSelf" => Some(Self::CloseSelf),
             _ => None,
         }
     }

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -1379,4 +1379,5 @@ pub enum PluginCommand {
     ScanHostFolder(PathBuf),   // TODO: rename to ScanHostFolder
     WatchFilesystem,
     DumpSessionLayout,
+    CloseSelf,
 }

--- a/zellij-utils/src/plugin_api/plugin_command.proto
+++ b/zellij-utils/src/plugin_api/plugin_command.proto
@@ -96,6 +96,7 @@ enum CommandName {
   ScanHostFolder = 82;
   WatchFilesystem = 83;
   DumpSessionLayout = 84;
+  CloseSelf = 85;
 }
 
 message PluginCommand {

--- a/zellij-utils/src/plugin_api/plugin_command.rs
+++ b/zellij-utils/src/plugin_api/plugin_command.rs
@@ -871,6 +871,10 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
                 Some(_) => Err("DumpSessionLayout should have no payload, found a payload"),
                 None => Ok(PluginCommand::DumpSessionLayout),
             },
+            Some(CommandName::CloseSelf) => match protobuf_plugin_command.payload {
+                Some(_) => Err("CloseSelf should have no payload, found a payload"),
+                None => Ok(PluginCommand::CloseSelf),
+            },
             None => Err("Unrecognized plugin command"),
         }
     }
@@ -1387,6 +1391,10 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
             }),
             PluginCommand::DumpSessionLayout => Ok(ProtobufPluginCommand {
                 name: CommandName::DumpSessionLayout as i32,
+                payload: None,
+            }),
+            PluginCommand::CloseSelf => Ok(ProtobufPluginCommand {
+                name: CommandName::CloseSelf as i32,
                 payload: None,
             }),
         }


### PR DESCRIPTION
This adds the `close_self` plugin API method that will allow plugins to close the current instance regardless of whether it's focused or not.