### PR TITLE
feat(layouts): allow consuming a layout from a url

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -444,6 +444,10 @@ pub(crate) fn start_client(opts: CliArgs) {
                         layout_dir.clone(),
                         config_without_layout.clone(),
                     ),
+                    LayoutInfo::Url(url) => Layout::from_url(
+                        &url,
+                        config_without_layout.clone(),
+                    ),
                 };
                 match new_session_layout {
                     Ok(new_session_layout) => {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -444,10 +444,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                         layout_dir.clone(),
                         config_without_layout.clone(),
                     ),
-                    LayoutInfo::Url(url) => Layout::from_url(
-                        &url,
-                        config_without_layout.clone(),
-                    ),
+                    LayoutInfo::Url(url) => Layout::from_url(&url, config_without_layout.clone()),
                 };
                 match new_session_layout {
                     Ok(new_session_layout) => {

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -797,6 +797,7 @@ pub struct SessionInfo {
 pub enum LayoutInfo {
     BuiltIn(String),
     File(String),
+    Url(String),
 }
 
 impl LayoutInfo {
@@ -804,12 +805,14 @@ impl LayoutInfo {
         match self {
             LayoutInfo::BuiltIn(name) => &name,
             LayoutInfo::File(name) => &name,
+            LayoutInfo::Url(url) => &url,
         }
     }
     pub fn is_builtin(&self) -> bool {
         match self {
             LayoutInfo::BuiltIn(_name) => true,
             LayoutInfo::File(_name) => false,
+            LayoutInfo::Url(_url) => false,
         }
     }
 }

--- a/zellij-utils/src/downloader.rs
+++ b/zellij-utils/src/downloader.rs
@@ -112,9 +112,8 @@ impl Downloader {
 
         Ok(())
     }
-    pub async fn download_without_cache(
-        url: &str,
-    ) -> Result<String, DownloaderError> { // result is the stringified body
+    pub async fn download_without_cache(url: &str) -> Result<String, DownloaderError> {
+        // result is the stringified body
         let client = surf::client().with(surf::middleware::Redirect::default());
 
         let res = client
@@ -131,7 +130,8 @@ impl Downloader {
         }
 
         log::debug!("Download complete");
-        let stringified = String::from_utf8(downloaded_bytes).map_err(|e| DownloaderError::InvalidUrlBody(format!("{}", e)))?;
+        let stringified = String::from_utf8(downloaded_bytes)
+            .map_err(|e| DownloaderError::InvalidUrlBody(format!("{}", e)))?;
 
         Ok(stringified)
     }

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -529,9 +529,15 @@ impl Action {
                     let layout_dir = layout_dir
                         .or_else(|| config.and_then(|c| c.options.layout_dir))
                         .or_else(|| get_layout_dir(find_default_config_dir()));
-                    let (path_to_raw_layout, raw_layout, swap_layouts) =
+
+                    let (path_to_raw_layout, raw_layout, swap_layouts) = if let Some(layout_url) = layout_path
+                        .to_str()
+                        .and_then(|l| if l.starts_with("http://") || l.starts_with("https://") { Some(l) } else { None }) {
+                            (layout_url.to_owned(), Layout::stringified_from_url(layout_url).map_err(|e| format!("Failed to load layout: {}", e))?, None)
+                    } else {
                         Layout::stringified_from_path_or_default(Some(&layout_path), layout_dir)
-                            .map_err(|e| format!("Failed to load layout: {}", e))?;
+                            .map_err(|e| format!("Failed to load layout: {}", e))?
+                    };
                     let layout = Layout::from_str(&raw_layout, path_to_raw_layout, swap_layouts.as_ref().map(|(f, p)| (f.as_str(), p.as_str())), cwd).map_err(|e| {
                         let stringified_error = match e {
                             ConfigError::KdlError(kdl_error) => {

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -530,10 +530,20 @@ impl Action {
                         .or_else(|| config.and_then(|c| c.options.layout_dir))
                         .or_else(|| get_layout_dir(find_default_config_dir()));
 
-                    let (path_to_raw_layout, raw_layout, swap_layouts) = if let Some(layout_url) = layout_path
-                        .to_str()
-                        .and_then(|l| if l.starts_with("http://") || l.starts_with("https://") { Some(l) } else { None }) {
-                            (layout_url.to_owned(), Layout::stringified_from_url(layout_url).map_err(|e| format!("Failed to load layout: {}", e))?, None)
+                    let (path_to_raw_layout, raw_layout, swap_layouts) = if let Some(layout_url) =
+                        layout_path.to_str().and_then(|l| {
+                            if l.starts_with("http://") || l.starts_with("https://") {
+                                Some(l)
+                            } else {
+                                None
+                            }
+                        }) {
+                        (
+                            layout_url.to_owned(),
+                            Layout::stringified_from_url(layout_url)
+                                .map_err(|e| format!("Failed to load layout: {}", e))?,
+                            None,
+                        )
                     } else {
                         Layout::stringified_from_path_or_default(Some(&layout_path), layout_dir)
                             .map_err(|e| format!("Failed to load layout: {}", e))?

--- a/zellij-utils/src/input/config.rs
+++ b/zellij-utils/src/input/config.rs
@@ -96,6 +96,8 @@ pub enum ConfigError {
     PluginsError(#[from] PluginsConfigError),
     #[error("{0}")]
     ConversionError(#[from] ConversionError),
+    #[error("{0}")]
+    DownloadError(String),
 }
 
 impl ConfigError {

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -18,6 +18,10 @@ use crate::{
     pane_size::{Constraint, Dimension, PaneGeom},
     setup::{self},
 };
+#[cfg(not(target_family = "wasm"))]
+use async_std::task::{self, JoinHandle};
+#[cfg(not(target_family = "wasm"))]
+use crate::downloader::Downloader;
 
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
@@ -1179,6 +1183,20 @@ impl Layout {
             ),
         }
     }
+    pub fn stringified_from_url(url: &str) -> Result<String, ConfigError> {
+        #[cfg(not(target_family = "wasm"))]
+        let raw_layout = task::block_on(async move {
+            let download = Downloader::download_without_cache(url).await;
+            match download {
+                Ok(stringified) => Ok(stringified),
+                Err(e) => Err(ConfigError::DownloadError(format!("{}", e))),
+            }
+        })?;
+        // silently fail - this should not happen in plugins and legacy architecture is hard
+        #[cfg(target_family = "wasm")]
+        let raw_layout = String::new();
+        Ok(raw_layout)
+    }
     pub fn from_path_or_default(
         layout_path: Option<&PathBuf>,
         layout_dir: Option<PathBuf>,
@@ -1196,6 +1214,34 @@ impl Layout {
         )?;
         let config = Config::from_kdl(&raw_layout, Some(config))?; // this merges the two config, with
         Ok((layout, config))
+    }
+    #[cfg(not(target_family = "wasm"))]
+    pub fn from_url(
+        url: &str,
+        config: Config,
+    ) -> Result<(Layout, Config), ConfigError> {
+        let raw_layout = task::block_on(async move {
+            let download = Downloader::download_without_cache(url).await;
+            match download {
+                Ok(stringified) => Ok(stringified),
+                Err(e) => Err(ConfigError::DownloadError(format!("{}", e))),
+            }
+        })?;
+        let layout = Layout::from_kdl(
+            &raw_layout,
+            url.into(),
+            None,
+            None,
+        )?;
+        let config = Config::from_kdl(&raw_layout, Some(config))?; // this merges the two config, with
+        Ok((layout, config))
+    }
+    #[cfg(target_family = "wasm")]
+    pub fn from_url(
+        url: &str,
+        config: Config,
+    ) -> Result<(Layout, Config), ConfigError> {
+        Err(ConfigError::DownloadError(format!("Unsupported platform, cannot download layout from the web")))
     }
     pub fn from_path_or_default_without_config(
         layout_path: Option<&PathBuf>,

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -19,7 +19,7 @@ use crate::{
     setup::{self},
 };
 #[cfg(not(target_family = "wasm"))]
-use async_std::task::{self, JoinHandle};
+use async_std::task;
 #[cfg(not(target_family = "wasm"))]
 use crate::downloader::Downloader;
 
@@ -1148,6 +1148,9 @@ impl Layout {
             },
             LayoutInfo::BuiltIn(layout_name) => {
                 Self::stringified_from_default_assets(&PathBuf::from(layout_name))?
+            },
+            LayoutInfo::Url(url) => {
+                (url.clone(), Self::stringified_from_url(&url)?, None)
             },
         };
         Layout::from_kdl(

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -2166,6 +2166,7 @@ impl SessionInfo {
             let (layout_name, layout_source) = match layout_info {
                 LayoutInfo::File(name) => (name.clone(), "file"),
                 LayoutInfo::BuiltIn(name) => (name.clone(), "built-in"),
+                LayoutInfo::Url(url) => (url.clone(), "url"),
             };
             let mut layout_node = KdlNode::new(format!("{}", layout_name));
             let layout_source = KdlEntry::new_prop("source", layout_source);

--- a/zellij-utils/src/plugin_api/event.rs
+++ b/zellij-utils/src/plugin_api/event.rs
@@ -545,6 +545,10 @@ impl TryFrom<LayoutInfo> for ProtobufLayoutInfo {
                 source: "built-in".to_owned(),
                 name,
             }),
+            LayoutInfo::Url(name) => Ok(ProtobufLayoutInfo {
+                source: "url".to_owned(),
+                name,
+            }),
         }
     }
 }
@@ -555,6 +559,7 @@ impl TryFrom<ProtobufLayoutInfo> for LayoutInfo {
         match protobuf_layout_info.source.as_str() {
             "file" => Ok(LayoutInfo::File(protobuf_layout_info.name)),
             "built-in" => Ok(LayoutInfo::BuiltIn(protobuf_layout_info.name)),
+            "url" => Ok(LayoutInfo::Url(protobuf_layout_info.name)),
             _ => Err("Unknown source for layout"),
         }
     }

--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -671,9 +671,13 @@ impl Setup {
                     .and_then(|cli_options| cli_options.default_layout.clone())
             })
             .or_else(|| config.options.default_layout.clone());
-        // we merge-override the config here because the layout might contain configuration
-        // that needs to take precedence
-        Layout::from_path_or_default(chosen_layout.as_ref(), layout_dir.clone(), config)
+        if let Some(layout_url) = chosen_layout.as_ref().and_then(|l| l.to_str()).and_then(|l| if l.starts_with("http://") || l.starts_with("https://") { Some(l) } else { None }) {
+            Layout::from_url(layout_url, config)
+        } else {
+            // we merge-override the config here because the layout might contain configuration
+            // that needs to take precedence
+            Layout::from_path_or_default(chosen_layout.as_ref(), layout_dir.clone(), config)
+        }
     }
     fn handle_setup_commands(cli_args: &CliArgs) {
         if let Some(Command::Setup(ref setup)) = &cli_args.command {

--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -671,7 +671,17 @@ impl Setup {
                     .and_then(|cli_options| cli_options.default_layout.clone())
             })
             .or_else(|| config.options.default_layout.clone());
-        if let Some(layout_url) = chosen_layout.as_ref().and_then(|l| l.to_str()).and_then(|l| if l.starts_with("http://") || l.starts_with("https://") { Some(l) } else { None }) {
+        if let Some(layout_url) = chosen_layout
+            .as_ref()
+            .and_then(|l| l.to_str())
+            .and_then(|l| {
+                if l.starts_with("http://") || l.starts_with("https://") {
+                    Some(l)
+                } else {
+                    None
+                }
+            })
+        {
             Layout::from_url(layout_url, config)
         } else {
             // we merge-override the config here because the layout might contain configuration


### PR DESCRIPTION
This adds the ability to consume layouts with an `http://` or `https://` prefix anywhere we consume layouts.

So for example:
`zellij --layout https://example.com/my-layout.kdl` will start a new session with the fetched layout
`zellij action new-tab --layout https://example.com/my-layout.kdl` will open new tab(s) from the specified layout

This also works for plugins with the existing `switch_session_with_layout` and `new_tabs_with_layout` commands.