### PR TITLE
feat(plugins): add stringified layout to switch_session_with_layout

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -445,6 +445,10 @@ pub(crate) fn start_client(opts: CliArgs) {
                         config_without_layout.clone(),
                     ),
                     LayoutInfo::Url(url) => Layout::from_url(&url, config_without_layout.clone()),
+                    LayoutInfo::Stringified(stringified_layout) => Layout::from_stringified_layout(
+                        &stringified_layout,
+                        config_without_layout.clone(),
+                    ),
                 };
                 match new_session_layout {
                     Ok(new_session_layout) => {

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -64,7 +64,7 @@ pub(crate) fn get_resurrectable_sessions() -> Vec<(String, Duration, Layout)> {
                     };
                     let layout = match Layout::from_kdl(
                         &raw_layout,
-                        layout_file_name.display().to_string(),
+                        Some(layout_file_name.display().to_string()),
                         None,
                         None,
                     ) {

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -922,6 +922,13 @@ fn switch_session(
 ) -> Result<()> {
     // pane_id is (id, is_plugin)
     let err_context = || format!("Failed to switch session");
+    if let Some(LayoutInfo::Stringified(stringified_layout)) = layout.as_ref() {
+        // we verify the stringified layout here to fail early rather than when parsing it at the
+        // session-switching phase
+        if let Err(e) = Layout::from_kdl(&stringified_layout, None, None, None) {
+            return Err(anyhow!("Failed to deserialize layout: {}", e));
+        }
+    }
     let client_id = env.client_id;
     let tab_position = tab_position.map(|p| p + 1); // ¯\_()_/¯
     let connect_to_session = ConnectToSession {

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -3151,7 +3151,7 @@ fn can_swap_tiled_layout_at_runtime() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -3204,7 +3204,7 @@ fn can_swap_floating_layout_at_runtime() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -3259,7 +3259,7 @@ fn swapping_layouts_after_resize_snaps_to_current_layout() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -3307,7 +3307,7 @@ fn swap_tiled_layout_with_stacked_children() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -3354,7 +3354,7 @@ fn swap_tiled_layout_with_only_stacked_children() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -3404,7 +3404,7 @@ fn swap_tiled_layout_with_stacked_children_and_no_pane_frames() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -3454,7 +3454,7 @@ fn move_focus_up_with_stacked_panes() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -3506,7 +3506,7 @@ fn move_focus_down_with_stacked_panes() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -3562,7 +3562,7 @@ fn move_focus_right_into_stacked_panes() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -3630,7 +3630,7 @@ fn move_focus_left_into_stacked_panes() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -3700,7 +3700,7 @@ fn move_focus_up_into_stacked_panes() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -3771,7 +3771,7 @@ fn move_focus_down_into_stacked_panes() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -3836,7 +3836,7 @@ fn close_main_stacked_pane() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -3887,7 +3887,7 @@ fn close_main_stacked_pane_in_mid_stack() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -3947,7 +3947,7 @@ fn close_one_liner_stacked_pane_below_main_pane() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -4008,7 +4008,7 @@ fn close_one_liner_stacked_pane_above_main_pane() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -4068,7 +4068,7 @@ fn can_increase_size_of_main_pane_in_stack_horizontally() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -4132,7 +4132,7 @@ fn can_increase_size_of_main_pane_in_stack_vertically() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -4196,7 +4196,7 @@ fn can_increase_size_of_main_pane_in_stack_non_directionally() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -4256,7 +4256,7 @@ fn can_increase_size_into_pane_stack_horizontally() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -4319,7 +4319,7 @@ fn can_increase_size_into_pane_stack_vertically() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -4384,7 +4384,7 @@ fn can_increase_size_into_pane_stack_non_directionally() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -4443,7 +4443,7 @@ fn decreasing_size_of_whole_tab_treats_stacked_panes_properly() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -4503,7 +4503,7 @@ fn increasing_size_of_whole_tab_treats_stacked_panes_properly() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -4568,7 +4568,7 @@ fn cannot_decrease_stack_size_beyond_minimum_height() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -4633,7 +4633,7 @@ fn focus_stacked_pane_over_flexible_pane_with_the_mouse() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -4692,7 +4692,7 @@ fn focus_stacked_pane_under_flexible_pane_with_the_mouse() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -4753,7 +4753,7 @@ fn close_stacked_pane_with_previously_focused_other_pane() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -4820,7 +4820,7 @@ fn close_pane_near_stacked_panes() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -4884,7 +4884,7 @@ fn focus_next_pane_expands_stacked_panes() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -4944,7 +4944,7 @@ fn stacked_panes_can_become_fullscreen() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -5027,7 +5027,7 @@ fn layout_with_plugins_and_commands_swaped_properly() {
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -5048,7 +5048,8 @@ fn layout_with_plugins_and_commands_swaped_properly() {
         vec![2],
     );
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -5122,7 +5123,7 @@ fn base_layout_is_included_in_swap_layouts() {
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -5143,7 +5144,8 @@ fn base_layout_is_included_in_swap_layouts() {
         vec![2],
     );
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -5218,7 +5220,7 @@ fn swap_layouts_including_command_panes_absent_from_existing_layout() {
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -5235,7 +5237,8 @@ fn swap_layouts_including_command_panes_absent_from_existing_layout() {
         vec![2],
     );
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -5309,7 +5312,7 @@ fn swap_layouts_not_including_command_panes_present_in_existing_layout() {
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -5330,7 +5333,8 @@ fn swap_layouts_not_including_command_panes_present_in_existing_layout() {
         vec![2],
     );
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -5400,7 +5404,7 @@ fn swap_layouts_including_plugin_panes_absent_from_existing_layout() {
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -5409,7 +5413,8 @@ fn swap_layouts_including_plugin_panes_absent_from_existing_layout() {
     let new_floating_terminal_ids = vec![];
     let new_plugin_ids = HashMap::new();
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -5477,7 +5482,7 @@ fn swap_layouts_not_including_plugin_panes_present_in_existing_layout() {
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -5498,7 +5503,8 @@ fn swap_layouts_not_including_plugin_panes_present_in_existing_layout() {
         vec![2],
     );
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -5558,7 +5564,7 @@ fn new_pane_in_auto_layout() {
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -5567,7 +5573,8 @@ fn new_pane_in_auto_layout() {
     let new_floating_terminal_ids = vec![];
     let new_plugin_ids = HashMap::new();
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -5651,7 +5658,7 @@ fn when_swapping_tiled_layouts_in_a_damaged_state_layout_and_pane_focus_are_unch
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -5660,7 +5667,8 @@ fn when_swapping_tiled_layouts_in_a_damaged_state_layout_and_pane_focus_are_unch
     let new_floating_terminal_ids = vec![];
     let new_plugin_ids = HashMap::new();
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -5729,7 +5737,7 @@ fn when_swapping_tiled_layouts_in_an_undamaged_state_pane_focuses_on_focused_nod
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -5738,7 +5746,8 @@ fn when_swapping_tiled_layouts_in_an_undamaged_state_pane_focuses_on_focused_nod
     let new_floating_terminal_ids = vec![];
     let new_plugin_ids = HashMap::new();
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -5803,7 +5812,7 @@ fn when_swapping_tiled_layouts_in_an_undamaged_state_with_no_focus_node_pane_foc
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -5812,7 +5821,8 @@ fn when_swapping_tiled_layouts_in_an_undamaged_state_with_no_focus_node_pane_foc
     let new_floating_terminal_ids = vec![];
     let new_plugin_ids = HashMap::new();
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -5876,7 +5886,7 @@ fn when_closing_a_pane_in_auto_layout_the_focus_goes_to_last_focused_pane() {
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -5885,7 +5895,8 @@ fn when_closing_a_pane_in_auto_layout_the_focus_goes_to_last_focused_pane() {
     let new_floating_terminal_ids = vec![];
     let new_plugin_ids = HashMap::new();
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -5962,7 +5973,7 @@ fn floating_layout_with_plugins_and_commands_swaped_properly() {
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -5983,7 +5994,8 @@ fn floating_layout_with_plugins_and_commands_swaped_properly() {
         vec![2],
     );
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -6055,7 +6067,7 @@ fn base_floating_layout_is_included_in_swap_layouts() {
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -6076,7 +6088,8 @@ fn base_floating_layout_is_included_in_swap_layouts() {
         vec![2],
     );
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -6151,7 +6164,7 @@ fn swap_floating_layouts_including_command_panes_absent_from_existing_layout() {
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -6168,7 +6181,8 @@ fn swap_floating_layouts_including_command_panes_absent_from_existing_layout() {
         vec![2],
     );
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -6242,7 +6256,7 @@ fn swap_floating_layouts_not_including_command_panes_present_in_existing_layout(
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -6263,7 +6277,8 @@ fn swap_floating_layouts_not_including_command_panes_present_in_existing_layout(
         vec![2],
     );
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -6326,7 +6341,7 @@ fn swap_floating_layouts_including_plugin_panes_absent_from_existing_layout() {
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -6335,7 +6350,8 @@ fn swap_floating_layouts_including_plugin_panes_absent_from_existing_layout() {
     let new_terminal_ids = vec![(4, None)];
     let new_plugin_ids = HashMap::new();
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -6399,7 +6415,7 @@ fn swap_floating_layouts_not_including_plugin_panes_present_in_existing_layout()
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -6420,7 +6436,8 @@ fn swap_floating_layouts_not_including_plugin_panes_present_in_existing_layout()
         vec![2],
     );
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -6480,7 +6497,7 @@ fn new_floating_pane_in_auto_layout() {
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -6489,7 +6506,8 @@ fn new_floating_pane_in_auto_layout() {
     let new_floating_terminal_ids = vec![];
     let new_plugin_ids = HashMap::new();
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -6566,7 +6584,7 @@ fn when_swapping_floating_layouts_in_a_damaged_state_layout_and_pane_focus_are_u
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -6575,7 +6593,8 @@ fn when_swapping_floating_layouts_in_a_damaged_state_layout_and_pane_focus_are_u
     let new_terminal_ids = vec![(4, None)];
     let new_plugin_ids = HashMap::new();
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -6643,7 +6662,7 @@ fn when_swapping_floating_layouts_in_an_undamaged_state_pane_focuses_on_focused_
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -6652,7 +6671,8 @@ fn when_swapping_floating_layouts_in_an_undamaged_state_pane_focuses_on_focused_
     let new_terminal_ids = vec![(4, None)];
     let new_plugin_ids = HashMap::new();
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -6716,7 +6736,7 @@ fn when_swapping_floating_layouts_in_an_undamaged_state_with_no_focus_node_pane_
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -6725,7 +6745,8 @@ fn when_swapping_floating_layouts_in_an_undamaged_state_with_no_focus_node_pane_
     let new_terminal_ids = vec![(4, None)];
     let new_plugin_ids = HashMap::new();
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -6788,7 +6809,7 @@ fn when_closing_a_floating_pane_in_auto_layout_the_focus_goes_to_last_focused_pa
         }
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -6797,7 +6818,8 @@ fn when_closing_a_floating_pane_in_auto_layout_the_focus_goes_to_last_focused_pa
     let new_terminal_ids = vec![(4, None)];
     let new_plugin_ids = HashMap::new();
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(
@@ -6853,7 +6875,7 @@ fn when_resizing_whole_tab_with_auto_layout_and_floating_panes_the_layout_is_mai
         layout
     "#;
     let (base_layout, base_floating_layout) =
-        Layout::from_kdl(base_layout, "file_name.kdl".into(), None, None)
+        Layout::from_kdl(base_layout, Some("file_name.kdl".into()), None, None)
             .unwrap()
             .template
             .unwrap();
@@ -6862,7 +6884,8 @@ fn when_resizing_whole_tab_with_auto_layout_and_floating_panes_the_layout_is_mai
     let new_terminal_ids = vec![(4, None)];
     let new_plugin_ids = HashMap::new();
 
-    let swap_layout = Layout::from_kdl(swap_layouts, "file_name.kdl".into(), None, None).unwrap();
+    let swap_layout =
+        Layout::from_kdl(swap_layouts, Some("file_name.kdl".into()), None, None).unwrap();
     let swap_tiled_layouts = swap_layout.swap_tiled_layouts.clone();
     let swap_floating_layouts = swap_layout.swap_floating_layouts.clone();
     let mut tab = create_new_tab_with_swap_layouts(

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -1184,6 +1184,7 @@ pub enum LayoutInfo {
     BuiltIn(String),
     File(String),
     Url(String),
+    Stringified(String),
 }
 
 impl LayoutInfo {
@@ -1192,6 +1193,7 @@ impl LayoutInfo {
             LayoutInfo::BuiltIn(name) => &name,
             LayoutInfo::File(name) => &name,
             LayoutInfo::Url(url) => &url,
+            LayoutInfo::Stringified(layout) => &layout,
         }
     }
     pub fn is_builtin(&self) -> bool {
@@ -1199,6 +1201,7 @@ impl LayoutInfo {
             LayoutInfo::BuiltIn(_name) => true,
             LayoutInfo::File(_name) => false,
             LayoutInfo::Url(_url) => false,
+            LayoutInfo::Stringified(_stringified) => false,
         }
     }
 }

--- a/zellij-utils/src/input/unit/layout_test.rs
+++ b/zellij-utils/src/input/unit/layout_test.rs
@@ -4,7 +4,7 @@ use insta::assert_snapshot;
 #[test]
 fn empty_layout() {
     let kdl_layout = "layout";
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         template: Some((TiledPaneLayout::default(), vec![])),
         ..Default::default()
@@ -19,7 +19,7 @@ fn layout_with_one_pane() {
             pane
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         template: Some((
             TiledPaneLayout {
@@ -42,7 +42,7 @@ fn layout_with_multiple_panes() {
             pane
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         template: Some((
             TiledPaneLayout {
@@ -74,7 +74,7 @@ fn layout_with_nested_panes() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         template: Some((
             TiledPaneLayout {
@@ -115,7 +115,7 @@ fn layout_with_floating_panes() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         template: Some((
             TiledPaneLayout::default(),
@@ -159,7 +159,7 @@ fn layout_with_mixed_panes_and_floating_panes() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         template: Some((
             TiledPaneLayout {
@@ -186,7 +186,7 @@ fn layout_with_hidden_floating_panes() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         tabs: vec![(
             None,
@@ -218,7 +218,7 @@ fn layout_with_floating_panes_template() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         template: Some((
             TiledPaneLayout {
@@ -253,7 +253,7 @@ fn layout_with_shared_tiled_and_floating_panes_template() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         template: Some((
             TiledPaneLayout {
@@ -301,7 +301,7 @@ fn layout_with_tabs_and_floating_panes() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -312,7 +312,7 @@ fn layout_with_tabs() {
             tab
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         tabs: vec![(None, TiledPaneLayout::default(), vec![])],
         template: Some((TiledPaneLayout::default(), vec![])),
@@ -336,7 +336,7 @@ fn layout_with_nested_differing_tabs() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         tabs: vec![
             (
@@ -378,7 +378,7 @@ fn layout_with_panes_in_different_mixed_split_sizes() {
             pane size=2;
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         template: Some((
             TiledPaneLayout {
@@ -416,7 +416,7 @@ fn layout_with_command_panes() {
             pane command="htop"
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         template: Some((
             TiledPaneLayout {
@@ -444,7 +444,7 @@ fn layout_with_command_panes_and_cwd() {
             pane command="htop" cwd="/path/to/my/cwd"
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         template: Some((
             TiledPaneLayout {
@@ -475,7 +475,7 @@ fn layout_with_command_panes_and_cwd_and_args() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         template: Some((
             TiledPaneLayout {
@@ -507,7 +507,7 @@ fn layout_with_command_panes_and_close_on_exit() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -520,7 +520,7 @@ fn layout_with_command_panes_and_start_suspended() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -542,7 +542,7 @@ fn layout_with_plugin_panes() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let mut expected_plugin_configuration = BTreeMap::new();
     expected_plugin_configuration.insert("config_key_1".to_owned(), "config_value_1".to_owned());
     expected_plugin_configuration.insert("2".to_owned(), "true".to_owned());
@@ -596,7 +596,7 @@ fn layout_with_borderless_panes() {
             pane borderless=true
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         template: Some((
             TiledPaneLayout {
@@ -620,7 +620,7 @@ fn layout_with_focused_panes() {
             pane focus=true
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         template: Some((
             TiledPaneLayout {
@@ -644,7 +644,7 @@ fn layout_with_pane_names() {
             pane name="my awesome pane"
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         template: Some((
             TiledPaneLayout {
@@ -669,7 +669,7 @@ fn layout_with_tab_names() {
             tab name="my cool tab name 2"
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         tabs: vec![
             (
@@ -704,7 +704,7 @@ fn layout_with_focused_tab() {
             tab
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         tabs: vec![
             (None, TiledPaneLayout::default(), vec![]),
@@ -738,7 +738,7 @@ fn layout_with_tab_templates() {
             one-above-one-below
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         tabs: vec![
             (
@@ -815,7 +815,7 @@ fn layout_with_default_tab_template() {
             tab
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -840,7 +840,7 @@ fn layout_with_new_tab_template() {
             tab
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -867,7 +867,7 @@ fn layout_with_pane_templates() {
             left-and-right
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -888,7 +888,7 @@ fn layout_with_tab_and_pane_templates() {
             left-right-and-htop
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -909,7 +909,7 @@ fn layout_with_nested_pane_templates() {
             left-and-right
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -935,7 +935,7 @@ fn layout_with_nested_branched_pane_templates() {
             left-and-right
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -959,7 +959,7 @@ fn circular_dependency_pane_templates_error() {
             one
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None);
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None);
     assert!(layout.is_err(), "circular dependency detected");
 }
 
@@ -981,7 +981,7 @@ fn children_not_as_first_child_of_tab_template() {
             horizontal-with-vertical-top
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1004,7 +1004,7 @@ fn error_on_more_than_one_children_block_in_tab_template() {
             horizontal-with-vertical-top
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None);
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None);
     assert!(
         layout.is_err(),
         "error provided for more than one children block"
@@ -1029,7 +1029,7 @@ fn children_not_as_first_child_of_pane_template() {
             horizontal-with-vertical-top
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1052,7 +1052,7 @@ fn error_on_more_than_one_children_block_in_pane_template() {
             horizontal-with-vertical-top
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None);
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None);
     assert!(
         layout.is_err(),
         "error provided for more than one children block"
@@ -1081,7 +1081,7 @@ fn combined_tab_and_pane_template_both_with_children() {
             horizontal-with-vertical-top
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1092,7 +1092,7 @@ fn layout_with_pane_excluded_from_sync() {
             pane exclude_from_sync=true
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1108,7 +1108,7 @@ fn cannot_define_tab_template_name_with_space() {
             pane
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None);
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None);
     assert!(layout.is_err(), "error provided for tab name with space");
 }
 
@@ -1124,7 +1124,7 @@ fn cannot_define_pane_template_name_with_space() {
             pane
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None);
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None);
     assert!(layout.is_err(), "error provided for tab name with space");
 }
 
@@ -1138,7 +1138,7 @@ fn cannot_define_panes_and_tabs_on_same_level() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None);
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None);
     assert!(
         layout.is_err(),
         "error provided for tab and pane on the same level"
@@ -1172,7 +1172,7 @@ fn cannot_define_tab_template_names_as_keywords() {
         ",
             keyword
         );
-        let layout = Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None, None);
+        let layout = Layout::from_kdl(&kdl_layout, Some("layout_file_name".into()), None, None);
         assert!(
             layout.is_err(),
             "{}",
@@ -1210,7 +1210,7 @@ fn cannot_define_pane_template_names_as_keywords() {
         ",
             keyword
         );
-        let layout = Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None, None);
+        let layout = Layout::from_kdl(&kdl_layout, Some("layout_file_name".into()), None, None);
         assert!(
             layout.is_err(),
             "{}",
@@ -1231,7 +1231,7 @@ fn error_on_multiple_layout_nodes_in_file() {
     "
     );
     let layout_error =
-        Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None, None).unwrap_err();
+        Layout::from_kdl(&kdl_layout, Some("layout_file_name".into()), None, None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
@@ -1247,7 +1247,7 @@ fn error_on_unknown_layout_node() {
     "
     );
     let layout_error =
-        Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None, None).unwrap_err();
+        Layout::from_kdl(&kdl_layout, Some("layout_file_name".into()), None, None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
@@ -1261,7 +1261,7 @@ fn error_on_unknown_layout_pane_property() {
     "
     );
     let layout_error =
-        Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None, None).unwrap_err();
+        Layout::from_kdl(&kdl_layout, Some("layout_file_name".into()), None, None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
@@ -1275,7 +1275,7 @@ fn error_on_unknown_layout_pane_template_property() {
     "
     );
     let layout_error =
-        Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None, None).unwrap_err();
+        Layout::from_kdl(&kdl_layout, Some("layout_file_name".into()), None, None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
@@ -1289,7 +1289,7 @@ fn error_on_unknown_layout_tab_property() {
     "
     );
     let layout_error =
-        Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None, None).unwrap_err();
+        Layout::from_kdl(&kdl_layout, Some("layout_file_name".into()), None, None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
@@ -1303,7 +1303,7 @@ fn error_on_unknown_layout_tab_template_property() {
     "
     );
     let layout_error =
-        Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None, None).unwrap_err();
+        Layout::from_kdl(&kdl_layout, Some("layout_file_name".into()), None, None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
@@ -1321,7 +1321,7 @@ fn error_on_pane_templates_without_a_name() {
     "
     );
     let layout_error =
-        Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None, None).unwrap_err();
+        Layout::from_kdl(&kdl_layout, Some("layout_file_name".into()), None, None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
@@ -1339,7 +1339,7 @@ fn error_on_tab_templates_without_a_name() {
     "
     );
     let layout_error =
-        Layout::from_kdl(&kdl_layout, "layout_file_name".into(), None, None).unwrap_err();
+        Layout::from_kdl(&kdl_layout, Some("layout_file_name".into()), None, None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
@@ -1353,7 +1353,7 @@ fn error_on_more_than_one_focused_tab() {
         }
     "#;
     let layout_error =
-        Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap_err();
+        Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap_err();
     assert_snapshot!(format!("{:?}", layout_error));
 }
 
@@ -1371,7 +1371,7 @@ fn args_override_args_in_template() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1389,7 +1389,7 @@ fn close_on_exit_overrides_close_on_exit_in_template() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1406,7 +1406,7 @@ fn args_added_to_args_in_template() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1423,7 +1423,7 @@ fn close_on_exit_added_to_close_on_exit_in_template() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1441,7 +1441,7 @@ fn cwd_override_cwd_in_template() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1458,7 +1458,7 @@ fn cwd_added_to_cwd_in_template() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1471,7 +1471,7 @@ fn error_on_mixed_command_and_child_panes() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None);
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None);
     assert!(layout.is_err(), "error provided");
 }
 
@@ -1485,7 +1485,7 @@ fn error_on_mixed_cwd_and_child_panes() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None);
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None);
     assert!(layout.is_err(), "error provided");
 }
 
@@ -1498,7 +1498,7 @@ fn error_on_bare_args_without_command() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None);
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None);
     assert!(layout.is_err(), "error provided");
 }
 
@@ -1511,7 +1511,7 @@ fn error_on_bare_close_on_exit_without_command() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None);
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None);
     assert!(layout.is_err(), "error provided");
 }
 
@@ -1525,7 +1525,7 @@ fn error_on_bare_args_in_template_without_command() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None);
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None);
     assert!(layout.is_err(), "error provided");
 }
 
@@ -1539,7 +1539,7 @@ fn error_on_bare_close_on_exit_in_template_without_command() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None);
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None);
     assert!(layout.is_err(), "error provided");
 }
 
@@ -1558,7 +1558,7 @@ fn pane_template_command_with_cwd_overriden_by_its_consumers_command_cwd() {
             // pane should have /tmp/foo and not /tmp/bar as cwd
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1575,7 +1575,7 @@ fn pane_template_command_with_cwd_remains_when_its_consumer_command_does_not_hav
             // pane should have /tmp/bar as its cwd with the pwd command
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1593,7 +1593,7 @@ fn pane_template_command_without_cwd_is_overriden_by_its_consumers_cwd() {
             // pane should have /tmp/bar as its cwd with the pwd command
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1612,7 +1612,7 @@ fn pane_template_command_with_cwd_is_overriden_by_its_consumers_bare_cwd() {
             // pane should have /tmp/bar as its cwd with the tail command
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1630,7 +1630,7 @@ fn pane_template_command_without_cwd_receives_its_consumers_bare_cwd() {
             // pane should have /tmp/bar as its cwd with the tail command
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1648,7 +1648,7 @@ fn pane_template_with_bare_cwd_overriden_by_its_consumers_bare_cwd() {
             // pane should have /tmp/foo without a command
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1664,7 +1664,7 @@ fn pane_template_with_bare_propagated_to_its_consumer_command_without_cwd() {
             // pane should have /tmp/foo with the tail command
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1682,7 +1682,7 @@ fn pane_template_with_bare_propagated_to_its_consumer_command_with_cwd() {
             // pane should have /tmp/bar with the tail command
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1698,7 +1698,7 @@ fn pane_template_with_bare_propagated_to_its_consumer_edit() {
             // pane should have /tmp/foo/bar with the edit file variant
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1714,7 +1714,7 @@ fn pane_template_with_command_propagated_to_its_consumer_edit() {
             // pane should have /tmp/foo/bar with the edit file variant
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1728,7 +1728,7 @@ fn global_cwd_given_to_panes_without_cwd() {
             // both should have the /tmp cwd
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1741,7 +1741,7 @@ fn global_cwd_prepended_to_panes_with_cwd() {
             pane command="tail" cwd="/home/foo" // should be /home/foo because its an absolute path
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1757,7 +1757,7 @@ fn global_cwd_passed_from_layout_constructor() {
     "#;
     let layout = Layout::from_kdl(
         kdl_layout,
-        "layout_file_name".into(),
+        Some("layout_file_name".into()),
         None,
         Some(PathBuf::from("/tmp")),
     )
@@ -1778,7 +1778,7 @@ fn global_cwd_passed_from_layout_constructor_overrides_global_cwd_in_layout_file
     "#;
     let layout = Layout::from_kdl(
         kdl_layout,
-        "layout_file_name".into(),
+        Some("layout_file_name".into()),
         None,
         Some(PathBuf::from("/tmp")),
     )
@@ -1798,7 +1798,7 @@ fn global_cwd_with_tab_cwd_given_to_panes_without_cwd() {
             // both should have the /tmp/foo cwd
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1813,7 +1813,7 @@ fn tab_cwd_given_to_panes_without_cwd() {
             // both should have the /tmp cwd
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1828,7 +1828,7 @@ fn tab_cwd_prepended_to_panes_with_cwd() {
             // both should have the /tmp/foo cwd
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1843,7 +1843,7 @@ fn global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1864,7 +1864,7 @@ fn global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd_in_pane_templa
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1883,7 +1883,7 @@ fn global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd_in_tab_templat
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1930,7 +1930,7 @@ fn can_load_swap_layouts_from_a_different_file() {
     "#;
     let layout = Layout::from_kdl(
         kdl_layout,
-        "layout_file_name".into(),
+        Some("layout_file_name".into()),
         Some(("swap_layout_file_name".into(), kdl_swap_layout)),
         None,
     )
@@ -1948,7 +1948,7 @@ fn can_define_stacked_children_for_pane_node() {
            }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1965,7 +1965,7 @@ fn can_define_stacked_children_for_pane_template() {
            }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1980,7 +1980,7 @@ fn can_define_a_stack_with_an_expanded_pane() {
            }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     assert_snapshot!(format!("{:#?}", layout));
 }
 
@@ -1991,7 +1991,7 @@ fn cannot_define_stacked_panes_for_bare_node() {
            pane stacked=true
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None);
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None);
     assert!(layout.is_err(), "error provided for tab name with space");
 }
 
@@ -2005,7 +2005,7 @@ fn cannot_define_an_expanded_pane_outside_of_a_stack() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None);
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None);
     assert!(layout.is_err(), "error provided for tab name with space");
 }
 
@@ -2019,7 +2019,7 @@ fn cannot_define_stacked_panes_with_vertical_split_direction() {
            }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None);
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None);
     assert!(layout.is_err(), "error provided for tab name with space");
 }
 
@@ -2036,7 +2036,7 @@ fn cannot_define_stacked_panes_with_grandchildren() {
            }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None);
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None);
     assert!(layout.is_err(), "error provided for tab name with space");
 }
 
@@ -2056,7 +2056,7 @@ fn cannot_define_stacked_panes_with_grandchildren_in_pane_template() {
            }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None);
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None);
     assert!(layout.is_err(), "error provided for tab name with space");
 }
 
@@ -2090,7 +2090,7 @@ fn run_plugin_location_parsing() {
             }
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None).unwrap();
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None).unwrap();
     let expected_layout = Layout {
         template: Some((
             TiledPaneLayout {
@@ -2218,7 +2218,7 @@ fn env_var_expansion() {
         old_vars.push((key, std::env::var(key).ok()));
         std::env::set_var(key, value);
     }
-    let layout = Layout::from_kdl(raw_layout, "layout_file_name".into(), None, None);
+    let layout = Layout::from_kdl(raw_layout, Some("layout_file_name".into()), None, None);
     // restore environment.
     for (key, opt) in old_vars {
         match opt {
@@ -2239,6 +2239,6 @@ fn env_var_missing() {
             pane cwd="relative"
         }
     "#;
-    let layout = Layout::from_kdl(kdl_layout, "layout_file_name".into(), None, None);
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None);
     assert!(layout.is_err(), "invalid env var lookup should fail");
 }

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -1658,18 +1658,21 @@ impl Options {
 impl Layout {
     pub fn from_kdl(
         raw_layout: &str,
-        file_name: String,
+        file_name: Option<String>,
         raw_swap_layouts: Option<(&str, &str)>, // raw_swap_layouts swap_layouts_file_name
         cwd: Option<PathBuf>,
     ) -> Result<Self, ConfigError> {
         let mut kdl_layout_parser = KdlLayoutParser::new(raw_layout, cwd, file_name.clone());
         let layout = kdl_layout_parser.parse().map_err(|e| match e {
-            ConfigError::KdlError(kdl_error) => {
-                ConfigError::KdlError(kdl_error.add_src(file_name, String::from(raw_layout)))
-            },
-            ConfigError::KdlDeserializationError(kdl_error) => {
-                kdl_layout_error(kdl_error, file_name, raw_layout)
-            },
+            ConfigError::KdlError(kdl_error) => ConfigError::KdlError(kdl_error.add_src(
+                file_name.unwrap_or_else(|| "N/A".to_owned()),
+                String::from(raw_layout),
+            )),
+            ConfigError::KdlDeserializationError(kdl_error) => kdl_layout_error(
+                kdl_error,
+                file_name.unwrap_or_else(|| "N/A".to_owned()),
+                raw_layout,
+            ),
             e => e,
         })?;
         match raw_swap_layouts {
@@ -2193,6 +2196,7 @@ impl SessionInfo {
                 LayoutInfo::File(name) => (name.clone(), "file"),
                 LayoutInfo::BuiltIn(name) => (name.clone(), "built-in"),
                 LayoutInfo::Url(url) => (url.clone(), "url"),
+                LayoutInfo::Stringified(stringified) => ("stringified-layout".to_owned(), "N/A"),
             };
             let mut layout_node = KdlNode::new(format!("{}", layout_name));
             let layout_source = KdlEntry::new_prop("source", layout_source);

--- a/zellij-utils/src/plugin_api/event.rs
+++ b/zellij-utils/src/plugin_api/event.rs
@@ -550,6 +550,10 @@ impl TryFrom<LayoutInfo> for ProtobufLayoutInfo {
                 source: "url".to_owned(),
                 name,
             }),
+            LayoutInfo::Stringified(stringified_layout) => Ok(ProtobufLayoutInfo {
+                source: "stringified".to_owned(),
+                name: stringified_layout.clone(),
+            }),
         }
     }
 }
@@ -561,6 +565,7 @@ impl TryFrom<ProtobufLayoutInfo> for LayoutInfo {
             "file" => Ok(LayoutInfo::File(protobuf_layout_info.name)),
             "built-in" => Ok(LayoutInfo::BuiltIn(protobuf_layout_info.name)),
             "url" => Ok(LayoutInfo::Url(protobuf_layout_info.name)),
+            "stringified" => Ok(LayoutInfo::Stringified(protobuf_layout_info.name)),
             _ => Err("Unknown source for layout"),
         }
     }


### PR DESCRIPTION
When switching sessions through the plugin API, there is now an option to provide a stringified layout rather than one of the builtin ones, from a file or from a URL.

eg.
```rust
switch_session_with_layout(Some("my-cool-session-name"), LayoutInfo::Stringified("
layout {
    tab split_direction=\"vertical\" {
        pane;
        pane;
    }
    tab {
        pane
        pane;
        pane;
    }
}".to_owned()), Some("/tmp".into()));

```