### PR TITLE
feat: add iceberg dark/light themes

### DIFF
--- a/zellij-utils/assets/themes/iceberg.kdl
+++ b/zellij-utils/assets/themes/iceberg.kdl
@@ -1,0 +1,30 @@
+themes {
+    // note: blue and green are actually swapped to better
+    // fit with the iceberg theme's emphasis on blue
+    iceberg-dark {
+        fg 198 200 209
+        bg 22 24 33
+        black 30 33 50
+        red 226 120 120
+        green 132 160 198
+        yellow 226 164 120
+        blue 180 190 130
+        magenta 160 147 199
+        cyan 137 184 194
+        white 198 200 209
+        orange 226 165 120
+    }
+    iceberg-light {
+        fg 51 55 76
+        bg 232 233 236
+        black 220 223 231
+        red 204 81 122
+        green 45 83 158
+        yellow 197 115 57
+        blue 102 142 61
+        magenta 119 89 180
+        cyan 63 131 166
+        white 51 55 76
+        orange 198 116 57
+    }
+}


### PR DESCRIPTION
Add light and dark themes based off the iceberg theme https://github.com/cocopon/iceberg.vim. The attached examples also set the relevant terminal colorscheme as well.


<img width="896" alt="Screenshot 2024-05-03 at 8 40 15 PM" src="https://github.com/zellij-org/zellij/assets/12422133/ff7bafc6-8c3a-42c3-87db-54d4c98fef59">
<img width="894" alt="Screenshot 2024-05-03 at 8 41 54 PM" src="https://github.com/zellij-org/zellij/assets/12422133/745cd1de-6d06-4ec9-b572-162ac47ad12c">
