### PR TITLE
Allow different users in the same group to share a session.

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -136,11 +136,11 @@ fn get_os_input<OsInputOutput>(
     }
 }
 
-pub(crate) fn start_server(path: PathBuf, debug: bool) {
+pub(crate) fn start_server(path: PathBuf, debug: bool, group: Option<u32>) {
     // Set instance-wide debug mode
     zellij_utils::consts::DEBUG_MODE.set(debug).unwrap();
     let os_input = get_os_input(get_server_os_input);
-    start_server_impl(Box::new(os_input), path);
+    start_server_impl(Box::new(os_input), path, group);
 }
 
 fn create_new_client() -> ClientInfo {

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,7 +189,7 @@ fn main() {
     {
         commands::delete_session(target_session, force);
     } else if let Some(path) = opts.server {
-        commands::start_server(path, opts.debug);
+        commands::start_server(path, opts.debug, opts.socket_group);
     } else {
         commands::start_client(opts);
     }

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 pub const ZELLIJ_CONFIG_FILE_ENV: &str = "ZELLIJ_CONFIG_FILE";
 pub const ZELLIJ_CONFIG_DIR_ENV: &str = "ZELLIJ_CONFIG_DIR";
 pub const ZELLIJ_LAYOUT_DIR_ENV: &str = "ZELLIJ_LAYOUT_DIR";
+pub const ZELLIJ_SOCKET_GROUP_ENV: &str = "ZELLIJ_SOCKET_GROUP";
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const DEFAULT_SCROLL_BUFFER_SIZE: usize = 10_000;
 pub static SCROLL_BUFFER_SIZE: OnceCell<usize> = OnceCell::new();
@@ -122,7 +123,7 @@ pub use unix_only::*;
 mod unix_only {
     use super::*;
     use crate::envs;
-    pub use crate::shared::set_permissions;
+    pub use crate::shared::{get_group, set_permissions};
     use lazy_static::lazy_static;
     use nix::unistd::Uid;
     use std::env::temp_dir;

--- a/zellij-utils/src/envs.rs
+++ b/zellij-utils/src/envs.rs
@@ -31,6 +31,11 @@ pub fn get_socket_dir() -> Result<String> {
     Ok(var(SOCKET_DIR_ENV_KEY)?)
 }
 
+pub const SOCKET_GROUP_ENV_KEY: &str = "ZELLIJ_SOCKET_GROUP";
+pub fn get_socket_group() -> Result<String> {
+    Ok(var(SOCKET_GROUP_ENV_KEY)?)
+}
+
 /// Manage ENVIRONMENT VARIABLES from the configuration and the layout files
 #[derive(Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EnvironmentVariables {

--- a/zellij-utils/src/shared.rs
+++ b/zellij-utils/src/shared.rs
@@ -13,20 +13,39 @@ pub use unix_only::*;
 
 #[cfg(unix)]
 mod unix_only {
-    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
     use std::path::Path;
-    use std::{fs, io};
+    use std::{fs, io, os::unix};
 
     pub fn set_permissions(path: &Path, mode: u32) -> io::Result<()> {
         let mut permissions = fs::metadata(path)?.permissions();
         permissions.set_mode(mode);
         fs::set_permissions(path, permissions)
     }
+
+    pub fn set_group(path: &Path, gid: u32) -> io::Result<()> {
+        unix::fs::chown(path, None, Some(gid))
+    }
+
+    pub fn get_group(path: &Path) -> io::Result<u32> {
+        let metadata = fs::metadata(path)?;
+        Ok(metadata.gid())
+    }
 }
 
 #[cfg(not(unix))]
 pub fn set_permissions(_path: &std::path::Path, _mode: u32) -> std::io::Result<()> {
     Ok(())
+}
+
+#[cfg(not(unix))]
+pub fn set_group(_path: &std::path::Path, _gid: u32) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(not(unix))]
+pub fn get_group(_path: &std::path::Path, _gid: u32) -> std::io::Result<u32> {
+    Ok(0)
 }
 
 pub fn ansi_len(s: &str) -> usize {


### PR DESCRIPTION
I understand from [the CONTRIBUTING.md document](https://github.com/zellij-org/zellij/blob/56baf0b13dfc177a095ae9b3267fe531d4453099/CONTRIBUTING.md#status-of-code-contributions-prs) that the project doesn't have the capacity to field random feature PRs while it works on its roadmap. And this random feature PR is a sketch that doesn't even have tests!

...but, @fzakaria encouraged me to open it to gauge interest. No worries if the answer is everyone's too busy to review or merge, but I'm totally willing to iterate on it -- I have a sequence of ideas about how this could be evolved into a more secure method of collaboration -- and, you know, add tests too.

Anyway, here's what's in the commit:

Adds a `ZELLIJ_SOCKET_GROUP` environment variable that specifies the group by name that should own the Zellij sockets and socket directory.

When this environment variable is set for a Zellij server, it will chown the Zellij socket directory and session socket to be owned by the named group with group read and execute (list) permissions set.

When this environment variable is set for a Zellij client, it will check that Zellij socket directory is owned by the expected group.

Example usage:

As user `foo`:

```
[foo@localhost:~$] id --name --groups
zellij-collab
[foo@localhost:~$] ZELLIJ_SOCKET_DIR=/tmp/example-sockets ZELLIJ_SOCKET_GROUP=zellij-collab zellij
[foo@localhost:~$] ls -lad /tmp/zellij-sockets/
drwxr-xr-x 2 foo zellij-collab 4096 Jun  7 00:00 /tmp/zellij-sockets/
```

As user `bar`:
```
[bar@localhost:~$] id --name --groups
zellij-collab
[bar@localhost:~$] ZELLIJ_SOCKET_DIR=/tmp/example-sockets ZELLIJ_SOCKET_GROUP=zellij-collab zellij attach
```