### PR TITLE
feat(plugins): allow plugins to specify own_url in pipe destination

### DIFF
--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -320,7 +320,13 @@ fn cli_pipe_output(env: &ForeignFunctionEnv, pipe_name: String, output: String) 
         .context("failed to send pipe output")
 }
 
-fn message_to_plugin(env: &ForeignFunctionEnv, message_to_plugin: MessageToPlugin) -> Result<()> {
+fn message_to_plugin(
+    env: &ForeignFunctionEnv,
+    mut message_to_plugin: MessageToPlugin,
+) -> Result<()> {
+    if message_to_plugin.plugin_url.as_ref().map(|s| s.as_str()) == Some("zellij:OWN_URL") {
+        message_to_plugin.plugin_url = Some(env.plugin_env.plugin.location.display());
+    }
     env.plugin_env
         .senders
         .send_to_plugin(PluginInstruction::MessageFromPlugin {


### PR DESCRIPTION
Plugins can often be in a position where they want to start another instance of themselves. While this could previously be done by starting a pipe to the same URL this plugin was launched with (eg. `https://example.com/my-plugin.wasm`), this would force the plugin to know which url it was launched from, whether it was launched through an alias, through a local file or a remote http url.

This PR solves this by allowing plugins to specify a special `zellij:OWN_URL` destination when posting messages to other plugins. When doing so, Zellij will internally replace this destination with the plugin's own URL.