### PR TITLE
feat(ux): reload config at runtime

### DIFF
--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -17,12 +17,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use zellij_utils::errors::FatalError;
 
-use zellij_utils::notify_debouncer_full::notify::{
-    self,
-    Event,
-    RecursiveMode,
-    Watcher,
-};
+use zellij_utils::notify_debouncer_full::notify::{self, Event, RecursiveMode, Watcher};
 use zellij_utils::setup::Setup;
 
 use crate::stdin_ansi_parser::{AnsiStdinInstruction, StdinAnsiParser, SyncOutput};

--- a/zellij-utils/src/input/config.rs
+++ b/zellij-utils/src/input/config.rs
@@ -234,7 +234,7 @@ impl Config {
         self.env = self.env.merge(other.env);
         Ok(())
     }
-    fn config_file_path(opts: &CliArgs) -> Option<PathBuf> {
+    pub fn config_file_path(opts: &CliArgs) -> Option<PathBuf> {
         opts.config_dir
             .clone()
             .or_else(home::find_default_config_dir)


### PR DESCRIPTION
This is the beginning of a series of changes that will allow fully reloading and reapplying the Zellij configuration file (by default `~/.config/zellij/config.kdl`) at runtime.

## What this does?
This PR adds a filesystem watcher to the config file on `zellij-client`. When the file is created or modified, we reload its contents and send them to `zellij-server` who reapplies them to the current session if they changed.

In this PR, aside from this infrastructure, we add support for reapplying the `keybinds` block and the `default_mode` option setting from the configuration file. Nothing else works yet!

## What's next?
Adding support for all the rest of the config file (themes, configuration options, plugin aliases, etc.) - upcoming in next PRs!