### PR TITLE
Fixed keybinding of Control J

### DIFF
--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -91,7 +91,11 @@ impl InputHandler {
                 Ok((InputInstruction::KeyEvent(input_event, raw_bytes), _error_context)) => {
                     match input_event {
                         InputEvent::Key(key_event) => {
-                            let key = cast_termwiz_key(key_event, &raw_bytes, Some((&self.config.keybinds, &self.mode)));
+                            let key = cast_termwiz_key(
+                                key_event,
+                                &raw_bytes,
+                                Some((&self.config.keybinds, &self.mode)),
+                            );
                             self.handle_key(&key, raw_bytes);
                         },
                         InputEvent::Mouse(mouse_event) => {

--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -91,7 +91,7 @@ impl InputHandler {
                 Ok((InputInstruction::KeyEvent(input_event, raw_bytes), _error_context)) => {
                     match input_event {
                         InputEvent::Key(key_event) => {
-                            let key = cast_termwiz_key(key_event, &raw_bytes);
+                            let key = cast_termwiz_key(key_event, &raw_bytes, Some((&self.config.keybinds, &self.mode)));
                             self.handle_key(&key, raw_bytes);
                         },
                         InputEvent::Mouse(mouse_event) => {

--- a/zellij-utils/src/input/mod.rs
+++ b/zellij-utils/src/input/mod.rs
@@ -66,7 +66,11 @@ mod not_wasm {
 
     // FIXME: This is an absolutely cursed function that should be destroyed as soon
     // as an alternative that doesn't touch zellij-tile can be developed...
-    pub fn cast_termwiz_key(event: KeyEvent, raw_bytes: &[u8], keybinds_mode: Option<(&Keybinds, &InputMode)>) -> Key {
+    pub fn cast_termwiz_key(
+        event: KeyEvent,
+        raw_bytes: &[u8],
+        keybinds_mode: Option<(&Keybinds, &InputMode)>,
+    ) -> Key {
         let modifiers = event.modifiers;
 
         // *** THIS IS WHERE WE SHOULD WORK AROUND ISSUES WITH TERMWIZ ***


### PR DESCRIPTION
Made it possible to bind Ctrl+j to a key, this would be very helpful for people using vim keybindings. 
Closes issue #2679 and #2954. 

Should be safe since it doesn't do anything as long as the key is not bound, this is the same behavior as tmux. I manually tested with Ctrl+j both bound and unbound in Kitty, Alacritty, Gnome Terminal and Konsole. 

One remark with this conditional parsing is that the keybindings are not available [here](https://github.com/zellij-org/zellij/blob/158260799b5112e31d86557af8a32b7ab0d77a26/zellij-server/src/tab/mod.rs#L1761C1-L1770C19). As a result, plugins still won't be able to use Ctrl+j, although I don't think that is so big of an issue.