### PR TITLE
feat(plugins): rerun_command_pane API

### DIFF
--- a/default-plugins/fixture-plugin-for-tests/src/main.rs
+++ b/default-plugins/fixture-plugin-for-tests/src/main.rs
@@ -359,6 +359,9 @@ impl ZellijPlugin for State {
                         BTreeMap::new(),
                     );
                 },
+                BareKey::Char('d') if key.has_modifiers(&[KeyModifier::Alt]) => {
+                    rerun_command_pane(1);
+                },
                 _ => {},
             },
             Event::CustomMessage(message, payload) => {

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -778,6 +778,18 @@ impl Pane for TerminalPane {
     fn serialize(&self, scrollback_lines_to_serialize: Option<usize>) -> Option<String> {
         self.grid.serialize(scrollback_lines_to_serialize)
     }
+    fn rerun(&mut self) -> Option<RunCommand> {
+        // if this is a command pane that has exited or is waiting to be rerun, will return its
+        // RunCommand, otherwise it is safe to assume this is not the right sort of pane or that it
+        // is not in the right sort of state
+        self.is_held.take().map(|(_, _, run_command)| {
+            self.is_held = None;
+            self.grid.reset_terminal_state();
+            self.set_should_render(true);
+            self.remove_banner();
+            run_command.clone()
+        })
+    }
 }
 
 impl TerminalPane {

--- a/zellij-server/src/plugins/unit/plugin_tests.rs
+++ b/zellij-server/src/plugins/unit/plugin_tests.rs
@@ -6879,3 +6879,74 @@ pub fn open_command_pane_background_plugin_command() {
         format!("{:#?}", new_tab_event).replace(&format!("{:?}", temp_folder.path()), "\"CWD\"")
     );
 }
+
+#[test]
+#[ignore]
+pub fn rerun_command_pane_plugin_command() {
+    let temp_folder = tempdir().unwrap(); // placed explicitly in the test scope because its
+                                          // destructor removes the directory
+    let plugin_host_folder = PathBuf::from(temp_folder.path());
+    let cache_path = plugin_host_folder.join("permissions_test.kdl");
+    let (plugin_thread_sender, screen_receiver, teardown) =
+        create_plugin_thread(Some(plugin_host_folder));
+    let plugin_should_float = Some(false);
+    let plugin_title = Some("test_plugin".to_owned());
+    let run_plugin = RunPluginOrAlias::RunPlugin(RunPlugin {
+        _allow_exec_host_cmd: false,
+        location: RunPluginLocation::File(PathBuf::from(&*PLUGIN_FIXTURE)),
+        configuration: Default::default(),
+        ..Default::default()
+    });
+    let tab_index = 1;
+    let client_id = 1;
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let received_screen_instructions = Arc::new(Mutex::new(vec![]));
+    let screen_thread = grant_permissions_and_log_actions_in_thread!(
+        received_screen_instructions,
+        ScreenInstruction::RerunCommandPane,
+        screen_receiver,
+        1,
+        &PermissionType::ChangeApplicationState,
+        cache_path,
+        plugin_thread_sender,
+        client_id
+    );
+
+    let _ = plugin_thread_sender.send(PluginInstruction::AddClient(client_id));
+    let _ = plugin_thread_sender.send(PluginInstruction::Load(
+        plugin_should_float,
+        false,
+        plugin_title,
+        run_plugin,
+        tab_index,
+        None,
+        client_id,
+        size,
+        None,
+        false,
+    ));
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    let _ = plugin_thread_sender.send(PluginInstruction::Update(vec![(
+        None,
+        Some(client_id),
+        Event::Key(KeyWithModifier::new(BareKey::Char('d')).with_alt_modifier()), // this triggers the enent in the fixture plugin
+    )]));
+    screen_thread.join().unwrap(); // this might take a while if the cache is cold
+    teardown();
+    let rerun_command_pane_event = received_screen_instructions
+        .lock()
+        .unwrap()
+        .iter()
+        .find_map(|i| {
+            if let ScreenInstruction::RerunCommandPane(..) = i {
+                Some(i.clone())
+            } else {
+                None
+            }
+        })
+        .clone();
+    assert_snapshot!(format!("{:#?}", rerun_command_pane_event));
+}

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__rerun_command_pane_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__rerun_command_pane_plugin_command.snap
@@ -1,0 +1,10 @@
+---
+source: zellij-server/src/plugins/./unit/plugin_tests.rs
+assertion_line: 6951
+expression: "format!(\"{:#?}\", rerun_command_pane_event)"
+---
+Some(
+    RerunCommandPane(
+        1,
+    ),
+)

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -267,6 +267,9 @@ fn host_run_plugin_command(caller: Caller<'_, PluginEnv>) {
                     PluginCommand::OpenCommandPaneBackground(command_to_run, context) => {
                         open_command_pane_background(env, command_to_run, context)
                     },
+                    PluginCommand::RerunCommandPane(terminal_pane_id) => {
+                        rerun_command_pane(env, terminal_pane_id)
+                    },
                 },
                 (PermissionStatus::Denied, permission) => {
                     log::error!(
@@ -692,6 +695,12 @@ fn open_command_pane_background(
         start_suppressed,
         ClientTabIndexOrPaneId::ClientId(env.client_id),
     ));
+}
+
+fn rerun_command_pane(env: &PluginEnv, terminal_pane_id: u32) {
+    let _ = env
+        .senders
+        .send_to_screen(ScreenInstruction::RerunCommandPane(terminal_pane_id));
 }
 
 fn switch_tab_to(env: &PluginEnv, tab_idx: u32) {
@@ -1554,6 +1563,7 @@ fn check_command_permission(
         | PluginCommand::DisconnectOtherClients
         | PluginCommand::ShowPaneWithId(..)
         | PluginCommand::HidePaneWithId(..)
+        | PluginCommand::RerunCommandPane(..)
         | PluginCommand::KillSessions(..) => PermissionType::ChangeApplicationState,
         PluginCommand::UnblockCliPipeInput(..)
         | PluginCommand::BlockCliPipeInput(..)

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -893,8 +893,6 @@ impl Pty {
                 ),
                 _ => (false, false, None, None),
             };
-        // TODO: CONTINUE HERE - get originating_plugin also from TerminalAction::OpenFile and do
-        // the right thing in the quit_cb below
 
         if hold_on_start {
             // we don't actually open a terminal in this case, just wait for the user to run it

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -368,6 +368,7 @@ pub enum ScreenInstruction {
         keybinds: Option<Keybinds>,
         default_mode: Option<InputMode>,
     },
+    RerunCommandPane(u32), // u32 - terminal pane id
 }
 
 impl From<&ScreenInstruction> for ScreenContext {
@@ -553,6 +554,7 @@ impl From<&ScreenInstruction> for ScreenContext {
             ScreenInstruction::RenameSession(..) => ScreenContext::RenameSession,
             ScreenInstruction::ListClientsMetadata(..) => ScreenContext::ListClientsMetadata,
             ScreenInstruction::Reconfigure { .. } => ScreenContext::Reconfigure,
+            ScreenInstruction::RerunCommandPane { .. } => ScreenContext::RerunCommandPane,
         }
     }
 }
@@ -1977,6 +1979,22 @@ impl Screen {
             },
         };
         Ok(())
