### PR TITLE
fix(terminal): only refresh process specifics for given PID in get_cwd()

### DIFF
--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -740,7 +740,7 @@ impl ServerOsApi for ServerOsInputOutput {
         let mut system_info = System::new();
         // Update by minimizing information.
         // See https://docs.rs/sysinfo/0.22.5/sysinfo/struct.ProcessRefreshKind.html#
-        system_info.refresh_processes_specifics(ProcessRefreshKind::default());
+        system_info.refresh_process_specifics(pid.into(), ProcessRefreshKind::default());
 
         if let Some(process) = system_info.process(pid.into()) {
             let cwd = process.cwd();


### PR DESCRIPTION
Update `get_cwd()` to only refresh process specifics for the given PID, matching the `get_cwds()` implementation.

This significantly reduces the latency of opening a new Pane or Tab.

On a 64-core Threadripper system, this reduces the latency of `get_cwd()` from 850ms to 1ms. On an 8-core Ryzen system, the improvement is smaller, but still perceptible.