### PR TITLE
feat(plugins): command pane re-run event

### DIFF
--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -1332,6 +1332,7 @@ fn check_event_permission(
         | Event::PaneClosed(..)
         | Event::EditPaneOpened(..)
         | Event::EditPaneExited(..)
+        | Event::CommandPaneReRun(..)
         | Event::InputReceived => PermissionType::ReadApplicationState,
         _ => return (PermissionStatus::Granted, None),
     };

--- a/zellij-utils/assets/prost/api.event.rs
+++ b/zellij-utils/assets/prost/api.event.rs
@@ -11,7 +11,7 @@ pub struct Event {
     pub name: i32,
     #[prost(
         oneof = "event::Payload",
-        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20"
+        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21"
     )]
     pub payload: ::core::option::Option<event::Payload>,
 }
@@ -58,7 +58,17 @@ pub mod event {
         EditPaneOpenedPayload(super::EditPaneOpenedPayload),
         #[prost(message, tag = "20")]
         EditPaneExitedPayload(super::EditPaneExitedPayload),
+        #[prost(message, tag = "21")]
+        CommandPaneRerunPayload(super::CommandPaneReRunPayload),
     }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CommandPaneReRunPayload {
+    #[prost(uint32, tag = "1")]
+    pub terminal_pane_id: u32,
+    #[prost(message, repeated, tag = "3")]
+    pub context: ::prost::alloc::vec::Vec<ContextItem>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -415,6 +425,7 @@ pub enum EventType {
     PaneClosed = 21,
     EditPaneOpened = 22,
     EditPaneExited = 23,
+    CommandPaneReRun = 24,
 }
 impl EventType {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -447,6 +458,7 @@ impl EventType {
             EventType::PaneClosed => "PaneClosed",
             EventType::EditPaneOpened => "EditPaneOpened",
             EventType::EditPaneExited => "EditPaneExited",
+            EventType::CommandPaneReRun => "CommandPaneReRun",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -476,6 +488,7 @@ impl EventType {
             "PaneClosed" => Some(Self::PaneClosed),
             "EditPaneOpened" => Some(Self::EditPaneOpened),
             "EditPaneExited" => Some(Self::EditPaneExited),
+            "CommandPaneReRun" => Some(Self::CommandPaneReRun),
             _ => None,
         }
     }

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -919,6 +919,7 @@ pub enum Event {
     PaneClosed(PaneId),
     EditPaneOpened(u32, Context),              // u32 - terminal_pane_id
     EditPaneExited(u32, Option<i32>, Context), // u32 - terminal_pane_id, Option<i32> - exit code
+    CommandPaneReRun(u32, Context),            // u32 - terminal_pane_id, Option<i32> -
 }
 
 #[derive(

--- a/zellij-utils/src/plugin_api/event.proto
+++ b/zellij-utils/src/plugin_api/event.proto
@@ -47,6 +47,7 @@ enum EventType {
     PaneClosed = 21;
     EditPaneOpened = 22;
     EditPaneExited = 23;
+    CommandPaneReRun = 24;
 }
 
 message EventNameList {
@@ -75,7 +76,13 @@ message Event {
     PaneClosedPayload pane_closed_payload = 18;
     EditPaneOpenedPayload edit_pane_opened_payload = 19;
     EditPaneExitedPayload edit_pane_exited_payload = 20;
+    CommandPaneReRunPayload command_pane_rerun_payload = 21;
   }
+}
+
+message CommandPaneReRunPayload {
+  uint32 terminal_pane_id = 1;
+  repeated ContextItem context = 3;
 }
 
 message PaneClosedPayload {

--- a/zellij-utils/src/plugin_api/event.rs
+++ b/zellij-utils/src/plugin_api/event.rs
@@ -299,6 +299,19 @@ impl TryFrom<ProtobufEvent> for Event {
                 },
                 _ => Err("Malformed payload for the EditPaneExited Event"),
             },
+            Some(ProtobufEventType::CommandPaneReRun) => match protobuf_event.payload {
+                Some(ProtobufEventPayload::CommandPaneRerunPayload(command_pane_rerun_payload)) => {
+                    Ok(Event::CommandPaneReRun(
+                        command_pane_rerun_payload.terminal_pane_id,
+                        command_pane_rerun_payload
+                            .context
+                            .into_iter()
+                            .map(|c_i| (c_i.name, c_i.value))
+                            .collect(),
+                    ))
+                },
+                _ => Err("Malformed payload for the CommandPaneReRun Event"),
+            },
             None => Err("Unknown Protobuf Event"),
         }
     }
@@ -589,6 +602,21 @@ impl TryFrom<Event> for ProtobufEvent {
                     name: ProtobufEventType::EditPaneExited as i32,
                     payload: Some(event::Payload::EditPaneExitedPayload(
                         command_pane_exited_payload,
+                    )),
+                })
+            },
+            Event::CommandPaneReRun(terminal_pane_id, context) => {
+                let command_pane_rerun_payload = CommandPaneReRunPayload {
+                    terminal_pane_id,
+                    context: context
+                        .into_iter()
+                        .map(|(name, value)| ContextItem { name, value })
+                        .collect(),
+                };
+                Ok(ProtobufEvent {
+                    name: ProtobufEventType::CommandPaneReRun as i32,
+                    payload: Some(event::Payload::CommandPaneRerunPayload(
+                        command_pane_rerun_payload,
                     )),
                 })
             },
@@ -1100,6 +1128,7 @@ impl TryFrom<ProtobufEventType> for EventType {
             ProtobufEventType::PaneClosed => EventType::PaneClosed,
             ProtobufEventType::EditPaneOpened => EventType::EditPaneOpened,
             ProtobufEventType::EditPaneExited => EventType::EditPaneExited,
+            ProtobufEventType::CommandPaneReRun => EventType::CommandPaneReRun,
         })
     }
 }
@@ -1132,6 +1161,7 @@ impl TryFrom<EventType> for ProtobufEventType {
             EventType::PaneClosed => ProtobufEventType::PaneClosed,
             EventType::EditPaneOpened => ProtobufEventType::EditPaneOpened,
             EventType::EditPaneExited => ProtobufEventType::EditPaneExited,
+            EventType::CommandPaneReRun => ProtobufEventType::CommandPaneReRun,
         })
     }
 }


### PR DESCRIPTION
This adds an `Event` plugins can subscribe to, letting them know when a command pane they opened has been re-run by the user or by a plugin (eg. the user focused on the pane after it exited and pressed `ENTER`).

This event, like the corresponding `CommandPaneOpened` and `CommandPaneExited` events, returns a copy of the context dictionary provided by the plugin.