### PR TITLE
fix(grid): fix DL/IL being ineffective without scrolling region

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -2740,13 +2740,21 @@ impl Perform for Grid {
                 self.clear_scroll_region();
             }
         } else if c == 'M' {
-            // delete lines if currently inside scroll region
+            // delete lines if currently inside scroll region, or otherwise
+            // delete lines in the entire viewport
+            if self.scroll_region.is_none() {
+                self.set_scroll_region_to_viewport_size();
+            }
             let line_count_to_delete = next_param_or(1);
             let mut pad_character = EMPTY_TERMINAL_CHARACTER;
             pad_character.styles = self.cursor.pending_styles.clone();
             self.delete_lines_in_scroll_region(line_count_to_delete, pad_character);
         } else if c == 'L' {
-            // insert blank lines if inside scroll region
+            // insert blank lines if inside scroll region, or otherwise insert
+            // blank lines in the entire viewport
+            if self.scroll_region.is_none() {
+                self.set_scroll_region_to_viewport_size();
+            }
             let line_count_to_add = next_param_or(1);
             let mut pad_character = EMPTY_TERMINAL_CHARACTER;
             pad_character.styles = self.cursor.pending_styles.clone();


### PR DESCRIPTION
### Summary

In the current `main` branch of Zellij, the standard control functions `DL` (`\e[%dM`) and `IL` (`\e[%dL`) are no-op until any other control function directly or indirectly sets the scrolling region.

### Problem

- **Steps to reproduce**: The following is a reduced case. Please run the command in **a new session** of Zellij [before any other terminal applications send `ED` (`\e[...J`) or `DECSTBM` (`\e[...r`). To make sure, you could use a simple shell such as Bash or Dash].

```bash
$ seq 10; printf '\e[10A\e[10MHello, world!\n'
```

- **What I expect**: The output of the `seq` command should be removed by `\e[10M` (delete 10 lines). Then, `Hello, world!` is printed.
- **What I get in the `main` branch**: Nothing happens with `\e[10M`. The output of the `seq` command remains in the terminal screen, and the message `Hello, world!` is printed over the output of the `seq` command.

Those control functions `DL` and `IL` defined by the ANSI standard (ANSI X 3.64 and corresponding ECMA-48) should operate on the entire viewport if the scrolling region is not defined. In the first place, the ANSI standard doesn't define the scroll region, so they should work even without specifying the scrolling regions (`DECSTBM` and `DECSLRM`).

The problem disappears when any other terminal application sends another standard control function `ED(2)` (`\e[2J`) because this control function is designed to set the scroll region to the entire viewport.

https://github.com/zellij-org/zellij/blob/c72f3a712bfa92a4a80b4c1ad1dbe7669892a324/zellij-server/src/panes/grid.rs#L2491-L2493

The control function `IL` has the same issue. This PR fixes `DL` and `IL` so that they operate on the entire viewport by setting the scroll region to the entire viewport (in a similar manner as `ED(2)`).

For the present behavior in the `main` branch, I suspect commit [`cd5ddd1`](https://github.com/zellij-org/zellij/commit/cd5ddd1d2995fd7495b223e17809247b19cfc4dd#diff-eee6f90451a46a505ddbce570e7aa27ed44e8bfe38f0ff928061861cfb5602efL1246), but I haven't tested it and haven't carefully looked at the change either.

This fixes the issue originally reported at https://github.com/akinomyoga/ble.sh/issues/450.

### Remarks

This is unrelated to the present fix, but with the current implementation of `ED`, the scroll region set by `DECSTBM` is lost when the terminal application sends `ED(2)` (`\e[2J`). Is this intended?
