### PR TITLE
fix(ui): various pane name fixes

### DIFF
--- a/default-plugins/configuration/src/main.rs
+++ b/default-plugins/configuration/src/main.rs
@@ -64,38 +64,22 @@ impl ZellijPlugin for State {
             .map(|v| v == "true")
             .unwrap_or(false);
         self.userspace_configuration = configuration;
-        // we need the ReadApplicationState permission to receive the ModeUpdate and TabUpdate
-        // events
-        // we need the RunCommands permission to run "cargo test" in a floating window
-        request_permission(&[
-            PermissionType::ReadApplicationState,
-            PermissionType::RunCommands,
-            PermissionType::ReadCliPipes,
-            PermissionType::MessageAndLaunchOtherPlugins,
-            PermissionType::Reconfigure,
-            PermissionType::ChangeApplicationState,
-        ]);
-        subscribe(&[
-            EventType::PermissionRequestResult,
-            EventType::Key,
-            EventType::FailedToWriteConfigToDisk,
-        ]);
+        subscribe(&[EventType::Key, EventType::FailedToWriteConfigToDisk]);
+        let own_plugin_id = get_plugin_ids().plugin_id;
         if self.is_setup_wizard {
             self.ui_size = 18;
             self.selected_index = Some(0);
-            let own_plugin_id = get_plugin_ids().plugin_id;
             rename_plugin_pane(own_plugin_id, "First Run Setup Wizard (Step 1/1)");
             resize_focused_pane(Resize::Increase);
             resize_focused_pane(Resize::Increase);
             resize_focused_pane(Resize::Increase);
+        } else {
+            rename_plugin_pane(own_plugin_id, "Configuration");
         }
     }
     fn update(&mut self, event: Event) -> bool {
         let mut should_render = false;
         match event {
-            Event::PermissionRequestResult(_) => {
-                should_render = true;
-            },
             Event::Key(key) => {
                 if self.remapping_leaders {
                     should_render = self.handle_remapping_screen_key(key);

--- a/default-plugins/plugin-manager/src/main.rs
+++ b/default-plugins/plugin-manager/src/main.rs
@@ -486,8 +486,9 @@ impl ZellijPlugin for State {
             EventType::TabUpdate,
             EventType::Key,
             EventType::SessionUpdate,
-            EventType::PermissionRequestResult,
         ]);
+        let own_plugin_id = get_plugin_ids().plugin_id;
+        rename_plugin_pane(own_plugin_id, "Plugin Manager");
     }
     fn pipe(&mut self, pipe_message: PipeMessage) -> bool {
         if pipe_message.name == "filepicker_result" {
@@ -523,11 +524,6 @@ impl ZellijPlugin for State {
     fn update(&mut self, event: Event) -> bool {
         let mut should_render = false;
         match event {
-            Event::PermissionRequestResult(_) => {
-                let own_plugin_id = get_plugin_ids().plugin_id;
-                rename_plugin_pane(own_plugin_id, "Plugin Manager");
-                should_render = true;
-            },
             Event::SessionUpdate(live_sessions, _dead_sessions) => {
                 for session in live_sessions {
                     if session.is_current_session {


### PR DESCRIPTION
This fixes:
1. An issue that prevented plugin panes from being renamed
2. The plugin manager now properly sets its title
3. The Configuration now properly sets its title