### PR TITLE
fix(ux): only damage the relevant swap layout layer when resizing panes

### DIFF
--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -2312,19 +2312,20 @@ impl Tab {
     }
     pub fn resize(&mut self, client_id: ClientId, strategy: ResizeStrategy) -> Result<()> {
         let err_context = || format!("unable to resize pane");
-        self.swap_layouts.set_is_floating_damaged();
-        self.swap_layouts.set_is_tiled_damaged();
         if self.floating_panes.panes_are_visible() {
             let successfully_resized = self
                 .floating_panes
                 .resize_active_pane(client_id, &mut self.os_api, &strategy)
                 .with_context(err_context)?;
             if successfully_resized {
+                self.swap_layouts.set_is_floating_damaged();
                 self.set_force_render(); // we force render here to make sure the panes under the floating pane render and don't leave "garbage" in case of a decrease
             }
         } else {
             match self.tiled_panes.resize_active_pane(client_id, &strategy) {
-                Ok(_) => {},
+                Ok(_) => {
+                    self.swap_layouts.set_is_tiled_damaged();
+                },
                 Err(err) => match err.downcast_ref::<ZellijError>() {
                     Some(ZellijError::CantResizeFixedPanes { pane_ids }) => {
                         let mut pane_ids_to_error = vec![];


### PR DESCRIPTION
This fixes an issue where when resizing panes we would set both the tiled and swap layout to "damaged", whereas we should only set the relevant layer (tiled for resizing tiled panes, floating for resizing floating panes).

The user-facing effect of this was that (for example) after resizing a floating pane, when opening new tiled panes they would be added in a "best effort" way rather than following the swap layouts and arranging themselves "nicely" on screen.