### PR TITLE
fix(compact-bar): properly pad mode indicator

### DIFF
--- a/default-plugins/compact-bar/src/line.rs
+++ b/default-plugins/compact-bar/src/line.rs
@@ -199,7 +199,7 @@ fn tab_line_prefix(
         tab_index: None,
     }];
     if let Some(name) = session_name {
-        let name_part = format!("({}) ", name);
+        let name_part = format!("({})", name);
         let name_part_len = name_part.width();
         let text_color = match palette.theme_hue {
             ThemeHue::Dark => palette.white,
@@ -215,7 +215,7 @@ fn tab_line_prefix(
         }
     }
     let mode_part = format!("{:?}", mode).to_uppercase();
-    let mode_part_padded = format!("{:^8}", mode_part);
+    let mode_part_padded = format!(" {} ", mode_part);
     let mode_part_len = mode_part_padded.width();
     let mode_part_styled_text = if mode == InputMode::Locked {
         style!(locked_mode_color, bg_color)


### PR DESCRIPTION
This PR updates the compact-bar plugin to make the mode indicator to be always centered.

### before

mode indicator section hard-coded to 8-chars length, on mode names > 6 there's no padding

![compact-bar-old](https://github.com/zellij-org/zellij/assets/6853656/997a5a38-e591-4085-9286-7b9d42491c4f)


### after

mode section gets printed as ` <mode-name> `, use a whitespace for padding.

![compact-bar-new](https://github.com/zellij-org/zellij/assets/6853656/c7894685-8f95-4748-84fb-d945ef425f2f)

Closes https://github.com/zellij-org/zellij/issues/3248
