### PR TITLE
feat(cli): list clients, their focused pane_id and the running command

### DIFF
--- a/zellij-server/src/plugins/mod.rs
+++ b/zellij-server/src/plugins/mod.rs
@@ -105,6 +105,7 @@ pub enum PluginInstruction {
         Option<PathBuf>,
     ),
     DumpLayout(SessionLayoutMetadata, ClientId),
+    ListClientsMetadata(SessionLayoutMetadata, ClientId),
     DumpLayoutToPlugin(SessionLayoutMetadata, PluginId),
     LogLayoutToHd(SessionLayoutMetadata),
     CliPipe {
@@ -173,6 +174,7 @@ impl From<&PluginInstruction> for PluginContext {
                 PluginContext::PermissionRequestResult
             },
             PluginInstruction::DumpLayout(..) => PluginContext::DumpLayout,
+            PluginInstruction::ListClientsMetadata(..) => PluginContext::ListClientsMetadata,
             PluginInstruction::LogLayoutToHd(..) => PluginContext::LogLayoutToHd,
             PluginInstruction::CliPipe { .. } => PluginContext::CliPipe,
             PluginInstruction::CachePluginEvents { .. } => PluginContext::CachePluginEvents,
@@ -485,6 +487,13 @@ pub(crate) fn plugin_thread_main(
             PluginInstruction::DumpLayout(mut session_layout_metadata, client_id) => {
                 populate_session_layout_metadata(&mut session_layout_metadata, &wasm_bridge);
                 drop(bus.senders.send_to_pty(PtyInstruction::DumpLayout(
+                    session_layout_metadata,
+                    client_id,
+                )));
+            },
+            PluginInstruction::ListClientsMetadata(mut session_layout_metadata, client_id) => {
+                populate_session_layout_metadata(&mut session_layout_metadata, &wasm_bridge);
+                drop(bus.senders.send_to_pty(PtyInstruction::ListClientsMetadata(
                     session_layout_metadata,
                     client_id,
                 )));

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -639,7 +639,13 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                 pty.populate_session_layout_metadata(&mut session_layout_metadata);
                 pty.bus
                     .senders
-                    .send_to_server(ServerInstruction::Log(vec![format!("{}", session_layout_metadata.list_clients_metadata())], client_id))
+                    .send_to_server(ServerInstruction::Log(
+                        vec![format!(
+                            "{}",
+                            session_layout_metadata.list_clients_metadata()
+                        )],
+                        client_id,
+                    ))
                     .with_context(err_context)
                     .non_fatal();
             },

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -932,7 +932,10 @@ pub(crate) fn route_action(
                 _ => None,
             };
             senders
-                .send_to_screen(ScreenInstruction::ListClientsMetadata(default_shell, client_id))
+                .send_to_screen(ScreenInstruction::ListClientsMetadata(
+                    default_shell,
+                    client_id,
+                ))
                 .with_context(err_context)?;
         },
     }

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -926,6 +926,15 @@ pub(crate) fn route_action(
                 log::error!("Message must have a name");
             }
         },
+        Action::ListClients => {
+            let default_shell = match default_shell {
+                Some(TerminalAction::RunCommand(run_command)) => Some(run_command.command),
+                _ => None,
+            };
+            senders
+                .send_to_screen(ScreenInstruction::ListClientsMetadata(default_shell, client_id))
+                .with_context(err_context)?;
+        },
     }
     Ok(should_break)
 }

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -2168,12 +2168,20 @@ impl Screen {
                 suppressed_panes.insert(*triggering_pane_id, p);
             }
 
-            let all_connected_clients: Vec<ClientId> =
-                self.connected_clients.borrow().iter().copied().filter(|c| self.active_tab_indices.get(&c) == Some(&tab_index)).collect();
+            let all_connected_clients: Vec<ClientId> = self
+                .connected_clients
+                .borrow()
+                .iter()
+                .copied()
+                .filter(|c| self.active_tab_indices.get(&c) == Some(&tab_index))
+                .collect();
 
             let mut active_pane_ids: HashMap<ClientId, Option<PaneId>> = HashMap::new();
             for connected_client_id in &all_connected_clients {
-                active_pane_ids.insert(*connected_client_id, tab.get_active_pane_id(*connected_client_id));
+                active_pane_ids.insert(
+                    *connected_client_id,
+                    tab.get_active_pane_id(*connected_client_id),
+                );
             }
 
             let tiled_panes: Vec<PaneLayoutMetadata> = tab
@@ -2192,7 +2200,12 @@ impl Screen {
                     }
                 })
                 .map(|(pane_id, p)| {
-                    let focused_clients: Vec<ClientId> = active_pane_ids.iter().filter_map(|(c_id, p_id)| p_id.and_then(|p_id| if p_id == pane_id { Some(*c_id) } else { None })).collect();
+                    let focused_clients: Vec<ClientId> = active_pane_ids
+                        .iter()
+                        .filter_map(|(c_id, p_id)| {
+                            p_id.and_then(|p_id| if p_id == pane_id { Some(*c_id) } else { None })
+                        })
+                        .collect();
                     PaneLayoutMetadata::new(
                         pane_id,
                         p.position_and_size(),
@@ -2205,7 +2218,7 @@ impl Screen {
                         } else {
                             None
                         },
-                        focused_clients
+                        focused_clients,
                     )
                 })
                 .collect();
