### PR TITLE
fix(ux): make sure esc works as expected in unlock-first

### DIFF
--- a/default-plugins/configuration/src/main.rs
+++ b/default-plugins/configuration/src/main.rs
@@ -1291,6 +1291,9 @@ keybinds clear-defaults=true {{
         bind "{primary_modifier} g" {{ SwitchToMode "Locked"; }}
         bind "{primary_modifier} q" {{ Quit; }}
     }}
+    shared_except "renamepane" "renametab" "entersearch" {{
+        bind "esc" {{ SwitchToMode "locked"; }}
+    }}
     shared_among "normal" "locked" {{
         bind "{secondary_modifier} n" {{ NewPane; }}
         bind "{secondary_modifier} f" {{ ToggleFloatingPanes; }}

--- a/default-plugins/configuration/src/main.rs
+++ b/default-plugins/configuration/src/main.rs
@@ -1291,7 +1291,7 @@ keybinds clear-defaults=true {{
         bind "{primary_modifier} g" {{ SwitchToMode "Locked"; }}
         bind "{primary_modifier} q" {{ Quit; }}
     }}
-    shared_except "renamepane" "renametab" "entersearch" {{
+    shared_except "renamepane" "renametab" "entersearch" "locked" {{
         bind "esc" {{ SwitchToMode "locked"; }}
     }}
     shared_among "normal" "locked" {{


### PR DESCRIPTION
Make sure `ESC` always drops us back to our base more (was the case in all keybinding presets except the new unlock-first one).