### PR TITLE
fix(terminal): repeat retry screen instruction sending during stdin cache replay (#3372)

### DIFF
--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -1180,13 +1180,17 @@ pub(crate) fn route_thread_main(
                     }
                     Ok(should_break)
                 };
+                let mut repeat_retries = VecDeque::new();
                 while let Some(instruction_to_retry) = retry_queue.pop_front() {
                     log::warn!("Server ready, retrying sending instruction.");
-                    let should_break = handle_instruction(instruction_to_retry, None)?;
+                    let should_break =
+                        handle_instruction(instruction_to_retry, Some(&mut repeat_retries))?;
                     if should_break {
                         break 'route_loop;
                     }
                 }
+                // retry on loop around
+                retry_queue.append(&mut repeat_retries);
                 let should_break = handle_instruction(instruction, Some(&mut retry_queue))?;
                 if should_break {
                     break 'route_loop;


### PR DESCRIPTION
The lack of re-retry on screen instruction playback from the stdin_cache ends up breaking sixel support as screen instructions such as pixel dimension detection response are unreliably replayed when the screen was not yet ready. This is a regression in sixel support introduced in 0.35.0.

Unsure if this is universal or something specific to our platform. However given it was seen by other users across multiple terminal emulators I started to look into it myself.
  
Existing tests pass though I'd much prefer to have written a test for this relatively complicated regression. Alas it'll be a while before I can invest the time so wanted to push the PR already and get some feedback / see how you feel about it.