### PR TITLE
feat(session-manager): allow Ctrl n and Ctrl p in attach to session to navigate items

### DIFF
--- a/default-plugins/session-manager/src/main.rs
+++ b/default-plugins/session-manager/src/main.rs
@@ -267,6 +267,12 @@ impl State {
         } else if let Key::Up = key {
             self.sessions.move_selection_up();
             should_render = true;
+        } else if let Key::Ctrl('n') = key {
+            self.sessions.move_selection_down();
+            should_render = true;
+        } else if let Key::Ctrl('p') = key {
+            self.sessions.move_selection_up();
+            should_render = true;
         } else if let Key::Char(character) = key {
             if character == '\n' {
                 self.handle_selection();


### PR DESCRIPTION
addresses https://github.com/zellij-org/zellij/issues/2740

Unfortunately, ctrl+hjkl doesn't seem to work in this context.