### PR TITLE
feat(plugins): allow opening command panes in the background (hidden)

### DIFF
--- a/default-plugins/fixture-plugin-for-tests/src/main.rs
+++ b/default-plugins/fixture-plugin-for-tests/src/main.rs
@@ -169,7 +169,7 @@ impl ZellijPlugin for State {
                     open_file(FileToOpen {
                         path: std::path::PathBuf::from("/path/to/my/file.rs"),
                         ..Default::default()
-                    });
+                    }, BTreeMap::new());
                 },
                 BareKey::Char('h') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
                     open_file_floating(
@@ -178,6 +178,7 @@ impl ZellijPlugin for State {
                             ..Default::default()
                         },
                         None,
+                        BTreeMap::new()
                     );
                 },
                 BareKey::Char('i') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
@@ -185,7 +186,7 @@ impl ZellijPlugin for State {
                         path: std::path::PathBuf::from("/path/to/my/file.rs"),
                         line_number: Some(42),
                         ..Default::default()
-                    });
+                    }, BTreeMap::new());
                 },
                 BareKey::Char('j') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
                     open_file_floating(
@@ -195,6 +196,7 @@ impl ZellijPlugin for State {
                             ..Default::default()
                         },
                         None,
+                        BTreeMap::new(),
                     );
                 },
                 BareKey::Char('k') if key.has_modifiers(&[KeyModifier::Ctrl]) => {

--- a/default-plugins/fixture-plugin-for-tests/src/main.rs
+++ b/default-plugins/fixture-plugin-for-tests/src/main.rs
@@ -337,6 +337,22 @@ impl ZellijPlugin for State {
                         .to_owned(),
                     );
                 },
+                BareKey::Char('a') if key.has_modifiers(&[KeyModifier::Alt]) => {
+                    hide_pane_with_id(PaneId::Terminal(1));
+                },
+                BareKey::Char('b') if key.has_modifiers(&[KeyModifier::Alt]) => {
+                    show_pane_with_id(PaneId::Terminal(1), true);
+                },
+                BareKey::Char('c') if key.has_modifiers(&[KeyModifier::Alt]) => {
+                    open_command_pane_background(
+                        CommandToRun {
+                            path: std::path::PathBuf::from("/path/to/my/file.rs"),
+                            args: vec!["arg1".to_owned(), "arg2".to_owned()],
+                            ..Default::default()
+                        },
+                        BTreeMap::new(),
+                    );
+                },
                 _ => {},
             },
             Event::CustomMessage(message, payload) => {

--- a/default-plugins/fixture-plugin-for-tests/src/main.rs
+++ b/default-plugins/fixture-plugin-for-tests/src/main.rs
@@ -166,10 +166,13 @@ impl ZellijPlugin for State {
                     start_or_reload_plugin(plugin_url)
                 },
                 BareKey::Char('g') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
-                    open_file(FileToOpen {
-                        path: std::path::PathBuf::from("/path/to/my/file.rs"),
-                        ..Default::default()
-                    }, BTreeMap::new());
+                    open_file(
+                        FileToOpen {
+                            path: std::path::PathBuf::from("/path/to/my/file.rs"),
+                            ..Default::default()
+                        },
+                        BTreeMap::new(),
+                    );
                 },
                 BareKey::Char('h') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
                     open_file_floating(
@@ -178,15 +181,18 @@ impl ZellijPlugin for State {
                             ..Default::default()
                         },
                         None,
-                        BTreeMap::new()
+                        BTreeMap::new(),
                     );
                 },
                 BareKey::Char('i') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
