### PR TITLE
fix(plugins): force use curl system lib on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5128,6 +5128,7 @@ dependencies = [
  "colorsys",
  "common-path",
  "crossbeam",
+ "curl-sys",
  "directories",
  "expect-test",
  "futures",

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -58,6 +58,7 @@ humantime = "2.1.0"
 futures = "0.3.28"
 openssl-sys = { version = "0.9.93", features = ["vendored"] }
 isahc = "1.7.2"
+curl-sys = { version = "0.4", features = ["force-system-lib-on-osx"] }
 
 [dev-dependencies]
 insta = { version = "1.6.0", features = ["backtrace"] }


### PR DESCRIPTION
There were in the past some problems with downloading plugins via HTTPS on macOS (https://github.com/zellij-org/zellij/issues/3036#issuecomment-2024214955, https://github.com/zellij-org/zellij/issues/3479#issuecomment-2407490553).

The cause is, that curl is not properly recognised when building zellij, especially after the latest changes to the isahc crate in favour of surf. This results in zellij not being linked to `libcurl`, which utilises some other dependencies in the background to implement the functionality, that results in crashes for certain scenarios. 

This pull request fixes the issue, as it forces `curl-sys` to use system libs of macOS instead of choosing it on its own. On my macOS with nix as build environment and in a VM with curl installed via brew, the issue is fixed and zellij is not crashing anymore.

In case there are some errors on linux, even though it was tested, we could introduce a target selector (`[target.'cfg(target_os = "macos")'.dependencies]`).