### PR TITLE
feat(ui): bring back fullscreen indication

### DIFF
--- a/default-plugins/compact-bar/src/tab.rs
+++ b/default-plugins/compact-bar/src/tab.rs
@@ -89,8 +89,11 @@ pub fn tab_style(
     capabilities: PluginCapabilities,
 ) -> LinePart {
     let separator = tab_separator(capabilities);
-    if tab.is_sync_panes_active {
-        tabname.push_str(" (Sync)");
+
+    if tab.is_fullscreen_active {
+        tabname.push_str(" (FULLSCREEN)");
+    } else if tab.is_sync_panes_active {
+        tabname.push_str(" (SYNC)");
     }
     // we only color alternate tabs differently if we can't use the arrow fonts to separate them
     if !capabilities.arrow_fonts {

--- a/default-plugins/tab-bar/src/tab.rs
+++ b/default-plugins/tab-bar/src/tab.rs
@@ -89,8 +89,10 @@ pub fn tab_style(
 ) -> LinePart {
     let separator = tab_separator(capabilities);
 
-    if tab.is_sync_panes_active {
-        tabname.push_str(" (Sync)");
+    if tab.is_fullscreen_active {
+        tabname.push_str(" (FULLSCREEN)");
+    } else if tab.is_sync_panes_active {
+        tabname.push_str(" (SYNC)");
     }
     // we only color alternate tabs differently if we can't use the arrow fonts to separate them
     if !capabilities.arrow_fonts {

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__toggle_pane_fullscreen.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__toggle_pane_fullscreen.snap
@@ -3,7 +3,7 @@ source: src/tests/e2e/cases.rs
 assertion_line: 386
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (e2e-test)  Tab #1 (FULLSCREEN) 
 ┌ Pane #2 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │$ █                                                                                                                   │
 │                                                                                                                      │


### PR DESCRIPTION
This brings back the full indication that has been removed when the UI was changed recently. Here, instead of having it on the extra status-bar line (which now does not exist) we add it to the tab name. The upshot of which is that we can see if a tab is in full-screen even if we're not focused on it.

![img-2024-10-22-160715](https://github.com/user-attachments/assets/bb30c9c9-454b-4447-98cb-37b2bddb8762)
