### PR TITLE
feat(plugins): some APIs for controlling and receiving information about other panes

### DIFF
--- a/default-plugins/fixture-plugin-for-tests/src/main.rs
+++ b/default-plugins/fixture-plugin-for-tests/src/main.rs
@@ -207,11 +207,14 @@ impl ZellijPlugin for State {
                     );
                 },
                 BareKey::Char('m') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
-                    open_command_pane(CommandToRun {
-                        path: std::path::PathBuf::from("/path/to/my/file.rs"),
-                        args: vec!["arg1".to_owned(), "arg2".to_owned()],
-                        ..Default::default()
-                    }, BTreeMap::new());
+                    open_command_pane(
+                        CommandToRun {
+                            path: std::path::PathBuf::from("/path/to/my/file.rs"),
+                            args: vec!["arg1".to_owned(), "arg2".to_owned()],
+                            ..Default::default()
+                        },
+                        BTreeMap::new(),
+                    );
                 },
                 BareKey::Char('n') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
                     open_command_pane_floating(

--- a/default-plugins/fixture-plugin-for-tests/src/main.rs
+++ b/default-plugins/fixture-plugin-for-tests/src/main.rs
@@ -211,7 +211,7 @@ impl ZellijPlugin for State {
                         path: std::path::PathBuf::from("/path/to/my/file.rs"),
                         args: vec!["arg1".to_owned(), "arg2".to_owned()],
                         ..Default::default()
-                    });
+                    }, BTreeMap::new());
                 },
                 BareKey::Char('n') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
                     open_command_pane_floating(
@@ -221,6 +221,7 @@ impl ZellijPlugin for State {
                             ..Default::default()
                         },
                         None,
+                        BTreeMap::new(),
                     );
                 },
                 BareKey::Char('o') if key.has_modifiers(&[KeyModifier::Ctrl]) => {

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -337,6 +337,7 @@ fn spawn_terminal(
                 cwd,
                 hold_on_close: false,
                 hold_on_start: false,
+                ..Default::default()
             }
         },
         TerminalAction::RunCommand(command) => command,

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_command_pane_floating_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_command_pane_floating_plugin_command.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/plugins/./unit/plugin_tests.rs
-assertion_line: 4400
+assertion_line: 4557
 expression: "format!(\"{:#?}\", new_tab_event)"
 ---
 Some(
@@ -16,6 +16,13 @@ Some(
                     cwd: None,
                     hold_on_close: true,
                     hold_on_start: false,
+                    originating_plugin: Some(
+                        OriginatingPlugin {
+                            plugin_id: 0,
+                            client_id: 1,
+                            context: {},
+                        },
+                    ),
                 },
             ),
         ),

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_command_pane_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_command_pane_plugin_command.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/plugins/./unit/plugin_tests.rs
-assertion_line: 4323
+assertion_line: 4479
 expression: "format!(\"{:#?}\", new_tab_event)"
 ---
 Some(
@@ -16,6 +16,13 @@ Some(
                     cwd: None,
                     hold_on_close: true,
                     hold_on_start: false,
+                    originating_plugin: Some(
+                        OriginatingPlugin {
+                            plugin_id: 0,
+                            client_id: 1,
+                            context: {},
+                        },
+                    ),
                 },
             ),
         ),

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_terminal_floating_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_terminal_floating_plugin_command.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/plugins/./unit/plugin_tests.rs
-assertion_line: 4390
+assertion_line: 4401
 expression: "format!(\"{:#?}\", new_tab_event)"
 ---
 Some(
@@ -15,6 +15,7 @@ Some(
                     ),
                     hold_on_close: false,
                     hold_on_start: false,
+                    originating_plugin: None,
                 },
             ),
         ),

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_terminal_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_terminal_plugin_command.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/plugins/./unit/plugin_tests.rs
-assertion_line: 4312
+assertion_line: 4323
 expression: "format!(\"{:#?}\", new_tab_event)"
 ---
 Some(
@@ -15,6 +15,7 @@ Some(
                     ),
                     hold_on_close: false,
                     hold_on_start: false,
+                    originating_plugin: None,
                 },
             ),
         ),

--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -1314,6 +1314,8 @@ fn check_event_permission(
         | Event::SessionUpdate(..)
         | Event::CopyToClipboard(..)
         | Event::SystemClipboardFailure
+        | Event::CommandPaneOpened(..)
+        | Event::CommandPaneExited(..)
         | Event::InputReceived => PermissionType::ReadApplicationState,
         _ => return (PermissionStatus::Granted, None),
     };

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -769,7 +769,6 @@ fn hide_self(env: &PluginEnv) -> Result<()> {
         .with_context(|| format!("failed to hide self"))
 }
 
