### PR TITLE
feat(ux): reload config options at runtime

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -271,6 +271,7 @@ impl SessionMetaData {
                     theme: new_config
                         .theme_config(new_config.options.theme.as_ref())
                         .or_else(|| Some(default_palette())),
+                    simplified_ui: new_config.options.simplified_ui.or(Some(false)),
                 })
                 .unwrap();
             self.senders

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -281,6 +281,12 @@ impl SessionMetaData {
                     simplified_ui: new_config.options.simplified_ui.or(Some(false)),
                     default_shell: new_config.options.default_shell,
                     pane_frames: new_config.options.pane_frames.or(Some(true)),
+                    copy_command: new_config.options.copy_command,
+                    copy_to_clipboard: new_config.options.copy_clipboard,
+                    copy_on_select: new_config.options.copy_on_select.or(Some(true)),
+                    auto_layout: new_config.options.auto_layout.or(Some(true)),
+                    rounded_corners: Some(new_config.ui.pane_frames.rounded_corners),
+                    hide_session_name: Some(new_config.ui.pane_frames.hide_session_name),
                 })
                 .unwrap();
             self.senders
@@ -289,6 +295,12 @@ impl SessionMetaData {
                     keybinds: Some(new_config.keybinds),
                     default_mode: new_config.options.default_mode,
                     default_shell: self.default_shell.clone(),
+                })
+                .unwrap();
+            self.senders
+                .send_to_pty(PtyInstruction::Reconfigure {
+                    client_id,
+                    default_editor: new_config.options.scrollback_editor,
                 })
                 .unwrap();
         }

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -273,20 +273,20 @@ impl SessionMetaData {
             self.senders
                 .send_to_screen(ScreenInstruction::Reconfigure {
                     client_id,
-                    keybinds: Some(new_config.keybinds.clone()),
-                    default_mode: new_config.options.default_mode,
+                    keybinds: new_config.keybinds.clone(),
+                    default_mode: new_config.options.default_mode.unwrap_or_else(Default::default),
                     theme: new_config
                         .theme_config(new_config.options.theme.as_ref())
-                        .or_else(|| Some(default_palette())),
-                    simplified_ui: new_config.options.simplified_ui.or(Some(false)),
+                        .unwrap_or_else(|| default_palette()),
+                    simplified_ui: new_config.options.simplified_ui.unwrap_or(false),
                     default_shell: new_config.options.default_shell,
-                    pane_frames: new_config.options.pane_frames.or(Some(true)),
+                    pane_frames: new_config.options.pane_frames.unwrap_or(true),
                     copy_command: new_config.options.copy_command,
                     copy_to_clipboard: new_config.options.copy_clipboard,
-                    copy_on_select: new_config.options.copy_on_select.or(Some(true)),
-                    auto_layout: new_config.options.auto_layout.or(Some(true)),
-                    rounded_corners: Some(new_config.ui.pane_frames.rounded_corners),
-                    hide_session_name: Some(new_config.ui.pane_frames.hide_session_name),
+                    copy_on_select: new_config.options.copy_on_select.unwrap_or(true),
+                    auto_layout: new_config.options.auto_layout.unwrap_or(true),
+                    rounded_corners: new_config.ui.pane_frames.rounded_corners,
+                    hide_session_name: new_config.ui.pane_frames.hide_session_name,
                 })
                 .unwrap();
             self.senders

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -280,6 +280,7 @@ impl SessionMetaData {
                         .or_else(|| Some(default_palette())),
                     simplified_ui: new_config.options.simplified_ui.or(Some(false)),
                     default_shell: new_config.options.default_shell,
+                    pane_frames: new_config.options.pane_frames.or(Some(true)),
                 })
                 .unwrap();
             self.senders

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -274,7 +274,10 @@ impl SessionMetaData {
                 .send_to_screen(ScreenInstruction::Reconfigure {
                     client_id,
                     keybinds: new_config.keybinds.clone(),
-                    default_mode: new_config.options.default_mode.unwrap_or_else(Default::default),
+                    default_mode: new_config
+                        .options
+                        .default_mode
+                        .unwrap_or_else(Default::default),
                     theme: new_config
                         .theme_config(new_config.options.theme.as_ref())
                         .unwrap_or_else(|| default_palette()),

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -924,4 +924,11 @@ impl FloatingPanes {
             pane.update_arrow_fonts(should_support_arrow_fonts);
         }
     }
+    pub fn update_pane_rounded_corners(&mut self, rounded_corners: bool) {
+        self.style.rounded_corners = rounded_corners;
+        for pane in self.panes.values_mut() {
+            pane.update_rounded_corners(rounded_corners);
+        }
+    }
+
 }

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -919,4 +919,9 @@ impl FloatingPanes {
             pane.update_theme(theme);
         }
     }
+    pub fn update_pane_arrow_fonts(&mut self, should_support_arrow_fonts: bool) {
+        for pane in self.panes.values_mut() {
+            pane.update_arrow_fonts(should_support_arrow_fonts);
+        }
+    }
 }

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -930,5 +930,4 @@ impl FloatingPanes {
             pane.update_rounded_corners(rounded_corners);
         }
     }
-
 }

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -2158,6 +2158,9 @@ impl Grid {
     pub fn update_theme(&mut self, theme: Palette) {
         self.style.colors = theme.clone();
     }
+    pub fn update_arrow_fonts(&mut self, should_support_arrow_fonts: bool) {
+        self.arrow_fonts = should_support_arrow_fonts;
+    }
 }
 
 impl Perform for Grid {

--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -688,6 +688,10 @@ impl Pane for PluginPane {
         }
         self.set_should_render(true);
     }
+    fn update_rounded_corners(&mut self, rounded_corners: bool) {
+        self.style.rounded_corners = rounded_corners;
+        self.frame.clear();
+    }
 }
 
 impl PluginPane {

--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -681,6 +681,13 @@ impl Pane for PluginPane {
             grid.update_theme(theme.clone());
         }
     }
+    fn update_arrow_fonts(&mut self, should_support_arrow_fonts: bool) {
+        self.arrow_fonts = should_support_arrow_fonts;
+        for grid in self.grids.values_mut() {
+            grid.update_arrow_fonts(should_support_arrow_fonts);
+        }
+        self.set_should_render(true);
+    }
 }
 
 impl PluginPane {

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -798,6 +798,10 @@ impl Pane for TerminalPane {
             self.render_first_run_banner();
         }
     }
