### PR TITLE
Add basic ANSI theme

### DIFF
--- a/zellij-utils/assets/themes/ansi.kdl
+++ b/zellij-utils/assets/themes/ansi.kdl
@@ -1,0 +1,21 @@
+// Basic theme using only the 16 ANSI colors
+// Allows one to customize theme via ones terminal color settings if the
+// terminal emulator does not support truecolor (e.g. macOS Terminal.app)
+
+// Note: there is no orange in the ANSI color palette, so we use bright red instead
+
+themes {
+  ansi {
+    fg 7 // white
+    bg 8 // bright black
+    red 1
+    green 2
+    yellow 3
+    blue 4
+    magenta 5
+    orange 9 // bright red
+    cyan 6
+    black 0
+    white 15 // bright white
+  }
+}


### PR DESCRIPTION
This adds a simple theme using only the base 16 ANSI colors.

Some terminal emulators (like the macOS Terminal.app) do not support truecolor, and one can get around this by applying custom values to the 16 ANSI colors through the terminal's "theme". This theme utilizes only those colors so that one's applied terminal theme will carry through to zellij.
