### PR TITLE
feat(cli): Add `alive` option to `ls`

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -208,14 +208,14 @@ pub(crate) fn send_action_to_session(
                         "Session '{}' not found. The following sessions are active:",
                         session_name
                     );
-                    list_sessions(false, false, true);
+                    list_sessions(false, false, true, false);
                     std::process::exit(1);
                 }
             } else if let Ok(session_name) = envs::get_session_name() {
                 attach_with_cli_client(cli_action, &session_name, config);
             } else {
                 eprintln!("Please specify the session name to send actions to. The following sessions are active:");
-                list_sessions(false, false, true);
+                list_sessions(false, false, true, false);
                 std::process::exit(1);
             }
         },
@@ -376,7 +376,7 @@ fn attach_with_session_name(
             ActiveSession::One(session_name) => ClientInfo::Attach(session_name, config_options),
             ActiveSession::Many => {
                 println!("Please specify the session to attach to, either by using the full name or a unique prefix.\nThe following sessions are active:");
-                list_sessions(false, false, true);
+                list_sessions(false, false, true, false);
                 process::exit(1);
             },
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,6 +165,7 @@ fn main() {
     }
 
     if let Some(Command::Sessions(Sessions::ListSessions {
+        alive,
         no_formatting,
         short,
         reverse,

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -110,6 +110,10 @@ pub enum Sessions {
         /// List the sessions in reverse order (default is ascending order)
         #[clap(short, long, value_parser, takes_value(false), default_value("false"))]
         reverse: bool,
+
+        /// Only show sessions that are not exited
+        #[clap(short, long, value_parser, takes_value(false), default_value("false"))]
+        alive: bool,
     },
     /// List existing plugin aliases
     #[clap(visible_alias = "la")]


### PR DESCRIPTION
Closes #3168 

In the end, I added the flag with the name `alive`, which I think is reasonable. Of course it can still be bikeshed, but since the issue hadn't had activity for a few months so I decided to go forward with what I think sounds best! 

I think it might make sense to only show alive session by default and have another `--exited` or `--show-exited` flag, but that would change the current behavior, so I figured I'd let a maintainer take that decision. 

As an FYI, I tried to run and test everything locally, but I couldn't get it to compile (the problem is some missing `target/../wasm32-wasi/...` plugin thingy) but the changes seem simple so I hope it just works 😅

