### PR TITLE
feat(themes): add Vesper theme

### DIFF
--- a/zellij-utils/assets/themes/vesper.kdl
+++ b/zellij-utils/assets/themes/vesper.kdl
@@ -1,0 +1,18 @@
+// Vesper theme
+// https://github.com/raunofreiberg/vesper
+
+themes {
+  vesper {
+    fg "#ffffff"
+    bg "#101010"
+    black "#101010"
+    red "#f5a191"
+    green "#90b99f"
+    yellow "#e6b99d"
+    blue "#aca1cf"
+    magenta "#e29eca"
+    cyan "#ea83a5"
+    white "#a0a0a0"
+    orange "#ffc799"
+  }
+}


### PR DESCRIPTION
Add Vesper theme, based on https://github.com/raunofreiberg/vesper.

## Preview

![](https://github.com/zellij-org/zellij/assets/874370/29293a65-8578-4a61-b185-860c03d3ce3c)
