### PR TITLE
fix(plugins): various plugin api and other fixes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod tests;
 use zellij_utils::{
     clap::Parser,
     cli::{CliAction, CliArgs, Command, Sessions},
+    consts::create_config_and_cache_folders,
     envs,
     input::config::Config,
     logging::*,
@@ -14,6 +15,7 @@ use zellij_utils::{
 
 fn main() {
     configure_logger();
+    create_config_and_cache_folders();
     let opts = CliArgs::parse();
 
     {

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -712,6 +712,15 @@ impl FloatingPanes {
         self.set_force_render();
     }
     pub fn focus_pane(&mut self, pane_id: PaneId, client_id: ClientId) {
+        let pane_is_selectable = self
+            .panes
+            .get(&pane_id)
+            .map(|p| p.selectable())
+            .unwrap_or(false);
+        if !pane_is_selectable {
+            log::error!("Cannot focus pane {:?} as it is not selectable!", pane_id);
+            return;
+        }
         self.active_panes
             .insert(client_id, pane_id, &mut self.panes);
         self.focus_pane_for_all_clients(pane_id);

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -524,6 +524,15 @@ impl TiledPanes {
         }
     }
     pub fn focus_pane(&mut self, pane_id: PaneId, client_id: ClientId) {
+        let pane_is_selectable = self
+            .panes
+            .get(&pane_id)
+            .map(|p| p.selectable())
+            .unwrap_or(false);
+        if !pane_is_selectable {
+            log::error!("Cannot focus pane {:?} as it is not selectable!", pane_id);
+            return;
+        }
         if self.panes_to_hide.contains(&pane_id) {
             // this means there is a fullscreen pane that is not the current pane, let's unset it
             // before changing focus

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -4105,7 +4105,8 @@ impl Tab {
                 focused_floating_pane
             })
             .or_else(|_| match self.suppressed_panes.remove(&pane_id) {
-                Some(pane) => {
+                Some(mut pane) => {
+                    pane.1.set_selectable(true);
                     if should_float {
                         self.show_floating_panes();
                         self.add_floating_pane(pane.1, pane_id, None, Some(client_id))

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -1,5 +1,6 @@
 //! Zellij program-wide constants.
 
+use crate::home::find_default_config_dir;
 use directories::ProjectDirs;
 use include_dir::{include_dir, Dir};
 use lazy_static::lazy_static;
@@ -30,6 +31,22 @@ pub fn session_layout_cache_file_name(session_name: &str) -> PathBuf {
 
 pub fn session_info_folder_for_session(session_name: &str) -> PathBuf {
     ZELLIJ_SESSION_INFO_CACHE_DIR.join(session_name)
+}
+
+pub fn create_config_and_cache_folders() {
+    if let Err(e) = std::fs::create_dir_all(&ZELLIJ_CACHE_DIR.as_path()) {
+        log::error!("Failed to create cache dir: {:?}", e);
+    }
+    if let Some(config_dir) = find_default_config_dir() {
+        if let Err(e) = std::fs::create_dir_all(&config_dir.as_path()) {
+            log::error!("Failed to create config dir: {:?}", e);
+        }
+    }
+    // while session_info is a child of cache currently, it won't necessarily always be this way,
+    // and so it's explicitly created here
+    if let Err(e) = std::fs::create_dir_all(&ZELLIJ_SESSION_INFO_CACHE_DIR.as_path()) {
+        log::error!("Failed to create session_info cache dir: {:?}", e);
+    }
 }
 
 const fn system_default_data_dir() -> &'static str {

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -741,16 +741,6 @@ impl Action {
                 &run_plugin_or_alias.location_string() == plugin_url
             },
             Action::LaunchOrFocusPlugin(run_plugin_or_alias, ..) => {
-                log::info!(
-                    "2: {:?} == {:?}",
-                    run_plugin_or_alias.location_string(),
-                    plugin_url
-                );
-                eprintln!(
-                    "2: {:?} == {:?}",
-                    run_plugin_or_alias.location_string(),
-                    plugin_url
-                );
                 &run_plugin_or_alias.location_string() == plugin_url
             },
             _ => false,


### PR DESCRIPTION
This fixes:
1. Plugins can now no-longer make unselectable panes selectable
2. We now make sure the cache/config folders are created on app start (this prevents some races with the http downloading client).