+    }
+    pub fn rerun_command_pane_with_id(&mut self, terminal_pane_id: u32) {
+        let mut found = false;
+        for tab in self.tabs.values_mut() {
+            if tab.has_pane_with_pid(&PaneId::Terminal(terminal_pane_id)) {
+                tab.rerun_terminal_pane_with_id(terminal_pane_id);
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            log::error!(
+                "Failed to find terminal pane with id: {} to run",
+                terminal_pane_id
+            );
+        }
     }
     pub fn break_pane(
         &mut self,
@@ -4066,6 +4084,9 @@ pub(crate) fn screen_thread_main(
                 screen
                     .reconfigure_mode_info(keybinds, default_mode, client_id)
                     .non_fatal();
+            },
+            ScreenInstruction::RerunCommandPane(terminal_pane_id) => {
+                screen.rerun_command_pane_with_id(terminal_pane_id)
             },
         }
     }

--- a/zellij-server/src/tab/layout_applier.rs
+++ b/zellij-server/src/tab/layout_applier.rs
@@ -399,7 +399,7 @@ impl<'a> LayoutApplier<'a> {
                         .with_context(err_context)?
                         .clone(),
                     pane_title,
-                    layout_name.clone().unwrap_or_default(),
+                    floating_pane_layout.name.clone().unwrap_or_default(),
                     self.sixel_image_store.clone(),
                     self.terminal_emulator_colors.clone(),
                     self.terminal_emulator_color_codes.clone(),

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__screen_can_break_floating_plugin_pane_to_a_new_tab-2.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__screen_can_break_floating_plugin_pane_to_a_new_tab-2.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 3502
+assertion_line: 3512
 expression: "format!(\"{}\", snapshot)"
 ---
 00 (C): ┌ tiled_pane ──────────────────────────────────────────────────────────────────┐
@@ -8,7 +8,7 @@ expression: "format!(\"{}\", snapshot)"
 02 (C): │                                                                              │
 03 (C): │                                                                              │
 04 (C): │                                                                              │
-05 (C): │                   ┌ file:/path/to/fake/plugin ───────────┐                   │
+05 (C): │                   ┌ floating_plugin_pane_to_eject ───────┐                   │
 06 (C): │                   │Loading file:/path/to/fake/plugin     │                   │
 07 (C): │                   │                                      │                   │
 08 (C): │                   │                                      │                   │

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__screen_can_break_floating_plugin_pane_to_a_new_tab-3.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__screen_can_break_floating_plugin_pane_to_a_new_tab-3.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 3502
+assertion_line: 3512
 expression: "format!(\"{}\", snapshot)"
 ---
 00 (C): ┌ Pane #1 ─────────────────────────────────────────────────────────────────────┐
@@ -10,7 +10,7 @@ expression: "format!(\"{}\", snapshot)"
 04 (C): │                                                                              │
 05 (C): │                                                                              │
 06 (C): │                                                                              │
-07 (C): │                     ┌ file:/path/to/fake/plugin ───────────┐                 │
+07 (C): │                     ┌ floating_plugin_pane_to_eject ───────┐                 │
 08 (C): │                     │Loading file:/path/to/fake/plugin     │                 │
 09 (C): │                     │                                      │                 │
 10 (C): │                     │                                      │                 │

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__screen_can_break_floating_plugin_pane_to_a_new_tab-4.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__screen_can_break_floating_plugin_pane_to_a_new_tab-4.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 3171
+assertion_line: 3512
 expression: "format!(\"{}\", snapshot)"
 ---
 00 (C): ┌ Pane #1 ─────────────────────────────────────────────────────────────────────┐
@@ -10,7 +10,7 @@ expression: "format!(\"{}\", snapshot)"
 04 (C): │                                                                              │
 05 (C): │                                                                              │
 06 (C): │                                                                              │
-07 (C): │                     ┌ file:/path/to/fake/plugin ───────────┐                 │
+07 (C): │                     ┌ floating_plugin_pane_to_eject ───────┐                 │
 08 (C): │                     │Loading file:/path/to/fake/plugin     │                 │
 09 (C): │                     │                                      │                 │
 10 (C): │                     │                                      │                 │

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__screen_can_break_floating_plugin_pane_to_a_new_tab-6.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__screen_can_break_floating_plugin_pane_to_a_new_tab-6.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 3171
+assertion_line: 3512
 expression: "format!(\"{}\", snapshot)"
 ---
 00 (C): ┌ Pane #1 ─────────────────────────────────────────────────────────────────────┐
@@ -10,7 +10,7 @@ expression: "format!(\"{}\", snapshot)"
 04 (C): │                                                                              │
 05 (C): │                                                                              │
 06 (C): │                                                                              │
-07 (C): │                     ┌ file:/path/to/fake/plugin ───────────┐                 │
+07 (C): │                     ┌ floating_plugin_pane_to_eject ───────┐                 │
 08 (C): │                     │Loading file:/path/to/fake/plugin     │                 │
 09 (C): │                     │                                      │                 │
 10 (C): │                     │                                      │                 │

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__screen_can_break_floating_plugin_pane_to_a_new_tab-7.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__screen_can_break_floating_plugin_pane_to_a_new_tab-7.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 3171
+assertion_line: 3512
 expression: "format!(\"{}\", snapshot)"
 ---
 00 (C): ┌ Pane #1 ─────────────────────────────────────────────────────────────────────┐
@@ -10,7 +10,7 @@ expression: "format!(\"{}\", snapshot)"
 04 (C): │                                                                              │
 05 (C): │                                                                              │
 06 (C): │                                                                              │
-07 (C): │                     ┌ file:/path/to/fake/plugin ───────────┐                 │
+07 (C): │                     ┌ floating_plugin_pane_to_eject ───────┐                 │
 08 (C): │                     │Loading file:/path/to/fake/plugin     │                 │
 09 (C): │                     │                                      │                 │
 10 (C): │                     │                                      │                 │

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__screen_can_break_floating_plugin_pane_to_a_new_tab.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__screen_can_break_floating_plugin_pane_to_a_new_tab.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/./unit/screen_tests.rs
-assertion_line: 3171
+assertion_line: 3512
 expression: "format!(\"{}\", snapshot)"
 ---
 00 (C): ┌ tiled_pane ──────────────────────────────────────────────────────────────────┐
@@ -8,7 +8,7 @@ expression: "format!(\"{}\", snapshot)"
 02 (C): │                                                                              │
 03 (C): │                                                                              │
 04 (C): │                                                                              │
-05 (C): │                   ┌ file:/path/to/fake/plugin ───────────┐                   │
+05 (C): │                   ┌ floating_plugin_pane_to_eject ───────┐                   │
 06 (C): │                   │Loading file:/path/to/fake/plugin     │                   │
 07 (C): │                   │                                      │                   │
 08 (C): │                   │                                      │                   │

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -849,6 +849,14 @@ pub fn reconfigure(new_config: String) {
     unsafe { host_run_plugin_command() };
 }
 
+/// Re-run command in pane
+pub fn rerun_command_pane(terminal_pane_id: u32) {
+    let plugin_command = PluginCommand::RerunCommandPane(terminal_pane_id);
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
 // Utility Functions
 
 #[allow(unused)]

--- a/zellij-utils/assets/prost/api.plugin_command.rs
+++ b/zellij-utils/assets/prost/api.plugin_command.rs
@@ -5,7 +5,7 @@ pub struct PluginCommand {
     pub name: i32,
     #[prost(
         oneof = "plugin_command::Payload",
-        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 60, 61, 62, 63, 64, 65, 66"
+        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 60, 61, 62, 63, 64, 65, 66, 67"
     )]
     pub payload: ::core::option::Option<plugin_command::Payload>,
 }
