### PR TITLE
fix(plugins): various pre-release issues

### DIFF
--- a/default-plugins/strider/src/state.rs
+++ b/default-plugins/strider/src/state.rs
@@ -158,7 +158,7 @@ impl State {
             }
         }
         if self.close_on_selection {
-            close_focus();
+            close_self();
         }
     }
     pub fn send_filepick_response(&mut self) {
@@ -178,7 +178,7 @@ impl State {
                         .with_payload(selected_path.display().to_string()),
                 );
                 #[cfg(target_family = "wasm")]
-                close_focus();
+                close_self();
             },
             Some((PipeSource::Cli(pipe_id), _args)) => {
                 #[cfg(target_family = "wasm")]
@@ -186,7 +186,7 @@ impl State {
                 #[cfg(target_family = "wasm")]
                 unblock_cli_pipe_input(pipe_id);
                 #[cfg(target_family = "wasm")]
-                close_focus();
+                close_self();
             },
             _ => {},
         }

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -3544,7 +3544,7 @@ pub(crate) fn screen_thread_main(
                             should_float,
                             Some(run_plugin),
                             None,
-                            None,
+                            Some(client_id),
                         )
                     }, ?);
                 } else if let Some(active_tab) =

--- a/zellij-utils/assets/config/default.kdl
+++ b/zellij-utils/assets/config/default.kdl
@@ -114,7 +114,7 @@ keybinds {
         bind "Ctrl s" { SwitchToMode "Scroll"; }
         bind "d" { Detach; }
         bind "w" {
-            LaunchOrFocusPlugin "zellij:session-manager" {
+            LaunchOrFocusPlugin "session-manager" {
                 floating true
                 move_to_focused_tab true
             };

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -380,15 +380,13 @@ impl Action {
                             })
                         },
                         Err(_) => {
-                            let mut user_configuration =
-                                configuration.map(|c| c.inner().clone()).unwrap_or_default();
-                            user_configuration
-                                .insert("caller_cwd".to_owned(), current_dir.display().to_string());
-                            RunPluginOrAlias::Alias(PluginAlias::new(
+                            let mut plugin_alias = PluginAlias::new(
                                 &plugin,
-                                &Some(user_configuration),
+                                &configuration.map(|c| c.inner().clone()),
                                 alias_cwd,
-                            ))
+                            );
+                            plugin_alias.set_caller_cwd_if_not_set(Some(current_dir));
+                            RunPluginOrAlias::Alias(plugin_alias)
                         },
                     };
                     if floating {

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -464,8 +464,15 @@ impl PluginAlias {
         // filepicker that has access to the whole filesystem but wants to start in a specific
         // folder)
         if let Some(caller_cwd) = caller_cwd {
-            if self.configuration.as_ref().map(|c| c.inner().get("caller_cwd").is_none()).unwrap_or(true) {
-                let configuration = self.configuration.get_or_insert_with(|| PluginUserConfiguration::new(BTreeMap::new()));
+            if self
+                .configuration
+                .as_ref()
+                .map(|c| c.inner().get("caller_cwd").is_none())
+                .unwrap_or(true)
+            {
+                let configuration = self
+                    .configuration
+                    .get_or_insert_with(|| PluginUserConfiguration::new(BTreeMap::new()));
                 configuration.insert("caller_cwd", caller_cwd.display().to_string());
             }
         }

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -456,6 +456,20 @@ impl PluginAlias {
             ..Default::default()
         }
     }
+    pub fn set_caller_cwd_if_not_set(&mut self, caller_cwd: Option<PathBuf>) {
+        // we do this only for an alias because in all other cases this will be handled by the
+        // "cwd" configuration key above
+        // for an alias we might have cases where the cwd is defined on the alias but we still
+        // want to pass the "caller" cwd for the plugin the alias resolves into (eg. a
+        // filepicker that has access to the whole filesystem but wants to start in a specific
+        // folder)
+        if let Some(caller_cwd) = caller_cwd {
+            if self.configuration.as_ref().map(|c| c.inner().get("caller_cwd").is_none()).unwrap_or(true) {
+                let configuration = self.configuration.get_or_insert_with(|| PluginUserConfiguration::new(BTreeMap::new()));
+                configuration.insert("caller_cwd", caller_cwd.display().to_string());
+            }
+        }
+    }
 }
 
 #[allow(clippy::derive_hash_xor_eq)]


### PR DESCRIPTION
This fixes various minor plugin issues:
1. Strider now uses `close_self` instead of `close_focus` when wanting to close itself
2. The `caller_cwd` in plugins is now also populated for plugins launched from a keybinding
3. The default config now launches the `session-manager` alias rather than the explicit built-in `zellij:session-manager` in order to allow plugin authors to swap the built-in plugin for their own implementation