@@ -2225,7 +2238,12 @@ impl Screen {
                     }
                 })
                 .map(|(pane_id, p)| {
-                    let focused_clients: Vec<ClientId> = active_pane_ids.iter().filter_map(|(c_id, p_id)| p_id.and_then(|p_id| if p_id == pane_id { Some(*c_id) } else { None })).collect();
+                    let focused_clients: Vec<ClientId> = active_pane_ids
+                        .iter()
+                        .filter_map(|(c_id, p_id)| {
+                            p_id.and_then(|p_id| if p_id == pane_id { Some(*c_id) } else { None })
+                        })
+                        .collect();
                     PaneLayoutMetadata::new(
                         pane_id,
                         p.position_and_size(),

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -736,4 +736,5 @@ tail -f /tmp/my-live-logfile | zellij action pipe --name logs --plugin https://e
         #[clap(short('t'), long, value_parser, display_order(10))]
         plugin_title: Option<String>,
     },
+    ListClients,
 }

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -352,6 +352,7 @@ pub enum ScreenContext {
     DumpLayoutToHd,
     RenameSession,
     DumpLayoutToPlugin,
+    ListClientsMetadata,
 }
 
 /// Stack call representations corresponding to the different types of [`PtyInstruction`]s.
@@ -373,6 +374,7 @@ pub enum PtyContext {
     LogLayoutToHd,
     FillPluginCwd,
     DumpLayoutToPlugin,
+    ListClientsMetadata,
     Exit,
 }
 
@@ -405,6 +407,7 @@ pub enum PluginContext {
     WatchFilesystem,
     KeybindPipe,
     DumpLayoutToPlugin,
+    ListClientsMetadata,
 }
 
 /// Stack call representations corresponding to the different types of [`ClientInstruction`]s.

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -297,6 +297,7 @@ pub enum Action {
         cwd: Option<PathBuf>,
         pane_title: Option<String>,
     },
+    ListClients,
 }
 
 impl Action {
@@ -689,6 +690,9 @@ impl Action {
                     skip_cache,
                 }])
             },
+            CliAction::ListClients => {
+                Ok(vec![Action::ListClients])
+            }
         }
     }
 }

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -690,9 +690,7 @@ impl Action {
                     skip_cache,
                 }])
             },
-            CliAction::ListClients => {
-                Ok(vec![Action::ListClients])
-            }
+            CliAction::ListClients => Ok(vec![Action::ListClients]),
         }
     }
 }

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -1293,6 +1293,7 @@ impl TryFrom<Action> for ProtobufAction {
             | Action::Copy
             | Action::DumpLayout
             | Action::CliPipe { .. }
+            | Action::ListClients
             | Action::SkipConfirm(..) => Err("Unsupported action"),
         }
     }

--- a/zellij-utils/src/session_serialization.rs
+++ b/zellij-utils/src/session_serialization.rs
@@ -216,7 +216,7 @@ fn kdl_string_from_tiled_pane(
     kdl_string
 }
 
-fn extract_command_and_args(layout_run: &Option<Run>) -> (Option<String>, Vec<String>) {
+pub fn extract_command_and_args(layout_run: &Option<Run>) -> (Option<String>, Vec<String>) {
     match layout_run {
         Some(Run::Command(run_command)) => (
             Some(run_command.command.display().to_string()),
@@ -225,7 +225,7 @@ fn extract_command_and_args(layout_run: &Option<Run>) -> (Option<String>, Vec<St
         _ => (None, vec![]),
     }
 }
-fn extract_plugin_and_config(
+pub fn extract_plugin_and_config(
     layout_run: &Option<Run>,
 ) -> (Option<String>, Option<PluginUserConfiguration>) {
     match &layout_run {
@@ -246,7 +246,7 @@ fn extract_plugin_and_config(
         _ => (None, None),
     }
 }
-fn extract_edit_and_line_number(layout_run: &Option<Run>) -> (Option<String>, Option<usize>) {
+pub fn extract_edit_and_line_number(layout_run: &Option<Run>) -> (Option<String>, Option<usize>) {
     match &layout_run {
         // TODO: line number in layouts?
         Some(Run::EditFile(path, line_number, _cwd)) => {


### PR DESCRIPTION
This adds the `zellij action list-clients` CLI command, which returns a list of the clients connected to the session, as well as their focused pane_id and (when available) the command running inside that pane..

Example output:
```
$ zellij action list-clients

CLIENT_ID ZELLIJ_PANE_ID RUNNING_COMMAND
1         plugin_2       zellij:session-manager
2         terminal_3     vim /tmp/my-file.txt
```

This is intended as a solution to those wanting to implemented integrated navigation with other multiplexers (eg. nvim).