### PR TITLE
fix(resurrection): some ui fixes and not listing unresurrectable sessions

### DIFF
--- a/zellij-server/src/background_jobs.rs
+++ b/zellij-server/src/background_jobs.rs
@@ -436,10 +436,10 @@ fn find_resurrectable_sessions(
                     {
                         Ok(created) => Some(created),
                         Err(e) => {
-                            if e.kind() != std::io::ErrorKind::NotFound {
-                                // let's not spam the
-                                // logs if serialization
-                                // is disabled
+                            if e.kind() == std::io::ErrorKind::NotFound {
+                                return None; // no layout file, cannot resurrect session, let's not
+                                             // list it
+                            } else {
                                 log::error!(
                                     "Failed to read created stamp of resurrection file: {:?}",
                                     e


### PR DESCRIPTION
This includes two fixes:
1. We now no longer list sessions that are not resurrectable in plugins as resurrectable (i.e. sessions that do not have a session-layout file saved on disk - namely short lived sessions)
2. Some UI fixes for the resurrectable sessions in the session-manager: namely allowing to delete resurrectable sessions while searching as well as properly updating search results when new session info events arrive