### PR TITLE
Update auto-start.SHELL to allow session name specification

### DIFF
--- a/zellij-utils/assets/shell/auto-start.bash
+++ b/zellij-utils/assets/shell/auto-start.bash
@@ -1,6 +1,10 @@
 if [[ -z "$ZELLIJ" ]]; then
     if [[ "$ZELLIJ_AUTO_ATTACH" == "true" ]]; then
-        zellij attach -c
+        if [[ -z "$ZELLIJ_AUTO_ATTACH_SESSION_NAME" ]]; then
+            zellij attach -c
+        else
+            zellij attach -c "$ZELLIJ_AUTO_ATTACH_SESSION_NAME"
+        fi
     else
         zellij
     fi

--- a/zellij-utils/assets/shell/auto-start.fish
+++ b/zellij-utils/assets/shell/auto-start.fish
@@ -8,7 +8,11 @@
 # end
 if not set -q ZELLIJ
     if test "$ZELLIJ_AUTO_ATTACH" = "true"
-        zellij attach -c
+        if not set -q ZELLIJ_AUTO_ATTACH_SESSION_NAME
+            zellij attach -c
+        else
+            zellij attach -c $ZELLIJ_AUTO_ATTACH_SESSION_NAME
+        end
     else
         zellij
     end

--- a/zellij-utils/assets/shell/auto-start.zsh
+++ b/zellij-utils/assets/shell/auto-start.zsh
@@ -1,6 +1,10 @@
 if [[ -z "$ZELLIJ" ]]; then
     if [[ "$ZELLIJ_AUTO_ATTACH" == "true" ]]; then
-        zellij attach -c
+        if [[ -z "$ZELLIJ_AUTO_ATTACH_SESSION_NAME" ]]; then
+            zellij attach -c
+        else
+            zellij attach -c "$ZELLIJ_AUTO_ATTACH_SESSION_NAME"
+        fi
     else
         zellij
     fi


### PR DESCRIPTION
Add new variable, ZELLIJ_AUTO_ATTACH_SESSION_NAME so that users can specify to which session name zellij will try to attach automatically.

If variable is unset or empty, legacy behavior is preserved.