-// TODO: permissions
 fn hide_pane_with_id(env: &PluginEnv, pane_id: PaneId) -> Result<()> {
     env.senders
         .send_to_screen(ScreenInstruction::SuppressPane(
@@ -785,7 +784,6 @@ fn show_self(env: &PluginEnv, should_float_if_hidden: bool) {
     apply_action!(action, error_msg, env);
 }
 
-// TODO: permissions
 fn show_pane_with_id(env: &PluginEnv, pane_id: PaneId, should_float_if_hidden: bool) {
     let _ = env.senders
         .send_to_screen(ScreenInstruction::FocusPaneWithId(

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -2596,6 +2596,7 @@ impl Tab {
         is_first_run: bool,
         run_command: RunCommand,
     ) {
+        log::info!("tab.hold_pane. run_command: {:?}, exit_status: {:#?}", exit_status, run_command);
         if self.is_pending {
             self.pending_instructions
                 .push(BufferedTabInstruction::HoldPane(

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -2596,7 +2596,6 @@ impl Tab {
         is_first_run: bool,
         run_command: RunCommand,
     ) {
-        log::info!("tab.hold_pane. run_command: {:?}, exit_status: {:#?}", exit_status, run_command);
         if self.is_pending {
             self.pending_instructions
                 .push(BufferedTabInstruction::HoldPane(

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_pane_action_with_command_and_cwd.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_pane_action_with_command_and_cwd.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 1915
+assertion_line: 2306
 expression: "format!(\"{:?}\", * received_pty_instructions.lock().unwrap())"
 ---
-[SpawnTerminalVertically(Some(RunCommand(RunCommand { command: "htop", args: [], cwd: Some("/some/folder"), hold_on_close: true, hold_on_start: false })), None, 10), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]
+[SpawnTerminalVertically(Some(RunCommand(RunCommand { command: "htop", args: [], cwd: Some("/some/folder"), hold_on_close: true, hold_on_start: false, originating_plugin: None })), None, 10), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_pane_action_with_floating_pane_and_coordinates.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_pane_action_with_floating_pane_and_coordinates.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 2040
+assertion_line: 2349
 expression: "format!(\"{:?}\", * received_pty_instructions.lock().unwrap())"
 ---
-[SpawnTerminal(Some(RunCommand(RunCommand { command: "htop", args: [], cwd: Some("/some/folder"), hold_on_close: true, hold_on_start: false })), Some(true), None, Some(FloatingPaneCoordinates { x: Some(Fixed(10)), y: None, width: Some(Percent(20)), height: None }), ClientId(10)), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]
+[SpawnTerminal(Some(RunCommand(RunCommand { command: "htop", args: [], cwd: Some("/some/folder"), hold_on_close: true, hold_on_start: false, originating_plugin: None })), Some(true), None, Some(FloatingPaneCoordinates { x: Some(Fixed(10)), y: None, width: Some(Percent(20)), height: None }), ClientId(10)), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -144,7 +144,8 @@ pub fn open_command_pane_floating(
     coordinates: Option<FloatingPaneCoordinates>,
     context: BTreeMap<String, String>,
 ) {
-    let plugin_command = PluginCommand::OpenCommandPaneFloating(command_to_run, coordinates, context);
+    let plugin_command =
+        PluginCommand::OpenCommandPaneFloating(command_to_run, coordinates, context);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
     unsafe { host_run_plugin_command() };

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -150,18 +150,6 @@ pub fn open_command_pane_floating(
     unsafe { host_run_plugin_command() };
 }
 
-// pub fn run_command(cmd: &[&str], context: BTreeMap<String, String>) {
-//     let plugin_command = PluginCommand::RunCommand(
-//         cmd.iter().cloned().map(|s| s.to_owned()).collect(),
-//         BTreeMap::new(),
-//         PathBuf::from("."),
-//         context,
-//     );
-//     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
-//     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
-//     unsafe { host_run_plugin_command() };
-// }
-
 /// Open a new in place command pane with the specified command and args (this sort of pane allows the user to control the command, re-run it and see its exit status through the Zellij UI).
 pub fn open_command_pane_in_place(command_to_run: CommandToRun, context: BTreeMap<String, String>) {
     let plugin_command = PluginCommand::OpenCommandPaneInPlace(command_to_run, context);

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -254,9 +254,25 @@ pub fn hide_self() {
     unsafe { host_run_plugin_command() };
 }
 
+/// Hide the pane (suppress it) with the specified [PaneId] from the UI
+pub fn hide_pane_with_id(pane_id: PaneId) {
+    let plugin_command = PluginCommand::HidePaneWithId(pane_id);
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
 /// Show the plugin pane (unsuppress it if it is suppressed), focus it and switch to its tab
 pub fn show_self(should_float_if_hidden: bool) {
     let plugin_command = PluginCommand::ShowSelf(should_float_if_hidden);
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
+/// Show the pane (unsuppress it if it is suppressed) with the specified [PaneId], focus it and switch to its tab
+pub fn show_pane_with_id(pane_id: PaneId, should_float_if_hidden: bool) {
+    let plugin_command = PluginCommand::ShowPaneWithId(pane_id, should_float_if_hidden);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
     unsafe { host_run_plugin_command() };

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -131,8 +131,8 @@ pub fn open_terminal_in_place<P: AsRef<Path>>(path: P) {
 }
 
 /// Open a new command pane with the specified command and args (this sort of pane allows the user to control the command, re-run it and see its exit status through the Zellij UI).
-pub fn open_command_pane(command_to_run: CommandToRun) {
-    let plugin_command = PluginCommand::OpenCommandPane(command_to_run);
+pub fn open_command_pane(command_to_run: CommandToRun, context: BTreeMap<String, String>) {
+    let plugin_command = PluginCommand::OpenCommandPane(command_to_run, context);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
     unsafe { host_run_plugin_command() };
@@ -142,16 +142,29 @@ pub fn open_command_pane(command_to_run: CommandToRun) {
 pub fn open_command_pane_floating(
     command_to_run: CommandToRun,
     coordinates: Option<FloatingPaneCoordinates>,
+    context: BTreeMap<String, String>,
 ) {
-    let plugin_command = PluginCommand::OpenCommandPaneFloating(command_to_run, coordinates);
+    let plugin_command = PluginCommand::OpenCommandPaneFloating(command_to_run, coordinates, context);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
     unsafe { host_run_plugin_command() };
 }
 
+// pub fn run_command(cmd: &[&str], context: BTreeMap<String, String>) {
+//     let plugin_command = PluginCommand::RunCommand(
+//         cmd.iter().cloned().map(|s| s.to_owned()).collect(),
+//         BTreeMap::new(),
+//         PathBuf::from("."),
+//         context,
+//     );
+//     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+//     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+//     unsafe { host_run_plugin_command() };
+// }
+
 /// Open a new in place command pane with the specified command and args (this sort of pane allows the user to control the command, re-run it and see its exit status through the Zellij UI).
-pub fn open_command_pane_in_place(command_to_run: CommandToRun) {
-    let plugin_command = PluginCommand::OpenCommandPaneInPlace(command_to_run);
+pub fn open_command_pane_in_place(command_to_run: CommandToRun, context: BTreeMap<String, String>) {
+    let plugin_command = PluginCommand::OpenCommandPaneInPlace(command_to_run, context);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
     unsafe { host_run_plugin_command() };

--- a/zellij-utils/assets/prost/api.event.rs
+++ b/zellij-utils/assets/prost/api.event.rs
@@ -11,7 +11,7 @@ pub struct Event {
     pub name: i32,
     #[prost(
         oneof = "event::Payload",
-        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15"
+        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17"
     )]
     pub payload: ::core::option::Option<event::Payload>,
 }
@@ -48,7 +48,29 @@ pub mod event {
         RunCommandResultPayload(super::RunCommandResultPayload),
         #[prost(message, tag = "15")]
         WebRequestResultPayload(super::WebRequestResultPayload),
+        #[prost(message, tag = "16")]
+        CommandPaneOpenedPayload(super::CommandPaneOpenedPayload),
+        #[prost(message, tag = "17")]
+        CommandPaneExitedPayload(super::CommandPaneExitedPayload),
     }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CommandPaneOpenedPayload {
+    #[prost(uint32, tag = "1")]
+    pub terminal_pane_id: u32,
+    #[prost(message, repeated, tag = "2")]
+    pub context: ::prost::alloc::vec::Vec<ContextItem>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CommandPaneExitedPayload {
+    #[prost(uint32, tag = "1")]
+    pub terminal_pane_id: u32,
+    #[prost(int32, optional, tag = "2")]
+    pub exit_code: ::core::option::Option<i32>,
+    #[prost(message, repeated, tag = "3")]
+    pub context: ::prost::alloc::vec::Vec<ContextItem>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -349,6 +371,8 @@ pub enum EventType {
     SessionUpdate = 16,
     RunCommandResult = 17,
     WebRequestResult = 18,
+    CommandPaneOpened = 19,
+    CommandPaneExited = 20,
 }
 impl EventType {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -376,6 +400,8 @@ impl EventType {
             EventType::SessionUpdate => "SessionUpdate",
             EventType::RunCommandResult => "RunCommandResult",
             EventType::WebRequestResult => "WebRequestResult",
+            EventType::CommandPaneOpened => "CommandPaneOpened",
+            EventType::CommandPaneExited => "CommandPaneExited",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -400,6 +426,8 @@ impl EventType {
             "SessionUpdate" => Some(Self::SessionUpdate),
             "RunCommandResult" => Some(Self::RunCommandResult),
             "WebRequestResult" => Some(Self::WebRequestResult),
+            "CommandPaneOpened" => Some(Self::CommandPaneOpened),
+            "CommandPaneExited" => Some(Self::CommandPaneExited),
             _ => None,
         }
     }

--- a/zellij-utils/assets/prost/api.plugin_command.rs
+++ b/zellij-utils/assets/prost/api.plugin_command.rs
@@ -235,6 +235,8 @@ pub struct OpenCommandPanePayload {
     pub command_to_run: ::core::option::Option<super::command::Command>,
     #[prost(message, optional, tag = "2")]
     pub floating_pane_coordinates: ::core::option::Option<FloatingPaneCoordinates>,
+    #[prost(message, repeated, tag = "3")]
+    pub context: ::prost::alloc::vec::Vec<ContextItem>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/zellij-utils/assets/prost/api.plugin_command.rs
+++ b/zellij-utils/assets/prost/api.plugin_command.rs
@@ -5,7 +5,7 @@ pub struct PluginCommand {
     pub name: i32,
     #[prost(
         oneof = "plugin_command::Payload",
-        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 60, 61, 62, 63"
+        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 60, 61, 62, 63, 64, 65"
     )]
     pub payload: ::core::option::Option<plugin_command::Payload>,
 }
@@ -120,7 +120,25 @@ pub mod plugin_command {
         NewTabsWithLayoutInfoPayload(super::NewTabsWithLayoutInfoPayload),
         #[prost(string, tag = "63")]
         ReconfigurePayload(::prost::alloc::string::String),
+        #[prost(message, tag = "64")]
+        HidePaneWithIdPayload(super::HidePaneWithIdPayload),
+        #[prost(message, tag = "65")]
+        ShowPaneWithIdPayload(super::ShowPaneWithIdPayload),
     }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HidePaneWithIdPayload {
+    #[prost(message, optional, tag = "1")]
+    pub pane_id: ::core::option::Option<PaneId>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ShowPaneWithIdPayload {
+    #[prost(message, optional, tag = "1")]
+    pub pane_id: ::core::option::Option<PaneId>,
+    #[prost(bool, tag = "2")]
+    pub should_float_if_hidden: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -436,6 +454,8 @@ pub enum CommandName {
     CloseSelf = 85,
     NewTabsWithLayoutInfo = 86,
     Reconfigure = 87,
+    HidePaneWithId = 88,
+    ShowPaneWithId = 89,
 }
 impl CommandName {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -532,6 +552,8 @@ impl CommandName {
             CommandName::CloseSelf => "CloseSelf",
             CommandName::NewTabsWithLayoutInfo => "NewTabsWithLayoutInfo",
             CommandName::Reconfigure => "Reconfigure",
+            CommandName::HidePaneWithId => "HidePaneWithId",
+            CommandName::ShowPaneWithId => "ShowPaneWithId",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -625,6 +647,8 @@ impl CommandName {
             "CloseSelf" => Some(Self::CloseSelf),
             "NewTabsWithLayoutInfo" => Some(Self::NewTabsWithLayoutInfo),
             "Reconfigure" => Some(Self::Reconfigure),
+            "HidePaneWithId" => Some(Self::HidePaneWithId),
+            "ShowPaneWithId" => Some(Self::ShowPaneWithId),
             _ => None,
         }
     }

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -1796,4 +1796,6 @@ pub enum PluginCommand {
     CloseSelf,
     NewTabsWithLayoutInfo(LayoutInfo),
     Reconfigure(String), // String -> stringified configuration
+    HidePaneWithId(PaneId),
+    ShowPaneWithId(PaneId, bool), // bool -> should_float_if_hidden
 }

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -913,6 +913,9 @@ pub enum Event {
        // headers,
        // body,
        // context
+    CommandPaneOpened(u32, Context), // u32 - terminal_pane_id
+    CommandPaneExited(u32, Option<i32>, Context), // u32 - terminal_pane_id, Option<i32> -
+                                                  // exit_code
 }
 
 #[derive(
@@ -1671,6 +1674,25 @@ impl FloatingPaneCoordinates {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OriginatingPlugin {
+    pub plugin_id: u32,
+    pub client_id: ClientId,
+    pub context: Context,
+}
+
+impl OriginatingPlugin {
+    pub fn new(plugin_id: u32, client_id: ClientId, context: Context) -> Self {
+        OriginatingPlugin {
+            plugin_id,
+            client_id,
+            context,
+        }
+    }
+}
+
+type Context = BTreeMap<String, String>;
+
 #[derive(Debug, Clone, EnumDiscriminants, ToString)]
 #[strum_discriminants(derive(EnumString, Hash, Serialize, Deserialize))]
 #[strum_discriminants(name(CommandType))]
@@ -1684,8 +1706,8 @@ pub enum PluginCommand {
     OpenFileFloating(FileToOpen, Option<FloatingPaneCoordinates>),
     OpenTerminal(FileToOpen), // only used for the path as cwd
     OpenTerminalFloating(FileToOpen, Option<FloatingPaneCoordinates>), // only used for the path as cwd
-    OpenCommandPane(CommandToRun),
-    OpenCommandPaneFloating(CommandToRun, Option<FloatingPaneCoordinates>),
+    OpenCommandPane(CommandToRun, Context),
+    OpenCommandPaneFloating(CommandToRun, Option<FloatingPaneCoordinates>, Context),
     SwitchTabTo(u32), // tab index
     SetTimeout(f64),  // seconds
     ExecCmd(Vec<String>),
@@ -1747,7 +1769,7 @@ pub enum PluginCommand {
     DeleteAllDeadSessions,           // String -> session name
     OpenTerminalInPlace(FileToOpen), // only used for the path as cwd
     OpenFileInPlace(FileToOpen),
-    OpenCommandPaneInPlace(CommandToRun),
+    OpenCommandPaneInPlace(CommandToRun, Context),
     RunCommand(
         Vec<String>,              // command
         BTreeMap<String, String>, // env_variables

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -910,12 +910,12 @@ pub enum Event {
         Vec<u8>,
         BTreeMap<String, String>,
     ), // status,
-       // headers,
-       // body,
-       // context
+    // headers,
+    // body,
+    // context
     CommandPaneOpened(u32, Context), // u32 - terminal_pane_id
     CommandPaneExited(u32, Option<i32>, Context), // u32 - terminal_pane_id, Option<i32> -
-                                                  // exit_code
+                                     // exit_code
 }
 
 #[derive(

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -432,6 +432,7 @@ impl Action {
                         direction,
                         hold_on_close,
                         hold_on_start,
+                        ..Default::default()
                     };
                     if floating {
                         Ok(vec![Action::NewFloatingPane(

--- a/zellij-utils/src/input/command.rs
+++ b/zellij-utils/src/input/command.rs
@@ -72,17 +72,6 @@ pub struct RunCommandAction {
     pub hold_on_start: bool,
     #[serde(default)]
     pub originating_plugin: Option<OriginatingPlugin>,
-    // TODO:
-    // * add am originating_plugin field:
-    // OriginatingPlugin {
-    //     plugin_id: u32
-    //     client_id: u32,
-    //     context: BTreeMap<String, String>
-    // }
-    // * then send it to Screen and have it reply to the plugin tread with the existing
-    // RunCommandResult(?) thing, as well as something similar when the command starts so that we
-    // know its ane id
-    // 
 }
 
 impl From<RunCommandAction> for RunCommand {

--- a/zellij-utils/src/input/command.rs
+++ b/zellij-utils/src/input/command.rs
@@ -1,5 +1,5 @@
 //! Trigger a command
-use crate::data::Direction;
+use crate::data::{Direction, OriginatingPlugin};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -35,6 +35,8 @@ pub struct RunCommand {
     pub hold_on_close: bool,
     #[serde(default)]
     pub hold_on_start: bool,
+    #[serde(default)]
+    pub originating_plugin: Option<OriginatingPlugin>,
 }
 
 impl std::fmt::Display for RunCommand {
@@ -68,6 +70,19 @@ pub struct RunCommandAction {
     pub hold_on_close: bool,
     #[serde(default)]
     pub hold_on_start: bool,
+    #[serde(default)]
+    pub originating_plugin: Option<OriginatingPlugin>,
+    // TODO:
+    // * add am originating_plugin field:
+    // OriginatingPlugin {
+    //     plugin_id: u32
+    //     client_id: u32,
+    //     context: BTreeMap<String, String>
+    // }
+    // * then send it to Screen and have it reply to the plugin tread with the existing
+    // RunCommandResult(?) thing, as well as something similar when the command starts so that we
+    // know its ane id
+    // 
 }
 
 impl From<RunCommandAction> for RunCommand {
@@ -78,6 +93,7 @@ impl From<RunCommandAction> for RunCommand {
             cwd: action.cwd,
             hold_on_close: action.hold_on_close,
             hold_on_start: action.hold_on_start,
+            originating_plugin: action.originating_plugin,
         }
     }
 }
@@ -91,6 +107,7 @@ impl From<RunCommand> for RunCommandAction {
             direction: None,
             hold_on_close: run_command.hold_on_close,
             hold_on_start: run_command.hold_on_start,
+            originating_plugin: run_command.originating_plugin,
         }
     }
 }

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__args_added_to_args_in_template.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__args_added_to_args_in_template.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1352
+assertion_line: 1410
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -25,6 +25,7 @@ Layout {
                                     cwd: None,
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),
@@ -54,6 +55,7 @@ Layout {
                                     cwd: None,
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__args_override_args_in_template.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__args_override_args_in_template.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1317
+assertion_line: 1375
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -28,6 +28,7 @@ Layout {
                                     cwd: None,
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),
@@ -57,6 +58,7 @@ Layout {
                                     cwd: None,
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__close_on_exit_added_to_close_on_exit_in_template.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__close_on_exit_added_to_close_on_exit_in_template.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1369
+assertion_line: 1427
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -25,6 +25,7 @@ Layout {
                                     cwd: None,
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),
@@ -51,6 +52,7 @@ Layout {
                                     cwd: None,
                                     hold_on_close: false,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__close_on_exit_overrides_close_on_exit_in_template.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__close_on_exit_overrides_close_on_exit_in_template.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1335
+assertion_line: 1393
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -25,6 +25,7 @@ Layout {
                                     cwd: None,
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),
@@ -51,6 +52,7 @@ Layout {
                                     cwd: None,
                                     hold_on_close: false,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__cwd_added_to_cwd_in_template.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__cwd_added_to_cwd_in_template.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1404
+assertion_line: 1462
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -25,6 +25,7 @@ Layout {
                                     cwd: None,
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),
@@ -53,6 +54,7 @@ Layout {
                                     ),
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__cwd_override_cwd_in_template.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__cwd_override_cwd_in_template.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1387
+assertion_line: 1445
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -27,6 +27,7 @@ Layout {
                                     ),
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),
@@ -55,6 +56,7 @@ Layout {
                                     ),
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__env_var_expansion.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__env_var_expansion.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 2141
+assertion_line: 2230
 expression: "format!(\"{layout:#?}\")"
 ---
 Layout {
@@ -107,6 +107,7 @@ Layout {
                                     ),
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),
@@ -183,6 +184,7 @@ Layout {
                                     ),
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1789
+assertion_line: 1847
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -46,6 +46,7 @@ Layout {
                                     ),
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd_in_pane_templates.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd_in_pane_templates.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1810
+assertion_line: 1868
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -50,6 +50,7 @@ Layout {
                                             ),
                                             hold_on_close: true,
                                             hold_on_start: false,
+                                            originating_plugin: None,
                                         },
                                     ),
                                 ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd_in_tab_templates.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd_in_tab_templates.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1829
+assertion_line: 1887
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -46,6 +46,7 @@ Layout {
                                     ),
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_given_to_panes_without_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_given_to_panes_without_cwd.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1674
+assertion_line: 1732
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -47,6 +47,7 @@ Layout {
                                     ),
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_passed_from_layout_constructor.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_passed_from_layout_constructor.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1707
+assertion_line: 1765
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -47,6 +47,7 @@ Layout {
                                     ),
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_passed_from_layout_constructor_overrides_global_cwd_in_layout_file.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_passed_from_layout_constructor_overrides_global_cwd_in_layout_file.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1728
+assertion_line: 1786
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -47,6 +47,7 @@ Layout {
                                     ),
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_prepended_to_panes_with_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_prepended_to_panes_with_cwd.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1687
+assertion_line: 1745
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -47,6 +47,7 @@ Layout {
                                     ),
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_with_tab_cwd_given_to_panes_without_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_with_tab_cwd_given_to_panes_without_cwd.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1744
+assertion_line: 1802
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -46,6 +46,7 @@ Layout {
                                     ),
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__layout_with_command_panes_and_close_on_exit.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__layout_with_command_panes_and_close_on_exit.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 481
+assertion_line: 511
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -25,6 +25,7 @@ Layout {
                                     cwd: None,
                                     hold_on_close: false,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__layout_with_command_panes_and_start_suspended.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__layout_with_command_panes_and_start_suspended.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 494
+assertion_line: 524
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -25,6 +25,7 @@ Layout {
                                     cwd: None,
                                     hold_on_close: true,
                                     hold_on_start: true,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__layout_with_tab_and_pane_templates.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__layout_with_tab_and_pane_templates.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 834
+assertion_line: 892
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -48,6 +48,7 @@ Layout {
                                                     cwd: None,
                                                     hold_on_close: true,
                                                     hold_on_start: false,
+                                                    originating_plugin: None,
                                                 },
                                             ),
                                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_with_cwd_is_overriden_by_its_consumers_bare_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_with_cwd_is_overriden_by_its_consumers_bare_cwd.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1558
+assertion_line: 1616
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -27,6 +27,7 @@ Layout {
                                     ),
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_with_cwd_overriden_by_its_consumers_command_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_with_cwd_overriden_by_its_consumers_command_cwd.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1504
+assertion_line: 1562
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -27,6 +27,7 @@ Layout {
                                     ),
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_with_cwd_remains_when_its_consumer_command_does_not_have_a_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_with_cwd_remains_when_its_consumer_command_does_not_have_a_cwd.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1521
+assertion_line: 1579
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -27,6 +27,7 @@ Layout {
                                     ),
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_without_cwd_is_overriden_by_its_consumers_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_without_cwd_is_overriden_by_its_consumers_cwd.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1539
+assertion_line: 1597
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -27,6 +27,7 @@ Layout {
                                     ),
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_without_cwd_receives_its_consumers_bare_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_without_cwd_receives_its_consumers_bare_cwd.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1576
+assertion_line: 1634
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -27,6 +27,7 @@ Layout {
                                     ),
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_bare_propagated_to_its_consumer_command_with_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_bare_propagated_to_its_consumer_command_with_cwd.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1628
+assertion_line: 1686
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -27,6 +27,7 @@ Layout {
                                     ),
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_bare_propagated_to_its_consumer_command_without_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_bare_propagated_to_its_consumer_command_without_cwd.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1610
+assertion_line: 1668
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -27,6 +27,7 @@ Layout {
                                     ),
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__tab_cwd_given_to_panes_without_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__tab_cwd_given_to_panes_without_cwd.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1759
+assertion_line: 1817
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -46,6 +46,7 @@ Layout {
                                     ),
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__tab_cwd_prepended_to_panes_with_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__tab_cwd_prepended_to_panes_with_cwd.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1774
+assertion_line: 1832
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -46,6 +46,7 @@ Layout {
                                     ),
                                     hold_on_close: true,
                                     hold_on_start: false,
+                                    originating_plugin: None,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/kdl/kdl_layout_parser.rs
+++ b/zellij-utils/src/kdl/kdl_layout_parser.rs
@@ -455,6 +455,7 @@ impl<'a> KdlLayoutParser<'a> {
                 cwd,
                 hold_on_close,
                 hold_on_start,
+                ..Default::default()
             }))),
             (None, Some(edit), Some(cwd)) => {
                 Ok(Some(Run::EditFile(cwd.join(edit), None, Some(cwd))))

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -946,6 +946,7 @@ impl TryFrom<(&KdlNode, &Options)> for Action {
                     direction,
                     hold_on_close,
                     hold_on_start,
+                    ..Default::default()
                 };
                 let x = command_metadata
                     .and_then(|c_m| kdl_child_string_value_for_entry(c_m, "x"))

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -1385,6 +1385,7 @@ impl TryFrom<ProtobufRunCommandAction> for RunCommandAction {
             direction,
             hold_on_close,
             hold_on_start,
+            ..Default::default()
         })
     }
 }

--- a/zellij-utils/src/plugin_api/event.proto
+++ b/zellij-utils/src/plugin_api/event.proto
@@ -42,6 +42,8 @@ enum EventType {
     SessionUpdate = 16;
     RunCommandResult = 17;
     WebRequestResult = 18;
+    CommandPaneOpened = 19;
+    CommandPaneExited = 20;
 }
 
 message EventNameList {
@@ -65,7 +67,20 @@ message Event {
     SessionUpdatePayload session_update_payload = 13;
     RunCommandResultPayload run_command_result_payload = 14;
     WebRequestResultPayload web_request_result_payload = 15;
+    CommandPaneOpenedPayload command_pane_opened_payload = 16;
+    CommandPaneExitedPayload command_pane_exited_payload = 17;
   }
+}
+
+message CommandPaneOpenedPayload {
+  uint32 terminal_pane_id = 1;
+  repeated ContextItem context = 2;
+}
+
+message CommandPaneExitedPayload {
+  uint32 terminal_pane_id = 1;
+  optional int32 exit_code = 2;
+  repeated ContextItem context = 3;
 }
 
 message SessionUpdatePayload {

--- a/zellij-utils/src/plugin_api/event.rs
+++ b/zellij-utils/src/plugin_api/event.rs
@@ -235,6 +235,33 @@ impl TryFrom<ProtobufEvent> for Event {
                 },
                 _ => Err("Malformed payload for the WebRequestResult Event"),
             },
+            Some(ProtobufEventType::CommandPaneOpened) => match protobuf_event.payload {
+                Some(ProtobufEventPayload::CommandPaneOpenedPayload(command_pane_opened_payload)) => {
+                    Ok(Event::CommandPaneOpened(
+                        command_pane_opened_payload.terminal_pane_id,
+                        command_pane_opened_payload
+                            .context
+                            .into_iter()
+                            .map(|c_i| (c_i.name, c_i.value))
+                            .collect(),
+                    ))
+                },
+                _ => Err("Malformed payload for the CommandPaneOpened Event"),
+            }
+            Some(ProtobufEventType::CommandPaneExited) => match protobuf_event.payload {
+                Some(ProtobufEventPayload::CommandPaneExitedPayload(command_pane_exited_payload)) => {
+                    Ok(Event::CommandPaneExited(
+                        command_pane_exited_payload.terminal_pane_id,
+                        command_pane_exited_payload.exit_code,
+                        command_pane_exited_payload
+                            .context
+                            .into_iter()
+                            .map(|c_i| (c_i.name, c_i.value))
+                            .collect(),
+                    ))
+                },
+                _ => Err("Malformed payload for the CommandPaneExited Event"),
+            }
             None => Err("Unknown Protobuf Event"),
         }
     }
@@ -457,6 +484,37 @@ impl TryFrom<Event> for ProtobufEvent {
                     name: ProtobufEventType::WebRequestResult as i32,
                     payload: Some(event::Payload::WebRequestResultPayload(
                         web_request_result_payload,
+                    )),
+                })
+            },
+            Event::CommandPaneOpened(terminal_pane_id, context) => {
+                let command_pane_opened_payload = CommandPaneOpenedPayload {
+                    terminal_pane_id,
+                    context: context
+                        .into_iter()
+                        .map(|(name, value)| ContextItem { name, value })
+                        .collect(),
+                };
+                Ok(ProtobufEvent {
+                    name: ProtobufEventType::CommandPaneOpened as i32,
+                    payload: Some(event::Payload::CommandPaneOpenedPayload(
+                        command_pane_opened_payload
+                    )),
+                })
+            },
+            Event::CommandPaneExited(terminal_pane_id, exit_code, context) => {
+                let command_pane_exited_payload = CommandPaneExitedPayload {
+                    terminal_pane_id,
+                    exit_code,
+                    context: context
+                        .into_iter()
+                        .map(|(name, value)| ContextItem { name, value })
+                        .collect(),
+                };
+                Ok(ProtobufEvent {
+                    name: ProtobufEventType::CommandPaneExited as i32,
+                    payload: Some(event::Payload::CommandPaneExitedPayload(
+                        command_pane_exited_payload
                     )),
                 })
             },
@@ -963,6 +1021,8 @@ impl TryFrom<ProtobufEventType> for EventType {
             ProtobufEventType::SessionUpdate => EventType::SessionUpdate,
             ProtobufEventType::RunCommandResult => EventType::RunCommandResult,
             ProtobufEventType::WebRequestResult => EventType::WebRequestResult,
+            ProtobufEventType::CommandPaneOpened => EventType::CommandPaneOpened,
+            ProtobufEventType::CommandPaneExited => EventType::CommandPaneExited,
         })
     }
 }
@@ -990,6 +1050,8 @@ impl TryFrom<EventType> for ProtobufEventType {
             EventType::SessionUpdate => ProtobufEventType::SessionUpdate,
             EventType::RunCommandResult => ProtobufEventType::RunCommandResult,
             EventType::WebRequestResult => ProtobufEventType::WebRequestResult,
+            EventType::CommandPaneOpened => ProtobufEventType::CommandPaneOpened,
+            EventType::CommandPaneExited => ProtobufEventType::CommandPaneExited,
         })
     }
 }

--- a/zellij-utils/src/plugin_api/event.rs
+++ b/zellij-utils/src/plugin_api/event.rs
@@ -236,32 +236,32 @@ impl TryFrom<ProtobufEvent> for Event {
                 _ => Err("Malformed payload for the WebRequestResult Event"),
             },
             Some(ProtobufEventType::CommandPaneOpened) => match protobuf_event.payload {
-                Some(ProtobufEventPayload::CommandPaneOpenedPayload(command_pane_opened_payload)) => {
-                    Ok(Event::CommandPaneOpened(
-                        command_pane_opened_payload.terminal_pane_id,
-                        command_pane_opened_payload
-                            .context
-                            .into_iter()
-                            .map(|c_i| (c_i.name, c_i.value))
-                            .collect(),
-                    ))
-                },
+                Some(ProtobufEventPayload::CommandPaneOpenedPayload(
+                    command_pane_opened_payload,
+                )) => Ok(Event::CommandPaneOpened(
+                    command_pane_opened_payload.terminal_pane_id,
+                    command_pane_opened_payload
+                        .context
+                        .into_iter()
+                        .map(|c_i| (c_i.name, c_i.value))
+                        .collect(),
+                )),
                 _ => Err("Malformed payload for the CommandPaneOpened Event"),
-            }
+            },
             Some(ProtobufEventType::CommandPaneExited) => match protobuf_event.payload {
-                Some(ProtobufEventPayload::CommandPaneExitedPayload(command_pane_exited_payload)) => {
-                    Ok(Event::CommandPaneExited(
-                        command_pane_exited_payload.terminal_pane_id,
-                        command_pane_exited_payload.exit_code,
-                        command_pane_exited_payload
-                            .context
-                            .into_iter()
-                            .map(|c_i| (c_i.name, c_i.value))
-                            .collect(),
-                    ))
-                },
+                Some(ProtobufEventPayload::CommandPaneExitedPayload(
+                    command_pane_exited_payload,
+                )) => Ok(Event::CommandPaneExited(
+                    command_pane_exited_payload.terminal_pane_id,
+                    command_pane_exited_payload.exit_code,
+                    command_pane_exited_payload
+                        .context
+                        .into_iter()
+                        .map(|c_i| (c_i.name, c_i.value))
+                        .collect(),
+                )),
                 _ => Err("Malformed payload for the CommandPaneExited Event"),
-            }
+            },
             None => Err("Unknown Protobuf Event"),
         }
     }
@@ -498,7 +498,7 @@ impl TryFrom<Event> for ProtobufEvent {
                 Ok(ProtobufEvent {
                     name: ProtobufEventType::CommandPaneOpened as i32,
                     payload: Some(event::Payload::CommandPaneOpenedPayload(
-                        command_pane_opened_payload
+                        command_pane_opened_payload,
                     )),
                 })
             },
@@ -514,7 +514,7 @@ impl TryFrom<Event> for ProtobufEvent {
                 Ok(ProtobufEvent {
                     name: ProtobufEventType::CommandPaneExited as i32,
                     payload: Some(event::Payload::CommandPaneExitedPayload(
-                        command_pane_exited_payload
+                        command_pane_exited_payload,
                     )),
                 })
             },

--- a/zellij-utils/src/plugin_api/plugin_command.proto
+++ b/zellij-utils/src/plugin_api/plugin_command.proto
@@ -99,6 +99,8 @@ enum CommandName {
   CloseSelf = 85;
   NewTabsWithLayoutInfo = 86;
   Reconfigure = 87;
+  HidePaneWithId = 88;
+  ShowPaneWithId = 89;
 }
 
 message PluginCommand {
@@ -157,7 +159,18 @@ message PluginCommand {
     string scan_host_folder_payload = 61;
     NewTabsWithLayoutInfoPayload new_tabs_with_layout_info_payload = 62;
     string reconfigure_payload = 63;
+    HidePaneWithIdPayload hide_pane_with_id_payload = 64;
+    ShowPaneWithIdPayload show_pane_with_id_payload = 65;
   }
+}
+
+message HidePaneWithIdPayload {
+  PaneId pane_id = 1;
+}
+
+message ShowPaneWithIdPayload {
+  PaneId pane_id = 1;
+  bool should_float_if_hidden = 2;
 }
 
 message NewTabsWithLayoutInfoPayload {

--- a/zellij-utils/src/plugin_api/plugin_command.proto
+++ b/zellij-utils/src/plugin_api/plugin_command.proto
@@ -230,6 +230,7 @@ message OpenFilePayload {
 message OpenCommandPanePayload {
   command.Command command_to_run = 1;
   optional FloatingPaneCoordinates floating_pane_coordinates = 2;
+  repeated ContextItem context = 3;
 }
 
 message SwitchTabToPayload {

--- a/zellij-utils/src/plugin_api/plugin_command.rs
+++ b/zellij-utils/src/plugin_api/plugin_command.rs
@@ -278,7 +278,12 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
                 Some(Payload::OpenCommandPanePayload(command_to_run_payload)) => {
                     match command_to_run_payload.command_to_run {
                         Some(command_to_run) => {
-                            Ok(PluginCommand::OpenCommandPane(command_to_run.try_into()?))
+                            let context: BTreeMap<String, String> = command_to_run_payload
+                                .context
+                                .into_iter()
+                                .map(|e| (e.name, e.value))
+                                .collect();
+                            Ok(PluginCommand::OpenCommandPane(command_to_run.try_into()?, context))
                         },
                         None => Err("Malformed open open command pane payload"),
                     }
@@ -291,10 +296,18 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
                         .floating_pane_coordinates
                         .map(|f| f.into());
                     match command_to_run_payload.command_to_run {
-                        Some(command_to_run) => Ok(PluginCommand::OpenCommandPaneFloating(
-                            command_to_run.try_into()?,
-                            floating_pane_coordinates,
-                        )),
+                        Some(command_to_run) => {
+                            let context: BTreeMap<String, String> = command_to_run_payload
+                                .context
+                                .into_iter()
+                                .map(|e| (e.name, e.value))
+                                .collect();
+                            Ok(PluginCommand::OpenCommandPaneFloating(
+                                command_to_run.try_into()?,
+                                floating_pane_coordinates,
+                                context,
+                            ))
+                        }
                         None => Err("Malformed open command pane floating payload"),
                     }
                 },
@@ -719,9 +732,17 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
             Some(CommandName::OpenCommandInPlace) => match protobuf_plugin_command.payload {
                 Some(Payload::OpenCommandPaneInPlacePayload(command_to_run_payload)) => {
                     match command_to_run_payload.command_to_run {
-                        Some(command_to_run) => Ok(PluginCommand::OpenCommandPaneInPlace(
-                            command_to_run.try_into()?,
-                        )),
+                        Some(command_to_run) => {
+                            let context: BTreeMap<String, String> = command_to_run_payload
+                                .context
+                                .into_iter()
+                                .map(|e| (e.name, e.value))
+                                .collect();
+                            Ok(PluginCommand::OpenCommandPaneInPlace(
+                                command_to_run.try_into()?,
+                                context,
+                            ))
+                        },
                         None => Err("Malformed open command pane in-place payload"),
                     }
                 },
@@ -965,20 +986,32 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
                     })),
                 })
             },
-            PluginCommand::OpenCommandPane(command_to_run) => Ok(ProtobufPluginCommand {
-                name: CommandName::OpenCommandPane as i32,
-                payload: Some(Payload::OpenCommandPanePayload(OpenCommandPanePayload {
-                    command_to_run: Some(command_to_run.try_into()?),
-                    floating_pane_coordinates: None,
-                })),
-            }),
-            PluginCommand::OpenCommandPaneFloating(command_to_run, floating_pane_coordinates) => {
+            PluginCommand::OpenCommandPane(command_to_run, context) => {
+                let context: Vec<_> = context
+                    .into_iter()
+                    .map(|(name, value)| ContextItem { name, value })
+                    .collect();
+                Ok(ProtobufPluginCommand {
+                    name: CommandName::OpenCommandPane as i32,
+                    payload: Some(Payload::OpenCommandPanePayload(OpenCommandPanePayload {
+                        command_to_run: Some(command_to_run.try_into()?),
+                        floating_pane_coordinates: None,
+                        context,
+                    })),
+                })
+            },
+            PluginCommand::OpenCommandPaneFloating(command_to_run, floating_pane_coordinates, context) => {
+                let context: Vec<_> = context
+                    .into_iter()
+                    .map(|(name, value)| ContextItem { name, value })
+                    .collect();
                 Ok(ProtobufPluginCommand {
                     name: CommandName::OpenCommandPaneFloating as i32,
                     payload: Some(Payload::OpenCommandPaneFloatingPayload(
                         OpenCommandPanePayload {
                             command_to_run: Some(command_to_run.try_into()?),
                             floating_pane_coordinates: floating_pane_coordinates.map(|f| f.into()),
+                            context,
                         },
                     )),
                 })
@@ -1277,15 +1310,22 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
                     floating_pane_coordinates: None,
                 })),
             }),
-            PluginCommand::OpenCommandPaneInPlace(command_to_run) => Ok(ProtobufPluginCommand {
-                name: CommandName::OpenCommandInPlace as i32,
-                payload: Some(Payload::OpenCommandPaneInPlacePayload(
-                    OpenCommandPanePayload {
-                        command_to_run: Some(command_to_run.try_into()?),
-                        floating_pane_coordinates: None,
-                    },
-                )),
-            }),
+            PluginCommand::OpenCommandPaneInPlace(command_to_run, context) => {
+                let context: Vec<_> = context
+                    .into_iter()
+                    .map(|(name, value)| ContextItem { name, value })
+                    .collect();
+                Ok(ProtobufPluginCommand {
+                    name: CommandName::OpenCommandInPlace as i32,
+                    payload: Some(Payload::OpenCommandPaneInPlacePayload(
+                        OpenCommandPanePayload {
+                            command_to_run: Some(command_to_run.try_into()?),
+                            floating_pane_coordinates: None,
+                            context,
+                        },
+                    )),
+                })
+            },
             PluginCommand::RunCommand(command_line, env_variables, cwd, context) => {
                 let env_variables: Vec<_> = env_variables
                     .into_iter()


### PR DESCRIPTION
This adjusts the `OpenCommandPane`, `OpenCommandPaneFloating` and `OpenCommandPaneInPlace` to also include a `Context` dictionary (in Rust: `BTreeMap<String, String>`) to allow plugins to send arbitrary information in a similar way that they do with `RunCommand` and similar APIs. The context will be returned back to them in the new `CommandPaneOpened` and `CommandPaneExited` events, allowing plugin authors to treat these panes just like they would running a background command - only like this, the command includes a terminal, allowing the user to see its output in real time and even interrupt it, with the plugin becoming aware of it as it happens.

This also adds two new plugin API commands:
`HidePaneWithId` which would hide (suppress) a pane with the specified ID.
`ShowPaneWithId` which would show a hidden (suppressed) pane with the specified ID.