### PR TITLE
fix(layouts): recover from resurrection crash and pick up swap layouts properly

### DIFF
--- a/zellij-server/src/tab/swap_layouts.rs
+++ b/zellij-server/src/tab/swap_layouts.rs
@@ -249,7 +249,7 @@ impl SwapLayouts {
                             let pane_count = tiled_panes.visible_panes_count();
                             let display_area = PaneGeom::from(&*display_area);
                             if layout
-                                .position_panes_in_space(&display_area, Some(pane_count))
+                                .position_panes_in_space(&display_area, Some(pane_count), false)
                                 .is_ok()
                             {
                                 return Some(layout.clone());
@@ -279,7 +279,7 @@ impl SwapLayouts {
                 let pane_count = tiled_panes.visible_panes_count();
                 let display_area = PaneGeom::from(&*display_area);
                 if layout
-                    .position_panes_in_space(&display_area, Some(pane_count))
+                    .position_panes_in_space(&display_area, Some(pane_count), false)
                     .is_ok()
                 {
                     return Some(layout.clone());

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -860,6 +860,9 @@ impl TryFrom<(&KdlNode, &Options)> for Action {
                     )
                 })?;
 
+                let swap_tiled_layouts = Some(layout.swap_tiled_layouts.clone());
+                let swap_floating_layouts = Some(layout.swap_floating_layouts.clone());
+
                 let mut tabs = layout.tabs();
                 if tabs.len() > 1 {
                     return Err(ConfigError::new_kdl_error(
@@ -874,8 +877,8 @@ impl TryFrom<(&KdlNode, &Options)> for Action {
                     Ok(Action::NewTab(
                         Some(layout),
                         floating_panes_layout,
-                        None,
-                        None,
+                        swap_tiled_layouts,
+                        swap_floating_layouts,
                         name,
                     ))
                 } else {
@@ -884,8 +887,8 @@ impl TryFrom<(&KdlNode, &Options)> for Action {
                     Ok(Action::NewTab(
                         Some(layout),
                         floating_panes_layout,
-                        None,
-                        None,
+                        swap_tiled_layouts,
+                        swap_floating_layouts,
                         name,
                     ))
                 }

--- a/zellij-utils/src/pane_size.rs
+++ b/zellij-utils/src/pane_size.rs
@@ -122,7 +122,7 @@ impl Dimension {
         self.inner += by;
     }
     pub fn decrease_inner(&mut self, by: usize) {
-        self.inner -= by;
+        self.inner = self.inner.saturating_sub(by);
     }
 
     pub fn is_fixed(&self) -> bool {


### PR DESCRIPTION
This fixes two issues:
1. In some cases, Zellij would not properly resurrect a session which had a certain layout (namely one that our constraint system cannot handle due to some ancient bugs I'll address separately)
2. Swap layouts were not picked up in the `NewTab` keybinding - now they are