@@ -126,7 +126,15 @@ pub mod plugin_command {
         ShowPaneWithIdPayload(super::ShowPaneWithIdPayload),
         #[prost(message, tag = "66")]
         OpenCommandPaneBackgroundPayload(super::OpenCommandPanePayload),
+        #[prost(message, tag = "67")]
+        RerunCommandPanePayload(super::RerunCommandPanePayload),
     }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RerunCommandPanePayload {
+    #[prost(uint32, tag = "1")]
+    pub terminal_pane_id: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -461,6 +469,7 @@ pub enum CommandName {
     HidePaneWithId = 88,
     ShowPaneWithId = 89,
     OpenCommandPaneBackground = 90,
+    RerunCommandPane = 91,
 }
 impl CommandName {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -560,6 +569,7 @@ impl CommandName {
             CommandName::HidePaneWithId => "HidePaneWithId",
             CommandName::ShowPaneWithId => "ShowPaneWithId",
             CommandName::OpenCommandPaneBackground => "OpenCommandPaneBackground",
+            CommandName::RerunCommandPane => "RerunCommandPane",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -656,6 +666,7 @@ impl CommandName {
             "HidePaneWithId" => Some(Self::HidePaneWithId),
             "ShowPaneWithId" => Some(Self::ShowPaneWithId),
             "OpenCommandPaneBackground" => Some(Self::OpenCommandPaneBackground),
+            "RerunCommandPane" => Some(Self::RerunCommandPane),
             _ => None,
         }
     }

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -1802,4 +1802,5 @@ pub enum PluginCommand {
     HidePaneWithId(PaneId),
     ShowPaneWithId(PaneId, bool), // bool -> should_float_if_hidden
     OpenCommandPaneBackground(CommandToRun, Context),
+    RerunCommandPane(u32), // u32  - terminal pane id
 }

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -354,6 +354,7 @@ pub enum ScreenContext {
     DumpLayoutToPlugin,
     ListClientsMetadata,
     Reconfigure,
+    RerunCommandPane,
 }
 
 /// Stack call representations corresponding to the different types of [`PtyInstruction`]s.

--- a/zellij-utils/src/plugin_api/plugin_command.proto
+++ b/zellij-utils/src/plugin_api/plugin_command.proto
@@ -102,6 +102,7 @@ enum CommandName {
   HidePaneWithId = 88;
   ShowPaneWithId = 89;
   OpenCommandPaneBackground = 90;
+  RerunCommandPane = 91;
 }
 
 message PluginCommand {
@@ -163,7 +164,12 @@ message PluginCommand {
     HidePaneWithIdPayload hide_pane_with_id_payload = 64;
     ShowPaneWithIdPayload show_pane_with_id_payload = 65;
     OpenCommandPanePayload open_command_pane_background_payload = 66;
+    RerunCommandPanePayload rerun_command_pane_payload = 67;
   }
+}
+
+message RerunCommandPanePayload {
+  uint32 terminal_pane_id = 1;
 }
 
 message HidePaneWithIdPayload {

--- a/zellij-utils/src/plugin_api/plugin_command.rs
+++ b/zellij-utils/src/plugin_api/plugin_command.rs
@@ -11,9 +11,9 @@ pub use super::generated_api::api::{
         MovePayload, NewPluginArgs as ProtobufNewPluginArgs, NewTabsWithLayoutInfoPayload,
         OpenCommandPanePayload, OpenFilePayload, PaneId as ProtobufPaneId,
         PaneType as ProtobufPaneType, PluginCommand as ProtobufPluginCommand, PluginMessagePayload,
-        RequestPluginPermissionPayload, ResizePayload, RunCommandPayload, SetTimeoutPayload,
-        ShowPaneWithIdPayload, SubscribePayload, SwitchSessionPayload, SwitchTabToPayload,
-        UnsubscribePayload, WebRequestPayload,
+        RequestPluginPermissionPayload, RerunCommandPanePayload, ResizePayload, RunCommandPayload,
+        SetTimeoutPayload, ShowPaneWithIdPayload, SubscribePayload, SwitchSessionPayload,
+        SwitchTabToPayload, UnsubscribePayload, WebRequestPayload,
     },
     plugin_permission::PermissionType as ProtobufPermissionType,
     resize::ResizeAction as ProtobufResizeAction,
@@ -982,6 +982,12 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
                 },
                 _ => Err("Mismatched payload for OpenCommandPaneBackground"),
             },
+            Some(CommandName::RerunCommandPane) => match protobuf_plugin_command.payload {
+                Some(Payload::RerunCommandPanePayload(rerun_command_pane_payload)) => Ok(
+                    PluginCommand::RerunCommandPane(rerun_command_pane_payload.terminal_pane_id),
+                ),
+                _ => Err("Mismatched payload for RerunCommandPane"),
+            },
             None => Err("Unrecognized plugin command"),
         }
     }
@@ -1587,6 +1593,12 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
                     )),
                 })
             },
+            PluginCommand::RerunCommandPane(terminal_pane_id) => Ok(ProtobufPluginCommand {
+                name: CommandName::RerunCommandPane as i32,
+                payload: Some(Payload::RerunCommandPanePayload(RerunCommandPanePayload {
+                    terminal_pane_id,
+                })),
+            }),
         }
     }
 }


### PR DESCRIPTION
This allows plugins to rerun a command pane that has exited (similar to what would happen if a user focused on the pane and pressed `<ENTER>`, only to any such pane without changing user focus).