### PR TITLE
Match Tmux's "o" behavior in default keybinds

### DIFF
--- a/zellij-utils/assets/config/default.kdl
+++ b/zellij-utils/assets/config/default.kdl
@@ -139,7 +139,7 @@ keybinds {
         bind "l" { MoveFocus "Right"; SwitchToMode "Normal"; }
         bind "j" { MoveFocus "Down"; SwitchToMode "Normal"; }
         bind "k" { MoveFocus "Up"; SwitchToMode "Normal"; }
-        bind "o" { FocusNextPane; }
+        bind "o" { FocusNextPane; SwitchToMode "Normal"; }
         bind "d" { Detach; }
         bind "Space" { NextSwapLayout; }
         bind "x" { CloseFocus; SwitchToMode "Normal"; }


### PR DESCRIPTION
Hello!

This is a very-minor fix to the default keybinds to mirror that Tmux goes back to Normal mode after `Ctrl-B o` by default. It's fine if you do not want to accept this, but this is how Tmux behaves for this bind (at least as of 3.4 which is on my systems, but I believe since much earlier). Thank you so much for making such a quality piece of software, and I really appreciate the inclusion of Tmux keybindings, as it's helping me transition to Zellij without relearning all my muscle-memory!

Thank you so much,
Arctic.