### PR TITLE
fix(resurrection): various serialization issues

### DIFF
--- a/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_multiple_tabs.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_multiple_tabs.snap
@@ -1,0 +1,16 @@
+---
+source: zellij-utils/src/session_serialization.rs
+assertion_line: 2025
+expression: kdl.0
+---
+layout {
+    tab name="First tab" {
+    }
+    tab name="Second tab" {
+        pane split_direction="vertical" {
+            pane size=10
+            pane size=10
+        }
+    }
+}
+

--- a/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_new_tab_template.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_new_tab_template.snap
@@ -1,0 +1,20 @@
+---
+source: zellij-utils/src/session_serialization.rs
+assertion_line: 2047
+expression: kdl.0
+---
+layout {
+    new_tab_template {
+        pane
+        pane
+        floating_panes {
+            pane {
+            }
+            pane {
+            }
+            pane {
+            }
+        }
+    }
+}
+

--- a/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_swap_floating_panes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_swap_floating_panes.snap
@@ -1,0 +1,76 @@
+---
+source: zellij-utils/src/session_serialization.rs
+assertion_line: 2111
+expression: kdl.0
+---
+layout {
+    swap_floating_layout {
+        floating_panes max_panes=1 {
+            pane {
+            }
+            pane {
+            }
+            pane {
+            }
+        }
+        floating_panes min_panes=1 {
+            pane {
+            }
+            pane {
+            }
+            pane {
+            }
+        }
+        floating_panes exact_panes=1 {
+            pane {
+            }
+            pane {
+            }
+            pane {
+            }
+        }
+        floating_panes {
+            pane {
+            }
+            pane {
+            }
+            pane {
+            }
+        }
+    }
+    swap_floating_layout name="swap_floating_layout_2" {
+        floating_panes max_panes=2 {
+            pane {
+            }
+            pane {
+            }
+            pane {
+            }
+        }
+        floating_panes min_panes=2 {
+            pane {
+            }
+            pane {
+            }
+            pane {
+            }
+        }
+        floating_panes exact_panes=2 {
+            pane {
+            }
+            pane {
+            }
+            pane {
+            }
+        }
+        floating_panes {
+            pane {
+            }
+            pane {
+            }
+            pane {
+            }
+        }
+    }
+}
+

--- a/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_swap_tiled_panes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_swap_tiled_panes.snap
@@ -1,0 +1,44 @@
+---
+source: zellij-utils/src/session_serialization.rs
+assertion_line: 2079
+expression: kdl.0
+---
+layout {
+    swap_tiled_layout {
+        tab max_panes=1 {
+            pane
+            pane
+        }
+        tab min_panes=1 {
+            pane
+            pane
+        }
+        tab exact_panes=1 {
+            pane
+            pane
+        }
+        tab {
+            pane
+            pane
+        }
+    }
+    swap_tiled_layout name="swap_tiled_layout_2" {
+        tab max_panes=2 {
+            pane
+            pane
+        }
+        tab min_panes=2 {
+            pane
+            pane
+        }
+        tab exact_panes=2 {
+            pane
+            pane
+        }
+        tab {
+            pane
+            pane
+        }
+    }
+}
+

--- a/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_tab_focus.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_tab_focus.snap
@@ -1,0 +1,10 @@
+---
+source: zellij-utils/src/session_serialization.rs
+assertion_line: 1654
+expression: kdl.0
+---
+layout {
+    tab name="Tab #1" focus=true {
+    }
+}
+

--- a/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_tab_hide_floating_panes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_tab_hide_floating_panes.snap
@@ -1,0 +1,10 @@
+---
+source: zellij-utils/src/session_serialization.rs
+assertion_line: 1667
+expression: kdl.0
+---
+layout {
+    tab name="Tab #1" hide_floating_panes=true {
+    }
+}
+

--- a/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_tab_name.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_tab_name.snap
@@ -1,0 +1,10 @@
+---
+source: zellij-utils/src/session_serialization.rs
+assertion_line: 1641
+expression: kdl.0
+---
+layout {
+    tab name="my \"tab \\name" {
+    }
+}
+