+    fn update_arrow_fonts(&mut self, should_support_arrow_fonts: bool) {
+        self.arrow_fonts = should_support_arrow_fonts;
+        self.grid.update_arrow_fonts(should_support_arrow_fonts);
+    }
 }
 
 impl TerminalPane {

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -802,6 +802,10 @@ impl Pane for TerminalPane {
         self.arrow_fonts = should_support_arrow_fonts;
         self.grid.update_arrow_fonts(should_support_arrow_fonts);
     }
+    fn update_rounded_corners(&mut self, rounded_corners: bool) {
+        self.style.rounded_corners = rounded_corners;
+        self.frame.clear();
+    }
 }
 
 impl TerminalPane {

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -1772,6 +1772,11 @@ impl TiledPanes {
             pane.update_theme(theme);
         }
     }
+    pub fn update_pane_arrow_fonts(&mut self, should_support_arrow_fonts: bool) {
+        for pane in self.panes.values_mut() {
+            pane.update_arrow_fonts(should_support_arrow_fonts);
+        }
+    }
 }
 
 #[allow(clippy::borrowed_box)]

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -1777,6 +1777,12 @@ impl TiledPanes {
             pane.update_arrow_fonts(should_support_arrow_fonts);
         }
     }
+    pub fn update_pane_rounded_corners(&mut self, rounded_corners: bool) {
+        self.style.rounded_corners = rounded_corners;
+        for pane in self.panes.values_mut() {
+            pane.update_rounded_corners(rounded_corners);
+        }
+    }
 }
 
 #[allow(clippy::borrowed_box)]

--- a/zellij-server/src/plugins/mod.rs
+++ b/zellij-server/src/plugins/mod.rs
@@ -148,6 +148,7 @@ pub enum PluginInstruction {
         client_id: ClientId,
         keybinds: Option<Keybinds>,
         default_mode: Option<InputMode>,
+        default_shell: Option<TerminalAction>,
     },
     FailedToWriteConfigToDisk {
         file_path: Option<PathBuf>,
@@ -778,11 +779,12 @@ pub(crate) fn plugin_thread_main(
                 client_id,
                 keybinds,
                 default_mode,
+                default_shell,
             } => {
                 // TODO: notify plugins that this happened so that they can eg. rebind temporary keys that
                 // were lost
                 wasm_bridge
-                    .reconfigure(client_id, keybinds, default_mode)
+                    .reconfigure(client_id, keybinds, default_mode, default_shell)
                     .non_fatal();
             },
             PluginInstruction::FailedToWriteConfigToDisk { file_path } => {

--- a/zellij-server/src/plugins/plugin_map.rs
+++ b/zellij-server/src/plugins/plugin_map.rs
@@ -432,4 +432,7 @@ impl RunningPlugin {
     pub fn update_default_mode(&mut self, default_mode: InputMode) {
         self.store.data_mut().default_mode = default_mode;
     }
+    pub fn update_default_shell(&mut self, default_shell: Option<TerminalAction>) {
+        self.store.data_mut().default_shell = default_shell;
+    }
 }

--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -826,6 +826,7 @@ impl WasmBridge {
         client_id: ClientId,
         keybinds: Option<Keybinds>,
         default_mode: Option<InputMode>,
+        default_shell: Option<TerminalAction>,
     ) -> Result<()> {
         let plugins_to_reconfigure: Vec<Arc<Mutex<RunningPlugin>>> = self
             .plugin_map
@@ -848,10 +849,12 @@ impl WasmBridge {
         if let Some(keybinds) = keybinds.as_ref() {
             self.keybinds.insert(client_id, keybinds.clone());
         }
+        self.default_shell = default_shell.clone();
         for running_plugin in plugins_to_reconfigure {
             task::spawn({
                 let running_plugin = running_plugin.clone();
                 let keybinds = keybinds.clone();
+                let default_shell = default_shell.clone();
                 async move {
                     let mut running_plugin = running_plugin.lock().unwrap();
                     if let Some(keybinds) = keybinds {
@@ -860,6 +863,7 @@ impl WasmBridge {
                     if let Some(default_mode) = default_mode {
                         running_plugin.update_default_mode(default_mode);
                     }
+                    running_plugin.update_default_shell(default_shell);
                 }
             });
         }

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -100,6 +100,10 @@ pub enum PtyInstruction {
         Option<FloatingPaneCoordinates>,
     ),
     ListClientsMetadata(SessionLayoutMetadata, ClientId),
+    Reconfigure {
+        client_id: ClientId,
+        default_editor: Option<PathBuf>
+    },
     Exit,
 }
 
@@ -123,6 +127,7 @@ impl From<&PtyInstruction> for PtyContext {
             PtyInstruction::LogLayoutToHd(..) => PtyContext::LogLayoutToHd,
             PtyInstruction::FillPluginCwd(..) => PtyContext::FillPluginCwd,
             PtyInstruction::ListClientsMetadata(..) => PtyContext::ListClientsMetadata,
+            PtyInstruction::Reconfigure{..} => PtyContext::Reconfigure,
             PtyInstruction::Exit => PtyContext::Exit,
         }
     }
@@ -765,6 +770,9 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                     floating_pane_coordinates,
                 )?;
             },
+            PtyInstruction::Reconfigure { default_editor, client_id } => {
+                pty.reconfigure(default_editor);
+            }
             PtyInstruction::Exit => break,
         }
     }
@@ -1544,6 +1552,9 @@ impl Pty {
             skip_cache,
         ))?;
         Ok(())
+    }
+    pub fn reconfigure(&mut self, default_editor: Option<PathBuf>) {
+        self.default_editor = default_editor;
     }
 }
 

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -102,7 +102,7 @@ pub enum PtyInstruction {
     ListClientsMetadata(SessionLayoutMetadata, ClientId),
     Reconfigure {
         client_id: ClientId,
-        default_editor: Option<PathBuf>
+        default_editor: Option<PathBuf>,
     },
     Exit,
 }
