### PR TITLE
fix(plugins): respect default shell when configured in the $SHELL env variable

### DIFF
--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_terminal_floating_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_terminal_floating_plugin_command.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/plugins/./unit/plugin_tests.rs
-assertion_line: 4246
+assertion_line: 4390
 expression: "format!(\"{:#?}\", new_tab_event)"
 ---
 Some(
@@ -8,7 +8,7 @@ Some(
         Some(
             RunCommand(
                 RunCommand {
-                    command: "",
+                    command: ".",
                     args: [],
                     cwd: Some(
                         "/path/to/my/file.rs",

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_terminal_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_terminal_plugin_command.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/plugins/./unit/plugin_tests.rs
-assertion_line: 4169
+assertion_line: 4312
 expression: "format!(\"{:#?}\", new_tab_event)"
 ---
 Some(
@@ -8,7 +8,7 @@ Some(
         Some(
             RunCommand(
                 RunCommand {
-                    command: "",
+                    command: ".",
                     args: [],
                     cwd: Some(
                         "/path/to/my/file.rs",

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -519,7 +519,12 @@ fn open_terminal(env: &ForeignFunctionEnv, cwd: PathBuf) {
         .plugin_env
         .default_shell
         .clone()
-        .unwrap_or_else(|| TerminalAction::RunCommand(RunCommand::default()));
+        .unwrap_or_else(|| TerminalAction::RunCommand(
+            RunCommand {
+                command: env.plugin_env.path_to_default_shell.clone(),
+                ..Default::default()
+            }
+        ));
     default_shell.change_cwd(cwd);
     let run_command_action: Option<RunCommandAction> = match default_shell {
         TerminalAction::RunCommand(run_command) => Some(run_command.into()),
@@ -540,7 +545,12 @@ fn open_terminal_floating(
         .plugin_env
         .default_shell
         .clone()
-        .unwrap_or_else(|| TerminalAction::RunCommand(RunCommand::default()));
+        .unwrap_or_else(|| TerminalAction::RunCommand(
+            RunCommand {
+                command: env.plugin_env.path_to_default_shell.clone(),
+                ..Default::default()
+            }
+        ));
     default_shell.change_cwd(cwd);
     let run_command_action: Option<RunCommandAction> = match default_shell {
         TerminalAction::RunCommand(run_command) => Some(run_command.into()),
@@ -557,7 +567,12 @@ fn open_terminal_in_place(env: &ForeignFunctionEnv, cwd: PathBuf) {
         .plugin_env
         .default_shell
         .clone()
-        .unwrap_or_else(|| TerminalAction::RunCommand(RunCommand::default()));
+        .unwrap_or_else(|| TerminalAction::RunCommand(
+            RunCommand {
+                command: env.plugin_env.path_to_default_shell.clone(),
+                ..Default::default()
+            }
+        ));
     default_shell.change_cwd(cwd);
     let run_command_action: Option<RunCommandAction> = match default_shell {
         TerminalAction::RunCommand(run_command) => Some(run_command.into()),

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -515,16 +515,12 @@ fn open_file_in_place(env: &ForeignFunctionEnv, file_to_open: FileToOpen) {
 fn open_terminal(env: &ForeignFunctionEnv, cwd: PathBuf) {
     let error_msg = || format!("failed to open file in plugin {}", env.plugin_env.name());
     let cwd = env.plugin_env.plugin_cwd.join(cwd);
-    let mut default_shell = env
-        .plugin_env
-        .default_shell
-        .clone()
-        .unwrap_or_else(|| TerminalAction::RunCommand(
-            RunCommand {
-                command: env.plugin_env.path_to_default_shell.clone(),
-                ..Default::default()
-            }
-        ));
+    let mut default_shell = env.plugin_env.default_shell.clone().unwrap_or_else(|| {
+        TerminalAction::RunCommand(RunCommand {
+            command: env.plugin_env.path_to_default_shell.clone(),
+            ..Default::default()
+        })
+    });
     default_shell.change_cwd(cwd);
     let run_command_action: Option<RunCommandAction> = match default_shell {
         TerminalAction::RunCommand(run_command) => Some(run_command.into()),
@@ -541,16 +537,12 @@ fn open_terminal_floating(
 ) {
     let error_msg = || format!("failed to open file in plugin {}", env.plugin_env.name());
     let cwd = env.plugin_env.plugin_cwd.join(cwd);
-    let mut default_shell = env
-        .plugin_env
-        .default_shell
-        .clone()
-        .unwrap_or_else(|| TerminalAction::RunCommand(
-            RunCommand {
-                command: env.plugin_env.path_to_default_shell.clone(),
-                ..Default::default()
-            }
-        ));
+    let mut default_shell = env.plugin_env.default_shell.clone().unwrap_or_else(|| {
+        TerminalAction::RunCommand(RunCommand {
+            command: env.plugin_env.path_to_default_shell.clone(),
+            ..Default::default()
+        })
+    });
     default_shell.change_cwd(cwd);
     let run_command_action: Option<RunCommandAction> = match default_shell {
         TerminalAction::RunCommand(run_command) => Some(run_command.into()),
@@ -563,16 +555,12 @@ fn open_terminal_floating(
 fn open_terminal_in_place(env: &ForeignFunctionEnv, cwd: PathBuf) {
     let error_msg = || format!("failed to open file in plugin {}", env.plugin_env.name());
     let cwd = env.plugin_env.plugin_cwd.join(cwd);
-    let mut default_shell = env
-        .plugin_env
-        .default_shell
-        .clone()
-        .unwrap_or_else(|| TerminalAction::RunCommand(
-            RunCommand {
-                command: env.plugin_env.path_to_default_shell.clone(),
-                ..Default::default()
-            }
-        ));
+    let mut default_shell = env.plugin_env.default_shell.clone().unwrap_or_else(|| {
+        TerminalAction::RunCommand(RunCommand {
+            command: env.plugin_env.path_to_default_shell.clone(),
+            ..Default::default()
+        })
+    });
     default_shell.change_cwd(cwd);
     let run_command_action: Option<RunCommandAction> = match default_shell {
         TerminalAction::RunCommand(run_command) => Some(run_command.into()),


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/3272 and https://github.com/zellij-org/zellij/issues/3267

Previously, this only worked when the shell was configured explicitly through `default_shell` in the config. Now it should work also when it isn't (and thus pick up `$SHELL`).