--- a/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_tab_with_floating_panes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_tab_with_floating_panes.snap
@@ -1,0 +1,74 @@
+---
+source: zellij-utils/src/session_serialization.rs
+assertion_line: 1929
+expression: kdl.0
+---
+layout {
+    tab name="Tab with \"floating panes\"" {
+        floating_panes {
+            pane {
+                height 10
+                width 10
+                x 0
+                y 0
+            }
+            pane cwd="/tmp/\"my/cool cwd" {
+                height 10
+                width 10
+                x 0
+                y 10
+            }
+            pane edit="/tmp/\"my/cool cwd/my-file" {
+                height 10
+                width 10
+                x 0
+                y 20
+            }
+            pane command="/tmp/\"my/cool cwd/command.sh" {
+                start_suspended true
+                height 10
+                width 10
+                x 0
+                y 30
+            }
+            pane command="/tmp/\"my/cool cwd/command.sh" {
+                start_suspended true
+                height 10
+                width 10
+                x 0
+                y 40
+                args "--arg1" "arg\"2" "arg > \\3"
+            }
+            pane {
+                height 10
+                width 10
+                x 0
+                y 50
+                plugin location="file:/tmp/\"my/cool cwd/plugin.wasm"
+            }
+            pane {
+                height 10
+                width 10
+                x 0
+                y 60
+                plugin location="file:/tmp/\"my/cool cwd/plugin.wasm" {
+                    "key 1\"\\" "val 1\"\\"
+                    "key 2\"\\" "val 2\"\\"
+                }
+            }
+            pane {
+                height 10
+                width 10
+                x 0
+                y 70
+            }
+            pane name="my cool \\ \"pane_title\"" focus=true contents_file="initial_contents_1" {
+                height 10
+                width 10
+                x 0
+                y 80
+            }
+        }
+    }
+}
+

--- a/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_tab_with_stacked_panes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_tab_with_stacked_panes.snap
@@ -1,0 +1,15 @@
+---
+source: zellij-utils/src/session_serialization.rs
+assertion_line: 1973
+expression: kdl.0
+---
+layout {
+    tab name="Tab with \"stacked panes\"" {
+        pane stacked=true {
+            pane
+            pane expanded=true
+            pane
+        }
+    }
+}
+

--- a/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_tab_with_tiled_panes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_tab_with_tiled_panes.snap
@@ -1,0 +1,31 @@
+---
+source: zellij-utils/src/session_serialization.rs
+assertion_line: 1799
+expression: kdl.0
+---
+layout {
+    tab name="Tab with \"tiled panes\"" {
+        pane size=10
+        pane cwd="/tmp/\"my/cool cwd" size=10
+        pane edit="/tmp/\"my/cool cwd/my-file" size=10
+        pane command="/tmp/\"my/cool cwd/command.sh" size=10 {
+            start_suspended true
+        }
+        pane command="/tmp/\"my/cool cwd/command.sh" size=10 {
+            args "--arg1" "arg\"2" "arg > \\3"
+            start_suspended true
+        }
+        pane size=10 {
+            plugin location="file:/tmp/\"my/cool cwd/plugin.wasm"
+        }
+        pane size=10 {
+            plugin location="file:/tmp/\"my/cool cwd/plugin.wasm" {
+                "key 1\"\\" "val 1\"\\"
+                "key 2\"\\" "val 2\"\\"
+            }
+        }
+        pane size=10 borderless=true
+        pane name="my cool \\ \"pane_title\"" focus=true contents_file="initial_contents_1" size=10
+    }
+}
+

--- a/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__global_cwd.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__global_cwd.snap
@@ -1,0 +1,9 @@
+---
+source: zellij-utils/src/session_serialization.rs
+assertion_line: 1168
+expression: kdl.0
+---
+layout {
+    cwd "/path/to/m\"y/global cwd"
+}
+


### PR DESCRIPTION
This fixes various serialization issues in regards to the session resurrection feature. Previously, we relied on our hand-rolled serialization of the session layout and metadata to disk. Now we use `kdl-rs` to do the serialization part after we've done the encoding.

This addresses lots of issues where sessions would not be resurrected properly.