### PR TITLE
fix: use ITU T.418 format for emitted CSI 58 sequences

### DIFF
--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -619,10 +619,10 @@ impl Display for CharacterStyles {
             if let Some(ansi_code) = self.underline_color {
                 match ansi_code {
                     AnsiCode::RgbCode((r, g, b)) => {
-                        write!(f, "\u{1b}[58;2;{};{};{}m", r, g, b)?;
+                        write!(f, "\u{1b}[58:2::{}:{}:{}m", r, g, b)?;
                     },
                     AnsiCode::ColorIndex(color_index) => {
-                        write!(f, "\u{1b}[58;5;{}m", color_index)?;
+                        write!(f, "\u{1b}[58:5:{}m", color_index)?;
                     },
                     AnsiCode::Reset => {
                         write!(f, "\u{1b}[59m")?;


### PR DESCRIPTION
Addresses https://github.com/microsoft/terminal/issues/17426 on our side.

Tested both on nightly wezterm on Windows WSL2, and on a native linux wezterm for a cursory regression check.