### PR TITLE
fix(startup): do not parse resurrectable sessions on startup

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -3,9 +3,10 @@ use std::{fs::File, io::prelude::*, path::PathBuf, process, time::Duration};
 
 use crate::sessions::{
     assert_dead_session, assert_session, assert_session_ne, delete_session as delete_session_impl,
-    get_active_session, get_name_generator, get_resurrectable_sessions, get_resurrectable_session_names, get_sessions,
-    get_sessions_sorted_by_mtime, kill_session as kill_session_impl, match_session_name,
-    print_sessions, print_sessions_with_index, resurrection_layout, session_exists, ActiveSession,
+    get_active_session, get_name_generator, get_resurrectable_session_names,
+    get_resurrectable_sessions, get_sessions, get_sessions_sorted_by_mtime,
+    kill_session as kill_session_impl, match_session_name, print_sessions,
+    print_sessions_with_index, resurrection_layout, session_exists, ActiveSession,
     SessionNameMatch,
 };
 use zellij_client::{

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -3,7 +3,7 @@ use std::{fs::File, io::prelude::*, path::PathBuf, process, time::Duration};
 
 use crate::sessions::{
     assert_dead_session, assert_session, assert_session_ne, delete_session as delete_session_impl,
-    get_active_session, get_name_generator, get_resurrectable_sessions, get_sessions,
+    get_active_session, get_name_generator, get_resurrectable_sessions, get_resurrectable_session_names, get_sessions,
     get_sessions_sorted_by_mtime, kill_session as kill_session_impl, match_session_name,
     print_sessions, print_sessions_with_index, resurrection_layout, session_exists, ActiveSession,
     SessionNameMatch,
@@ -673,10 +673,7 @@ fn generate_unique_session_name() -> String {
             .map(|s| s.0.clone())
             .collect::<Vec<String>>()
     });
-    let dead_sessions: Vec<String> = get_resurrectable_sessions()
-        .iter()
-        .map(|(s, _, _)| s.clone())
-        .collect();
+    let dead_sessions = get_resurrectable_session_names();
     let Ok(sessions) = sessions else {
         eprintln!("Failed to list existing sessions: {:?}", sessions);
         process::exit(1);

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -106,10 +106,11 @@ pub(crate) fn get_resurrectable_session_names() -> Vec<String> {
             files_that_are_folders
                 .filter_map(|folder_name| {
                     let folder = folder_name.display().to_string();
-                    let resurrection_layout_file =
-                        session_layout_cache_file_name(&folder);
+                    let resurrection_layout_file = session_layout_cache_file_name(&folder);
                     if std::path::Path::new(&resurrection_layout_file).exists() {
-                        folder_name.file_name().map(|f| format!("{}", f.to_string_lossy()))
+                        folder_name
+                            .file_name()
+                            .map(|f| format!("{}", f.to_string_lossy()))
                     } else {
                         None
                     }


### PR DESCRIPTION
Previously, when starting a new session we would parse all the layouts of the resurrectable sessions in order to make sure the name is not colliding.

This could be a lengthy process if there were lots of dead sessions in the cache. Now we forgo this process and use the file-name instead to determine the session name (previously this would not be accurate, since the file name would stick around when renaming sessions, but this is no longer the case - making this improvement possible).