### PR TITLE
fix(swap-layouts): properly identify plugin aliases with initial cwd

### DIFF
--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -435,8 +435,7 @@ pub struct PluginAlias {
 
 impl PartialEq for PluginAlias {
     fn eq(&self, other: &Self) -> bool {
-        self.name == other.name
-            && self.configuration == other.configuration
+        self.name == other.name && self.configuration == other.configuration
     }
 }
 

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -437,7 +437,6 @@ impl PartialEq for PluginAlias {
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name
             && self.configuration == other.configuration
-            && self.initial_cwd == other.initial_cwd
     }
 }
 


### PR DESCRIPTION
Fixes an edge case where plugins would sometimes switch locations (eg. the filepicker and the status-bar) when starting a session in a specific directory.