### PR TITLE
feat(plugins): API to temporarily bind keys to send a message to a specific plugin id

### DIFF
--- a/zellij-server/src/plugins/mod.rs
+++ b/zellij-server/src/plugins/mod.rs
@@ -134,6 +134,7 @@ pub enum PluginInstruction {
         cwd: Option<PathBuf>,
         skip_cache: bool,
         cli_client_id: ClientId,
+        plugin_and_client_id: Option<(u32, ClientId)>,
     },
     CachePluginEvents {
         plugin_id: PluginId,
@@ -624,42 +625,52 @@ pub(crate) fn plugin_thread_main(
                 cwd,
                 skip_cache,
                 cli_client_id,
+                plugin_and_client_id,
             } => {
                 let should_float = floating.unwrap_or(true);
                 let mut pipe_messages = vec![];
-                match plugin {
-                    Some(plugin_url) => {
-                        // send to specific plugin(s)
-                        pipe_to_specific_plugins(
-                            PipeSource::Keybind,
-                            &plugin_url,
-                            &configuration,
-                            &cwd,
-                            skip_cache,
-                            should_float,
-                            &pane_id_to_replace,
-                            &pane_title,
-                            Some(cli_client_id),
-                            &mut pipe_messages,
-                            &name,
-                            &payload,
-                            &args,
-                            &bus,
-                            &mut wasm_bridge,
-                            &plugin_aliases,
-                        );
-                    },
-                    None => {
-                        // no specific destination, send to all plugins
-                        pipe_to_all_plugins(
-                            PipeSource::Keybind,
-                            &name,
-                            &payload,
-                            &args,
-                            &mut wasm_bridge,
-                            &mut pipe_messages,
-                        );
-                    },
+                if let Some((plugin_id, client_id)) = plugin_and_client_id {
+                    let is_private = true;
+                    pipe_messages.push((
+                        Some(plugin_id),
+                        Some(client_id),
+                        PipeMessage::new(PipeSource::Keybind, name, &payload, &args, is_private),
+                    ));
+                } else {
+                    match plugin {
+                        Some(plugin_url) => {
+                            // send to specific plugin(s)
+                            pipe_to_specific_plugins(
+                                PipeSource::Keybind,
+                                &plugin_url,
+                                &configuration,
+                                &cwd,
+                                skip_cache,
+                                should_float,
+                                &pane_id_to_replace,
+                                &pane_title,
+                                Some(cli_client_id),
+                                &mut pipe_messages,
+                                &name,
+                                &payload,
+                                &args,
+                                &bus,
+                                &mut wasm_bridge,
+                                &plugin_aliases,
+                            );
+                        },
+                        None => {
+                            // no specific destination, send to all plugins
+                            pipe_to_all_plugins(
+                                PipeSource::Keybind,
+                                &name,
+                                &payload,
+                                &args,
+                                &mut wasm_bridge,
+                                &mut pipe_messages,
+                            );
+                        },
+                    }
                 }
                 wasm_bridge.pipe_messages(pipe_messages, shutdown_send.clone())?;
             },
@@ -768,6 +779,8 @@ pub(crate) fn plugin_thread_main(
                 keybinds,
                 default_mode,
             } => {
+                // TODO: notify plugins that this happened so that they can eg. rebind temporary keys that
+                // were lost
                 wasm_bridge
                     .reconfigure(client_id, keybinds, default_mode)
                     .non_fatal();

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -921,12 +921,13 @@ pub(crate) fn route_action(
             cwd,
             pane_title,
             launch_new,
+            plugin_id,
             ..
         } => {
             if let Some(name) = name.take() {
                 let should_open_in_place = in_place.unwrap_or(false);
                 let pane_id_to_replace = if should_open_in_place { pane_id } else { None };
-                if launch_new {
+                if launch_new && plugin_id.is_none() {
                     // we do this to make sure the plugin is unique (has a unique configuration parameter)
                     configuration
                         .get_or_insert_with(BTreeMap::new)
@@ -945,6 +946,7 @@ pub(crate) fn route_action(
                         pane_title,
                         skip_cache,
                         cli_client_id: client_id,
+                        plugin_and_client_id: plugin_id.map(|plugin_id| (plugin_id, client_id)),
                     })
                     .with_context(err_context)?;
             } else {

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -289,6 +289,7 @@ pub enum Action {
         payload: Option<String>,
         args: Option<BTreeMap<String, String>>,
         plugin: Option<String>,
+        plugin_id: Option<u32>, // supercedes plugin if present
         configuration: Option<BTreeMap<String, String>>,
         launch_new: bool,
         skip_cache: bool,

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -703,6 +703,7 @@ impl TryFrom<ProtobufAction> for Action {
                     in_place: None,
                     cwd: None,
                     pane_title: None,
+                    plugin_id: None,
                 }),
             },
             _ => Err("Unknown Action"),


### PR DESCRIPTION
This adds the `MessagePluginId` bindable keybind action. Similar to `MessagePlugin`, this will create a pipe that will send a message to a specific plugin - only here it will be done by this plugin's runtime ID.

The purpose is to use this with the `reconfigure` plugin API to essentially allow plugins to temporarily bind global keys in the session to send messages to themselves.

Example:

```rust
let own_plugin_id = Some(get_plugin_ids().plugin_id);
let save_configuration_to_file = false;
reconfigure(format!(r#"
    keybinds {{
        shared {{
            bind "F1" {{
                MessagePluginId {own_plugin_id}  {{
                    name "F1"
                }}
            }}
            bind "F2" {{
                MessagePluginId {own_plugin_id} {{
                    name "F2"
                }}
            }}
            bind "F3" {{
                MessagePluginId {own_plugin_id} {{
                    name "F3"
                }}
            }}
        }}
    }}
"#), save_configuration_to_file);
// ...
impl State {
    fn pipe(&mut self, pipe_message: PipeMessage) -> bool {
        let mut should_render = false;
        if pipe_message.name == "F1" {
            eprintln!("F1 key pressed globally");
        }
        if pipe_message.name == "F2" {
            eprintln!("F2 key pressed globally");
        }
        if pipe_message.name == "F3" {
            eprintln!("F3 key pressed globally");
        }
        should_render
    }
}
```

Note: this sort of keybind action should only be used in this case. It is not serialized with the user's config and should not be trusted to persist across sessions. If placed statically in a configuration it might have unintended consequences (seeing as plugin ids are assigned at runtime).