### PR TITLE
fix(plugins): allow switching to a new session with cwd without specifying a layout

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -483,6 +483,10 @@ pub(crate) fn start_client(opts: CliArgs) {
                         log::error!("Failed to parse new session layout: {:?}", e);
                     },
                 }
+            } else {
+                if let Some(cwd) = reconnect_to_session.cwd.as_ref() {
+                    config_options.default_cwd = Some(cwd.clone());
+                }
             }
 
             is_a_reconnect = true;

--- a/zellij-server/src/plugins/mod.rs
+++ b/zellij-server/src/plugins/mod.rs
@@ -426,9 +426,13 @@ pub(crate) fn plugin_thread_main(
 
                 let mut plugin_ids: HashMap<RunPluginOrAlias, Vec<PluginId>> = HashMap::new();
                 tab_layout = tab_layout.or_else(|| Some(layout.new_tab().0));
-                tab_layout
-                    .as_mut()
-                    .map(|t| t.populate_plugin_aliases_in_layout(&plugin_aliases));
+                tab_layout.as_mut().map(|t| {
+                    t.populate_plugin_aliases_in_layout(&plugin_aliases);
+                    if let Some(cwd) = cwd.as_ref() {
+                        t.add_cwd_to_layout(cwd);
+                    }
+                    t
+                });
                 floating_panes_layout.iter_mut().for_each(|f| {
                     f.run
                         .as_mut()

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -721,6 +721,18 @@ pub fn switch_session_with_layout(name: Option<&str>, layout: LayoutInfo, cwd: O
     unsafe { host_run_plugin_command() };
 }
 
+/// Switch to a session with the given name, create one if no name is given
+pub fn switch_session_with_cwd(name: Option<&str>, cwd: Option<PathBuf>) {
+    let plugin_command = PluginCommand::SwitchSession(ConnectToSession {
+        name: name.map(|n| n.to_string()),
+        cwd,
+        ..Default::default()
+    });
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
 /// Switch to a session with the given name, focusing either the provided pane_id or the provided
 /// tab position (in that order)
 pub fn switch_session_with_focus(

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -960,7 +960,7 @@ impl PermissionType {
                 "Access Zellij state (Panes, Tabs and UI)".to_owned()
             },
             PermissionType::ChangeApplicationState => {
-                "Change Zellij state (Panes, Tabs and UI)".to_owned()
+                "Change Zellij state (Panes, Tabs and UI) and run commands".to_owned()
             },
             PermissionType::OpenFiles => "Open files (eg. for editing)".to_owned(),
             PermissionType::RunCommands => "Run commands".to_owned(),


### PR DESCRIPTION
This adds a new plugin API `switch_session_with_cwd` that allows switching to a new session with the default layout and specifying a cwd (eg. `/tmp`).

This also includes some fixes that get `default_cwd` to work once more when specified as a CLI option.