### PR TITLE
fix(theme): this was a fast fix for gruvbox light and dark

### DIFF
--- a/zellij-utils/assets/themes/gruvbox.kdl
+++ b/zellij-utils/assets/themes/gruvbox.kdl
@@ -1,20 +1,20 @@
 themes {
     gruvbox-light {
-        fg 124 111 100
-        bg 251 82 75
-        black 40 40 40
-        red 205 75 69
-        green 152 151 26
+        bg 213 196 161
+        fg 80 73 69
+        orange 152 0 5
+        green 121 116 14
         yellow 215 153 33
         blue 69 133 136
         magenta 177 98 134
         cyan 104 157 106
-        white 213 196 161
-        orange 214 93 14
+        black 235 219 178
+        white 60 56 54
+        red 214 93 14
     }
     gruvbox-dark {
-        fg 213 196 161
-        bg 40 40 40
+        fg 235 219 178
+        bg 80 73 69
         black 60 56 54
         red 204 36 29
         green 152 151 26
@@ -26,4 +26,3 @@ themes {
         orange 214 93 14
     }
 }
-


### PR DESCRIPTION
the previous themes do not have the correct colors and aren't great for the eyes. when selecting e.g. to copy text, it uses red for light theme and the same bg for dark theme for highlighting text.

the previous light theme is not even a light theme so I also fixed that as well.

### Dark Theme Now
![image](https://github.com/zellij-org/zellij/assets/66054069/75cca651-4322-4a9e-8c06-45291ad32469)

### Light Theme Now
![image](https://github.com/zellij-org/zellij/assets/66054069/d06f485d-37a6-4439-ad8e-11d7820ea649)