@@ -127,7 +127,7 @@ impl From<&PtyInstruction> for PtyContext {
             PtyInstruction::LogLayoutToHd(..) => PtyContext::LogLayoutToHd,
             PtyInstruction::FillPluginCwd(..) => PtyContext::FillPluginCwd,
             PtyInstruction::ListClientsMetadata(..) => PtyContext::ListClientsMetadata,
-            PtyInstruction::Reconfigure{..} => PtyContext::Reconfigure,
+            PtyInstruction::Reconfigure { .. } => PtyContext::Reconfigure,
             PtyInstruction::Exit => PtyContext::Exit,
         }
     }
@@ -770,9 +770,12 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                     floating_pane_coordinates,
                 )?;
             },
-            PtyInstruction::Reconfigure { default_editor, client_id } => {
+            PtyInstruction::Reconfigure {
+                default_editor,
+                client_id,
+            } => {
                 pty.reconfigure(default_editor);
-            }
+            },
             PtyInstruction::Exit => break,
         }
     }

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -370,6 +370,7 @@ pub enum ScreenInstruction {
         default_mode: Option<InputMode>,
         theme: Option<Palette>,
         simplified_ui: Option<bool>,
+        default_shell: Option<PathBuf>,
     },
     RerunCommandPane(u32), // u32 - terminal pane id
 }
@@ -2184,12 +2185,13 @@ impl Screen {
         }
         Ok(())
     }
