### PR TITLE
style(fmt): remove plugin compilation warnings

### DIFF
--- a/default-plugins/session-manager/src/new_session_info.rs
+++ b/default-plugins/session-manager/src/new_session_info.rs
@@ -1,6 +1,5 @@
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
-use std::cmp::Ordering;
 use std::path::PathBuf;
 use zellij_tile::prelude::*;
 
@@ -30,9 +29,6 @@ impl NewSessionInfo {
     }
     pub fn layout_search_term(&self) -> &str {
         &self.layout_list.layout_search_term
-    }
-    pub fn entering_new_session_info(&self) -> bool {
-        true
     }
     pub fn entering_new_session_name(&self) -> bool {
         self.entering_new_session_info == EnteringState::EnteringName

--- a/default-plugins/strider/src/file_list_view.rs
+++ b/default-plugins/strider/src/file_list_view.rs
@@ -161,7 +161,7 @@ impl FsEntry {
     }
     pub fn size(&self) -> Option<u64> {
         match self {
-            FsEntry::Dir(p) => None,
+            FsEntry::Dir(_p) => None,
             FsEntry::File(_, size) => Some(*size),
         }
     }


### PR DESCRIPTION
Removes some compilation warnings from the built-in plugins