### PR TITLE
refactor(themes): adjust `catppuccin-latte` & add comments

### DIFF
--- a/zellij-utils/assets/themes/catppuccin.kdl
+++ b/zellij-utils/assets/themes/catppuccin.kdl
@@ -4,7 +4,7 @@
 themes {
   catppuccin-latte {
     bg "#acb0be" // Surface2
-    fg "#acb0be" // Surface2
+    fg "#4c4f69" // Text
     red "#d20f39"
     green "#40a02b"
     blue "#1e66f5"
@@ -12,13 +12,13 @@ themes {
     magenta "#ea76cb" // Pink
     orange "#fe640b" // Peach
     cyan "#04a5e5" // Sky
-    black "#dce0e8" // Crust
+    black "#e6e9ef" // Mantle
     white "#4c4f69" // Text
   }
 
   catppuccin-frappe {
     bg "#626880" // Surface2
-    fg "#c6d0f5"
+    fg "#c6d0f5" // Text
     red "#e78284"
     green "#a6d189"
     blue "#8caaee"
@@ -27,12 +27,12 @@ themes {
     orange "#ef9f76" // Peach
     cyan "#99d1db" // Sky
     black "#292c3c" // Mantle
-    white "#c6d0f5"
+    white "#c6d0f5" // Text
   }
 
   catppuccin-macchiato {
     bg "#5b6078" // Surface2
-    fg "#cad3f5"
+    fg "#cad3f5" // Text
     red "#ed8796"
     green "#a6da95"
     blue "#8aadf4"
@@ -41,12 +41,12 @@ themes {
     orange "#f5a97f" // Peach
     cyan "#91d7e3" // Sky
     black "#1e2030" // Mantle
-    white "#cad3f5"
+    white "#cad3f5" // Text
   }
 
   catppuccin-mocha {
     bg "#585b70" // Surface2
-    fg "#cdd6f4"
+    fg "#cdd6f4" // Text
     red "#f38ba8"
     green "#a6e3a1"
     blue "#89b4fa"
@@ -55,6 +55,6 @@ themes {
     orange "#fab387" // Peach
     cyan "#89dceb" // Sky
     black "#181825" // Mantle
-    white "#cdd6f4"
+    white "#cdd6f4" // Text
   }
 }


### PR DESCRIPTION
Hey :wave:, this PR introduces some changes as part of merging https://github.com/catppuccin/zellij/pull/11 downstream.

We noticed that the `fg` and `bg` keys for `catppuccin-latte` were the same which seemed incorrect, however, we couldn't find any noticeable changes on the UI when changing these keys. I'd appreciate any insight into why the theme seemed to function well even with the foreground and background keys set to the same colour.

I've also added comments to map `white` and `fg` to the Catppuccin palette colour of `text`. 

Hope these changes are fine and let me know if there's anything else I need to edit, thanks!