-    pub fn reconfigure_mode_info(
+    pub fn reconfigure( // TODO: rename to just reconfigure?
         &mut self,
         new_keybinds: Option<Keybinds>,
         new_default_mode: Option<InputMode>,
         theme: Option<Palette>,
         simplified_ui: Option<bool>,
+        default_shell: Option<PathBuf>,
         client_id: ClientId,
     ) -> Result<()> {
         let should_update_mode_info =
@@ -2201,6 +2203,11 @@ impl Screen {
             for tab in self.tabs.values_mut() {
                 tab.update_theme(theme);
             }
+        }
+
+        self.default_shell = default_shell.clone();
+        for tab in self.tabs.values_mut() {
+            tab.update_default_shell(default_shell.clone());
         }
 
         if let Some(simplified_ui) = simplified_ui {
@@ -4120,9 +4127,10 @@ pub(crate) fn screen_thread_main(
                 default_mode,
                 theme,
                 simplified_ui,
+                default_shell,
             } => {
                 screen
-                    .reconfigure_mode_info(keybinds, default_mode, theme, simplified_ui, client_id)
+                    .reconfigure(keybinds, default_mode, theme, simplified_ui, default_shell, client_id)
                     .non_fatal();
             },
             ScreenInstruction::RerunCommandPane(terminal_pane_id) => {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -2212,14 +2212,17 @@ impl Screen {
 
         // global configuration
         self.default_mode_info.update_theme(theme);
-        self.default_mode_info.update_rounded_corners(rounded_corners);
+        self.default_mode_info
+            .update_rounded_corners(rounded_corners);
         self.default_shell = default_shell.clone();
         self.auto_layout = auto_layout;
         self.copy_options.command = copy_command.clone();
         self.copy_options.copy_on_select = copy_on_select;
         self.draw_pane_frames = pane_frames;
-        self.default_mode_info.update_arrow_fonts(should_support_arrow_fonts);
-        self.default_mode_info.update_hide_session_name(hide_session_name);
+        self.default_mode_info
+            .update_arrow_fonts(should_support_arrow_fonts);
+        self.default_mode_info
+            .update_hide_session_name(hide_session_name);
         if let Some(copy_to_clipboard) = copy_to_clipboard {
             self.copy_options.clipboard = copy_to_clipboard;
         }
@@ -2232,7 +2235,6 @@ impl Screen {
             tab.set_pane_frames(pane_frames);
             tab.update_arrow_fonts(should_support_arrow_fonts);
         }
-
 
         // client specific configuration
         if self.connected_clients_contains(&client_id) {
@@ -4143,7 +4145,21 @@ pub(crate) fn screen_thread_main(
                 hide_session_name,
             } => {
                 screen
-                    .reconfigure(keybinds, default_mode, theme, simplified_ui, default_shell, pane_frames, copy_command, copy_to_clipboard, copy_on_select, auto_layout, rounded_corners, hide_session_name, client_id)
+                    .reconfigure(
+                        keybinds,
+                        default_mode,
+                        theme,
+                        simplified_ui,
+                        default_shell,
+                        pane_frames,
+                        copy_command,
+                        copy_to_clipboard,
+                        copy_on_select,
+                        auto_layout,
+                        rounded_corners,
+                        hide_session_name,
+                        client_id,
+                    )
                     .non_fatal();
             },
             ScreenInstruction::RerunCommandPane(terminal_pane_id) => {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -371,6 +371,7 @@ pub enum ScreenInstruction {
         theme: Option<Palette>,
         simplified_ui: Option<bool>,
         default_shell: Option<PathBuf>,
+        pane_frames: Option<bool>,
     },
     RerunCommandPane(u32), // u32 - terminal pane id
 }
@@ -2192,6 +2193,7 @@ impl Screen {
         theme: Option<Palette>,
         simplified_ui: Option<bool>,
         default_shell: Option<PathBuf>,
+        pane_frames: Option<bool>,
         client_id: ClientId,
     ) -> Result<()> {
         let should_update_mode_info =
@@ -2208,6 +2210,13 @@ impl Screen {
         self.default_shell = default_shell.clone();
         for tab in self.tabs.values_mut() {
             tab.update_default_shell(default_shell.clone());
+        }
+        
+        if let Some(pane_frames) = pane_frames {
+            self.draw_pane_frames = pane_frames;
+            for tab in self.tabs.values_mut() {
+                tab.set_pane_frames(pane_frames);
+            }
         }
 
         if let Some(simplified_ui) = simplified_ui {
@@ -4128,9 +4137,10 @@ pub(crate) fn screen_thread_main(
                 theme,
                 simplified_ui,
                 default_shell,
+                pane_frames
             } => {
                 screen
-                    .reconfigure(keybinds, default_mode, theme, simplified_ui, default_shell, client_id)
+                    .reconfigure(keybinds, default_mode, theme, simplified_ui, default_shell, pane_frames, client_id)
                     .non_fatal();
             },
             ScreenInstruction::RerunCommandPane(terminal_pane_id) => {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -54,7 +54,7 @@ use zellij_utils::{
         PluginCapabilities, Style, TabInfo,
     },
     errors::{ContextType, ScreenContext},
-    input::{get_mode_info, options::Options},
+    input::get_mode_info,
     ipc::{ClientAttributes, PixelDimensions, ServerToClientMsg},
 };
 
@@ -366,18 +366,18 @@ pub enum ScreenInstruction {
     ListClientsMetadata(Option<PathBuf>, ClientId), // Option<PathBuf> - default shell
     Reconfigure {
         client_id: ClientId,
-        keybinds: Option<Keybinds>,
-        default_mode: Option<InputMode>,
-        theme: Option<Palette>,
-        simplified_ui: Option<bool>,
+        keybinds: Keybinds,
+        default_mode: InputMode,
+        theme: Palette,
+        simplified_ui: bool,
         default_shell: Option<PathBuf>,
-        pane_frames: Option<bool>,
+        pane_frames: bool,
         copy_command: Option<String>,
         copy_to_clipboard: Option<Clipboard>,
-        copy_on_select: Option<bool>,
-        auto_layout: Option<bool>,
-        rounded_corners: Option<bool>,
-        hide_session_name: Option<bool>,
+        copy_on_select: bool,
+        auto_layout: bool,
+        rounded_corners: bool,
+        hide_session_name: bool,
     },
     RerunCommandPane(u32), // u32 - terminal pane id
 }
@@ -2194,80 +2194,45 @@ impl Screen {
     }
     pub fn reconfigure(
         &mut self,
-        new_keybinds: Option<Keybinds>,
-        new_default_mode: Option<InputMode>,
-        theme: Option<Palette>,
-        simplified_ui: Option<bool>,
+        new_keybinds: Keybinds,
+        new_default_mode: InputMode,
+        theme: Palette,
+        simplified_ui: bool,
         default_shell: Option<PathBuf>,
-        pane_frames: Option<bool>,
+        pane_frames: bool,
         copy_command: Option<String>,
         copy_to_clipboard: Option<Clipboard>,
-        copy_on_select: Option<bool>,
-        auto_layout: Option<bool>,
-        rounded_corners: Option<bool>,
-        hide_session_name: Option<bool>,
+        copy_on_select: bool,
+        auto_layout: bool,
+        rounded_corners: bool,
+        hide_session_name: bool,
         client_id: ClientId,
     ) -> Result<()> {
-        let should_update_mode_info =
-            new_keybinds.is_some() || new_default_mode.is_some() || theme.is_some() || simplified_ui.is_some() || hide_session_name.is_some();
+        let should_support_arrow_fonts = !simplified_ui;
 
-        // themes are currently global and not per-client
-        if let Some(theme) = theme {
-            self.default_mode_info.update_theme(theme);
-            for tab in self.tabs.values_mut() {
-                tab.update_theme(theme);
-            }
-        }
-
-        if let Some(rounded_corners) = rounded_corners {
-            self.default_mode_info.update_rounded_corners(rounded_corners);
-            for tab in self.tabs.values_mut() {
-                tab.update_rounded_corners(rounded_corners);
-            }
-        }
-
+        // global configuration
+        self.default_mode_info.update_theme(theme);
+        self.default_mode_info.update_rounded_corners(rounded_corners);
         self.default_shell = default_shell.clone();
-        for tab in self.tabs.values_mut() {
-            tab.update_default_shell(default_shell.clone());
-        }
-
-        if let Some(auto_layout) = auto_layout {
-            self.auto_layout = auto_layout;
-            for tab in self.tabs.values_mut() {
-                tab.update_auto_layout(auto_layout);
-            }
-        }
-
+        self.auto_layout = auto_layout;
         self.copy_options.command = copy_command.clone();
-        if let Some(clipboard) = copy_to_clipboard {
-            self.copy_options.clipboard = clipboard;
-        }
-        if let Some(copy_on_select) = copy_on_select {
-            self.copy_options.copy_on_select = copy_on_select;
+        self.copy_options.copy_on_select = copy_on_select;
+        self.draw_pane_frames = pane_frames;
+        self.default_mode_info.update_arrow_fonts(should_support_arrow_fonts);
+        self.default_mode_info.update_hide_session_name(hide_session_name);
+        if let Some(copy_to_clipboard) = copy_to_clipboard {
+            self.copy_options.clipboard = copy_to_clipboard;
         }
         for tab in self.tabs.values_mut() {
+            tab.update_theme(theme);
+            tab.update_rounded_corners(rounded_corners);
+            tab.update_default_shell(default_shell.clone());
+            tab.update_auto_layout(auto_layout);
             tab.update_copy_options(&self.copy_options);
+            tab.set_pane_frames(pane_frames);
+            tab.update_arrow_fonts(should_support_arrow_fonts);
         }
 
-        
-        if let Some(pane_frames) = pane_frames {
-            self.draw_pane_frames = pane_frames;
-            for tab in self.tabs.values_mut() {
-                tab.set_pane_frames(pane_frames);
-            }
-        }
-
-        if let Some(simplified_ui) = simplified_ui {
-            let should_support_arrow_fonts = !simplified_ui;
-            self.default_mode_info.update_arrow_fonts(should_support_arrow_fonts);
-            for tab in self.tabs.values_mut() {
-                tab.update_arrow_fonts(should_support_arrow_fonts);
-            }
-        }
-
-        if let Some(hide_session_name) = hide_session_name {
-            self.default_mode_info.update_hide_session_name(hide_session_name);
-        }
 
         // client specific configuration
         if self.connected_clients_contains(&client_id) {
@@ -2275,34 +2240,21 @@ impl Screen {
                 .mode_info
                 .entry(client_id)
                 .or_insert_with(|| self.default_mode_info.clone());
-            if let Some(new_keybinds) = new_keybinds {
-                mode_info.update_keybinds(new_keybinds);
-            }
-            if let Some(new_default_mode) = new_default_mode {
-                mode_info.update_default_mode(new_default_mode);
-            }
-            if let Some(theme) = theme {
-                mode_info.update_theme(theme);
-            }
-            if let Some(simplified_ui) = simplified_ui {
-                let should_support_arrow_fonts = !simplified_ui;
-                mode_info.update_arrow_fonts(should_support_arrow_fonts);
-            }
-            if let Some(hide_session_name) = hide_session_name {
-                mode_info.update_hide_session_name(hide_session_name);
-            }
-            if should_update_mode_info {
-                for tab in self.tabs.values_mut() {
-                    tab.change_mode_info(mode_info.clone(), client_id);
-                    tab.mark_active_pane_for_rerender(client_id);
-                }
+            mode_info.update_keybinds(new_keybinds);
+            mode_info.update_default_mode(new_default_mode);
+            mode_info.update_theme(theme);
+            mode_info.update_arrow_fonts(should_support_arrow_fonts);
+            mode_info.update_hide_session_name(hide_session_name);
+            for tab in self.tabs.values_mut() {
+                tab.change_mode_info(mode_info.clone(), client_id);
+                tab.mark_active_pane_for_rerender(client_id);
             }
         }
 
-        if should_update_mode_info {
-            for tab in self.tabs.values_mut() {
-                tab.update_input_modes()?;
-            }
+        // this needs to be done separately at the end because it applies some of the above changes
+        // and propagates them to plugins
+        for tab in self.tabs.values_mut() {
+            tab.update_input_modes()?;
         }
         Ok(())
     }

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -493,7 +493,8 @@ pub trait Pane {
         None
     } // only relevant to terminal panes
     fn update_theme(&mut self, _theme: Palette) {}
-    fn update_arrow_fonts(&mut self, should_support_arrow_fonts: bool) {}
+    fn update_arrow_fonts(&mut self, _should_support_arrow_fonts: bool) {}
+    fn update_rounded_corners(&mut self, _rounded_corners: bool) {}
 }
 
 #[derive(Clone, Debug)]
@@ -3961,6 +3962,14 @@ impl Tab {
             pane.update_theme(theme);
         }
     }
+    pub fn update_rounded_corners(&mut self, rounded_corners: bool) {
+        self.style.rounded_corners = rounded_corners;
+        self.floating_panes.update_pane_rounded_corners(rounded_corners);
+        self.tiled_panes.update_pane_rounded_corners(rounded_corners);
+        for (_, pane) in self.suppressed_panes.values_mut() {
+            pane.update_rounded_corners(rounded_corners);
+        }
+    }
     pub fn update_arrow_fonts(&mut self, should_support_arrow_fonts: bool) {
         self.arrow_fonts = should_support_arrow_fonts;
         self.floating_panes.update_pane_arrow_fonts(should_support_arrow_fonts);
@@ -3971,6 +3980,16 @@ impl Tab {
     }
     pub fn update_default_shell(&mut self, default_shell: Option<PathBuf>) {
         self.default_shell = default_shell;
+    }
+    pub fn update_copy_options(&mut self, copy_options: &CopyOptions) {
+        self.clipboard_provider = match &copy_options.command {
+            Some(command) => ClipboardProvider::Command(CopyCommand::new(command.clone())),
+            None => ClipboardProvider::Osc52(copy_options.clipboard),
+        };
+        self.copy_on_select = copy_options.copy_on_select;
+    }
+    pub fn update_auto_layout(&mut self, auto_layout: bool) {
+        self.auto_layout = auto_layout;
     }
 }
 

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -3964,16 +3964,20 @@ impl Tab {
     }
     pub fn update_rounded_corners(&mut self, rounded_corners: bool) {
         self.style.rounded_corners = rounded_corners;
-        self.floating_panes.update_pane_rounded_corners(rounded_corners);
-        self.tiled_panes.update_pane_rounded_corners(rounded_corners);
+        self.floating_panes
+            .update_pane_rounded_corners(rounded_corners);
+        self.tiled_panes
+            .update_pane_rounded_corners(rounded_corners);
         for (_, pane) in self.suppressed_panes.values_mut() {
             pane.update_rounded_corners(rounded_corners);
         }
     }
     pub fn update_arrow_fonts(&mut self, should_support_arrow_fonts: bool) {
         self.arrow_fonts = should_support_arrow_fonts;
-        self.floating_panes.update_pane_arrow_fonts(should_support_arrow_fonts);
-        self.tiled_panes.update_pane_arrow_fonts(should_support_arrow_fonts);
+        self.floating_panes
+            .update_pane_arrow_fonts(should_support_arrow_fonts);
+        self.tiled_panes
+            .update_pane_arrow_fonts(should_support_arrow_fonts);
         for (_, pane) in self.suppressed_panes.values_mut() {
             pane.update_arrow_fonts(should_support_arrow_fonts);
         }

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -3969,6 +3969,9 @@ impl Tab {
             pane.update_arrow_fonts(should_support_arrow_fonts);
         }
     }
+    pub fn update_default_shell(&mut self, default_shell: Option<PathBuf>) {
+        self.default_shell = default_shell;
+    }
 }
 
 pub fn pane_info_for_pane(pane_id: &PaneId, pane: &Box<dyn Pane>) -> PaneInfo {

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -493,6 +493,7 @@ pub trait Pane {
         None
     } // only relevant to terminal panes
     fn update_theme(&mut self, _theme: Palette) {}
+    fn update_arrow_fonts(&mut self, should_support_arrow_fonts: bool) {}
 }
 
 #[derive(Clone, Debug)]
@@ -3958,6 +3959,14 @@ impl Tab {
         self.tiled_panes.update_pane_themes(theme);
         for (_, pane) in self.suppressed_panes.values_mut() {
             pane.update_theme(theme);
+        }
+    }
+    pub fn update_arrow_fonts(&mut self, should_support_arrow_fonts: bool) {
+        self.arrow_fonts = should_support_arrow_fonts;
+        self.floating_panes.update_pane_arrow_fonts(should_support_arrow_fonts);
+        self.tiled_panes.update_pane_arrow_fonts(should_support_arrow_fonts);
+        for (_, pane) in self.suppressed_panes.values_mut() {
+            pane.update_arrow_fonts(should_support_arrow_fonts);
         }
     }
 }

--- a/zellij-utils/assets/config/default.kdl
+++ b/zellij-utils/assets/config/default.kdl
@@ -209,7 +209,7 @@ plugins {
 }
 
 // Choose what to do when zellij receives SIGTERM, SIGINT, SIGQUIT or SIGHUP
-// eg. when terminal window with an active zellij session is closed
+// eg. when terminal window with an active zellij session is closed (requires restart)
 // Options:
 //   - detach (Default)
 //   - quit

--- a/zellij-utils/assets/config/default.kdl
+++ b/zellij-utils/assets/config/default.kdl
@@ -193,6 +193,8 @@ keybinds {
     }
 }
 
+// Plugin aliases - can be used to change the implementation of Zellij
+// changing these requires a restart to take effect
 plugins {
     tab-bar location="zellij:tab-bar"
     status-bar location="zellij:status-bar"
@@ -209,7 +211,8 @@ plugins {
 }
 
 // Choose what to do when zellij receives SIGTERM, SIGINT, SIGQUIT or SIGHUP
-// eg. when terminal window with an active zellij session is closed (requires restart)
+// eg. when terminal window with an active zellij session is closed
+// (Requires restart)
 // Options:
 //   - detach (Default)
 //   - quit
@@ -247,6 +250,7 @@ plugins {
 // auto_layout true
 
 // Whether sessions should be serialized to the cache folder (including their tabs/panes, cwds and running commands) so that they can later be resurrected
+// (Requires restart)
 // Options:
 //   - true (default)
 //   - false
@@ -254,14 +258,17 @@ plugins {
 // session_serialization false
 
 // Whether pane viewports are serialized along with the session, default is false
+// (Requires restart)
 // Options:
 //   - true
 //   - false (default)
+//
 // serialize_pane_viewport true
 
 // Scrollback lines to serialize along with the pane viewport when serializing sessions, 0
 // defaults to the scrollback size. If this number is higher than the scrollback size, it will
 // also default to the scrollback size. This does nothing if `serialize_pane_viewport` is not true.
+// (Requires restart)
 //
 // scrollback_lines_to_serialize 10000
 
@@ -292,6 +299,7 @@ plugins {
 
 // The name of the default layout to load on startup
 // Default: "default"
+// (Requires restart)
 //
 // default_layout "compact"
 
@@ -303,6 +311,7 @@ plugins {
 // Toggle enabling the mouse mode.
 // On certain configurations, or terminals this could
 // potentially interfere with copying text.
+// (Requires restart)
 // Options:
 //   - true (default)
 //   - false
@@ -312,6 +321,7 @@ plugins {
 // Configure the scroll back buffer size
 // This is the number of lines zellij stores for each pane in the scroll back
 // buffer. Excess number of lines are discarded in a FIFO fashion.
+// (Requires restart)
 // Valid values: positive integers
 // Default value: 10000
 //
@@ -349,31 +359,37 @@ plugins {
 // When attaching to an existing session with other users,
 // should the session be mirrored (true)
 // or should each user have their own cursor (false)
+// (Requires restart)
 // Default: false
 //
 // mirror_session true
 
 // The folder in which Zellij will look for layouts
+// (Requires restart)
 //
 // layout_dir "/path/to/my/layout_dir"
 
 // The folder in which Zellij will look for themes
+// (Requires restart)
 //
 // theme_dir "/path/to/my/theme_dir"
 
 // Enable or disable the rendering of styled and colored underlines (undercurl).
 // May need to be disabled for certain unsupported terminals
+// (Requires restart)
 // Default: true
 //
 // styled_underlines false
 
 // Enable or disable writing of session metadata to disk (if disabled, other sessions might not know
 // metadata info on this session)
+// (Requires restart)
 // Default: false
 //
 // disable_session_metadata true
 
 // Enable or disable support for the enhanced Kitty Keyboard Protocol (the host terminal must also support it)
+// (Requires restart)
 // Default: true (if the host terminal supports it)
 //
 // support_kitty_keyboard_protocol false

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -1178,6 +1178,11 @@ impl ModeInfo {
     pub fn update_theme(&mut self, theme: Palette) {
         self.style.colors = theme;
     }
+    pub fn update_arrow_fonts(&mut self, should_support_arrow_fonts: bool) {
+        // it is honestly quite baffling to me how "arrow_fonts: false" can mean "I support arrow
+        // fonts", but since this is a public API... ¯\_(ツ)_/¯
+        self.capabilities.arrow_fonts = !should_support_arrow_fonts;
+    }
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize, Serialize)]

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -1178,10 +1178,16 @@ impl ModeInfo {
     pub fn update_theme(&mut self, theme: Palette) {
         self.style.colors = theme;
     }
+    pub fn update_rounded_corners(&mut self, rounded_corners: bool) {
+        self.style.rounded_corners = rounded_corners;
+    }
     pub fn update_arrow_fonts(&mut self, should_support_arrow_fonts: bool) {
         // it is honestly quite baffling to me how "arrow_fonts: false" can mean "I support arrow
         // fonts", but since this is a public API... ¯\_(ツ)_/¯
         self.capabilities.arrow_fonts = !should_support_arrow_fonts;
+    }
+    pub fn update_hide_session_name(&mut self, hide_session_name: bool) {
+        self.style.hide_session_name = hide_session_name;
     }
 }
 

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -377,6 +377,7 @@ pub enum PtyContext {
     FillPluginCwd,
     DumpLayoutToPlugin,
     ListClientsMetadata,
+    Reconfigure,
     Exit,
 }
 

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -2427,8 +2427,11 @@ impl Options {
     }
     fn layout_dir_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
         let comment_text = format!(
-            "{}\n{}\n{}",
-            " ", "// The folder in which Zellij will look for layouts", "// ",
+            "{}\n{}\n{}\n{}",
+            " ",
+            "// The folder in which Zellij will look for layouts",
+            "// (Requires restart)",
+            "// ",
         );
 
         let create_node = |node_value: &str| -> KdlNode {
@@ -2452,8 +2455,11 @@ impl Options {
     }
     fn theme_dir_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
         let comment_text = format!(
-            "{}\n{}\n{}",
-            " ", "// The folder in which Zellij will look for themes", "// ",
+            "{}\n{}\n{}\n{}",
+            " ",
+            "// The folder in which Zellij will look for themes",
+            "// (Requires restart)",
+            "// ",
         );
 
         let create_node = |node_value: &str| -> KdlNode {
@@ -2539,11 +2545,12 @@ impl Options {
     }
     fn mirror_session_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
         let comment_text = format!(
-            "{}\n{}\n{}\n{}\n{}\n{}",
+            "{}\n{}\n{}\n{}\n{}\n{}\n{}",
             " ",
             "// When attaching to an existing session with other users,",
             "// should the session be mirrored (true)",
             "// or should each user have their own cursor (false)",
+            "// (Requires restart)",
             "// Default: false",
             "// ",
         );
@@ -2604,11 +2611,12 @@ impl Options {
     }
     fn scroll_buffer_size_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
         let comment_text = format!(
-            "{}\n{}\n{}\n{}\n{}\n{}\n{}",
+            "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
             " ",
             "// Configure the scroll back buffer size",
             "// This is the number of lines zellij stores for each pane in the scroll back",
             "// buffer. Excess number of lines are discarded in a FIFO fashion.",
+            "// (Requires restart)",
             "// Valid values: positive integers",
             "// Default value: 10000",
             "// ",
@@ -2934,10 +2942,11 @@ impl Options {
     }
     fn styled_underlines_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
         let comment_text = format!(
-            "{}\n{}\n{}\n{}\n{}",
+            "{}\n{}\n{}\n{}\n{}\n{}",
             " ",
             "// Enable or disable the rendering of styled and colored underlines (undercurl).",
             "// May need to be disabled for certain unsupported terminals",
+            "// (Requires restart)",
             "// Default: true",
             "// ",
         );
@@ -2987,10 +2996,11 @@ impl Options {
         }
     }
     fn disable_session_metadata_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
-        let comment_text = format!("{}\n{}\n{}\n{}\n{}",
+        let comment_text = format!("{}\n{}\n{}\n{}\n{}\n{}",
             " ",
             "// Enable or disable writing of session metadata to disk (if disabled, other sessions might not know",
             "// metadata info on this session)",
+            "// (Requires restart)",
             "// Default: false",
             "// ",
         );
@@ -3015,9 +3025,10 @@ impl Options {
         }
     }
     fn support_kitty_keyboard_protocol_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
-        let comment_text = format!("{}\n{}\n{}\n{}",
+        let comment_text = format!("{}\n{}\n{}\n{}\n{}",
             " ",
             "// Enable or disable support for the enhanced Kitty Keyboard Protocol (the host terminal must also support it)",
+            "// (Requires restart)",
             "// Default: true (if the host terminal supports it)",
             "// ",
         );
@@ -3626,7 +3637,7 @@ impl Config {
             document.nodes_mut().push(themes);
         }
 
-        let plugins = self.plugins.to_kdl();
+        let plugins = self.plugins.to_kdl(add_comments);
         document.nodes_mut().push(plugins);
 
         if let Some(ui_config) = self.ui.to_kdl() {
@@ -3668,7 +3679,7 @@ impl PluginAliases {
         }
         Ok(PluginAliases { aliases })
     }
-    pub fn to_kdl(&self) -> KdlNode {
+    pub fn to_kdl(&self, add_comments: bool) -> KdlNode {
         let mut plugins = KdlNode::new("plugins");
         let mut plugins_children = KdlDocument::new();
         for (alias_name, plugin_alias) in self.aliases.iter() {
@@ -3706,6 +3717,14 @@ impl PluginAliases {
             plugins_children.nodes_mut().push(plugin_alias_node);
         }
         plugins.set_children(plugins_children);
+
+        if add_comments {
+            plugins.set_leading(format!(
+                "\n{}\n{}\n",
+                "// Plugin aliases - can be used to change the implementation of Zellij",
+                "// changing these requires a restart to take effect",
+            ));
+        }
         plugins
     }
 }
@@ -5148,7 +5167,7 @@ fn plugins_to_string() {
         }"##;
     let document: KdlDocument = fake_config.parse().unwrap();
     let deserialized = PluginAliases::from_kdl(document.get("plugins").unwrap()).unwrap();
-    let serialized = PluginAliases::to_kdl(&deserialized);
+    let serialized = PluginAliases::to_kdl(&deserialized, true);
     let deserialized_from_serialized = PluginAliases::from_kdl(
         serialized
             .to_string()
@@ -5176,7 +5195,7 @@ fn plugins_to_string_with_file_and_web() {
         }"##;
     let document: KdlDocument = fake_config.parse().unwrap();
     let deserialized = PluginAliases::from_kdl(document.get("plugins").unwrap()).unwrap();
-    let serialized = PluginAliases::to_kdl(&deserialized);
+    let serialized = PluginAliases::to_kdl(&deserialized, true);
     let deserialized_from_serialized = PluginAliases::from_kdl(
         serialized
             .to_string()

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -2569,10 +2569,11 @@ impl Options {
     }
     fn on_force_close_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
         let comment_text = format!(
-            "{}\n{}\n{}\n{}\n{}\n{}\n{}",
+            "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
             " ",
             "// Choose what to do when zellij receives SIGTERM, SIGINT, SIGQUIT or SIGHUP",
             "// eg. when terminal window with an active zellij session is closed",
+            "// (Requires restart)",
             "// Options:",
             "//   - detach (Default)",
             "//   - quit",

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__bare_config_from_default_assets_to_string_with_comments.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__bare_config_from_default_assets_to_string_with_comments.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/kdl/mod.rs
-assertion_line: 5422
+assertion_line: 5441
 expression: fake_config_stringified
 ---
 keybinds clear-defaults=true {
@@ -223,6 +223,9 @@ keybinds clear-defaults=true {
         bind "z" { ToggleFocusFullscreen; SwitchToMode "normal"; }
     }
 }
+
+// Plugin aliases - can be used to change the implementation of Zellij
+// changing these requires a restart to take effect
 plugins {
     compact-bar location="zellij:compact-bar"
     configuration location="zellij:configuration"
@@ -270,10 +273,12 @@ plugins {
 // default_layout "compact"
  
 // The folder in which Zellij will look for layouts
+// (Requires restart)
 // 
 // layout_dir "/tmp"
  
 // The folder in which Zellij will look for themes
+// (Requires restart)
 // 
 // theme_dir "/tmp"
  
@@ -296,6 +301,7 @@ plugins {
 // When attaching to an existing session with other users,
 // should the session be mirrored (true)
 // or should each user have their own cursor (false)
+// (Requires restart)
 // Default: false
 // 
 // mirror_session true
@@ -312,6 +318,7 @@ plugins {
 // Configure the scroll back buffer size
 // This is the number of lines zellij stores for each pane in the scroll back
 // buffer. Excess number of lines are discarded in a FIFO fashion.
+// (Requires restart)
 // Valid values: positive integers
 // Default value: 10000
 // 
@@ -389,6 +396,7 @@ plugins {
  
 // Enable or disable the rendering of styled and colored underlines (undercurl).
 // May need to be disabled for certain unsupported terminals
+// (Requires restart)
 // Default: true
 // 
 // styled_underlines false
@@ -399,11 +407,13 @@ plugins {
  
 // Enable or disable writing of session metadata to disk (if disabled, other sessions might not know
 // metadata info on this session)
+// (Requires restart)
 // Default: false
 // 
 // disable_session_metadata false
  
 // Enable or disable support for the enhanced Kitty Keyboard Protocol (the host terminal must also support it)
+// (Requires restart)
 // Default: true (if the host terminal supports it)
 // 
 // support_kitty_keyboard_protocol false

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__bare_config_from_default_assets_to_string_with_comments.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__bare_config_from_default_assets_to_string_with_comments.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/kdl/mod.rs
-assertion_line: 5069
+assertion_line: 5422
 expression: fake_config_stringified
 ---
 keybinds clear-defaults=true {
@@ -302,6 +302,7 @@ plugins {
  
 // Choose what to do when zellij receives SIGTERM, SIGINT, SIGQUIT or SIGHUP
 // eg. when terminal window with an active zellij session is closed
+// (Requires restart)
 // Options:
 //   - detach (Default)
 //   - quit

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__config_options_to_string_with_comments.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__config_options_to_string_with_comments.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/kdl/mod.rs
-assertion_line: 4987
+assertion_line: 5361
 expression: fake_document.to_string()
 ---
  
@@ -68,6 +68,7 @@ mirror_session true
  
 // Choose what to do when zellij receives SIGTERM, SIGINT, SIGQUIT or SIGHUP
 // eg. when terminal window with an active zellij session is closed
+// (Requires restart)
 // Options:
 //   - detach (Default)
 //   - quit

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__config_options_to_string_with_comments.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__config_options_to_string_with_comments.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-utils/src/kdl/mod.rs
-assertion_line: 5361
+assertion_line: 5380
 expression: fake_document.to_string()
 ---
  
@@ -36,10 +36,12 @@ default_cwd "/tmp/foo"
 default_layout "compact"
  
 // The folder in which Zellij will look for layouts
+// (Requires restart)
 // 
 layout_dir "/tmp/layouts"
  
 // The folder in which Zellij will look for themes
+// (Requires restart)
 // 
 theme_dir "/tmp/themes"
  
@@ -62,6 +64,7 @@ pane_frames false
 // When attaching to an existing session with other users,
 // should the session be mirrored (true)
 // or should each user have their own cursor (false)
+// (Requires restart)
 // Default: false
 // 
 mirror_session true
@@ -78,6 +81,7 @@ on_force_close "quit"
 // Configure the scroll back buffer size
 // This is the number of lines zellij stores for each pane in the scroll back
 // buffer. Excess number of lines are discarded in a FIFO fashion.
+// (Requires restart)
 // Valid values: positive integers
 // Default value: 10000
 // 
@@ -155,6 +159,7 @@ scrollback_lines_to_serialize 1000
  
 // Enable or disable the rendering of styled and colored underlines (undercurl).
 // May need to be disabled for certain unsupported terminals
+// (Requires restart)
 // Default: true
 // 
 styled_underlines false
@@ -165,11 +170,13 @@ serialization_interval 1
  
 // Enable or disable writing of session metadata to disk (if disabled, other sessions might not know
 // metadata info on this session)
+// (Requires restart)
 // Default: false
 // 
 disable_session_metadata true
  
 // Enable or disable support for the enhanced Kitty Keyboard Protocol (the host terminal must also support it)
+// (Requires restart)
 // Default: true (if the host terminal supports it)
 // 
 support_kitty_keyboard_protocol false

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__plugins_to_string.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__plugins_to_string.snap
@@ -1,8 +1,11 @@
 ---
 source: zellij-utils/src/kdl/mod.rs
-assertion_line: 3874
+assertion_line: 5184
 expression: serialized.to_string()
 ---
+
+// Plugin aliases - can be used to change the implementation of Zellij
+// changing these requires a restart to take effect
 plugins {
     compact-bar location="zellij:compact-bar"
     filepicker location="zellij:strider" {

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__plugins_to_string_with_file_and_web.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__plugins_to_string_with_file_and_web.snap
@@ -1,8 +1,11 @@
 ---
 source: zellij-utils/src/kdl/mod.rs
-assertion_line: 3891
+assertion_line: 5212
 expression: serialized.to_string()
 ---
+
+// Plugin aliases - can be used to change the implementation of Zellij
+// changing these requires a restart to take effect
 plugins {
     filepicker location="file:/path/to/my/plugin.wasm" {
         cwd "/"


### PR DESCRIPTION
This concludes the work began in https://github.com/zellij-org/zellij/pull/3558 and continued in https://github.com/zellij-org/zellij/pull/3559, to now allow reloading everything defined in the config at runtime with a few notable exceptions (see below).

## What now also works (can be reloaded at runtime from the config or changed from a plugin)
* Reloading `simplified_ui` (i.e. changing arrow font support)
* Reloading `default_shell`
* Reloading `pane_frames`
* Reloading `copy_command` (i.e. clipboard replacement for terminals not supporting OSC52)
* Reloading `copy_to_clipboard` (i.e. the clipboard destination)
* Reloading `copy_on_select`
* Reloading `auto_layout`
* Reloading `rounded_corners`
* Reloading `hide_session_name`
* Reloading `scrollback_editor`

## What still requires a restart
Most of these were not worked on due to some internal limitations that would have required considerable development to get around. I deemed these to be high-effort/low-reward and will look into implementing hot-reloading for them as well if there's a need I missed while making this judgement call.

* The `plugins` (plugin aliases) - this is because it has not yet been decided whether reloading these should reload the existing plugins loaded with aliases or not. More thought needs to be devoted to the best behavior in this context.
* `on_force_close` - due to internal limitations
* `session_serialization`, `serialize_pane_viewport`, `scrollback_lines_to_serialize` - due to internal limitations
* `default_layout` - this requires some reworking of the layout implementation inside Zellij
* `mouse_mode` - currently being worked on in a different context
* `scroll_buffer_size` - due to internal limitations
* `mirror_session` - does not make sense as this only applies to new sessions
* `layout_dir`, `theme_dir` - due to internal limitations
* `styled_underlines` - does not make a lot of sense to change without finer control of scrollback
* `disable_session_metadata` - due to internal limitations
* `support_kitty_keyboard_protocol` - due to internal limitations