-                    open_file(FileToOpen {
-                        path: std::path::PathBuf::from("/path/to/my/file.rs"),
-                        line_number: Some(42),
-                        ..Default::default()
-                    }, BTreeMap::new());
+                    open_file(
+                        FileToOpen {
+                            path: std::path::PathBuf::from("/path/to/my/file.rs"),
+                            line_number: Some(42),
+                            ..Default::default()
+                        },
+                        BTreeMap::new(),
+                    );
                 },
                 BareKey::Char('j') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
                     open_file_floating(

--- a/default-plugins/status-bar/src/one_line_ui.rs
+++ b/default-plugins/status-bar/src/one_line_ui.rs
@@ -677,7 +677,7 @@ fn secondary_keybinds(help: &ModeInfo, tab_info: Option<&TabInfo>, max_len: usiz
     let mut secondary_info = LinePart::default();
     let binds = &help.get_mode_keybinds();
     // New Pane
-    let new_pane_action_key = action_key(binds, &[Action::NewPane(None, None)]);
+    let new_pane_action_key = action_key(binds, &[Action::NewPane(None, None, false)]);
     let mut new_pane_key_to_display = new_pane_action_key
         .iter()
         .find(|k| k.is_key_with_alt_modifier(BareKey::Char('n')))
@@ -1163,7 +1163,7 @@ fn get_keys_and_hints(mi: &ModeInfo) -> Vec<(String, String, Vec<KeyWithModifier
     }
 
     if mi.mode == IM::Pane { vec![
-        (s("New"), s("New"), single_action_key(&km, &[A::NewPane(None, None), TO_NORMAL])),
+        (s("New"), s("New"), single_action_key(&km, &[A::NewPane(None, None, false), TO_NORMAL])),
         (s("Change Focus"), s("Move"),
             action_key_group(&km, &[&[A::MoveFocus(Dir::Left)], &[A::MoveFocus(Dir::Down)],
                 &[A::MoveFocus(Dir::Up)], &[A::MoveFocus(Dir::Right)]])),
@@ -1271,8 +1271,8 @@ fn get_keys_and_hints(mi: &ModeInfo) -> Vec<(String, String, Vec<KeyWithModifier
         (s("Move focus"), s("Move"), action_key_group(&km, &[
             &[A::MoveFocus(Dir::Left)], &[A::MoveFocus(Dir::Down)],
             &[A::MoveFocus(Dir::Up)], &[A::MoveFocus(Dir::Right)]])),
-        (s("Split down"), s("Down"), action_key(&km, &[A::NewPane(Some(Dir::Down), None), TO_NORMAL])),
-        (s("Split right"), s("Right"), action_key(&km, &[A::NewPane(Some(Dir::Right), None), TO_NORMAL])),
+        (s("Split down"), s("Down"), action_key(&km, &[A::NewPane(Some(Dir::Down), None, false), TO_NORMAL])),
+        (s("Split right"), s("Right"), action_key(&km, &[A::NewPane(Some(Dir::Right), None, false), TO_NORMAL])),
         (s("Fullscreen"), s("Fullscreen"), action_key(&km, &[A::ToggleFocusFullscreen, TO_NORMAL])),
         (s("New tab"), s("New"), action_key(&km, &[A::NewTab(None, vec![], None, None, None), TO_NORMAL])),
         (s("Rename tab"), s("Rename"),

--- a/default-plugins/status-bar/src/second_line.rs
+++ b/default-plugins/status-bar/src/second_line.rs
@@ -149,7 +149,7 @@ fn get_keys_and_hints(mi: &ModeInfo) -> Vec<(String, String, Vec<KeyWithModifier
     }
 
     if mi.mode == IM::Pane { vec![
-        (s("New"), s("New"), action_key(&km, &[A::NewPane(None, None), TO_NORMAL])),
+        (s("New"), s("New"), action_key(&km, &[A::NewPane(None, None, false), TO_NORMAL])),
         (s("Change Focus"), s("Move"),
             action_key_group(&km, &[&[A::MoveFocus(Dir::Left)], &[A::MoveFocus(Dir::Down)],
                 &[A::MoveFocus(Dir::Up)], &[A::MoveFocus(Dir::Right)]])),
@@ -256,8 +256,8 @@ fn get_keys_and_hints(mi: &ModeInfo) -> Vec<(String, String, Vec<KeyWithModifier
         (s("Move focus"), s("Move"), action_key_group(&km, &[
             &[A::MoveFocus(Dir::Left)], &[A::MoveFocus(Dir::Down)],
             &[A::MoveFocus(Dir::Up)], &[A::MoveFocus(Dir::Right)]])),
-        (s("Split down"), s("Down"), action_key(&km, &[A::NewPane(Some(Dir::Down), None), TO_NORMAL])),
-        (s("Split right"), s("Right"), action_key(&km, &[A::NewPane(Some(Dir::Right), None), TO_NORMAL])),
+        (s("Split down"), s("Down"), action_key(&km, &[A::NewPane(Some(Dir::Down), None, false), TO_NORMAL])),
+        (s("Split right"), s("Right"), action_key(&km, &[A::NewPane(Some(Dir::Right), None, false), TO_NORMAL])),
         (s("Fullscreen"), s("Fullscreen"), action_key(&km, &[A::ToggleFocusFullscreen, TO_NORMAL])),
         (s("New tab"), s("New"), action_key(&km, &[A::NewTab(None, vec![], None, None, None), TO_NORMAL])),
         (s("Rename tab"), s("Rename"),
@@ -713,7 +713,7 @@ mod tests {
                     ),
                     (
                         KeyWithModifier::new(BareKey::Char('n')),
-                        vec![Action::NewPane(None, None), TO_NORMAL],
+                        vec![Action::NewPane(None, None, false), TO_NORMAL],
                     ),
                     (
                         KeyWithModifier::new(BareKey::Char('x')),
@@ -763,7 +763,7 @@ mod tests {
                     ),
                     (
                         KeyWithModifier::new(BareKey::Char('n')),
-                        vec![Action::NewPane(None, None), TO_NORMAL],
+                        vec![Action::NewPane(None, None, false), TO_NORMAL],
                     ),
                     (
                         KeyWithModifier::new(BareKey::Char('x')),
@@ -809,7 +809,7 @@ mod tests {
                     ),
                     (
                         KeyWithModifier::new(BareKey::Backspace),
-                        vec![Action::NewPane(None, None), TO_NORMAL],
+                        vec![Action::NewPane(None, None, false), TO_NORMAL],
                     ),
                     (
                         KeyWithModifier::new(BareKey::Esc),

--- a/default-plugins/status-bar/src/tip/data/quicknav.rs
+++ b/default-plugins/status-bar/src/tip/data/quicknav.rs
@@ -62,7 +62,7 @@ struct Keygroups<'a> {
 
 fn add_keybinds(help: &ModeInfo) -> Keygroups {
     let normal_keymap = help.get_mode_keybinds();
-    let new_pane_keys = action_key(&normal_keymap, &[Action::NewPane(None, None)]);
+    let new_pane_keys = action_key(&normal_keymap, &[Action::NewPane(None, None, false)]);
     let new_pane = if new_pane_keys.is_empty() {
         vec![Style::new().bold().paint("UNBOUND")]
     } else {

--- a/default-plugins/strider/src/state.rs
+++ b/default-plugins/strider/src/state.rs
@@ -152,9 +152,10 @@ impl State {
             if let Some(parent_folder) = self.file_list_view.path.parent() {
                 open_file(
                     FileToOpen::new(&self.file_list_view.path).with_cwd(parent_folder.into()),
+                    BTreeMap::new(),
                 );
             } else {
-                open_file(FileToOpen::new(&self.file_list_view.path));
+                open_file(FileToOpen::new(&self.file_list_view.path), BTreeMap::new());
             }
         }
         if self.close_on_selection {

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -306,7 +306,8 @@ fn spawn_terminal(
             if !command.is_dir() {
                 separate_command_arguments(&mut command, &mut args);
             }
-            let file_to_open = payload.path
+            let file_to_open = payload
+                .path
                 .into_os_string()
                 .into_string()
                 .expect("Not valid Utf8 Encoding");

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -288,7 +288,6 @@ fn spawn_terminal(
     // secondary fd
     let mut failover_cmd_args = None;
     let cmd = match terminal_action {
-        // TerminalAction::OpenFile(mut file_to_open, line_number, cwd) => {
         TerminalAction::OpenFile(mut payload) => {
             if payload.path.is_relative() {
                 if let Some(cwd) = payload.cwd.as_ref() {

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -288,10 +288,11 @@ fn spawn_terminal(
     // secondary fd
     let mut failover_cmd_args = None;
     let cmd = match terminal_action {
-        TerminalAction::OpenFile(mut file_to_open, line_number, cwd) => {
-            if file_to_open.is_relative() {
-                if let Some(cwd) = cwd.as_ref() {
-                    file_to_open = cwd.join(file_to_open);
+        // TerminalAction::OpenFile(mut file_to_open, line_number, cwd) => {
+        TerminalAction::OpenFile(mut payload) => {
+            if payload.path.is_relative() {
+                if let Some(cwd) = payload.cwd.as_ref() {
+                    payload.path = cwd.join(payload.path);
                 }
             }
             let mut command = default_editor.unwrap_or_else(|| {
@@ -306,11 +307,11 @@ fn spawn_terminal(
             if !command.is_dir() {
                 separate_command_arguments(&mut command, &mut args);
             }
-            let file_to_open = file_to_open
+            let file_to_open = payload.path
                 .into_os_string()
                 .into_string()
                 .expect("Not valid Utf8 Encoding");
-            if let Some(line_number) = line_number {
+            if let Some(line_number) = payload.line_number {
                 if command.ends_with("vim")
                     || command.ends_with("nvim")
                     || command.ends_with("emacs")
@@ -334,7 +335,7 @@ fn spawn_terminal(
             RunCommand {
                 command,
                 args,
-                cwd,
+                cwd: payload.cwd,
                 hold_on_close: false,
                 hold_on_start: false,
                 ..Default::default()

--- a/zellij-server/src/panes/floating_panes/floating_pane_grid.rs
+++ b/zellij-server/src/panes/floating_panes/floating_pane_grid.rs
@@ -854,7 +854,7 @@ impl<'a> FloatingPaneGrid<'a> {
     }
 }
 
-fn half_size_middle_geom(space: &Viewport, offset: usize) -> PaneGeom {
+pub fn half_size_middle_geom(space: &Viewport, offset: usize) -> PaneGeom {
     let mut geom = PaneGeom {
         x: space.x + (space.cols as f64 / 4.0).round() as usize + offset,
         y: space.y + (space.rows as f64 / 4.0).round() as usize + offset,

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -1,4 +1,4 @@
-mod floating_pane_grid;
+pub mod floating_pane_grid;
 use zellij_utils::{
     data::{Direction, PaneInfo, ResizeStrategy},
     position::Position,

--- a/zellij-server/src/panes/mod.rs
+++ b/zellij-server/src/panes/mod.rs
@@ -6,7 +6,7 @@ pub mod sixel;
 pub mod terminal_character;
 
 mod active_panes;
-mod floating_panes;
+pub mod floating_panes;
 mod plugin_pane;
 mod search;
 mod terminal_pane;

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -98,6 +98,15 @@ impl From<ZellijUtilsPaneId> for PaneId {
     }
 }
 
+impl Into<ZellijUtilsPaneId> for PaneId {
+    fn into(self) -> ZellijUtilsPaneId {
+        match self {
+            PaneId::Terminal(id) => ZellijUtilsPaneId::Terminal(id),
+            PaneId::Plugin(id) => ZellijUtilsPaneId::Plugin(id),
+        }
+    }
+}
+
 type IsFirstRun = bool;
 
 // FIXME: This should hold an os_api handle so that terminal panes can set their own size via FD in

--- a/zellij-server/src/plugins/mod.rs
+++ b/zellij-server/src/plugins/mod.rs
@@ -369,6 +369,17 @@ pub(crate) fn plugin_thread_main(
                 tab_index,
                 client_id,
             ) => {
+
+                // prefer connected clients so as to avoid opening plugins in the background for
+                // CLI clients unless no-one else is connected
+                let client_id = if wasm_bridge.client_is_connected(&client_id) {
+                    client_id
+                } else if let Some(first_client_id) = wasm_bridge.get_first_client_id() {
+                    first_client_id
+                } else {
+                    client_id
+                };
+
                 let mut plugin_ids: HashMap<RunPluginOrAlias, Vec<PluginId>> = HashMap::new();
                 tab_layout = tab_layout.or_else(|| Some(layout.new_tab().0));
                 tab_layout

--- a/zellij-server/src/plugins/mod.rs
+++ b/zellij-server/src/plugins/mod.rs
@@ -369,7 +369,6 @@ pub(crate) fn plugin_thread_main(
                 tab_index,
                 client_id,
             ) => {
-
                 // prefer connected clients so as to avoid opening plugins in the background for
                 // CLI clients unless no-one else is connected
                 let client_id = if wasm_bridge.client_is_connected(&client_id) {

--- a/zellij-server/src/plugins/mod.rs
+++ b/zellij-server/src/plugins/mod.rs
@@ -249,6 +249,7 @@ pub(crate) fn plugin_thread_main(
                 run_plugin_or_alias.populate_run_plugin_if_needed(&plugin_aliases);
                 let cwd = run_plugin_or_alias.get_initial_cwd().or(cwd);
                 let run_plugin = run_plugin_or_alias.get_run_plugin();
+                let start_suppressed = false;
                 match wasm_bridge.load_plugin(
                     &run_plugin,
                     Some(tab_index),
@@ -268,6 +269,7 @@ pub(crate) fn plugin_thread_main(
                             plugin_id,
                             pane_id_to_replace,
                             cwd,
+                            start_suppressed,
                             Some(client_id),
                         )));
                     },
@@ -307,6 +309,7 @@ pub(crate) fn plugin_thread_main(
                                     // we intentionally do not provide the client_id here because it belongs to
                                     // the cli who spawned the command and is not an existing client_id
                                     let skip_cache = true; // when reloading we always skip cache
+                                    let start_suppressed = false;
                                     match wasm_bridge.load_plugin(
                                         &Some(run_plugin),
                                         Some(tab_index),
@@ -328,6 +331,7 @@ pub(crate) fn plugin_thread_main(
                                                     plugin_id,
                                                     None,
                                                     None,
+                                                    start_suppressed,
                                                     None,
                                                 ),
                                             ));

--- a/zellij-server/src/plugins/plugin_loader.rs
+++ b/zellij-server/src/plugins/plugin_loader.rs
@@ -620,6 +620,7 @@ impl<'a> PluginLoader<'a> {
         instance: &Instance,
         plugin_map: &Arc<Mutex<PluginMap>>,
     ) -> Result<()> {
+        log::info!("load_plugin_instance");
         let err_context = || format!("failed to load plugin from instance {instance:#?}");
         let main_user_instance = instance.clone();
         display_loading_stage!(
@@ -719,6 +720,7 @@ impl<'a> PluginLoader<'a> {
         connected_clients: &[ClientId],
         plugin_map: &Arc<Mutex<PluginMap>>,
     ) -> Result<()> {
+        log::info!("clone_instance_for_other_clients");
         if !connected_clients.is_empty() {
             display_loading_stage!(
                 indicate_cloning_plugin_for_other_clients,

--- a/zellij-server/src/plugins/plugin_loader.rs
+++ b/zellij-server/src/plugins/plugin_loader.rs
@@ -620,7 +620,6 @@ impl<'a> PluginLoader<'a> {
         instance: &Instance,
         plugin_map: &Arc<Mutex<PluginMap>>,
     ) -> Result<()> {
-        log::info!("load_plugin_instance");
         let err_context = || format!("failed to load plugin from instance {instance:#?}");
         let main_user_instance = instance.clone();
         display_loading_stage!(
@@ -720,7 +719,6 @@ impl<'a> PluginLoader<'a> {
         connected_clients: &[ClientId],
         plugin_map: &Arc<Mutex<PluginMap>>,
     ) -> Result<()> {
-        log::info!("clone_instance_for_other_clients");
         if !connected_clients.is_empty() {
             display_loading_stage!(
                 indicate_cloning_plugin_for_other_clients,

--- a/zellij-server/src/plugins/plugin_map.rs
+++ b/zellij-server/src/plugins/plugin_map.rs
@@ -375,7 +375,6 @@ impl PluginEnv {
     }
 
     pub fn set_permissions(&mut self, permissions: HashSet<PermissionType>) {
-        log::info!("set_permissions to: {:?}", permissions);
         self.permissions.lock().unwrap().replace(permissions);
     }
 }

--- a/zellij-server/src/plugins/plugin_map.rs
+++ b/zellij-server/src/plugins/plugin_map.rs
@@ -375,6 +375,7 @@ impl PluginEnv {
     }
 
     pub fn set_permissions(&mut self, permissions: HashSet<PermissionType>) {
+        log::info!("set_permissions to: {:?}", permissions);
         self.permissions.lock().unwrap().replace(permissions);
     }
 }

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__hide_pane_with_id_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__hide_pane_with_id_plugin_command.snap
@@ -1,0 +1,13 @@
+---
+source: zellij-server/src/plugins/./unit/plugin_tests.rs
+assertion_line: 6727
+expression: "format!(\"{:#?}\", suppress_pane_event)"
+---
+Some(
+    SuppressPane(
+        Terminal(
+            1,
+        ),
+        1,
+    ),
+)

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_command_pane_background_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_command_pane_background_plugin_command.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/plugins/./unit/plugin_tests.rs
-assertion_line: 4479
+assertion_line: 6876
 expression: "format!(\"{:#?}\", new_tab_event)"
 ---
 Some(
@@ -26,12 +26,10 @@ Some(
                 },
             ),
         ),
-        Some(
-            false,
-        ),
         None,
         None,
-        false,
+        None,
+        true,
         ClientId(
             1,
         ),

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_command_pane_floating_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_command_pane_floating_plugin_command.snap
@@ -31,6 +31,7 @@ Some(
         ),
         None,
         None,
+        false,
         ClientId(
             1,
         ),

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_file_floating_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_file_floating_plugin_command.snap
@@ -1,17 +1,26 @@
 ---
 source: zellij-server/src/plugins/./unit/plugin_tests.rs
-assertion_line: 3846
+assertion_line: 3996
 expression: "format!(\"{:#?}\",\n        new_tab_event).replace(&format!(\"{:?}\", temp_folder.path()),\n    \"\\\"CWD\\\"\")"
 ---
 Some(
     SpawnTerminal(
         Some(
             OpenFile(
-                "/path/to/my/file.rs",
-                None,
-                Some(
-                    "CWD",
-                ),
+                OpenFilePayload {
+                    path: "/path/to/my/file.rs",
+                    line_number: None,
+                    cwd: Some(
+                        "CWD",
+                    ),
+                    originating_plugin: Some(
+                        OriginatingPlugin {
+                            plugin_id: 0,
+                            client_id: 1,
+                            context: {},
+                        },
+                    ),
+                },
             ),
         ),
         Some(
@@ -21,6 +30,7 @@ Some(
             "Editing: /path/to/my/file.rs",
         ),
         None,
+        false,
         ClientId(
             1,
         ),

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_file_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_file_plugin_command.snap
@@ -1,17 +1,26 @@
 ---
 source: zellij-server/src/plugins/./unit/plugin_tests.rs
-assertion_line: 3927
+assertion_line: 4078
 expression: "format!(\"{:#?}\",\n        new_tab_event).replace(&format!(\"{:?}\", temp_folder.path()),\n    \"\\\"CWD\\\"\")"
 ---
 Some(
     SpawnTerminal(
         Some(
             OpenFile(
-                "/path/to/my/file.rs",
-                None,
-                Some(
-                    "CWD",
-                ),
+                OpenFilePayload {
+                    path: "/path/to/my/file.rs",
+                    line_number: None,
+                    cwd: Some(
+                        "CWD",
+                    ),
+                    originating_plugin: Some(
+                        OriginatingPlugin {
+                            plugin_id: 0,
+                            client_id: 1,
+                            context: {},
+                        },
+                    ),
+                },
             ),
         ),
         Some(
@@ -21,6 +30,7 @@ Some(
             "Editing: /path/to/my/file.rs",
         ),
         None,
+        false,
         ClientId(
             1,
         ),

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_file_with_line_floating_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_file_with_line_floating_plugin_command.snap
@@ -1,19 +1,28 @@
 ---
 source: zellij-server/src/plugins/./unit/plugin_tests.rs
-assertion_line: 4090
+assertion_line: 4243
 expression: "format!(\"{:#?}\",\n        new_tab_event).replace(&format!(\"{:?}\", temp_folder.path()),\n    \"\\\"CWD\\\"\")"
 ---
 Some(
     SpawnTerminal(
         Some(
             OpenFile(
-                "/path/to/my/file.rs",
-                Some(
-                    42,
-                ),
-                Some(
-                    "CWD",
-                ),
+                OpenFilePayload {
+                    path: "/path/to/my/file.rs",
+                    line_number: Some(
+                        42,
+                    ),
+                    cwd: Some(
+                        "CWD",
+                    ),
+                    originating_plugin: Some(
+                        OriginatingPlugin {
+                            plugin_id: 0,
+                            client_id: 1,
+                            context: {},
+                        },
+                    ),
+                },
             ),
         ),
         Some(
@@ -23,6 +32,7 @@ Some(
             "Editing: /path/to/my/file.rs",
         ),
         None,
+        false,
         ClientId(
             1,
         ),

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_file_with_line_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_file_with_line_plugin_command.snap
@@ -1,19 +1,28 @@
 ---
 source: zellij-server/src/plugins/./unit/plugin_tests.rs
-assertion_line: 4009
+assertion_line: 4161
 expression: "format!(\"{:#?}\",\n        new_tab_event).replace(&format!(\"{:?}\", temp_folder.path()),\n    \"\\\"CWD\\\"\")"
 ---
 Some(
     SpawnTerminal(
         Some(
             OpenFile(
-                "/path/to/my/file.rs",
-                Some(
-                    42,
-                ),
-                Some(
-                    "CWD",
-                ),
+                OpenFilePayload {
+                    path: "/path/to/my/file.rs",
+                    line_number: Some(
+                        42,
+                    ),
+                    cwd: Some(
+                        "CWD",
+                    ),
+                    originating_plugin: Some(
+                        OriginatingPlugin {
+                            plugin_id: 0,
+                            client_id: 1,
+                            context: {},
+                        },
+                    ),
+                },
             ),
         ),
         Some(
@@ -23,6 +32,7 @@ Some(
             "Editing: /path/to/my/file.rs",
         ),
         None,
+        false,
         ClientId(
             1,
         ),

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_terminal_floating_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_terminal_floating_plugin_command.snap
@@ -24,6 +24,7 @@ Some(
         ),
         None,
         None,
+        false,
         ClientId(
             1,
         ),

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_terminal_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_terminal_plugin_command.snap
@@ -24,6 +24,7 @@ Some(
         ),
         None,
         None,
+        false,
         ClientId(
             1,
         ),

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__show_pane_with_id_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__show_pane_with_id_plugin_command.snap
@@ -1,0 +1,14 @@
+---
+source: zellij-server/src/plugins/./unit/plugin_tests.rs
+assertion_line: 6798
+expression: "format!(\"{:#?}\", focus_pane_event)"
+---
+Some(
+    FocusPaneWithId(
+        Terminal(
+            1,
+        ),
+        true,
+        1,
+    ),
+)

--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -1193,6 +1193,7 @@ impl WasmBridge {
                         cli_client_id,
                     ) {
                         Ok((plugin_id, client_id)) => {
+                            let start_suppressed = false;
                             drop(self.senders.send_to_screen(ScreenInstruction::AddPlugin(
                                 Some(should_float),
                                 should_be_open_in_place,
@@ -1202,6 +1203,7 @@ impl WasmBridge {
                                 plugin_id,
                                 pane_id_to_replace,
                                 cwd,
+                                start_suppressed,
                                 Some(client_id),
                             )));
                             vec![(plugin_id, Some(client_id))]

--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -1270,6 +1270,12 @@ impl WasmBridge {
             || (message_cid.is_none() && message_pid == Some(*plugin_id))
             || (message_cid == Some(*client_id) && message_pid == Some(*plugin_id))
     }
+    pub fn client_is_connected(&self, client_id: &ClientId) -> bool {
+        self.connected_clients.lock().unwrap().contains(client_id)
+    }
+    pub fn get_first_client_id(&self) -> Option<ClientId> {
+        self.connected_clients.lock().unwrap().iter().next().copied()
+    }
 }
 
 fn handle_plugin_successful_loading(senders: &ThreadSenders, plugin_id: PluginId) {
@@ -1318,6 +1324,9 @@ fn check_event_permission(
         | Event::SystemClipboardFailure
         | Event::CommandPaneOpened(..)
         | Event::CommandPaneExited(..)
+        | Event::PaneClosed(..)
+        | Event::EditPaneOpened(..)
+        | Event::EditPaneExited(..)
         | Event::InputReceived => PermissionType::ReadApplicationState,
         _ => return (PermissionStatus::Granted, None),
     };

--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -1274,7 +1274,12 @@ impl WasmBridge {
         self.connected_clients.lock().unwrap().contains(client_id)
     }
     pub fn get_first_client_id(&self) -> Option<ClientId> {
-        self.connected_clients.lock().unwrap().iter().next().copied()
+        self.connected_clients
+            .lock()
+            .unwrap()
+            .iter()
+            .next()
+            .copied()
     }
 }
 

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -438,9 +438,6 @@ fn open_file(env: &PluginEnv, file_to_open: FileToOpen, context: BTreeMap<String
             env.client_id,
             context,
         )),
-//         path,
-//         file_to_open.line_number,
-//         cwd,
         None,
         floating,
         in_place,
@@ -456,7 +453,6 @@ fn open_file_floating(
     floating_pane_coordinates: Option<FloatingPaneCoordinates>,
     context: BTreeMap<String, String>,
 ) {
-    // TODO: CONTINUE HERE - send the context
     let error_msg = || format!("failed to open file in plugin {}", env.name());
     let floating = true;
     let in_place = false;
@@ -472,9 +468,6 @@ fn open_file_floating(
             env.client_id,
             context,
         )),
-//         path,
-//         file_to_open.line_number,
-//         cwd,
         None,
         floating,
         in_place,
@@ -501,9 +494,6 @@ fn open_file_in_place(env: &PluginEnv, file_to_open: FileToOpen, context: BTreeM
             env.client_id,
             context,
         )),
-//         path,
-//         file_to_open.line_number,
-//         cwd,
         None,
         floating,
         in_place,
@@ -667,7 +657,6 @@ fn open_command_pane_background(
     command_to_run: CommandToRun,
     context: BTreeMap<String, String>,
 ) {
-    let error_msg = || format!("failed to open command in plugin {}", env.name());
     let command = command_to_run.path;
     let cwd = command_to_run.cwd.map(|cwd| env.plugin_cwd.join(cwd));
     let args = command_to_run.args;

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -23,6 +23,7 @@ use zellij_utils::data::{
 };
 use zellij_utils::input::permission::PermissionCache;
 use zellij_utils::{
+    async_std::task,
     interprocess::local_socket::LocalSocketStream,
     ipc::{ClientToServerMsg, IpcSenderWithContext},
 };
@@ -38,7 +39,7 @@ use zellij_utils::{
     errors::prelude::*,
     input::{
         actions::Action,
-        command::{RunCommand, RunCommandAction, TerminalAction},
+        command::{RunCommand, RunCommandAction, TerminalAction, OpenFilePayload},
         layout::{Layout, RunPluginOrAlias},
         plugins::PluginType,
     },
@@ -92,9 +93,9 @@ fn host_run_plugin_command(caller: Caller<'_, PluginEnv>) {
                     PluginCommand::SetSelectable(selectable) => set_selectable(env, selectable),
                     PluginCommand::GetPluginIds => get_plugin_ids(env),
                     PluginCommand::GetZellijVersion => get_zellij_version(env),
-                    PluginCommand::OpenFile(file_to_open) => open_file(env, file_to_open),
-                    PluginCommand::OpenFileFloating(file_to_open, floating_pane_coordinates) => {
-                        open_file_floating(env, file_to_open, floating_pane_coordinates)
+                    PluginCommand::OpenFile(file_to_open, context) => open_file(env, file_to_open, context),
+                    PluginCommand::OpenFileFloating(file_to_open, floating_pane_coordinates, context) => {
+                        open_file_floating(env, file_to_open, floating_pane_coordinates, context)
                     },
                     PluginCommand::OpenTerminal(cwd) => open_terminal(env, cwd.path.try_into()?),
                     PluginCommand::OpenTerminalFloating(cwd, floating_pane_coordinates) => {
@@ -222,8 +223,8 @@ fn host_run_plugin_command(caller: Caller<'_, PluginEnv>) {
                         delete_dead_session(session_name)?
                     },
                     PluginCommand::DeleteAllDeadSessions => delete_all_dead_sessions()?,
-                    PluginCommand::OpenFileInPlace(file_to_open) => {
-                        open_file_in_place(env, file_to_open)
+                    PluginCommand::OpenFileInPlace(file_to_open, context) => {
+                        open_file_in_place(env, file_to_open, context)
                     },
                     PluginCommand::OpenTerminalInPlace(cwd) => {
                         open_terminal_in_place(env, cwd.path.try_into()?)
@@ -359,6 +360,7 @@ fn request_permission(env: &PluginEnv, permissions: Vec<PermissionType>) -> Resu
     if PermissionCache::from_path_or_default(None)
         .check_permissions(env.plugin.location.to_string(), &permissions)
     {
+        log::info!("PermissionRequestResult 1");
         return env
             .senders
             .send_to_plugin(PluginInstruction::PermissionRequestResult(
@@ -420,7 +422,7 @@ fn get_zellij_version(env: &PluginEnv) {
         .non_fatal();
 }
 
-fn open_file(env: &PluginEnv, file_to_open: FileToOpen) {
+fn open_file(env: &PluginEnv, file_to_open: FileToOpen, context: BTreeMap<String, String>) {
     let error_msg = || format!("failed to open file in plugin {}", env.name());
     let floating = false;
     let in_place = false;
@@ -431,9 +433,14 @@ fn open_file(env: &PluginEnv, file_to_open: FileToOpen) {
         .map(|cwd| env.plugin_cwd.join(cwd))
         .or_else(|| Some(env.plugin_cwd.clone()));
     let action = Action::EditFile(
-        path,
-        file_to_open.line_number,
-        cwd,
+        OpenFilePayload::new(path, file_to_open.line_number, cwd).with_originating_plugin(OriginatingPlugin::new(
+            env.plugin_id,
+            env.client_id,
+            context,
+        )),
+//         path,
+//         file_to_open.line_number,
+//         cwd,
         None,
         floating,
         in_place,
@@ -447,7 +454,9 @@ fn open_file_floating(
     env: &PluginEnv,
     file_to_open: FileToOpen,
     floating_pane_coordinates: Option<FloatingPaneCoordinates>,
+    context: BTreeMap<String, String>,
 ) {
+    // TODO: CONTINUE HERE - send the context
     let error_msg = || format!("failed to open file in plugin {}", env.name());
     let floating = true;
     let in_place = false;
@@ -458,9 +467,14 @@ fn open_file_floating(
         .map(|cwd| env.plugin_cwd.join(cwd))
         .or_else(|| Some(env.plugin_cwd.clone()));
     let action = Action::EditFile(
-        path,
-        file_to_open.line_number,
-        cwd,
+        OpenFilePayload::new(path, file_to_open.line_number, cwd).with_originating_plugin(OriginatingPlugin::new(
+            env.plugin_id,
+            env.client_id,
+            context,
+        )),
+//         path,
+//         file_to_open.line_number,
+//         cwd,
         None,
         floating,
         in_place,
@@ -470,7 +484,7 @@ fn open_file_floating(
     apply_action!(action, error_msg, env);
 }
 
-fn open_file_in_place(env: &PluginEnv, file_to_open: FileToOpen) {
+fn open_file_in_place(env: &PluginEnv, file_to_open: FileToOpen, context: BTreeMap<String, String>) {
     let error_msg = || format!("failed to open file in plugin {}", env.name());
     let floating = false;
     let in_place = true;
@@ -482,9 +496,14 @@ fn open_file_in_place(env: &PluginEnv, file_to_open: FileToOpen) {
         .or_else(|| Some(env.plugin_cwd.clone()));
 
     let action = Action::EditFile(
-        path,
-        file_to_open.line_number,
-        cwd,
+        OpenFilePayload::new(path, file_to_open.line_number, cwd).with_originating_plugin(OriginatingPlugin::new(
+            env.plugin_id,
+            env.client_id,
+            context,
+        )),
+//         path,
+//         file_to_open.line_number,
+//         cwd,
         None,
         floating,
         in_place,
@@ -694,23 +713,13 @@ fn switch_tab_to(env: &PluginEnv, tab_idx: u32) {
 }
 
 fn set_timeout(env: &PluginEnv, secs: f64) {
-    // There is a fancy, high-performance way to do this with zero additional threads:
-    // If the plugin thread keeps a BinaryHeap of timer structs, it can manage multiple and easily `.peek()` at the
-    // next time to trigger in O(1) time. Once the wake-up time is known, the `wasm` thread can use `recv_timeout()`
-    // to wait for an event with the timeout set to be the time of the next wake up. If events come in in the meantime,
-    // they are handled, but if the timeout triggers, we replace the event from `recv()` with an
-    // `Update(pid, TimerEvent)` and pop the timer from the Heap (or reschedule it). No additional threads for as many
-    // timers as we'd like.
-    //
-    // But that's a lot of code, and this is a few lines:
     let send_plugin_instructions = env.senders.to_plugin.clone();
     let update_target = Some(env.plugin_id);
     let client_id = env.client_id;
     let plugin_name = env.name();
-    // TODO: we should really use an async task for this
-    thread::spawn(move || {
+    task::spawn(async move {
         let start_time = Instant::now();
-        thread::sleep(Duration::from_secs_f64(secs));
+        task::sleep(Duration::from_secs_f64(secs)).await;
         // FIXME: The way that elapsed time is being calculated here is not exact; it doesn't take into account the
         // time it takes an event to actually reach the plugin after it's sent to the `wasm` thread.
         let elapsed_time = Instant::now().duration_since(start_time).as_secs_f64();

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -274,7 +274,7 @@ pub(crate) fn route_action(
                 .send_to_screen(ScreenInstruction::TogglePaneFrames)
                 .with_context(err_context)?;
         },
-        Action::NewPane(direction, name) => {
+        Action::NewPane(direction, name, start_suppressed) => {
             let shell = default_shell.clone();
             let pty_instr = match direction {
                 Some(Direction::Left) => {
@@ -295,6 +295,7 @@ pub(crate) fn route_action(
                     None,
                     name,
                     None,
+                    start_suppressed,
                     ClientTabIndexOrPaneId::ClientId(client_id),
                 ),
             };
@@ -307,6 +308,7 @@ pub(crate) fn route_action(
             split_direction,
             should_float,
             should_open_in_place,
+            start_suppressed,
             floating_pane_coordinates,
         ) => {
             let title = format!("Editing: {}", path_to_file.display());
@@ -348,6 +350,7 @@ pub(crate) fn route_action(
                     Some(should_float),
                     Some(title),
                     floating_pane_coordinates,
+                    start_suppressed,
                     ClientTabIndexOrPaneId::ClientId(client_id),
                 ),
             };
@@ -394,6 +397,7 @@ pub(crate) fn route_action(
                     Some(should_float),
                     name,
                     floating_pane_coordinates,
+                    false,
                     ClientTabIndexOrPaneId::ClientId(client_id),
                 ))
                 .with_context(err_context)?;
@@ -447,6 +451,7 @@ pub(crate) fn route_action(
                     Some(should_float),
                     name,
                     None,
+                    false,
                     ClientTabIndexOrPaneId::ClientId(client_id),
                 ),
             };
@@ -496,6 +501,7 @@ pub(crate) fn route_action(
                     None,
                     None,
                     None,
+                    false,
                     ClientTabIndexOrPaneId::ClientId(client_id),
                 ),
             };

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -303,9 +303,6 @@ pub(crate) fn route_action(
         },
         Action::EditFile(
             open_file_payload,
-//             path_to_file,
-//             line_number,
-//             cwd,
             split_direction,
             should_float,
             should_open_in_place,
@@ -313,7 +310,6 @@ pub(crate) fn route_action(
             floating_pane_coordinates,
         ) => {
             let title = format!("Editing: {}", open_file_payload.path.display());
-            // let open_file = TerminalAction::OpenFile(OpenFilePayload::new(path_to_file, line_number, cwd));
             let open_file = TerminalAction::OpenFile(open_file_payload);
             let pty_instr = match (split_direction, should_float, should_open_in_place) {
                 (Some(Direction::Left), false, false) => {
@@ -521,7 +517,6 @@ pub(crate) fn route_action(
             swap_floating_layouts,
             tab_name,
         ) => {
-            log::info!("NewTab, client_id: {:?}", client_id);
             let shell = default_shell.clone();
             let swap_tiled_layouts =
                 swap_tiled_layouts.unwrap_or_else(|| default_layout.swap_tiled_layouts.clone());

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -17,7 +17,7 @@ use zellij_utils::{
     errors::prelude::*,
     input::{
         actions::{Action, SearchDirection, SearchOption},
-        command::{TerminalAction},
+        command::TerminalAction,
         get_mode_info,
         keybinds::Keybinds,
         layout::Layout,

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -17,7 +17,7 @@ use zellij_utils::{
     errors::prelude::*,
     input::{
         actions::{Action, SearchDirection, SearchOption},
-        command::TerminalAction,
+        command::{TerminalAction},
         get_mode_info,
         keybinds::Keybinds,
         layout::Layout,
@@ -302,17 +302,19 @@ pub(crate) fn route_action(
             senders.send_to_pty(pty_instr).with_context(err_context)?;
         },
         Action::EditFile(
-            path_to_file,
-            line_number,
-            cwd,
+            open_file_payload,
+//             path_to_file,
+//             line_number,
+//             cwd,
             split_direction,
             should_float,
             should_open_in_place,
             start_suppressed,
             floating_pane_coordinates,
         ) => {
-            let title = format!("Editing: {}", path_to_file.display());
-            let open_file = TerminalAction::OpenFile(path_to_file, line_number, cwd);
+            let title = format!("Editing: {}", open_file_payload.path.display());
+            // let open_file = TerminalAction::OpenFile(OpenFilePayload::new(path_to_file, line_number, cwd));
+            let open_file = TerminalAction::OpenFile(open_file_payload);
             let pty_instr = match (split_direction, should_float, should_open_in_place) {
                 (Some(Direction::Left), false, false) => {
                     PtyInstruction::SpawnTerminalVertically(Some(open_file), Some(title), client_id)
@@ -519,6 +521,7 @@ pub(crate) fn route_action(
             swap_floating_layouts,
             tab_name,
         ) => {
+            log::info!("NewTab, client_id: {:?}", client_id);
             let shell = default_shell.clone();
             let swap_tiled_layouts =
                 swap_tiled_layouts.unwrap_or_else(|| default_layout.swap_tiled_layouts.clone());

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -2987,7 +2987,6 @@ pub(crate) fn screen_thread_main(
                 screen.log_and_report_session_state()?;
             },
             ScreenInstruction::ClosePane(id, client_id) => {
-                log::info!("ScreenInstruction::ClosePane: {:?}", id);
                 match client_id {
                     Some(client_id) => {
                         active_tab!(screen, client_id, |tab: &mut Tab| tab.close_pane(

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -313,7 +313,7 @@ pub enum ScreenInstruction {
         u32,            // plugin id
         Option<PaneId>,
         Option<PathBuf>, // cwd
-        bool, // start suppressed
+        bool,            // start suppressed
         Option<ClientId>,
     ),
     UpdatePluginLoadingStage(u32, LoadingIndication), // u32 - plugin_id
@@ -3004,7 +3004,6 @@ pub(crate) fn screen_thread_main(
                         }
                     },
                 }
-
 
                 screen.unblock_input()?;
                 screen.log_and_report_session_state()?;

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -2522,14 +2522,10 @@ impl Tab {
         id: PaneId,
         ignore_suppressed_panes: bool,
         client_id: Option<ClientId>,
-    // ) -> Option<Box<dyn Pane>> {
     ) {
         // we need to ignore suppressed panes when we toggle a pane to be floating/embedded(tiled)
         // this is because in that case, while we do use this logic, we're not actually closing the
         // pane, we're moving it
-        //
-        // TODO: separate the "close_pane" logic and the "move_pane_somewhere_else" logic, they're
-        // overloaded here and that's not great
         if !ignore_suppressed_panes && self.suppressed_panes.contains_key(&id) {
             return match self.replace_pane_with_suppressed_pane(id) {
                 Ok(_pane) => {},
@@ -2541,7 +2537,7 @@ impl Tab {
             };
         }
         if self.floating_panes.panes_contain(&id) {
-            let closed_pane = self.floating_panes.remove_pane(id);
+            let _closed_pane = self.floating_panes.remove_pane(id);
             self.floating_panes.move_clients_out_of_pane(id);
             if !self.floating_panes.has_panes() {
                 self.hide_floating_panes();
@@ -2561,7 +2557,7 @@ impl Tab {
             if self.tiled_panes.fullscreen_is_active() {
                 self.tiled_panes.unset_fullscreen();
             }
-            let closed_pane = self.tiled_panes.remove_pane(id);
+            let _closed_pane = self.tiled_panes.remove_pane(id);
             self.set_force_render();
             self.tiled_panes.set_force_render();
             if self.auto_layout && !self.swap_layouts.is_tiled_damaged() {
@@ -2656,17 +2652,6 @@ impl Tab {
         } else if let Some(pane) = self.suppressed_panes.values_mut().find(|p| p.1.pid() == id) {
             pane.1.hold(exit_status, is_first_run, run_command);
         }
-
-        //         ORIG
-//         if self.floating_panes.panes_contain(&id) {
-//             log::info!("tab.hold_pane 1");
-//             self.floating_panes
-//                 .hold_pane(id, exit_status, is_first_run, run_command);
-//         } else {
-//             log::info!("tab.hold_pane 3");
-//             self.tiled_panes
-//                 .hold_pane(id, exit_status, is_first_run, run_command);
-//         }
     }
     pub fn replace_pane_with_suppressed_pane(
         &mut self,
@@ -3826,7 +3811,6 @@ impl Tab {
         // not take it out of there when another pane is closed (eg. like happens with the
         // scrollback editor), but it has to take itself out on its own (eg. a plugin using the
         // show_self() method)
-        // if let Some(pane) = self.close_pane(pane_id, true, Some(client_id)) {
         if let Some(pane) = self.extract_pane(pane_id, true, Some(client_id)) {
             let is_scrollback_editor = false;
             self.suppressed_panes

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -30,9 +30,9 @@ use self::clipboard::ClipboardProvider;
 use crate::{
     os_input_output::ServerOsApi,
     output::{CharacterChunk, Output, SixelImageChunk},
+    panes::floating_panes::floating_pane_grid::half_size_middle_geom,
     panes::sixel::SixelImageStore,
     panes::{FloatingPanes, TiledPanes},
-    panes::floating_panes::floating_pane_grid::half_size_middle_geom,
     panes::{LinkHandler, PaneId, PluginPane, TerminalPane},
     plugins::PluginInstruction,
     pty::{ClientTabIndexOrPaneId, PtyInstruction, VteBytes},
@@ -1141,15 +1141,18 @@ impl Tab {
             // the default geom of the first floating pane - this is just in order to give it some
             // reasonable size, when it is shown - if needed - it will be given the proper geom as if it were
             // resized
-            let viewport = {
-                self.viewport.borrow().clone()
-            };
+            let viewport = { self.viewport.borrow().clone() };
             let new_pane_geom = half_size_middle_geom(&viewport, 0);
             new_pane.set_active_at(Instant::now());
             new_pane.set_geom(new_pane_geom);
             new_pane.set_content_offset(Offset::frame(1));
-            resize_pty!(new_pane, self.os_api, self.senders, self.character_cell_size)
-                .with_context(err_context)?;
+            resize_pty!(
+                new_pane,
+                self.os_api,
+                self.senders,
+                self.character_cell_size
+            )
+            .with_context(err_context)?;
             let is_scrollback_editor = false;
             self.suppressed_panes
                 .insert(pid, (is_scrollback_editor, new_pane));
@@ -2475,7 +2478,11 @@ impl Tab {
     }
     pub fn get_all_pane_ids(&self) -> Vec<PaneId> {
         let mut static_and_floating_pane_ids = self.get_static_and_floating_pane_ids();
-        let mut suppressed_pane_ids = self.suppressed_panes.values().map(|(_key, pane)| pane.pid()).collect();
+        let mut suppressed_pane_ids = self
+            .suppressed_panes
+            .values()
+            .map(|(_key, pane)| pane.pid())
+            .collect();
         static_and_floating_pane_ids.append(&mut suppressed_pane_ids);
         static_and_floating_pane_ids
     }
@@ -2567,9 +2574,11 @@ impl Tab {
                 let _ = self.next_swap_layout(client_id, false);
             }
         };
-        let _ = self
-            .senders
-            .send_to_plugin(PluginInstruction::Update(vec![(None, None, Event::PaneClosed(id.into()))]));
+        let _ = self.senders.send_to_plugin(PluginInstruction::Update(vec![(
+            None,
+            None,
+            Event::PaneClosed(id.into()),
+        )]));
     }
     pub fn extract_pane(
         &mut self,

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -955,16 +955,56 @@ fn five_new_floating_panes() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_pty_bytes(
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
@@ -999,8 +1039,16 @@ fn increase_floating_pane_size() {
     let new_pane_id_1 = PaneId::Terminal(2);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_pty_bytes(
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
@@ -1029,8 +1077,16 @@ fn decrease_floating_pane_size() {
     let new_pane_id_1 = PaneId::Terminal(2);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_pty_bytes(
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
@@ -1059,8 +1115,16 @@ fn resize_floating_pane_left() {
     let new_pane_id_1 = PaneId::Terminal(2);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_pty_bytes(
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
@@ -1092,8 +1156,16 @@ fn resize_floating_pane_right() {
     let new_pane_id_1 = PaneId::Terminal(2);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_pty_bytes(
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
@@ -1125,8 +1197,16 @@ fn resize_floating_pane_up() {
     let new_pane_id_1 = PaneId::Terminal(2);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_pty_bytes(
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
@@ -1158,8 +1238,16 @@ fn resize_floating_pane_down() {
     let new_pane_id_1 = PaneId::Terminal(2);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_pty_bytes(
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
@@ -1195,16 +1283,56 @@ fn move_floating_pane_focus_left() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_pty_bytes(
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
@@ -1250,16 +1378,56 @@ fn move_floating_pane_focus_right() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_pty_bytes(
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
@@ -1306,16 +1474,56 @@ fn move_floating_pane_focus_up() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_pty_bytes(
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
@@ -1361,16 +1569,56 @@ fn move_floating_pane_focus_down() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_pty_bytes(
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
@@ -1417,16 +1665,56 @@ fn move_floating_pane_focus_with_mouse() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_pty_bytes(
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
@@ -1475,16 +1763,56 @@ fn move_pane_focus_with_mouse_to_non_floating_pane() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_pty_bytes(
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
@@ -1533,16 +1861,56 @@ fn drag_pane_with_mouse() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_pty_bytes(
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
@@ -1591,16 +1959,56 @@ fn mark_text_inside_floating_pane() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_pty_bytes(
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
@@ -1657,16 +2065,56 @@ fn resize_tab_with_floating_panes() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_pty_bytes(
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
@@ -1711,16 +2159,56 @@ fn shrink_whole_tab_with_floating_panes_horizontally_and_vertically() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_pty_bytes(
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
@@ -1761,16 +2249,56 @@ fn shrink_whole_tab_with_floating_panes_horizontally_and_vertically_and_expand_b
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_pty_bytes(
         2,
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
@@ -2979,8 +3507,16 @@ fn move_pane_focus_sends_tty_csi_event() {
     });
     let mut tab = create_new_tab_with_os_api(size, ModeInfo::default(), &os_api);
     let new_pane_id_1 = PaneId::Terminal(2);
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_pty_bytes(
         1,
         // subscribe to focus events
@@ -3014,10 +3550,26 @@ fn move_floating_pane_focus_sends_tty_csi_event() {
     let new_pane_id_2 = PaneId::Terminal(3);
 
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_pty_bytes(
         1,
         // subscribe to focus events
@@ -3057,10 +3609,26 @@ fn toggle_floating_panes_on_sends_tty_csi_event() {
     let new_pane_id_2 = PaneId::Terminal(3);
 
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
     tab.handle_pty_bytes(
         1,
@@ -3101,10 +3669,26 @@ fn toggle_floating_panes_off_sends_tty_csi_event() {
     let new_pane_id_2 = PaneId::Terminal(3);
 
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_pty_bytes(
         1,
         // subscribe to focus events
@@ -3163,8 +3747,16 @@ fn can_swap_tiled_layout_at_runtime() {
     );
     let new_pane_id_1 = PaneId::Terminal(2);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.next_swap_layout(Some(client_id), false).unwrap();
     tab.render(&mut output).unwrap();
     let snapshot = take_snapshot(
@@ -3218,10 +3810,26 @@ fn can_swap_floating_layout_at_runtime() {
     let new_pane_id_2 = PaneId::Terminal(3);
 
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.next_swap_layout(Some(client_id), false).unwrap();
     tab.render(&mut output).unwrap();
     let snapshot = take_snapshot(
@@ -3271,8 +3879,16 @@ fn swapping_layouts_after_resize_snaps_to_current_layout() {
     );
     let new_pane_id_1 = PaneId::Terminal(2);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.next_swap_layout(Some(client_id), false).unwrap();
     tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None))
         .unwrap();
@@ -3321,12 +3937,36 @@ fn swap_tiled_layout_with_stacked_children() {
     let new_pane_id_2 = PaneId::Terminal(3);
     let new_pane_id_3 = PaneId::Terminal(4);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.render(&mut output).unwrap();
     let snapshot = take_snapshot(
         output.serialize().unwrap().get(&client_id).unwrap(),
@@ -3368,12 +4008,36 @@ fn swap_tiled_layout_with_only_stacked_children() {
     let new_pane_id_2 = PaneId::Terminal(3);
     let new_pane_id_3 = PaneId::Terminal(4);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.render(&mut output).unwrap();
     let snapshot = take_snapshot(
         output.serialize().unwrap().get(&client_id).unwrap(),
@@ -3418,12 +4082,36 @@ fn swap_tiled_layout_with_stacked_children_and_no_pane_frames() {
     let new_pane_id_2 = PaneId::Terminal(3);
     let new_pane_id_3 = PaneId::Terminal(4);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.render(&mut output).unwrap();
     let snapshot = take_snapshot(
         output.serialize().unwrap().get(&client_id).unwrap(),
@@ -3468,12 +4156,36 @@ fn move_focus_up_with_stacked_panes() {
     let new_pane_id_2 = PaneId::Terminal(3);
     let new_pane_id_3 = PaneId::Terminal(4);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.move_focus_right(client_id);
     tab.move_focus_up(client_id);
     tab.render(&mut output).unwrap();
@@ -3520,12 +4232,36 @@ fn move_focus_down_with_stacked_panes() {
     let new_pane_id_2 = PaneId::Terminal(3);
     let new_pane_id_3 = PaneId::Terminal(4);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.move_focus_right(client_id);
     tab.move_focus_up(client_id);
     tab.move_focus_down(client_id);
@@ -3854,12 +4590,36 @@ fn close_main_stacked_pane() {
     let new_pane_id_2 = PaneId::Terminal(3);
     let new_pane_id_3 = PaneId::Terminal(4);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.close_pane(new_pane_id_2, false, None);
     tab.render(&mut output).unwrap();
     let snapshot = take_snapshot(
@@ -3907,16 +4667,56 @@ fn close_main_stacked_pane_in_mid_stack() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.move_focus_right(client_id);
     tab.move_focus_up(client_id);
     tab.move_focus_up(client_id);
@@ -3967,16 +4767,56 @@ fn close_one_liner_stacked_pane_below_main_pane() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.move_focus_left(client_id);
     tab.move_focus_right(client_id);
     tab.move_focus_up(client_id);
@@ -4028,16 +4868,56 @@ fn close_one_liner_stacked_pane_above_main_pane() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.move_focus_right(client_id);
     tab.move_focus_up(client_id);
     tab.move_focus_up(client_id);
@@ -4088,16 +4968,56 @@ fn can_increase_size_of_main_pane_in_stack_horizontally() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.move_focus_right(client_id);
     tab.resize(
         client_id,
@@ -4152,16 +5072,56 @@ fn can_increase_size_of_main_pane_in_stack_vertically() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.move_focus_right(client_id);
     tab.resize(
         client_id,
@@ -4216,16 +5176,56 @@ fn can_increase_size_of_main_pane_in_stack_non_directionally() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     let _ = tab.move_focus_up(client_id);
     let _ = tab.move_focus_right(client_id);
     tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None))
@@ -4276,16 +5276,56 @@ fn can_increase_size_into_pane_stack_horizontally() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.resize(
         client_id,
         ResizeStrategy::new(Resize::Increase, Some(Direction::Right)),
@@ -4339,16 +5379,56 @@ fn can_increase_size_into_pane_stack_vertically() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.move_focus_right(client_id);
     tab.move_focus_down(client_id);
     tab.resize(
@@ -4404,16 +5484,56 @@ fn can_increase_size_into_pane_stack_non_directionally() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     let _ = tab.move_focus_up(client_id);
     tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None))
         .unwrap();
@@ -4463,16 +5583,56 @@ fn decreasing_size_of_whole_tab_treats_stacked_panes_properly() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.resize_whole_tab(Size {
         cols: 100,
         rows: 10,
@@ -4523,16 +5683,56 @@ fn increasing_size_of_whole_tab_treats_stacked_panes_properly() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.resize_whole_tab(Size {
         cols: 100,
         rows: 10,
@@ -4588,16 +5788,56 @@ fn cannot_decrease_stack_size_beyond_minimum_height() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.move_focus_down(client_id);
     for _ in 0..6 {
         tab.resize(
@@ -4653,16 +5893,56 @@ fn focus_stacked_pane_over_flexible_pane_with_the_mouse() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_left_click(&Position::new(1, 71), client_id)
         .unwrap();
     tab.render(&mut output).unwrap();
@@ -4712,16 +5992,56 @@ fn focus_stacked_pane_under_flexible_pane_with_the_mouse() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_left_click(&Position::new(1, 71), client_id)
         .unwrap();
     tab.handle_left_click(&Position::new(9, 71), client_id)
@@ -4773,16 +6093,56 @@ fn close_stacked_pane_with_previously_focused_other_pane() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.handle_left_click(&Position::new(2, 71), client_id)
         .unwrap();
     tab.handle_left_click(&Position::new(1, 71), client_id)
@@ -4840,16 +6200,56 @@ fn close_pane_near_stacked_panes() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.close_pane(PaneId::Terminal(6), false, None);
     tab.render(&mut output).unwrap();
     let (snapshot, cursor_coordinates) = take_snapshot_and_cursor_position(
@@ -4904,16 +6304,56 @@ fn focus_next_pane_expands_stacked_panes() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.move_focus_left(client_id);
     tab.focus_next_pane(client_id);
     tab.render(&mut output).unwrap();
@@ -4964,16 +6404,56 @@ fn stacked_panes_can_become_fullscreen() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
-        .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
-        .unwrap();
+    tab.new_pane(
+        new_pane_id_1,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_2,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_3,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_4,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
+    tab.new_pane(
+        new_pane_id_5,
+        None,
+        None,
+        None,
+        None,
+        false,
+        Some(client_id),
+    )
+    .unwrap();
     tab.move_focus_up(client_id);
     tab.toggle_active_pane_fullscreen(client_id);
     tab.render(&mut output).unwrap();

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -778,7 +778,7 @@ fn dump_screen() {
         ..Default::default()
     });
     let new_pane_id = PaneId::Terminal(2);
-    tab.new_pane(new_pane_id, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(2, Vec::from("scratch".as_bytes()))
         .unwrap();
@@ -806,7 +806,7 @@ fn clear_screen() {
         ..Default::default()
     });
     let new_pane_id = PaneId::Terminal(2);
-    tab.new_pane(new_pane_id, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(2, Vec::from("scratch".as_bytes()))
         .unwrap();
@@ -832,7 +832,7 @@ fn new_floating_pane() {
     let new_pane_id = PaneId::Terminal(2);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -860,7 +860,7 @@ fn floating_panes_persist_across_toggles() {
     let new_pane_id = PaneId::Terminal(2);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
     // here we send bytes to the pane when it's not visible to make sure they're still handled and
@@ -892,7 +892,7 @@ fn toggle_floating_panes_off() {
     let new_pane_id = PaneId::Terminal(2);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -921,7 +921,7 @@ fn toggle_floating_panes_on() {
     let new_pane_id = PaneId::Terminal(2);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -955,15 +955,15 @@ fn five_new_floating_panes() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -999,7 +999,7 @@ fn increase_floating_pane_size() {
     let new_pane_id_1 = PaneId::Terminal(2);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -1029,7 +1029,7 @@ fn decrease_floating_pane_size() {
     let new_pane_id_1 = PaneId::Terminal(2);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -1059,7 +1059,7 @@ fn resize_floating_pane_left() {
     let new_pane_id_1 = PaneId::Terminal(2);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -1092,7 +1092,7 @@ fn resize_floating_pane_right() {
     let new_pane_id_1 = PaneId::Terminal(2);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -1125,7 +1125,7 @@ fn resize_floating_pane_up() {
     let new_pane_id_1 = PaneId::Terminal(2);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -1158,7 +1158,7 @@ fn resize_floating_pane_down() {
     let new_pane_id_1 = PaneId::Terminal(2);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -1195,15 +1195,15 @@ fn move_floating_pane_focus_left() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -1250,15 +1250,15 @@ fn move_floating_pane_focus_right() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -1306,15 +1306,15 @@ fn move_floating_pane_focus_up() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -1361,15 +1361,15 @@ fn move_floating_pane_focus_down() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -1417,15 +1417,15 @@ fn move_floating_pane_focus_with_mouse() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -1475,15 +1475,15 @@ fn move_pane_focus_with_mouse_to_non_floating_pane() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -1533,15 +1533,15 @@ fn drag_pane_with_mouse() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -1591,15 +1591,15 @@ fn mark_text_inside_floating_pane() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -1657,15 +1657,15 @@ fn resize_tab_with_floating_panes() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -1711,15 +1711,15 @@ fn shrink_whole_tab_with_floating_panes_horizontally_and_vertically() {
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -1761,15 +1761,15 @@ fn shrink_whole_tab_with_floating_panes_horizontally_and_vertically_and_expand_b
     let new_pane_id_5 = PaneId::Terminal(6);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -1812,7 +1812,7 @@ fn embed_floating_pane() {
     let new_pane_id = PaneId::Terminal(2);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -1840,7 +1840,7 @@ fn float_embedded_pane() {
     let mut tab = create_new_tab(size, ModeInfo::default());
     let new_pane_id = PaneId::Terminal(2);
     let mut output = Output::default();
-    tab.new_pane(new_pane_id, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -1870,7 +1870,7 @@ fn embed_floating_pane_without_pane_frames() {
     let mut output = Output::default();
     tab.set_pane_frames(false);
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -1899,7 +1899,7 @@ fn float_embedded_pane_without_pane_frames() {
     let new_pane_id = PaneId::Terminal(2);
     let mut output = Output::default();
     tab.set_pane_frames(false);
-    tab.new_pane(new_pane_id, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -2002,7 +2002,7 @@ fn rename_floating_pane() {
     let mut tab = create_new_tab(size, ModeInfo::default());
     let new_pane_id = PaneId::Terminal(2);
     let mut output = Output::default();
-    tab.new_pane(new_pane_id, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         2,
@@ -2098,7 +2098,7 @@ fn move_floating_pane_with_sixel_image() {
     let mut output = Output::new(sixel_image_store.clone(), character_cell_size, true);
 
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id, None, None, None, None, false, Some(client_id))
         .unwrap();
     let fixture = read_fixture("sixel-image-500px.six");
     tab.handle_pty_bytes(2, fixture).unwrap();
@@ -2136,7 +2136,7 @@ fn floating_pane_above_sixel_image() {
     let mut output = Output::new(sixel_image_store.clone(), character_cell_size, true);
 
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id, None, None, None, None, false, Some(client_id))
         .unwrap();
     let fixture = read_fixture("sixel-image-500px.six");
     tab.handle_pty_bytes(1, fixture).unwrap();
@@ -2194,7 +2194,7 @@ fn suppress_floating_pane() {
     let mut output = Output::default();
 
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.replace_active_pane_with_editor_pane(editor_pane_id, client_id)
         .unwrap();
@@ -2250,7 +2250,7 @@ fn close_suppressing_floating_pane() {
     let mut output = Output::default();
 
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.replace_active_pane_with_editor_pane(editor_pane_id, client_id)
         .unwrap();
@@ -2310,7 +2310,7 @@ fn suppress_floating_pane_embed_it_and_close_it() {
     let mut output = Output::default();
 
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.replace_active_pane_with_editor_pane(editor_pane_id, client_id)
         .unwrap();
@@ -2372,7 +2372,7 @@ fn resize_whole_tab_while_floting_pane_is_suppressed() {
     let mut output = Output::default();
 
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.replace_active_pane_with_editor_pane(editor_pane_id, client_id)
         .unwrap();
@@ -2474,7 +2474,7 @@ fn enter_search_floating_pane() {
     let new_pane_id = PaneId::Terminal(2);
     let mut output = Output::default();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id, None, None, None, None, false, Some(client_id))
         .unwrap();
 
     let pane_content = read_fixture("grid_copy");
@@ -2979,7 +2979,7 @@ fn move_pane_focus_sends_tty_csi_event() {
     });
     let mut tab = create_new_tab_with_os_api(size, ModeInfo::default(), &os_api);
     let new_pane_id_1 = PaneId::Terminal(2);
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         1,
@@ -3014,9 +3014,9 @@ fn move_floating_pane_focus_sends_tty_csi_event() {
     let new_pane_id_2 = PaneId::Terminal(3);
 
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         1,
@@ -3057,9 +3057,9 @@ fn toggle_floating_panes_on_sends_tty_csi_event() {
     let new_pane_id_2 = PaneId::Terminal(3);
 
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
     tab.handle_pty_bytes(
@@ -3101,9 +3101,9 @@ fn toggle_floating_panes_off_sends_tty_csi_event() {
     let new_pane_id_2 = PaneId::Terminal(3);
 
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_pty_bytes(
         1,
@@ -3163,7 +3163,7 @@ fn can_swap_tiled_layout_at_runtime() {
     );
     let new_pane_id_1 = PaneId::Terminal(2);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.next_swap_layout(Some(client_id), false).unwrap();
     tab.render(&mut output).unwrap();
@@ -3218,9 +3218,9 @@ fn can_swap_floating_layout_at_runtime() {
     let new_pane_id_2 = PaneId::Terminal(3);
 
     tab.toggle_floating_panes(Some(client_id), None).unwrap();
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.next_swap_layout(Some(client_id), false).unwrap();
     tab.render(&mut output).unwrap();
@@ -3271,7 +3271,7 @@ fn swapping_layouts_after_resize_snaps_to_current_layout() {
     );
     let new_pane_id_1 = PaneId::Terminal(2);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.next_swap_layout(Some(client_id), false).unwrap();
     tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None))
@@ -3321,11 +3321,11 @@ fn swap_tiled_layout_with_stacked_children() {
     let new_pane_id_2 = PaneId::Terminal(3);
     let new_pane_id_3 = PaneId::Terminal(4);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.render(&mut output).unwrap();
     let snapshot = take_snapshot(
@@ -3368,11 +3368,11 @@ fn swap_tiled_layout_with_only_stacked_children() {
     let new_pane_id_2 = PaneId::Terminal(3);
     let new_pane_id_3 = PaneId::Terminal(4);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.render(&mut output).unwrap();
     let snapshot = take_snapshot(
@@ -3418,11 +3418,11 @@ fn swap_tiled_layout_with_stacked_children_and_no_pane_frames() {
     let new_pane_id_2 = PaneId::Terminal(3);
     let new_pane_id_3 = PaneId::Terminal(4);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.render(&mut output).unwrap();
     let snapshot = take_snapshot(
@@ -3468,11 +3468,11 @@ fn move_focus_up_with_stacked_panes() {
     let new_pane_id_2 = PaneId::Terminal(3);
     let new_pane_id_3 = PaneId::Terminal(4);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.move_focus_right(client_id);
     tab.move_focus_up(client_id);
@@ -3520,11 +3520,11 @@ fn move_focus_down_with_stacked_panes() {
     let new_pane_id_2 = PaneId::Terminal(3);
     let new_pane_id_3 = PaneId::Terminal(4);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.move_focus_right(client_id);
     tab.move_focus_up(client_id);
@@ -3580,6 +3580,7 @@ fn move_focus_right_into_stacked_panes() {
             None,
             None,
             None,
+            false,
             Some(client_id),
         )
         .unwrap();
@@ -3648,6 +3649,7 @@ fn move_focus_left_into_stacked_panes() {
             None,
             None,
             None,
+            false,
             Some(client_id),
         )
         .unwrap();
@@ -3718,6 +3720,7 @@ fn move_focus_up_into_stacked_panes() {
             None,
             None,
             None,
+            false,
             Some(client_id),
         )
         .unwrap();
@@ -3789,6 +3792,7 @@ fn move_focus_down_into_stacked_panes() {
             None,
             None,
             None,
+            false,
             Some(client_id),
         )
         .unwrap();
@@ -3850,11 +3854,11 @@ fn close_main_stacked_pane() {
     let new_pane_id_2 = PaneId::Terminal(3);
     let new_pane_id_3 = PaneId::Terminal(4);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.close_pane(new_pane_id_2, false, None);
     tab.render(&mut output).unwrap();
@@ -3903,15 +3907,15 @@ fn close_main_stacked_pane_in_mid_stack() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.move_focus_right(client_id);
     tab.move_focus_up(client_id);
@@ -3963,15 +3967,15 @@ fn close_one_liner_stacked_pane_below_main_pane() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.move_focus_left(client_id);
     tab.move_focus_right(client_id);
@@ -4024,15 +4028,15 @@ fn close_one_liner_stacked_pane_above_main_pane() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.move_focus_right(client_id);
     tab.move_focus_up(client_id);
@@ -4084,15 +4088,15 @@ fn can_increase_size_of_main_pane_in_stack_horizontally() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.move_focus_right(client_id);
     tab.resize(
@@ -4148,15 +4152,15 @@ fn can_increase_size_of_main_pane_in_stack_vertically() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.move_focus_right(client_id);
     tab.resize(
@@ -4212,15 +4216,15 @@ fn can_increase_size_of_main_pane_in_stack_non_directionally() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     let _ = tab.move_focus_up(client_id);
     let _ = tab.move_focus_right(client_id);
@@ -4272,15 +4276,15 @@ fn can_increase_size_into_pane_stack_horizontally() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.resize(
         client_id,
@@ -4335,15 +4339,15 @@ fn can_increase_size_into_pane_stack_vertically() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.move_focus_right(client_id);
     tab.move_focus_down(client_id);
@@ -4400,15 +4404,15 @@ fn can_increase_size_into_pane_stack_non_directionally() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     let _ = tab.move_focus_up(client_id);
     tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None))
@@ -4459,15 +4463,15 @@ fn decreasing_size_of_whole_tab_treats_stacked_panes_properly() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.resize_whole_tab(Size {
         cols: 100,
@@ -4519,15 +4523,15 @@ fn increasing_size_of_whole_tab_treats_stacked_panes_properly() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.resize_whole_tab(Size {
         cols: 100,
@@ -4584,15 +4588,15 @@ fn cannot_decrease_stack_size_beyond_minimum_height() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.move_focus_down(client_id);
     for _ in 0..6 {
@@ -4649,15 +4653,15 @@ fn focus_stacked_pane_over_flexible_pane_with_the_mouse() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_left_click(&Position::new(1, 71), client_id)
         .unwrap();
@@ -4708,15 +4712,15 @@ fn focus_stacked_pane_under_flexible_pane_with_the_mouse() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_left_click(&Position::new(1, 71), client_id)
         .unwrap();
@@ -4769,15 +4773,15 @@ fn close_stacked_pane_with_previously_focused_other_pane() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.handle_left_click(&Position::new(2, 71), client_id)
         .unwrap();
@@ -4836,15 +4840,15 @@ fn close_pane_near_stacked_panes() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.close_pane(PaneId::Terminal(6), false, None);
     tab.render(&mut output).unwrap();
@@ -4900,15 +4904,15 @@ fn focus_next_pane_expands_stacked_panes() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.move_focus_left(client_id);
     tab.focus_next_pane(client_id);
@@ -4960,15 +4964,15 @@ fn stacked_panes_can_become_fullscreen() {
     let new_pane_id_4 = PaneId::Terminal(5);
     let new_pane_id_5 = PaneId::Terminal(6);
 
-    tab.new_pane(new_pane_id_1, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_1, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_2, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_2, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_3, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_3, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_4, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_4, None, None, None, None, false, Some(client_id))
         .unwrap();
-    tab.new_pane(new_pane_id_5, None, None, None, None, Some(client_id))
+    tab.new_pane(new_pane_id_5, None, None, None, None, false, Some(client_id))
         .unwrap();
     tab.move_focus_up(client_id);
     tab.toggle_active_pane_fullscreen(client_id);
@@ -5608,6 +5612,7 @@ fn new_pane_in_auto_layout() {
             None,
             None,
             None,
+            false,
             Some(client_id),
         )
         .unwrap();
@@ -6534,6 +6539,7 @@ fn new_floating_pane_in_auto_layout() {
             Some(should_float),
             None,
             None,
+            false,
             Some(client_id),
         )
         .unwrap();

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -571,7 +571,7 @@ fn split_largest_pane() {
     let mut tab = create_new_tab(size);
     for i in 2..5 {
         let new_pane_id = PaneId::Terminal(i);
-        tab.new_pane(new_pane_id, None, None, None, None, Some(1))
+        tab.new_pane(new_pane_id, None, None, None, None, false, Some(1))
             .unwrap();
     }
     assert_eq!(tab.tiled_panes.panes.len(), 4, "The tab has four panes");
@@ -777,7 +777,7 @@ pub fn cannot_split_panes_horizontally_when_active_pane_is_too_small() {
 pub fn cannot_split_largest_pane_when_there_is_no_room() {
     let size = Size { cols: 8, rows: 4 };
     let mut tab = create_new_tab(size);
-    tab.new_pane(PaneId::Terminal(2), None, None, None, None, Some(1))
+    tab.new_pane(PaneId::Terminal(2), None, None, None, None, false, Some(1))
         .unwrap();
     assert_eq!(
         tab.tiled_panes.panes.len(),
@@ -821,7 +821,7 @@ pub fn toggle_focused_pane_fullscreen() {
     let mut tab = create_new_tab(size);
     for i in 2..5 {
         let new_pane_id = PaneId::Terminal(i);
-        tab.new_pane(new_pane_id, None, None, None, None, Some(1))
+        tab.new_pane(new_pane_id, None, None, None, None, false, Some(1))
             .unwrap();
     }
     tab.toggle_active_pane_fullscreen(1);
@@ -896,16 +896,16 @@ fn switch_to_next_pane_fullscreen() {
     let mut active_tab = create_new_tab(size);
 
     active_tab
-        .new_pane(PaneId::Terminal(1), None, None, None, None, Some(1))
+        .new_pane(PaneId::Terminal(1), None, None, None, None, false, Some(1))
         .unwrap();
     active_tab
-        .new_pane(PaneId::Terminal(2), None, None, None, None, Some(1))
+        .new_pane(PaneId::Terminal(2), None, None, None, None, false, Some(1))
         .unwrap();
     active_tab
-        .new_pane(PaneId::Terminal(3), None, None, None, None, Some(1))
+        .new_pane(PaneId::Terminal(3), None, None, None, None, false, Some(1))
         .unwrap();
     active_tab
-        .new_pane(PaneId::Terminal(4), None, None, None, None, Some(1))
+        .new_pane(PaneId::Terminal(4), None, None, None, None, false, Some(1))
         .unwrap();
     active_tab.toggle_active_pane_fullscreen(1);
 
@@ -936,16 +936,16 @@ fn switch_to_prev_pane_fullscreen() {
     //testing four consecutive switches in fullscreen mode
 
     active_tab
-        .new_pane(PaneId::Terminal(1), None, None, None, None, Some(1))
+        .new_pane(PaneId::Terminal(1), None, None, None, None, false, Some(1))
         .unwrap();
     active_tab
-        .new_pane(PaneId::Terminal(2), None, None, None, None, Some(1))
+        .new_pane(PaneId::Terminal(2), None, None, None, None, false, Some(1))
         .unwrap();
     active_tab
-        .new_pane(PaneId::Terminal(3), None, None, None, None, Some(1))
+        .new_pane(PaneId::Terminal(3), None, None, None, None, false, Some(1))
         .unwrap();
     active_tab
-        .new_pane(PaneId::Terminal(4), None, None, None, None, Some(1))
+        .new_pane(PaneId::Terminal(4), None, None, None, None, false, Some(1))
         .unwrap();
     active_tab.toggle_active_pane_fullscreen(1);
     // order is now 1 2 3 4
@@ -14427,7 +14427,7 @@ fn correctly_resize_frameless_panes_on_pane_close() {
     let content_size = (pane.get_content_columns(), pane.get_content_rows());
     assert_eq!(content_size, (cols, rows));
 
-    tab.new_pane(PaneId::Terminal(2), None, None, None, None, Some(1))
+    tab.new_pane(PaneId::Terminal(2), None, None, None, None, false, Some(1))
         .unwrap();
     tab.close_pane(PaneId::Terminal(2), true, None);
 

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -1166,7 +1166,7 @@ fn switch_to_tab_with_fullscreen() {
     {
         let active_tab = screen.get_active_tab_mut(1).unwrap();
         active_tab
-            .new_pane(PaneId::Terminal(2), None, None, None, None, Some(1))
+            .new_pane(PaneId::Terminal(2), None, None, None, None, false, Some(1))
             .unwrap();
         active_tab.toggle_active_pane_fullscreen(1);
     }
@@ -1281,7 +1281,7 @@ fn attach_after_first_tab_closed() {
     {
         let active_tab = screen.get_active_tab_mut(1).unwrap();
         active_tab
-            .new_pane(PaneId::Terminal(2), None, None, None, None, Some(1))
+            .new_pane(PaneId::Terminal(2), None, None, None, None, false, Some(1))
             .unwrap();
         active_tab.toggle_active_pane_fullscreen(1);
     }
@@ -1315,6 +1315,7 @@ fn open_new_floating_pane_with_custom_coordinates() {
                 width: Some(SplitSize::Percent(1)),
                 height: Some(SplitSize::Fixed(2)),
             }),
+            false,
             Some(1),
         )
         .unwrap();
@@ -1348,6 +1349,7 @@ fn open_new_floating_pane_with_custom_coordinates_exceeding_viewport() {
                 width: Some(SplitSize::Fixed(10)),
                 height: Some(SplitSize::Fixed(10)),
             }),
+            false,
             Some(1),
         )
         .unwrap();

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_edit_action_with_default_parameters.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_edit_action_with_default_parameters.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 2031
+assertion_line: 2389
 expression: "format!(\"{:?}\", * received_pty_instructions.lock().unwrap())"
 ---
-[SpawnTerminal(Some(OpenFile("/file/to/edit", None, Some("."))), Some(false), Some("Editing: /file/to/edit"), None, ClientId(10)), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]
+[SpawnTerminal(Some(OpenFile("/file/to/edit", None, Some("."))), Some(false), Some("Editing: /file/to/edit"), None, false, ClientId(10)), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_edit_action_with_default_parameters.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_edit_action_with_default_parameters.snap
@@ -3,4 +3,4 @@ source: zellij-server/src/./unit/screen_tests.rs
 assertion_line: 2389
 expression: "format!(\"{:?}\", * received_pty_instructions.lock().unwrap())"
 ---
-[SpawnTerminal(Some(OpenFile("/file/to/edit", None, Some("."))), Some(false), Some("Editing: /file/to/edit"), None, false, ClientId(10)), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]
+[SpawnTerminal(Some(OpenFile(OpenFilePayload { path: "/file/to/edit", line_number: None, cwd: Some("."), originating_plugin: None })), Some(false), Some("Editing: /file/to/edit"), None, false, ClientId(10)), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_edit_action_with_line_number.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_edit_action_with_line_number.snap
@@ -3,4 +3,4 @@ source: zellij-server/src/./unit/screen_tests.rs
 assertion_line: 2427
 expression: "format!(\"{:?}\", * received_pty_instructions.lock().unwrap())"
 ---
-[SpawnTerminal(Some(OpenFile("/file/to/edit", Some(100), Some("."))), Some(false), Some("Editing: /file/to/edit"), None, false, ClientId(10)), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]
+[SpawnTerminal(Some(OpenFile(OpenFilePayload { path: "/file/to/edit", line_number: Some(100), cwd: Some("."), originating_plugin: None })), Some(false), Some("Editing: /file/to/edit"), None, false, ClientId(10)), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_edit_action_with_line_number.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_edit_action_with_line_number.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 2065
+assertion_line: 2427
 expression: "format!(\"{:?}\", * received_pty_instructions.lock().unwrap())"
 ---
-[SpawnTerminal(Some(OpenFile("/file/to/edit", Some(100), Some("."))), Some(false), Some("Editing: /file/to/edit"), None, ClientId(10)), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]
+[SpawnTerminal(Some(OpenFile("/file/to/edit", Some(100), Some("."))), Some(false), Some("Editing: /file/to/edit"), None, false, ClientId(10)), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_edit_action_with_split_direction.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_edit_action_with_split_direction.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 2178
+assertion_line: 2465
 expression: "format!(\"{:?}\", * received_pty_instructions.lock().unwrap())"
 ---
-[SpawnTerminalHorizontally(Some(OpenFile("/file/to/edit", None, Some("."))), Some("Editing: /file/to/edit"), 10), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]
+[SpawnTerminalHorizontally(Some(OpenFile(OpenFilePayload { path: "/file/to/edit", line_number: None, cwd: Some("."), originating_plugin: None })), Some("Editing: /file/to/edit"), 10), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_pane_action_with_default_parameters.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_pane_action_with_default_parameters.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 1911
+assertion_line: 2222
 expression: "format!(\"{:?}\", * received_pty_instructions.lock().unwrap())"
 ---
-[SpawnTerminal(None, Some(false), None, None, ClientId(10)), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]
+[SpawnTerminal(None, Some(false), None, None, false, ClientId(10)), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_pane_action_with_floating_pane_and_coordinates.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_pane_action_with_floating_pane_and_coordinates.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 2349
+assertion_line: 2351
 expression: "format!(\"{:?}\", * received_pty_instructions.lock().unwrap())"
 ---
-[SpawnTerminal(Some(RunCommand(RunCommand { command: "htop", args: [], cwd: Some("/some/folder"), hold_on_close: true, hold_on_start: false, originating_plugin: None })), Some(true), None, Some(FloatingPaneCoordinates { x: Some(Fixed(10)), y: None, width: Some(Percent(20)), height: None }), ClientId(10)), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]
+[SpawnTerminal(Some(RunCommand(RunCommand { command: "htop", args: [], cwd: Some("/some/folder"), hold_on_close: true, hold_on_start: false, originating_plugin: None })), Some(true), None, Some(FloatingPaneCoordinates { x: Some(Fixed(10)), y: None, width: Some(Percent(20)), height: None }), false, ClientId(10)), UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), Exit]

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -84,7 +84,11 @@ pub fn open_file(file_to_open: FileToOpen, context: BTreeMap<String, String>) {
 }
 
 /// Open a file in the user's default `$EDITOR` in a new floating pane
-pub fn open_file_floating(file_to_open: FileToOpen, coordinates: Option<FloatingPaneCoordinates>, context: BTreeMap<String, String>) {
+pub fn open_file_floating(
+    file_to_open: FileToOpen,
+    coordinates: Option<FloatingPaneCoordinates>,
+    context: BTreeMap<String, String>,
+) {
     let plugin_command = PluginCommand::OpenFileFloating(file_to_open, coordinates, context);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -76,24 +76,24 @@ pub fn get_zellij_version() -> String {
 // Host Functions
 
 /// Open a file in the user's default `$EDITOR` in a new pane
-pub fn open_file(file_to_open: FileToOpen) {
-    let plugin_command = PluginCommand::OpenFile(file_to_open);
+pub fn open_file(file_to_open: FileToOpen, context: BTreeMap<String, String>) {
+    let plugin_command = PluginCommand::OpenFile(file_to_open, context);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
     unsafe { host_run_plugin_command() };
 }
 
 /// Open a file in the user's default `$EDITOR` in a new floating pane
-pub fn open_file_floating(file_to_open: FileToOpen, coordinates: Option<FloatingPaneCoordinates>) {
-    let plugin_command = PluginCommand::OpenFileFloating(file_to_open, coordinates);
+pub fn open_file_floating(file_to_open: FileToOpen, coordinates: Option<FloatingPaneCoordinates>, context: BTreeMap<String, String>) {
+    let plugin_command = PluginCommand::OpenFileFloating(file_to_open, coordinates, context);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
     unsafe { host_run_plugin_command() };
 }
 
 /// Open a file in the user's default `$EDITOR`, replacing the focused pane
-pub fn open_file_in_place(file_to_open: FileToOpen) {
-    let plugin_command = PluginCommand::OpenFileInPlace(file_to_open);
+pub fn open_file_in_place(file_to_open: FileToOpen, context: BTreeMap<String, String>) {
+    let plugin_command = PluginCommand::OpenFileInPlace(file_to_open, context);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
     unsafe { host_run_plugin_command() };

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -159,6 +159,17 @@ pub fn open_command_pane_in_place(command_to_run: CommandToRun, context: BTreeMa
     unsafe { host_run_plugin_command() };
 }
 
+/// Open a new hidden (background) command pane with the specified command and args (this sort of pane allows the user to control the command, re-run it and see its exit status through the Zellij UI).
+pub fn open_command_pane_background(
+    command_to_run: CommandToRun,
+    context: BTreeMap<String, String>,
+) {
+    let plugin_command = PluginCommand::OpenCommandPaneBackground(command_to_run, context);
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
 /// Change the focused tab to the specified index (corresponding with the default tab names, to starting at `1`, `0` will be considered as `1`).
 pub fn switch_tab_to(tab_idx: u32) {
     let plugin_command = PluginCommand::SwitchTabTo(tab_idx);

--- a/zellij-utils/assets/prost/api.event.rs
+++ b/zellij-utils/assets/prost/api.event.rs
@@ -11,7 +11,7 @@ pub struct Event {
     pub name: i32,
     #[prost(
         oneof = "event::Payload",
-        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17"
+        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20"
     )]
     pub payload: ::core::option::Option<event::Payload>,
 }
@@ -52,7 +52,28 @@ pub mod event {
         CommandPaneOpenedPayload(super::CommandPaneOpenedPayload),
         #[prost(message, tag = "17")]
         CommandPaneExitedPayload(super::CommandPaneExitedPayload),
+        #[prost(message, tag = "18")]
+        PaneClosedPayload(super::PaneClosedPayload),
+        #[prost(message, tag = "19")]
+        EditPaneOpenedPayload(super::EditPaneOpenedPayload),
+        #[prost(message, tag = "20")]
+        EditPaneExitedPayload(super::EditPaneExitedPayload),
     }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PaneClosedPayload {
+    #[prost(message, optional, tag = "1")]
+    pub pane_id: ::core::option::Option<PaneId>,
+}
+/// duplicate of plugin_command.PaneId because protobuffs don't like recursive imports
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PaneId {
+    #[prost(enumeration = "PaneType", tag = "1")]
+    pub pane_type: i32,
+    #[prost(uint32, tag = "2")]
+    pub id: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -64,7 +85,25 @@ pub struct CommandPaneOpenedPayload {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EditPaneOpenedPayload {
+    #[prost(uint32, tag = "1")]
+    pub terminal_pane_id: u32,
+    #[prost(message, repeated, tag = "2")]
+    pub context: ::prost::alloc::vec::Vec<ContextItem>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CommandPaneExitedPayload {
+    #[prost(uint32, tag = "1")]
+    pub terminal_pane_id: u32,
+    #[prost(int32, optional, tag = "2")]
+    pub exit_code: ::core::option::Option<i32>,
+    #[prost(message, repeated, tag = "3")]
+    pub context: ::prost::alloc::vec::Vec<ContextItem>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EditPaneExitedPayload {
     #[prost(uint32, tag = "1")]
     pub terminal_pane_id: u32,
     #[prost(int32, optional, tag = "2")]
@@ -373,6 +412,9 @@ pub enum EventType {
     WebRequestResult = 18,
     CommandPaneOpened = 19,
     CommandPaneExited = 20,
+    PaneClosed = 21,
+    EditPaneOpened = 22,
+    EditPaneExited = 23,
 }
 impl EventType {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -402,6 +444,9 @@ impl EventType {
             EventType::WebRequestResult => "WebRequestResult",
             EventType::CommandPaneOpened => "CommandPaneOpened",
             EventType::CommandPaneExited => "CommandPaneExited",
+            EventType::PaneClosed => "PaneClosed",
+            EventType::EditPaneOpened => "EditPaneOpened",
+            EventType::EditPaneExited => "EditPaneExited",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -428,6 +473,36 @@ impl EventType {
             "WebRequestResult" => Some(Self::WebRequestResult),
             "CommandPaneOpened" => Some(Self::CommandPaneOpened),
             "CommandPaneExited" => Some(Self::CommandPaneExited),
+            "PaneClosed" => Some(Self::PaneClosed),
+            "EditPaneOpened" => Some(Self::EditPaneOpened),
+            "EditPaneExited" => Some(Self::EditPaneExited),
+            _ => None,
+        }
+    }
+}
+/// duplicate of plugin_command.PaneType because protobuffs don't like recursive imports
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum PaneType {
+    Terminal = 0,
+    Plugin = 1,
+}
+impl PaneType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            PaneType::Terminal => "Terminal",
+            PaneType::Plugin => "Plugin",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "Terminal" => Some(Self::Terminal),
+            "Plugin" => Some(Self::Plugin),
             _ => None,
         }
     }

--- a/zellij-utils/assets/prost/api.plugin_command.rs
+++ b/zellij-utils/assets/prost/api.plugin_command.rs
@@ -247,6 +247,8 @@ pub struct OpenFilePayload {
     pub file_to_open: ::core::option::Option<super::file::File>,
     #[prost(message, optional, tag = "2")]
     pub floating_pane_coordinates: ::core::option::Option<FloatingPaneCoordinates>,
+    #[prost(message, repeated, tag = "3")]
+    pub context: ::prost::alloc::vec::Vec<ContextItem>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/zellij-utils/assets/prost/api.plugin_command.rs
+++ b/zellij-utils/assets/prost/api.plugin_command.rs
@@ -5,7 +5,7 @@ pub struct PluginCommand {
     pub name: i32,
     #[prost(
         oneof = "plugin_command::Payload",
-        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 60, 61, 62, 63, 64, 65"
+        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 60, 61, 62, 63, 64, 65, 66"
     )]
     pub payload: ::core::option::Option<plugin_command::Payload>,
 }
@@ -124,6 +124,8 @@ pub mod plugin_command {
         HidePaneWithIdPayload(super::HidePaneWithIdPayload),
         #[prost(message, tag = "65")]
         ShowPaneWithIdPayload(super::ShowPaneWithIdPayload),
+        #[prost(message, tag = "66")]
+        OpenCommandPaneBackgroundPayload(super::OpenCommandPanePayload),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -456,6 +458,7 @@ pub enum CommandName {
     Reconfigure = 87,
     HidePaneWithId = 88,
     ShowPaneWithId = 89,
+    OpenCommandPaneBackground = 90,
 }
 impl CommandName {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -554,6 +557,7 @@ impl CommandName {
             CommandName::Reconfigure => "Reconfigure",
             CommandName::HidePaneWithId => "HidePaneWithId",
             CommandName::ShowPaneWithId => "ShowPaneWithId",
+            CommandName::OpenCommandPaneBackground => "OpenCommandPaneBackground",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -649,6 +653,7 @@ impl CommandName {
             "Reconfigure" => Some(Self::Reconfigure),
             "HidePaneWithId" => Some(Self::HidePaneWithId),
             "ShowPaneWithId" => Some(Self::ShowPaneWithId),
+            "OpenCommandPaneBackground" => Some(Self::OpenCommandPaneBackground),
             _ => None,
         }
     }

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -1798,4 +1798,5 @@ pub enum PluginCommand {
     Reconfigure(String), // String -> stringified configuration
     HidePaneWithId(PaneId),
     ShowPaneWithId(PaneId, bool), // bool -> should_float_if_hidden
+    OpenCommandPaneBackground(CommandToRun, Context),
 }

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -916,6 +916,9 @@ pub enum Event {
     CommandPaneOpened(u32, Context), // u32 - terminal_pane_id
     CommandPaneExited(u32, Option<i32>, Context), // u32 - terminal_pane_id, Option<i32> -
                                      // exit_code
+    PaneClosed(PaneId),
+    EditPaneOpened(u32, Context), // u32 - terminal_pane_id
+    EditPaneExited(u32, Option<i32>, Context), // u32 - terminal_pane_id, Option<i32> - exit code
 }
 
 #[derive(
@@ -1446,7 +1449,7 @@ pub struct NewPluginArgs {
     pub skip_cache: bool,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum PaneId {
     Terminal(u32),
     Plugin(u32),
@@ -1702,8 +1705,8 @@ pub enum PluginCommand {
     SetSelectable(bool),
     GetPluginIds,
     GetZellijVersion,
-    OpenFile(FileToOpen),
-    OpenFileFloating(FileToOpen, Option<FloatingPaneCoordinates>),
+    OpenFile(FileToOpen, Context),
+    OpenFileFloating(FileToOpen, Option<FloatingPaneCoordinates>, Context),
     OpenTerminal(FileToOpen), // only used for the path as cwd
     OpenTerminalFloating(FileToOpen, Option<FloatingPaneCoordinates>), // only used for the path as cwd
     OpenCommandPane(CommandToRun, Context),
@@ -1768,7 +1771,7 @@ pub enum PluginCommand {
     DeleteDeadSession(String),       // String -> session name
     DeleteAllDeadSessions,           // String -> session name
     OpenTerminalInPlace(FileToOpen), // only used for the path as cwd
-    OpenFileInPlace(FileToOpen),
+    OpenFileInPlace(FileToOpen, Context),
     OpenCommandPaneInPlace(CommandToRun, Context),
     RunCommand(
         Vec<String>,              // command

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -915,9 +915,9 @@ pub enum Event {
     // context
     CommandPaneOpened(u32, Context), // u32 - terminal_pane_id
     CommandPaneExited(u32, Option<i32>, Context), // u32 - terminal_pane_id, Option<i32> -
-                                     // exit_code
+    // exit_code
     PaneClosed(PaneId),
-    EditPaneOpened(u32, Context), // u32 - terminal_pane_id
+    EditPaneOpened(u32, Context),              // u32 - terminal_pane_id
     EditPaneExited(u32, Option<i32>, Context), // u32 - terminal_pane_id, Option<i32> - exit code
 }
 

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -1,6 +1,6 @@
 //! Definition of the actions that can be bound to keys.
 
-use super::command::RunCommandAction;
+use super::command::{RunCommandAction, OpenFilePayload};
 use super::layout::{
     FloatingPaneLayout, Layout, PluginAlias, RunPlugin, RunPluginLocation, RunPluginOrAlias,
     SwapFloatingLayout, SwapTiledLayout, TiledPaneLayout,
@@ -160,15 +160,17 @@ pub enum Action {
     NewPane(Option<Direction>, Option<String>, bool), // String is an optional pane name
     /// Open the file in a new pane using the default editor, bool -> start suppressed
     EditFile(
-        PathBuf,
-        Option<usize>,
-        Option<PathBuf>,
+        OpenFilePayload,
+//         PathBuf,
+//         Option<usize>,
+//         Option<PathBuf>,
+
         Option<Direction>,
         bool,
         bool,
         bool,
         Option<FloatingPaneCoordinates>,
-    ), // usize is an optional line number, Option<PathBuf> is an optional cwd, bool is floating true/false, second bool is in_place
+    ), // bool is floating true/false, second bool is in_place
        // third bool is start_suppressed
     /// Open a new floating pane
     NewFloatingPane(
@@ -489,9 +491,10 @@ impl Action {
                 }
                 let start_suppressed = false;
                 Ok(vec![Action::EditFile(
-                    file,
-                    line_number,
-                    cwd,
+                    OpenFilePayload::new(file, line_number, cwd),
+//                     file,
+//                     line_number,
+//                     cwd,
                     direction,
                     floating,
                     in_place,

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -157,8 +157,8 @@ pub enum Action {
     ToggleActiveSyncTab,
     /// Open a new pane in the specified direction (relative to focus).
     /// If no direction is specified, will try to use the biggest available space.
-    NewPane(Option<Direction>, Option<String>), // String is an optional pane name
-    /// Open the file in a new pane using the default editor
+    NewPane(Option<Direction>, Option<String>, bool), // String is an optional pane name
+    /// Open the file in a new pane using the default editor, bool -> start suppressed
     EditFile(
         PathBuf,
         Option<usize>,
@@ -166,8 +166,10 @@ pub enum Action {
         Option<Direction>,
         bool,
         bool,
+        bool,
         Option<FloatingPaneCoordinates>,
     ), // usize is an optional line number, Option<PathBuf> is an optional cwd, bool is floating true/false, second bool is in_place
+       // third bool is start_suppressed
     /// Open a new floating pane
     NewFloatingPane(
         Option<RunCommandAction>,
@@ -485,6 +487,7 @@ impl Action {
                         file = cwd.join(file);
                     }
                 }
+                let start_suppressed = false;
                 Ok(vec![Action::EditFile(
                     file,
                     line_number,
@@ -492,6 +495,7 @@ impl Action {
                     direction,
                     floating,
                     in_place,
+                    start_suppressed,
                     FloatingPaneCoordinates::new(x, y, width, height),
                 )])
             },

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -1,6 +1,6 @@
 //! Definition of the actions that can be bound to keys.
 
-use super::command::{RunCommandAction, OpenFilePayload};
+use super::command::{OpenFilePayload, RunCommandAction};
 use super::layout::{
     FloatingPaneLayout, Layout, PluginAlias, RunPlugin, RunPluginLocation, RunPluginOrAlias,
     SwapFloatingLayout, SwapTiledLayout, TiledPaneLayout,
@@ -167,7 +167,7 @@ pub enum Action {
         bool,
         Option<FloatingPaneCoordinates>,
     ), // bool is floating true/false, second bool is in_place
-       // third bool is start_suppressed
+    // third bool is start_suppressed
     /// Open a new floating pane
     NewFloatingPane(
         Option<RunCommandAction>,

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -161,10 +161,6 @@ pub enum Action {
     /// Open the file in a new pane using the default editor, bool -> start suppressed
     EditFile(
         OpenFilePayload,
-//         PathBuf,
-//         Option<usize>,
-//         Option<PathBuf>,
-
         Option<Direction>,
         bool,
         bool,
@@ -492,9 +488,6 @@ impl Action {
                 let start_suppressed = false;
                 Ok(vec![Action::EditFile(
                     OpenFilePayload::new(file, line_number, cwd),
-//                     file,
-//                     line_number,
-//                     cwd,
                     direction,
                     floating,
                     in_place,

--- a/zellij-utils/src/input/command.rs
+++ b/zellij-utils/src/input/command.rs
@@ -5,7 +5,10 @@ use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 pub enum TerminalAction {
-    OpenFile(PathBuf, Option<usize>, Option<PathBuf>), // path to file (should be absolute), optional line_number and an
+    // TODO: CONTINUE HERE - make this work, and once we compile move to pty.rs and take the
+    // originating_plugin from here
+    OpenFile(OpenFilePayload),
+    // OpenFile(PathBuf, Option<usize>, Option<PathBuf>), // path to file (should be absolute), optional line_number and an
     // optional cwd
     RunCommand(RunCommand),
 }
@@ -13,13 +16,36 @@ pub enum TerminalAction {
 impl TerminalAction {
     pub fn change_cwd(&mut self, new_cwd: PathBuf) {
         match self {
-            TerminalAction::OpenFile(_, _, cwd) => {
-                *cwd = Some(new_cwd);
+            TerminalAction::OpenFile(open_file_payload) => {
+                open_file_payload.cwd = Some(new_cwd);
             },
             TerminalAction::RunCommand(run_command) => {
                 run_command.cwd = Some(new_cwd);
             },
         }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OpenFilePayload {
+    pub path: PathBuf,
+    pub line_number: Option<usize>,
+    pub cwd: Option<PathBuf>,
+    pub originating_plugin: Option<OriginatingPlugin>,
+}
+
+impl OpenFilePayload {
+    pub fn new(path: PathBuf, line_number: Option<usize>, cwd: Option<PathBuf>) -> Self {
+        OpenFilePayload {
+            path,
+            line_number,
+            cwd,
+            originating_plugin: None,
+        }
+    }
+    pub fn with_originating_plugin(mut self, originating_plugin: OriginatingPlugin) -> Self {
+        self.originating_plugin = Some(originating_plugin);
+        self
     }
 }
 

--- a/zellij-utils/src/input/command.rs
+++ b/zellij-utils/src/input/command.rs
@@ -5,11 +5,7 @@ use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 pub enum TerminalAction {
-    // TODO: CONTINUE HERE - make this work, and once we compile move to pty.rs and take the
-    // originating_plugin from here
     OpenFile(OpenFilePayload),
-    // OpenFile(PathBuf, Option<usize>, Option<PathBuf>), // path to file (should be absolute), optional line_number and an
-    // optional cwd
     RunCommand(RunCommand),
 }
 

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -507,7 +507,7 @@ impl Action {
             "DumpLayout" => Ok(Action::DumpLayout),
             "NewPane" => {
                 if string.is_empty() {
-                    return Ok(Action::NewPane(None, None));
+                    return Ok(Action::NewPane(None, None, false));
                 } else {
                     let direction = Direction::from_str(string.as_str()).map_err(|_| {
                         ConfigError::new_kdl_error(
@@ -516,7 +516,7 @@ impl Action {
                             action_node.span().len(),
                         )
                     })?;
-                    Ok(Action::NewPane(Some(direction), None))
+                    Ok(Action::NewPane(Some(direction), None, false))
                 }
             },
             "SearchToggleOption" => {

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -220,7 +220,7 @@ impl TryFrom<ProtobufAction> for Action {
                         .and_then(|d| ProtobufResizeDirection::from_i32(d))
                         .and_then(|d| d.try_into().ok());
                     let pane_name = payload.pane_name;
-                    Ok(Action::NewPane(direction, pane_name))
+                    Ok(Action::NewPane(direction, pane_name, false))
                 },
                 _ => Err("Wrong payload for Action::NewPane"),
             },
@@ -242,6 +242,7 @@ impl TryFrom<ProtobufAction> for Action {
                         direction,
                         should_float,
                         should_be_in_place,
+                        false,
                         None,
                     ))
                 },
@@ -885,7 +886,7 @@ impl TryFrom<Action> for ProtobufAction {
                 name: ProtobufActionName::ToggleActiveSyncTab as i32,
                 optional_payload: None,
             }),
-            Action::NewPane(direction, new_pane_name) => {
+            Action::NewPane(direction, new_pane_name, _start_suppressed) => {
                 let direction = direction.and_then(|direction| {
                     let protobuf_direction: ProtobufResizeDirection = direction.try_into().ok()?;
                     Some(protobuf_direction as i32)
@@ -906,6 +907,7 @@ impl TryFrom<Action> for ProtobufAction {
                 should_float,
                 _should_be_in_place,
                 _floating_pane_coordinates,
+                _start_suppressed,
             ) => {
                 let file_to_edit = path_to_file.display().to_string();
                 let cwd = cwd.map(|cwd| cwd.display().to_string());

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -17,7 +17,7 @@ use crate::data::{Direction, InputMode, ResizeStrategy};
 use crate::errors::prelude::*;
 use crate::input::actions::Action;
 use crate::input::actions::{SearchDirection, SearchOption};
-use crate::input::command::{RunCommandAction, OpenFilePayload};
+use crate::input::command::{OpenFilePayload, RunCommandAction};
 use crate::input::layout::{
     PluginUserConfiguration, RunPlugin, RunPluginLocation, RunPluginOrAlias,
 };
@@ -236,11 +236,7 @@ impl TryFrom<ProtobufAction> for Action {
                     let should_float = payload.should_float;
                     let should_be_in_place = false;
                     Ok(Action::EditFile(
-                        OpenFilePayload::new(
-                            file_to_edit,
-                            line_number,
-                            cwd,
-                        ),
+                        OpenFilePayload::new(file_to_edit, line_number, cwd),
                         direction,
                         should_float,
                         should_be_in_place,
@@ -903,9 +899,9 @@ impl TryFrom<Action> for ProtobufAction {
             },
             Action::EditFile(
                 open_file_payload,
-//                 path_to_file,
-//                 line_number,
-//                 cwd,
+                //                 path_to_file,
+                //                 line_number,
+                //                 cwd,
                 direction,
                 should_float,
                 _should_be_in_place,

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -17,7 +17,7 @@ use crate::data::{Direction, InputMode, ResizeStrategy};
 use crate::errors::prelude::*;
 use crate::input::actions::Action;
 use crate::input::actions::{SearchDirection, SearchOption};
-use crate::input::command::RunCommandAction;
+use crate::input::command::{RunCommandAction, OpenFilePayload};
 use crate::input::layout::{
     PluginUserConfiguration, RunPlugin, RunPluginLocation, RunPluginOrAlias,
 };
@@ -236,9 +236,11 @@ impl TryFrom<ProtobufAction> for Action {
                     let should_float = payload.should_float;
                     let should_be_in_place = false;
                     Ok(Action::EditFile(
-                        file_to_edit,
-                        line_number,
-                        cwd,
+                        OpenFilePayload::new(
+                            file_to_edit,
+                            line_number,
+                            cwd,
+                        ),
                         direction,
                         should_float,
                         should_be_in_place,
@@ -900,21 +902,22 @@ impl TryFrom<Action> for ProtobufAction {
                 })
             },
             Action::EditFile(
-                path_to_file,
-                line_number,
-                cwd,
+                open_file_payload,
+//                 path_to_file,
+//                 line_number,
+//                 cwd,
                 direction,
                 should_float,
                 _should_be_in_place,
                 _floating_pane_coordinates,
                 _start_suppressed,
             ) => {
-                let file_to_edit = path_to_file.display().to_string();
-                let cwd = cwd.map(|cwd| cwd.display().to_string());
+                let file_to_edit = open_file_payload.path.display().to_string();
+                let cwd = open_file_payload.cwd.map(|cwd| cwd.display().to_string());
                 let direction: Option<i32> = direction
                     .and_then(|d| ProtobufResizeDirection::try_from(d).ok())
                     .map(|d| d as i32);
-                let line_number = line_number.map(|l| l as u32);
+                let line_number = open_file_payload.line_number.map(|l| l as u32);
                 Ok(ProtobufAction {
                     name: ProtobufActionName::EditFile as i32,
                     optional_payload: Some(OptionalPayload::EditFilePayload(EditFilePayload {

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -899,9 +899,6 @@ impl TryFrom<Action> for ProtobufAction {
             },
             Action::EditFile(
                 open_file_payload,
-                //                 path_to_file,
-                //                 line_number,
-                //                 cwd,
                 direction,
                 should_float,
                 _should_be_in_place,

--- a/zellij-utils/src/plugin_api/event.proto
+++ b/zellij-utils/src/plugin_api/event.proto
@@ -44,6 +44,9 @@ enum EventType {
     WebRequestResult = 18;
     CommandPaneOpened = 19;
     CommandPaneExited = 20;
+    PaneClosed = 21;
+    EditPaneOpened = 22;
+    EditPaneExited = 23;
 }
 
 message EventNameList {
@@ -69,7 +72,26 @@ message Event {
     WebRequestResultPayload web_request_result_payload = 15;
     CommandPaneOpenedPayload command_pane_opened_payload = 16;
     CommandPaneExitedPayload command_pane_exited_payload = 17;
+    PaneClosedPayload pane_closed_payload = 18;
+    EditPaneOpenedPayload edit_pane_opened_payload = 19;
+    EditPaneExitedPayload edit_pane_exited_payload = 20;
   }
+}
+
+message PaneClosedPayload {
+  PaneId pane_id = 1;
+}
+
+// duplicate of plugin_command.PaneId because protobuffs don't like recursive imports
+message PaneId {
+  PaneType pane_type = 1;
+  uint32 id = 2;
+}
+
+// duplicate of plugin_command.PaneType because protobuffs don't like recursive imports
+enum PaneType {
+  Terminal = 0;
+  Plugin = 1;
 }
 
 message CommandPaneOpenedPayload {
@@ -77,7 +99,18 @@ message CommandPaneOpenedPayload {
   repeated ContextItem context = 2;
 }
 
+message EditPaneOpenedPayload {
+  uint32 terminal_pane_id = 1;
+  repeated ContextItem context = 2;
+}
+
 message CommandPaneExitedPayload {
+  uint32 terminal_pane_id = 1;
+  optional int32 exit_code = 2;
+  repeated ContextItem context = 3;
+}
+
+message EditPaneExitedPayload {
   uint32 terminal_pane_id = 1;
   optional int32 exit_code = 2;
   repeated ContextItem context = 3;

--- a/zellij-utils/src/plugin_api/plugin_command.proto
+++ b/zellij-utils/src/plugin_api/plugin_command.proto
@@ -101,6 +101,7 @@ enum CommandName {
   Reconfigure = 87;
   HidePaneWithId = 88;
   ShowPaneWithId = 89;
+  OpenCommandPaneBackground = 90;
 }
 
 message PluginCommand {
@@ -161,6 +162,7 @@ message PluginCommand {
     string reconfigure_payload = 63;
     HidePaneWithIdPayload hide_pane_with_id_payload = 64;
     ShowPaneWithIdPayload show_pane_with_id_payload = 65;
+    OpenCommandPanePayload open_command_pane_background_payload = 66;
   }
 }
 

--- a/zellij-utils/src/plugin_api/plugin_command.proto
+++ b/zellij-utils/src/plugin_api/plugin_command.proto
@@ -240,6 +240,7 @@ message UnsubscribePayload {
 message OpenFilePayload {
   file.File file_to_open = 1;
   optional FloatingPaneCoordinates floating_pane_coordinates = 2;
+  repeated ContextItem context = 3;
 }
 
 message OpenCommandPanePayload {

--- a/zellij-utils/src/plugin_api/plugin_command.rs
+++ b/zellij-utils/src/plugin_api/plugin_command.rs
@@ -227,7 +227,14 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
             Some(CommandName::OpenFile) => match protobuf_plugin_command.payload {
                 Some(Payload::OpenFilePayload(file_to_open_payload)) => {
                     match file_to_open_payload.file_to_open {
-                        Some(file_to_open) => Ok(PluginCommand::OpenFile(file_to_open.try_into()?)),
+                        Some(file_to_open) => {
+                            let context: BTreeMap<String, String> = file_to_open_payload
+                                .context
+                                .into_iter()
+                                .map(|e| (e.name, e.value))
+                                .collect();
+                            Ok(PluginCommand::OpenFile(file_to_open.try_into()?, context))
+                        },
                         None => Err("Malformed open file payload"),
                     }
                 },
@@ -238,10 +245,16 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
                     let floating_pane_coordinates = file_to_open_payload
                         .floating_pane_coordinates
                         .map(|f| f.into());
+                    let context: BTreeMap<String, String> = file_to_open_payload
+                        .context
+                        .into_iter()
+                        .map(|e| (e.name, e.value))
+                        .collect();
                     match file_to_open_payload.file_to_open {
                         Some(file_to_open) => Ok(PluginCommand::OpenFileFloating(
                             file_to_open.try_into()?,
                             floating_pane_coordinates,
+                            context,
                         )),
                         None => Err("Malformed open file payload"),
                     }
@@ -725,7 +738,12 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
                 Some(Payload::OpenFileInPlacePayload(file_to_open_payload)) => {
                     match file_to_open_payload.file_to_open {
                         Some(file_to_open) => {
-                            Ok(PluginCommand::OpenFileInPlace(file_to_open.try_into()?))
+                            let context: BTreeMap<String, String> = file_to_open_payload
+                                .context
+                                .into_iter()
+                                .map(|e| (e.name, e.value))
+                                .collect();
+                            Ok(PluginCommand::OpenFileInPlace(file_to_open.try_into()?, context))
                         },
                         None => Err("Malformed open file in place payload"),
                     }
@@ -1000,19 +1018,27 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
                 name: CommandName::GetZellijVersion as i32,
                 payload: None,
             }),
-            PluginCommand::OpenFile(file_to_open) => Ok(ProtobufPluginCommand {
+            PluginCommand::OpenFile(file_to_open, context) => Ok(ProtobufPluginCommand {
                 name: CommandName::OpenFile as i32,
                 payload: Some(Payload::OpenFilePayload(OpenFilePayload {
                     file_to_open: Some(file_to_open.try_into()?),
                     floating_pane_coordinates: None,
+                    context: context
+                        .into_iter()
+                        .map(|(name, value)| ContextItem { name, value })
+                        .collect(),
                 })),
             }),
-            PluginCommand::OpenFileFloating(file_to_open, floating_pane_coordinates) => {
+            PluginCommand::OpenFileFloating(file_to_open, floating_pane_coordinates, context) => {
                 Ok(ProtobufPluginCommand {
                     name: CommandName::OpenFileFloating as i32,
                     payload: Some(Payload::OpenFileFloatingPayload(OpenFilePayload {
                         file_to_open: Some(file_to_open.try_into()?),
                         floating_pane_coordinates: floating_pane_coordinates.map(|f| f.into()),
+                        context: context
+                            .into_iter()
+                            .map(|(name, value)| ContextItem { name, value })
+                            .collect(),
                     })),
                 })
             },
@@ -1021,6 +1047,7 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
                 payload: Some(Payload::OpenTerminalPayload(OpenFilePayload {
                     file_to_open: Some(cwd.try_into()?),
                     floating_pane_coordinates: None,
+                    context: vec![], // will be added in the future
                 })),
             }),
             PluginCommand::OpenTerminalFloating(cwd, floating_pane_coordinates) => {
@@ -1029,6 +1056,7 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
                     payload: Some(Payload::OpenTerminalFloatingPayload(OpenFilePayload {
                         file_to_open: Some(cwd.try_into()?),
                         floating_pane_coordinates: floating_pane_coordinates.map(|f| f.into()),
+                        context: vec![], // will be added in the future
                     })),
                 })
             },
@@ -1351,13 +1379,18 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
                 payload: Some(Payload::OpenTerminalInPlacePayload(OpenFilePayload {
                     file_to_open: Some(cwd.try_into()?),
                     floating_pane_coordinates: None,
+                    context: vec![], // will be added in the future
                 })),
             }),
-            PluginCommand::OpenFileInPlace(file_to_open) => Ok(ProtobufPluginCommand {
+            PluginCommand::OpenFileInPlace(file_to_open, context) => Ok(ProtobufPluginCommand {
                 name: CommandName::OpenFileInPlace as i32,
                 payload: Some(Payload::OpenFileInPlacePayload(OpenFilePayload {
                     file_to_open: Some(file_to_open.try_into()?),
                     floating_pane_coordinates: None,
+                    context: context
+                        .into_iter()
+                        .map(|(name, value)| ContextItem { name, value })
+                        .collect(),
                 })),
             }),
             PluginCommand::OpenCommandPaneInPlace(command_to_run, context) => {

--- a/zellij-utils/src/plugin_api/plugin_command.rs
+++ b/zellij-utils/src/plugin_api/plugin_command.rs
@@ -743,7 +743,10 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
                                 .into_iter()
                                 .map(|e| (e.name, e.value))
                                 .collect();
-                            Ok(PluginCommand::OpenFileInPlace(file_to_open.try_into()?, context))
+                            Ok(PluginCommand::OpenFileInPlace(
+                                file_to_open.try_into()?,
+                                context,
+                            ))
                         },
                         None => Err("Malformed open file in place payload"),
                     }

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
@@ -234,6 +234,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -731,6 +732,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -990,6 +992,7 @@ Config {
                         Down,
                     ),
                     None,
+                    false,
                 ),
                 SwitchToMode(
                     Normal,
@@ -1160,6 +1163,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
                 SwitchToMode(
                     Normal,
@@ -1188,6 +1192,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -1255,6 +1260,7 @@ Config {
                         Right,
                     ),
                     None,
+                    false,
                 ),
                 SwitchToMode(
                     Normal,
@@ -1786,6 +1792,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -2255,6 +2262,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -2608,6 +2616,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -3043,6 +3052,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -3411,6 +3421,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -3742,6 +3753,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -4097,6 +4109,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -4541,6 +4554,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -4875,6 +4889,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -5068,6 +5083,7 @@ Config {
                         Down,
                     ),
                     None,
+                    false,
                 ),
                 SwitchToMode(
                     Normal,
@@ -5084,6 +5100,7 @@ Config {
                         Right,
                     ),
                     None,
+                    false,
                 ),
                 SwitchToMode(
                     Normal,
@@ -5392,6 +5409,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
@@ -234,6 +234,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -731,6 +732,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -990,6 +992,7 @@ Config {
                         Down,
                     ),
                     None,
+                    false,
                 ),
                 SwitchToMode(
                     Normal,
@@ -1160,6 +1163,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
                 SwitchToMode(
                     Normal,
@@ -1188,6 +1192,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -1255,6 +1260,7 @@ Config {
                         Right,
                     ),
                     None,
+                    false,
                 ),
                 SwitchToMode(
                     Normal,
@@ -1786,6 +1792,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -2255,6 +2262,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -2608,6 +2616,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -3043,6 +3052,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -3411,6 +3421,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -3742,6 +3753,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -4097,6 +4109,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -4541,6 +4554,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -4875,6 +4889,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -5068,6 +5083,7 @@ Config {
                         Down,
                     ),
                     None,
+                    false,
                 ),
                 SwitchToMode(
                     Normal,
@@ -5084,6 +5100,7 @@ Config {
                         Right,
                     ),
                     None,
+                    false,
                 ),
                 SwitchToMode(
                     Normal,
@@ -5392,6 +5409,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
@@ -234,6 +234,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -731,6 +732,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -990,6 +992,7 @@ Config {
                         Down,
                     ),
                     None,
+                    false,
                 ),
                 SwitchToMode(
                     Normal,
@@ -1160,6 +1163,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
                 SwitchToMode(
                     Normal,
@@ -1188,6 +1192,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -1255,6 +1260,7 @@ Config {
                         Right,
                     ),
                     None,
+                    false,
                 ),
                 SwitchToMode(
                     Normal,
@@ -1786,6 +1792,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -2255,6 +2262,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -2608,6 +2616,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -3043,6 +3052,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -3411,6 +3421,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -3742,6 +3753,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -4097,6 +4109,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -4541,6 +4554,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -4875,6 +4889,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -5068,6 +5083,7 @@ Config {
                         Down,
                     ),
                     None,
+                    false,
                 ),
                 SwitchToMode(
                     Normal,
@@ -5084,6 +5100,7 @@ Config {
                         Right,
                     ),
                     None,
+                    false,
                 ),
                 SwitchToMode(
                     Normal,
@@ -5392,6 +5409,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
@@ -234,6 +234,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -731,6 +732,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -990,6 +992,7 @@ Config {
                         Down,
                     ),
                     None,
+                    false,
                 ),
                 SwitchToMode(
                     Normal,
@@ -1160,6 +1163,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
                 SwitchToMode(
                     Normal,
@@ -1188,6 +1192,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -1255,6 +1260,7 @@ Config {
                         Right,
                     ),
                     None,
+                    false,
                 ),
                 SwitchToMode(
                     Normal,
@@ -1786,6 +1792,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -2255,6 +2262,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -2608,6 +2616,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -3043,6 +3052,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -3411,6 +3421,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -3742,6 +3753,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -4097,6 +4109,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -4541,6 +4554,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -4875,6 +4889,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {
@@ -5068,6 +5083,7 @@ Config {
                         Down,
                     ),
                     None,
+                    false,
                 ),
                 SwitchToMode(
                     Normal,
@@ -5084,6 +5100,7 @@ Config {
                         Right,
                     ),
                     None,
+                    false,
                 ),
                 SwitchToMode(
                     Normal,
@@ -5392,6 +5409,7 @@ Config {
                 NewPane(
                     None,
                     None,
+                    false,
                 ),
             ],
             KeyWithModifier {


### PR DESCRIPTION
This adds APIs for plugins to open command panes in the background (`open_command_pane_background`) and receive events (`CommandPaneOpened` / `CommandPaneExited`) when they are opened or exited (an exited command pane usually does not mean it was closed, but rather that its command exited and the pane is still lying around waiting to be re-run or closed).

This will allow plugin authors to treat command panes just like they do running arbitrary commands. Meaning that the command will run in the context of a terminal (no need for hacks to get the command to bypass STDOUT for example), and also the user will be able to toggle it through the plugin (with the recently added `show_pane_with_id` plugin API) to see its output either in real time or once it exited.