### PR TITLE
fix(cli): rename `attach --background` to `attach --create-background`

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -418,7 +418,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                 opts.command = Some(Command::Sessions(Sessions::Attach {
                     session_name: reconnect_to_session.name.clone(),
                     create: true,
-                    background: false,
+                    create_background: false,
                     force_run_commands: false,
                     index: None,
                     options: None,
@@ -478,7 +478,7 @@ pub(crate) fn start_client(opts: CliArgs) {
         if let Some(Command::Sessions(Sessions::Attach {
             session_name,
             create,
-            background,
+            create_background,
             force_run_commands,
             index,
             options,
@@ -490,7 +490,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                 },
                 None => config_options,
             };
-            should_create_detached = background;
+            should_create_detached = create_background;
 
             let client = if let Some(idx) = index {
                 attach_with_session_index(

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -126,7 +126,7 @@ pub enum Sessions {
         create: bool,
 
         /// Create a detached session in the background if one does not exist
-        #[clap(short, long, value_parser)]
+        #[clap(short('b'), long, value_parser)]
         create_background: bool,
 
         /// Number of the session index in the active sessions ordered creation date.

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -127,7 +127,7 @@ pub enum Sessions {
 
         /// Create a detached session in the background if one does not exist
         #[clap(short, long, value_parser)]
-        background: bool,
+        create_background: bool,
 
         /// Number of the session index in the active sessions ordered creation date.
         #[clap(long, value_parser)]


### PR DESCRIPTION
Following https://github.com/zellij-org/zellij/pull/3257 - after some comments from the Discord gang, I changed the name of this flag to make it a little clearer.