### PR TITLE
fix(serialization): do not serialize junk sessions

### DIFF
--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -664,20 +664,22 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
             PtyInstruction::LogLayoutToHd(mut session_layout_metadata) => {
                 let err_context = || format!("Failed to dump layout");
                 pty.populate_session_layout_metadata(&mut session_layout_metadata);
-                match session_serialization::serialize_session_layout(
-                    session_layout_metadata.into(),
-                ) {
-                    Ok(kdl_layout_and_pane_contents) => {
-                        pty.bus
-                            .senders
-                            .send_to_background_jobs(BackgroundJob::ReportLayoutInfo(
-                                kdl_layout_and_pane_contents,
-                            ))
-                            .with_context(err_context)?;
-                    },
-                    Err(e) => {
-                        log::error!("Failed to log layout to HD: {}", e);
-                    },
+                if session_layout_metadata.is_dirty() {
+                    match session_serialization::serialize_session_layout(
+                        session_layout_metadata.into(),
+                    ) {
+                        Ok(kdl_layout_and_pane_contents) => {
+                            pty.bus
+                                .senders
+                                .send_to_background_jobs(BackgroundJob::ReportLayoutInfo(
+                                    kdl_layout_and_pane_contents,
+                                ))
+                                .with_context(err_context)?;
+                        },
+                        Err(e) => {
+                            log::error!("Failed to log layout to HD: {}", e);
+                        },
+                    }
                 }
             },
             PtyInstruction::FillPluginCwd(

--- a/zellij-server/src/session_layout_metadata.rs
+++ b/zellij-server/src/session_layout_metadata.rs
@@ -100,7 +100,7 @@ impl SessionLayoutMetadata {
                         &run_command.command.display().to_string(),
                         &run_command.args,
                     ) {
-                        return true
+                        return true;
                     }
                 }
             }
@@ -111,7 +111,7 @@ impl SessionLayoutMetadata {
                         &run_command.command.display().to_string(),
                         &run_command.args,
                     ) {
-                        return true
+                        return true;
                     }
                 }
             }

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -1511,6 +1511,22 @@ impl Layout {
             }
         }
     }
+    pub fn pane_count(&self) -> usize {
+        let mut pane_count = 0;
+        if let Some((tiled_pane_layout, floating_panes)) = self.template.as_ref() {
+            pane_count += tiled_pane_layout.pane_count();
+            for _ in floating_panes {
+                pane_count += 1;
+            }
+        }
+        for (_, tiled_pane_layout, floating_panes) in &self.tabs {
+            pane_count += tiled_pane_layout.pane_count();
+            for _ in floating_panes {
+                pane_count += 1;
+            }
+        }
+        pane_count
+    }
 }
 
 fn split_space(


### PR DESCRIPTION
Previously, sessions would be serialized (for resurrection later) every `serialization_interval` (default: 60 seconds) regardless of their content. This created a situation where lots of "junk sessions" were created in the cache and clogged it up. Most of these sessions would just be one-offs - not something that we'd actually want to serialize and later resurrect.

This fixes the problem by only serializing a session if it has more than 1 pane*, or if a command is running inside a pane that is not the default shell (eg. vim).

*more accurately, a different number of panes than the layout it was created with - by default this means more than one terminal pane.