### PR TITLE
fix(plugins): handle concurrent http downloads

### DIFF
--- a/zellij-utils/src/downloader.rs
+++ b/zellij-utils/src/downloader.rs
@@ -1,3 +1,4 @@
+use async_std::sync::Mutex;
 use async_std::{
     fs,
     io::{ReadExt, WriteExt},
@@ -5,7 +6,9 @@ use async_std::{
 };
 use isahc::prelude::*;
 use isahc::{config::RedirectPolicy, HttpClient, Request};
+use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::Arc;
 use thiserror::Error;
 use url::Url;
 
@@ -17,16 +20,22 @@ pub enum DownloaderError {
     HttpError(#[from] isahc::http::Error),
     #[error("IoError: {0}")]
     Io(#[source] std::io::Error),
+    #[error("StdIoError: {0}")]
+    StdIoError(#[from] std::io::Error),
     #[error("File name cannot be found in URL: {0}")]
     NotFoundFileName(String),
     #[error("Failed to parse URL body: {0}")]
     InvalidUrlBody(String),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Downloader {
     client: Option<HttpClient>,
     location: PathBuf,
+    // the whole thing is an Arc/Mutex so that Downloader is thread safe, and the individual values of
+    // the HashMap are Arc/Mutexes (Mutexi?) to represent that individual downloads should not
+    // happen concurrently
+    download_locks: Arc<Mutex<HashMap<String, Arc<Mutex<()>>>>>,
 }
 
 impl Default for Downloader {
@@ -38,6 +47,7 @@ impl Default for Downloader {
                 .build()
                 .ok(),
             location: PathBuf::from(""),
+            download_locks: Default::default(),
         }
     }
 }
@@ -51,6 +61,7 @@ impl Downloader {
                 .build()
                 .ok(),
             location,
+            download_locks: Default::default(),
         }
     }
 
@@ -67,6 +78,14 @@ impl Downloader {
             Some(name) => name.to_string(),
             None => self.parse_name(url)?,
         };
+
+        // we do this to make sure only one download of a specific url is happening at a time
+        // otherwise the downloads corrupt each other (and we waste lots of system resources)
+        let download_lock = self.acquire_download_lock(&file_name).await;
+        // it's important that _lock remains in scope, otherwise it gets dropped and the lock is
+        // released before the download is complete
+        let _lock = download_lock.lock().await;
+
         let file_path = self.location.join(file_name.as_str());
         if file_path.exists() {
             log::debug!("File already exists: {:?}", file_path);
@@ -156,6 +175,13 @@ impl Downloader {
             .last()
             .ok_or_else(|| DownloaderError::NotFoundFileName(url.to_string()))
             .map(|s| s.to_string())
+    }
+    async fn acquire_download_lock(&self, file_name: &String) -> Arc<Mutex<()>> {
+        let mut lock_dict = self.download_locks.lock().await;
+        let download_lock = lock_dict
+            .entry(file_name.clone())
+            .or_insert_with(|| Default::default());
+        download_lock.clone()
     }
 }
 


### PR DESCRIPTION
This should hopefully fix https://github.com/zellij-org/zellij/issues/3479

Previously, if loading the same plugin multiple times from a remote URL - the downloads would each cache to the same file on the HD and corrupt each other.

This solves the problem by creating a concurrent locking mechanism, making sure there's only one download of the same URL happening at the same time.