### PR TITLE
fix(cli): tab and pane name input

### DIFF
--- a/zellij-client/src/cli_client.rs
+++ b/zellij-client/src/cli_client.rs
@@ -64,10 +64,11 @@ pub fn start_cli_client(
                 );
             },
             action => {
-                single_message_client(&mut os_input, action, pane_id);
+                individual_messages_client(&mut os_input, action, pane_id);
             },
         }
     }
+    os_input.send_to_server(ClientToServerMsg::ClientExited);
 }
 
 fn pipe_client(
@@ -198,7 +199,7 @@ fn pipe_client(
     }
 }
 
-fn single_message_client(
+fn individual_messages_client(
     os_input: &mut Box<dyn ClientOsApi>,
     action: Action,
     pane_id: Option<u32>,
@@ -208,12 +209,11 @@ fn single_message_client(
     loop {
         match os_input.recv_from_server() {
             Some((ServerToClientMsg::UnblockInputThread, _)) => {
-                os_input.send_to_server(ClientToServerMsg::ClientExited);
-                process::exit(0);
+                break;
             },
             Some((ServerToClientMsg::Log(log_lines), _)) => {
                 log_lines.iter().for_each(|line| println!("{line}"));
-                process::exit(0);
+                break;
             },
             Some((ServerToClientMsg::LogError(log_lines), _)) => {
                 log_lines.iter().for_each(|line| eprintln!("{line}"));
@@ -225,7 +225,7 @@ fn single_message_client(
                     process::exit(2);
                 },
                 _ => {
-                    process::exit(0);
+                    break;
                 },
             },
             _ => {},


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/3269

This was a regression caused by the `pipes` implementation and some refactoring in this area. Namely, only the first action created from a single cli command was used and the rest were ignored. This only affected renaming panes and tabs through the CLI.