### PR TITLE
make session config poll interval configurable

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -889,6 +889,7 @@ fn init_session(
     };
 
     let serialization_interval = config_options.serialization_interval;
+    let session_read_interval = config_options.session_read_interval;
     let disable_session_metadata = config_options.disable_session_metadata.unwrap_or(false);
 
     let default_shell = config_options.default_shell.clone().map(|command| {
@@ -1031,6 +1032,7 @@ fn init_session(
                     background_jobs_bus,
                     serialization_interval,
                     disable_session_metadata,
+                    session_read_interval,
                 )
                 .fatal()
             }

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -152,6 +152,10 @@ pub struct Options {
     #[clap(long, value_parser)]
     pub serialization_interval: Option<u64>,
 
+    /// The interval at which sessions config is re-read and re-written back (in seconds)
+    #[clap(long, value_parser)]
+    pub session_read_interval: Option<u64>,
+
     /// If true, will disable writing session metadata to disk
     #[clap(long, value_parser)]
     pub disable_session_metadata: Option<bool>,
@@ -227,6 +231,7 @@ impl Options {
             .or(self.scrollback_lines_to_serialize);
         let styled_underlines = other.styled_underlines.or(self.styled_underlines);
         let serialization_interval = other.serialization_interval.or(self.serialization_interval);
+        let session_read_interval = other.session_read_interval.or(self.session_read_interval);
         let disable_session_metadata = other
             .disable_session_metadata
             .or(self.disable_session_metadata);
@@ -257,6 +262,7 @@ impl Options {
             scrollback_lines_to_serialize,
             styled_underlines,
             serialization_interval,
+            session_read_interval,
             disable_session_metadata,
         }
     }
@@ -310,6 +316,7 @@ impl Options {
             .or_else(|| self.scrollback_lines_to_serialize.clone());
         let styled_underlines = other.styled_underlines.or(self.styled_underlines);
         let serialization_interval = other.serialization_interval.or(self.serialization_interval);
+        let session_read_interval = other.session_read_interval.or(self.session_read_interval);
         let disable_session_metadata = other
             .disable_session_metadata
             .or(self.disable_session_metadata);
@@ -340,6 +347,7 @@ impl Options {
             scrollback_lines_to_serialize,
             styled_underlines,
             serialization_interval,
+            session_read_interval,
             disable_session_metadata,
         }
     }
@@ -405,6 +413,7 @@ impl From<CliOptions> for Options {
             scrollback_lines_to_serialize: opts.scrollback_lines_to_serialize,
             styled_underlines: opts.styled_underlines,
             serialization_interval: opts.serialization_interval,
+            session_read_interval: opts.session_read_interval,
             ..Default::default()
         }
     }

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -1611,6 +1611,9 @@ impl Options {
         let serialization_interval =
             kdl_property_first_arg_as_i64_or_error!(kdl_options, "serialization_interval")
                 .map(|(scroll_buffer_size, _entry)| scroll_buffer_size as u64);
+        let session_read_interval =
+            kdl_property_first_arg_as_i64_or_error!(kdl_options, "session_read_interval")
+                .map(|(scroll_buffer_size, _entry)| scroll_buffer_size as u64);
         let disable_session_metadata =
             kdl_property_first_arg_as_bool_or_error!(kdl_options, "disable_session_metadata")
                 .map(|(v, _)| v);
@@ -1640,6 +1643,7 @@ impl Options {
             scrollback_lines_to_serialize,
             styled_underlines,
             serialization_interval,
+            session_read_interval,
             disable_session_metadata,
         })
     }


### PR DESCRIPTION
Make the interval at which session files are re-read from (and re-written to) disc configurable, instead of hardcoded 1 sec.

This PR illustrates one possible solution to #3127 issue