### PR TITLE
utils/cli: Add `move-tab` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix(plugins): properly serialize remote urls (https://github.com/zellij-org/zellij/pull/3224)
 * feat(plugins): add close_self API to allow plugins to close their own instance (https://github.com/zellij-org/zellij/pull/3228)
 * feat(plugins): allow plugins to specify `zellij:OWN_URL` as a pipe destination (https://github.com/zellij-org/zellij/pull/3232)
+* feat(cli): Add `move-tab` action (https://github.com/zellij-org/zellij/pull/3244)
 
 ## [0.39.2] - 2023-11-29
 * fix(cli): typo in cli help (https://github.com/zellij-org/zellij/pull/2906)

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -617,6 +617,10 @@ pub enum CliAction {
         #[clap(short, long, value_parser, requires("layout"))]
         cwd: Option<PathBuf>,
     },
+    /// Move the focused tab in the specified direction. [right|left]
+    MoveTab {
+        direction: Direction,
+    },
     PreviousSwapLayout,
     NextSwapLayout,
     /// Query all tab names

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -325,6 +325,7 @@ impl Action {
             CliAction::MoveFocusOrTab { direction } => Ok(vec![Action::MoveFocusOrTab(direction)]),
             CliAction::MovePane { direction } => Ok(vec![Action::MovePane(direction)]),
             CliAction::MovePaneBackwards => Ok(vec![Action::MovePaneBackwards]),
+            CliAction::MoveTab { direction } => Ok(vec![Action::MoveTab(direction)]),
             CliAction::Clear => Ok(vec![Action::ClearScreen]),
             CliAction::DumpScreen { path, full } => Ok(vec![Action::DumpScreen(
                 path.as_os_str().to_string_lossy().into(),


### PR DESCRIPTION
which was previously only exposed through keybindings. This is a follow-up to #3047 which likely forgot to add this.