### PR TITLE
feat(cli): allow starting a session detached

### DIFF
--- a/zellij-client/src/cli_client.rs
+++ b/zellij-client/src/cli_client.rs
@@ -138,8 +138,8 @@ fn pipe_client(
             let mut buffer = String::new();
             let _ = stdin.read_line(&mut buffer);
             if buffer.is_empty() {
-                // TODO: consider notifying the relevant plugin that the pipe has ended with a
-                // specialized message
+                let msg = create_msg(None);
+                os_input.send_to_server(msg);
                 break;
             } else {
                 // we've got data! send it down the pipe (most common)

--- a/zellij-client/src/os_input_output.rs
+++ b/zellij-client/src/os_input_output.rs
@@ -317,8 +317,8 @@ impl Clone for Box<dyn ClientOsApi> {
 }
 
 pub fn get_client_os_input() -> Result<ClientOsInputOutput, nix::Error> {
-    let current_termios = termios::tcgetattr(0)?;
-    let orig_termios = Some(Arc::new(Mutex::new(current_termios)));
+    let current_termios = termios::tcgetattr(0).ok();
+    let orig_termios = current_termios.map(|termios| Arc::new(Mutex::new(termios)));
     let reading_from_stdin = Arc::new(Mutex::new(None));
     Ok(ClientOsInputOutput {
         orig_termios,

--- a/zellij-server/src/unit/os_input_output_tests.rs
+++ b/zellij-server/src/unit/os_input_output_tests.rs
@@ -36,7 +36,7 @@ fn get_cwd() {
         termios::tcgetattr(test_terminal.slave()).expect("Could not configure the termios");
 
     let server = ServerOsInputOutput {
-        orig_termios: Arc::new(Mutex::new(test_termios)),
+        orig_termios: Arc::new(Mutex::new(Some(test_termios))),
         client_senders: Arc::default(),
         terminal_id_to_raw_fd: Arc::default(),
         cached_resizes: Arc::default(),

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -125,6 +125,10 @@ pub enum Sessions {
         #[clap(short, long, value_parser)]
         create: bool,
 
+        /// Create a detached session in the background if one does not exist
+        #[clap(short, long, value_parser)]
+        background: bool,
+
         /// Number of the session index in the active sessions ordered creation date.
         #[clap(long, value_parser)]
         index: Option<usize>,


### PR DESCRIPTION
This adds the `zellij attach --background <session-name>` command, which allows creating a session in the background through the CLI.

This also (unrelated) makes sure pipes send an empty message to plugins when they end (similar to how pipes work in the shell, so that plugins know when a pipe has ended and can eg. close themselves).