### PR TITLE
fix(plugins): various cwd fixes

### DIFF
--- a/zellij-server/src/plugins/unit/plugin_tests.rs
+++ b/zellij-server/src/plugins/unit/plugin_tests.rs
@@ -6873,5 +6873,9 @@ pub fn open_command_pane_background_plugin_command() {
             }
         })
         .clone();
-    assert_snapshot!(format!("{:#?}", new_tab_event));
+    // we do the replace below to avoid the randomness of the temporary folder in the snapshot
+    // while still testing it
+    assert_snapshot!(
+        format!("{:#?}", new_tab_event).replace(&format!("{:?}", temp_folder.path()), "\"CWD\"")
+    );
 }

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_command_pane_background_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_command_pane_background_plugin_command.snap
@@ -1,7 +1,7 @@
 ---
 source: zellij-server/src/plugins/./unit/plugin_tests.rs
-assertion_line: 6876
-expression: "format!(\"{:#?}\", new_tab_event)"
+assertion_line: 6878
+expression: "format!(\"{:#?}\",\n        new_tab_event).replace(&format!(\"{:?}\", temp_folder.path()),\n    \"\\\"CWD\\\"\")"
 ---
 Some(
     SpawnTerminal(
@@ -13,7 +13,9 @@ Some(
                         "arg1",
                         "arg2",
                     ],
-                    cwd: None,
+                    cwd: Some(
+                        "CWD",
+                    ),
                     hold_on_close: true,
                     hold_on_start: false,
                     originating_plugin: Some(

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -660,7 +660,10 @@ fn open_command_pane_background(
     context: BTreeMap<String, String>,
 ) {
     let command = command_to_run.path;
-    let cwd = command_to_run.cwd.map(|cwd| env.plugin_cwd.join(cwd));
+    let cwd = command_to_run
+        .cwd
+        .map(|cwd| env.plugin_cwd.join(cwd))
+        .or_else(|| Some(env.plugin_cwd.clone()));
     let args = command_to_run.args;
     let direction = None;
     let hold_on_close = true;

--- a/zellij-utils/src/kdl/kdl_layout_parser.rs
+++ b/zellij-utils/src/kdl/kdl_layout_parser.rs
@@ -1177,6 +1177,9 @@ impl<'a> KdlLayoutParser<'a> {
         };
         if let Some(cwd_prefix) = &self.cwd_prefix(tab_cwd.as_ref())? {
             pane_layout.add_cwd_to_layout(&cwd_prefix);
+            for floating_pane in child_floating_panes.iter_mut() {
+                floating_pane.add_cwd_to_layout(&cwd_prefix);
+            }
         }
         Ok((is_focused, tab_name, pane_layout, child_floating_panes))
     }
@@ -1583,6 +1586,9 @@ impl<'a> KdlLayoutParser<'a> {
         }
         if let Some(cwd_prefix) = self.cwd_prefix(tab_cwd.as_ref())? {
             tab_layout.add_cwd_to_layout(&cwd_prefix);
+            for floating_pane in tab_template_floating_panes.iter_mut() {
+                floating_pane.add_cwd_to_layout(&cwd_prefix);
+            }
         }
         tab_layout.external_children_index = None;
         Ok((


### PR DESCRIPTION
This fixes two issues:
1. Background command panes were based on the Zellij cwd rather than the plugin cwd
2. Floating panes defined in layouts did not get the cwd of the tab they were in if it were set