### PR TITLE
fix(ui): set background color for UI components according to theme

### DIFF
--- a/zellij-server/src/ui/components/table.rs
+++ b/zellij-server/src/ui/components/table.rs
@@ -40,7 +40,8 @@ pub fn table(
             }
             // here we intentionally don't pass our coordinates even if we have them, because
             // these cells have already been padded and truncated
-            let (text, _text_width) = stringify_text(&cell, None, &None, style, text_style);
+            let (text, _text_width) =
+                stringify_text(&cell, None, &None, style, text_style, cell.selected);
             stringified.push_str(&format!("{}{}{} ", text_style, text, reset_styles_for_item));
         }
         let next_row_instruction = coordinates

--- a/zellij-utils/assets/themes/catppuccin.kdl
+++ b/zellij-utils/assets/themes/catppuccin.kdl
@@ -4,7 +4,7 @@
 themes {
   catppuccin-latte {
     bg "#acb0be" // Surface2
-    fg "#acb0be" // Surface2
+    fg "#5c5f77" // Subtext1
     red "#d20f39"
     green "#40a02b"
     blue "#1e66f5"


### PR DESCRIPTION
This fixes a minor issue in the UI components where `Text` and its various consumers would not set the theme background as their background - causing the UI to look a bit disjointed at times.