### PR TITLE
cargo: Remove `rust-version` (msrv) field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix(terminal): workaround for windows terminal not interpreting underline colors with semicolons (https://github.com/zellij-org/zellij/pull/3440)
 * dependencies: switch from wasmer to wasmtime (https://github.com/zellij-org/zellij/pull/3349)
 * feat(ui): status-bar redesign (https://github.com/zellij-org/zellij/pull/3475)
+* chore: Remove MSRV from Cargo.toml (https://github.com/zellij-org/zellij/pull/3480)
 
 ## [0.40.1] - 2024-05-02
 * fix(sessions): issue where sessions would occasionally become unresponsive (https://github.com/zellij-org/zellij/pull/3281)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT"
 repository = "https://github.com/zellij-org/zellij"
 homepage = "https://zellij.dev"
 include = ["src/**/*", "assets/layouts/*", "assets/config/*", "LICENSE.md", "README.md", "!**/*_test.*", "!**/tests/**/*"]
-rust-version = "1.60"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
from `Cargo.toml`. This has gone out of sync with the rust version specified in `rust-toolchain.toml` and appears to have little consequence to development, since it defines only the MSRV. We're using `rust-toolchain.toml` to strictly enforce a specific rust version for development, hence we stick with that.

Closes #3476