### PR TITLE
cargo: Reintroduce `rust-version` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix(terminal): workaround for windows terminal not interpreting underline colors with semicolons (https://github.com/zellij-org/zellij/pull/3440)
 * dependencies: switch from wasmer to wasmtime (https://github.com/zellij-org/zellij/pull/3349)
 * feat(ui): status-bar redesign (https://github.com/zellij-org/zellij/pull/3475)
-* chore: Remove MSRV from Cargo.toml (https://github.com/zellij-org/zellij/pull/3480)
+* chore: Update MSRV in Cargo.toml (https://github.com/zellij-org/zellij/pull/3482)
 
 ## [0.40.1] - 2024-05-02
 * fix(sessions): issue where sessions would occasionally become unresponsive (https://github.com/zellij-org/zellij/pull/3281)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ license = "MIT"
 repository = "https://github.com/zellij-org/zellij"
 homepage = "https://zellij.dev"
 include = ["src/**/*", "assets/layouts/*", "assets/config/*", "LICENSE.md", "README.md", "!**/*_test.*", "!**/tests/**/*"]
+# NOTE: When updating this, modify `channel` in `rust-toolchain.toml` accordingly
+rust-version = "1.75"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,6 @@
 # This file is updated by `update-toolchain.sh`
 [toolchain]
+# NOTE: When updating this, modify `rust-version` in `Cargo.toml` accordingly
 channel = "1.75.0"
 components = ["rustfmt", "clippy", "rust-analysis"]
 targets = ["wasm32-wasi", "x86_64-unknown-linux-musl"]


### PR DESCRIPTION
in `Cargo.toml` since it appears that client-side `cargo` will check this field and [error when the users rust toolchain is too old][1]. Add comments in `Cargo.toml` and `rust-toolchain.toml` pointing to each other so the rust versions mentioned in each file are hopefully kept in sync in the future.

Reverts #3480.

[1]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field