### PR TITLE
feat(config): allow disabling writing session metadata to disk

### DIFF
--- a/zellij-server/src/background_jobs.rs
+++ b/zellij-server/src/background_jobs.rs
@@ -84,6 +84,7 @@ static DEFAULT_SERIALIZATION_INTERVAL: u64 = 60000;
 pub(crate) fn background_jobs_main(
     bus: Bus<BackgroundJob>,
     serialization_interval: Option<u64>,
+    disable_session_metadata: bool,
 ) -> Result<()> {
     let err_context = || "failed to write to pty".to_string();
     let mut running_jobs: HashMap<BackgroundJob, Instant> = HashMap::new();
@@ -175,11 +176,13 @@ pub(crate) fn background_jobs_main(
                             let current_session_info = current_session_info.lock().unwrap().clone();
                             let current_session_layout =
                                 current_session_layout.lock().unwrap().clone();
-                            write_session_state_to_disk(
-                                current_session_name.clone(),
-                                current_session_info,
-                                current_session_layout,
-                            );
+                            if !disable_session_metadata {
+                                write_session_state_to_disk(
+                                    current_session_name.clone(),
+                                    current_session_info,
+                                    current_session_layout,
+                                );
+                            }
                             let session_infos_on_machine =
                                 read_other_live_session_states(&current_session_name);
                             let resurrectable_sessions =

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -881,6 +881,7 @@ fn init_session(
     };
 
     let serialization_interval = config_options.serialization_interval;
+    let disable_session_metadata = config_options.disable_session_metadata.unwrap_or(false);
 
     let default_shell = config_options.default_shell.clone().map(|command| {
         TerminalAction::RunCommand(RunCommand {
@@ -1017,7 +1018,7 @@ fn init_session(
                 None,
                 Some(os_input.clone()),
             );
-            move || background_jobs_main(background_jobs_bus, serialization_interval).fatal()
+            move || background_jobs_main(background_jobs_bus, serialization_interval, disable_session_metadata).fatal()
         })
         .unwrap();
 

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -1018,7 +1018,14 @@ fn init_session(
                 None,
                 Some(os_input.clone()),
             );
-            move || background_jobs_main(background_jobs_bus, serialization_interval, disable_session_metadata).fatal()
+            move || {
+                background_jobs_main(
+                    background_jobs_bus,
+                    serialization_interval,
+                    disable_session_metadata,
+                )
+                .fatal()
+            }
         })
         .unwrap();
 

--- a/zellij-utils/assets/config/default.kdl
+++ b/zellij-utils/assets/config/default.kdl
@@ -357,3 +357,9 @@ plugins {
 // Default: true
 //
 // styled_underlines false
+
+// Enable or disable writing of session metadata to disk (if disabled, other sessions might not know
+// metadata info on this session)
+// Default: false
+//
+// disable_session_metadata true

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -227,7 +227,9 @@ impl Options {
             .or(self.scrollback_lines_to_serialize);
         let styled_underlines = other.styled_underlines.or(self.styled_underlines);
         let serialization_interval = other.serialization_interval.or(self.serialization_interval);
-        let disable_session_metadata = other.disable_session_metadata.or(self.disable_session_metadata);
+        let disable_session_metadata = other
+            .disable_session_metadata
+            .or(self.disable_session_metadata);
 
         Options {
             simplified_ui,
@@ -308,7 +310,9 @@ impl Options {
             .or_else(|| self.scrollback_lines_to_serialize.clone());
         let styled_underlines = other.styled_underlines.or(self.styled_underlines);
         let serialization_interval = other.serialization_interval.or(self.serialization_interval);
-        let disable_session_metadata = other.disable_session_metadata.or(self.disable_session_metadata);
+        let disable_session_metadata = other
+            .disable_session_metadata
+            .or(self.disable_session_metadata);
 
         Options {
             simplified_ui,

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -151,6 +151,10 @@ pub struct Options {
     /// The interval at which to serialize sessions for resurrection (in seconds)
     #[clap(long, value_parser)]
     pub serialization_interval: Option<u64>,
+
+    /// If true, will disable writing session metadata to disk
+    #[clap(long, value_parser)]
+    pub disable_session_metadata: Option<bool>,
 }
 
 #[derive(ArgEnum, Deserialize, Serialize, Debug, Clone, Copy, PartialEq)]
@@ -223,6 +227,7 @@ impl Options {
             .or(self.scrollback_lines_to_serialize);
         let styled_underlines = other.styled_underlines.or(self.styled_underlines);
         let serialization_interval = other.serialization_interval.or(self.serialization_interval);
+        let disable_session_metadata = other.disable_session_metadata.or(self.disable_session_metadata);
 
         Options {
             simplified_ui,
@@ -250,6 +255,7 @@ impl Options {
             scrollback_lines_to_serialize,
             styled_underlines,
             serialization_interval,
+            disable_session_metadata,
         }
     }
 
@@ -302,6 +308,7 @@ impl Options {
             .or_else(|| self.scrollback_lines_to_serialize.clone());
         let styled_underlines = other.styled_underlines.or(self.styled_underlines);
         let serialization_interval = other.serialization_interval.or(self.serialization_interval);
+        let disable_session_metadata = other.disable_session_metadata.or(self.disable_session_metadata);
 
         Options {
             simplified_ui,
@@ -329,6 +336,7 @@ impl Options {
             scrollback_lines_to_serialize,
             styled_underlines,
             serialization_interval,
+            disable_session_metadata,
         }
     }
 

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -1611,6 +1611,9 @@ impl Options {
         let serialization_interval =
             kdl_property_first_arg_as_i64_or_error!(kdl_options, "serialization_interval")
                 .map(|(scroll_buffer_size, _entry)| scroll_buffer_size as u64);
+        let disable_session_metadata =
+            kdl_property_first_arg_as_bool_or_error!(kdl_options, "disable_session_metadata")
+                .map(|(v, _)| v);
         Ok(Options {
             simplified_ui,
             theme,
@@ -1637,6 +1640,7 @@ impl Options {
             scrollback_lines_to_serialize,
             styled_underlines,
             serialization_interval,
+            disable_session_metadata,
         })
     }
 }

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
-assertion_line: 686
+assertion_line: 713
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -31,4 +31,5 @@ Options {
     scrollback_lines_to_serialize: None,
     styled_underlines: None,
     serialization_interval: None,
+    disable_session_metadata: None,
 }

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
-assertion_line: 714
+assertion_line: 741
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -31,4 +31,5 @@ Options {
     scrollback_lines_to_serialize: None,
     styled_underlines: None,
     serialization_interval: None,
+    disable_session_metadata: None,
 }

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
-assertion_line: 673
+assertion_line: 700
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -29,4 +29,5 @@ Options {
     scrollback_lines_to_serialize: None,
     styled_underlines: None,
     serialization_interval: None,
+    disable_session_metadata: None,
 }

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
@@ -3830,6 +3830,7 @@ Config {
         scrollback_lines_to_serialize: None,
         styled_underlines: None,
         serialization_interval: None,
+        disable_session_metadata: None,
     },
     themes: {},
     plugins: PluginAliases {

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
@@ -3830,6 +3830,7 @@ Config {
         scrollback_lines_to_serialize: None,
         styled_underlines: None,
         serialization_interval: None,
+        disable_session_metadata: None,
     },
     themes: {},
     plugins: PluginAliases {

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
@@ -87,6 +87,7 @@ Config {
         scrollback_lines_to_serialize: None,
         styled_underlines: None,
         serialization_interval: None,
+        disable_session_metadata: None,
     },
     themes: {},
     plugins: PluginAliases {

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
-assertion_line: 696
+assertion_line: 723
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -31,4 +31,5 @@ Options {
     scrollback_lines_to_serialize: None,
     styled_underlines: None,
     serialization_interval: None,
+    disable_session_metadata: None,
 }

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
@@ -3830,6 +3830,7 @@ Config {
         scrollback_lines_to_serialize: None,
         styled_underlines: None,
         serialization_interval: None,
+        disable_session_metadata: None,
     },
     themes: {
         "other-theme-from-config": Theme {

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
@@ -3830,6 +3830,7 @@ Config {
         scrollback_lines_to_serialize: None,
         styled_underlines: None,
         serialization_interval: None,
+        disable_session_metadata: None,
     },
     themes: {},
     plugins: PluginAliases {


### PR DESCRIPTION
This adds the `disable_session_metadata true/false` configuration option to the config file and the CLI, allowing users to disable Zellij's periodic writes of session metadata to the HD (for access by other sessions in eg. the session-manager).