### PR TITLE
fix(ux): new interface/configuration touch-ups

### DIFF
--- a/default-plugins/configuration/src/presets.rs
+++ b/default-plugins/configuration/src/presets.rs
@@ -80,6 +80,14 @@ keybinds clear-defaults=true {{
         bind "Ctrl b" "PageUp" "Left" "h" {{ PageScrollUp; }}
         bind "d" {{ HalfPageScrollDown; }}
         bind "u" {{ HalfPageScrollUp; }}
+        bind "Alt left" {{ MoveFocusOrTab "left"; SwitchToMode "locked"; }}
+        bind "Alt down" {{ MoveFocus "down"; SwitchToMode "locked"; }}
+        bind "Alt up" {{ MoveFocus "up"; SwitchToMode "locked"; }}
+        bind "Alt right" {{ MoveFocusOrTab "right"; SwitchToMode "locked"; }}
+        bind "Alt h" {{ MoveFocusOrTab "left"; SwitchToMode "locked"; }}
+        bind "Alt j" {{ MoveFocus "down"; SwitchToMode "locked"; }}
+        bind "Alt k" {{ MoveFocus "up"; SwitchToMode "locked"; }}
+        bind "Alt l" {{ MoveFocusOrTab "right"; SwitchToMode "locked"; }}
     }}
     search {{
         bind "Ctrl c" {{ ScrollToBottom; SwitchToMode "Locked"; }}
@@ -268,6 +276,14 @@ keybinds clear-defaults=true {{
         bind "Ctrl b" "PageUp" "Left" "h" {{ PageScrollUp; }}
         bind "d" {{ HalfPageScrollDown; }}
         bind "u" {{ HalfPageScrollUp; }}
+        bind "{secondary_modifier} left" {{ MoveFocusOrTab "left"; SwitchToMode "normal"; }}
+        bind "{secondary_modifier} down" {{ MoveFocus "down"; SwitchToMode "normal"; }}
+        bind "{secondary_modifier} up" {{ MoveFocus "up"; SwitchToMode "normal"; }}
+        bind "{secondary_modifier} right" {{ MoveFocusOrTab "right"; SwitchToMode "normal"; }}
+        bind "{secondary_modifier} h" {{ MoveFocusOrTab "left"; SwitchToMode "normal"; }}
+        bind "{secondary_modifier} j" {{ MoveFocus "down"; SwitchToMode "normal"; }}
+        bind "{secondary_modifier} k" {{ MoveFocus "up"; SwitchToMode "normal"; }}
+        bind "{secondary_modifier} l" {{ MoveFocusOrTab "right"; SwitchToMode "normal"; }}
     }}
     search {{
         bind "{primary_modifier} s" {{ SwitchToMode "Normal"; }}
@@ -461,6 +477,14 @@ keybinds clear-defaults=true {{
         bind "k" "Up" {{ ScrollUp; }}
         bind "d" {{ HalfPageScrollDown; }}
         bind "u" {{ HalfPageScrollUp; }}
+        bind "{secondary_modifier} left" {{ MoveFocusOrTab "left"; SwitchToMode "normal"; }}
+        bind "{secondary_modifier} down" {{ MoveFocus "down"; SwitchToMode "normal"; }}
+        bind "{secondary_modifier} up" {{ MoveFocus "up"; SwitchToMode "normal"; }}
+        bind "{secondary_modifier} right" {{ MoveFocusOrTab "right"; SwitchToMode "normal"; }}
+        bind "{secondary_modifier} h" {{ MoveFocusOrTab "left"; SwitchToMode "normal"; }}
+        bind "{secondary_modifier} j" {{ MoveFocus "down"; SwitchToMode "normal"; }}
+        bind "{secondary_modifier} k" {{ MoveFocus "up"; SwitchToMode "normal"; }}
+        bind "{secondary_modifier} l" {{ MoveFocusOrTab "right"; SwitchToMode "normal"; }}
     }}
     search {{
         bind "Ctrl c" {{ ScrollToBottom; SwitchToMode "Normal"; }}
@@ -986,6 +1010,14 @@ keybinds clear-defaults=true {{
         bind "Ctrl b" "PageUp" "Left" "h" {{ PageScrollUp; }}
         bind "d" {{ HalfPageScrollDown; }}
         bind "u" {{ HalfPageScrollUp; }}
+        bind "{secondary_modifier} left" {{ MoveFocusOrTab "left"; SwitchToMode "normal"; }}
+        bind "{secondary_modifier} down" {{ MoveFocus "down"; SwitchToMode "normal"; }}
+        bind "{secondary_modifier} up" {{ MoveFocus "up"; SwitchToMode "normal"; }}
+        bind "{secondary_modifier} right" {{ MoveFocusOrTab "right"; SwitchToMode "normal"; }}
+        bind "{secondary_modifier} h" {{ MoveFocusOrTab "left"; SwitchToMode "normal"; }}
+        bind "{secondary_modifier} j" {{ MoveFocus "down"; SwitchToMode "normal"; }}
+        bind "{secondary_modifier} k" {{ MoveFocus "up"; SwitchToMode "normal"; }}
+        bind "{secondary_modifier} l" {{ MoveFocusOrTab "right"; SwitchToMode "normal"; }}
     }}
     search {{
         bind "{primary_modifier} s" {{ SwitchToMode "Normal"; }}

--- a/default-plugins/status-bar/src/main.rs
+++ b/default-plugins/status-bar/src/main.rs
@@ -262,7 +262,9 @@ impl ZellijPlugin for State {
                     active_tab,
                     cols,
                     separator,
-                    self.base_mode_is_locked
+                    self.base_mode_is_locked,
+                    self.text_copy_destination,
+                    self.display_system_clipboard_failure,
                 )
             );
             return;

--- a/default-plugins/status-bar/src/one_line_ui.rs
+++ b/default-plugins/status-bar/src/one_line_ui.rs
@@ -9,7 +9,7 @@ use zellij_tile::prelude::*;
 use zellij_tile_utils::palette_match;
 
 use crate::first_line::{to_char, KeyAction, KeyMode, KeyShortcut};
-use crate::second_line::{text_copied_hint, system_clipboard_error};
+use crate::second_line::{system_clipboard_error, text_copied_hint};
 use crate::{action_key, action_key_group, color_elements, MORE_MSG, TO_NORMAL};
 use crate::{ColoredElements, LinePart};
 use unicode_width::UnicodeWidthStr;

--- a/default-plugins/status-bar/src/one_line_ui.rs
+++ b/default-plugins/status-bar/src/one_line_ui.rs
@@ -9,6 +9,7 @@ use zellij_tile::prelude::*;
 use zellij_tile_utils::palette_match;
 
 use crate::first_line::{to_char, KeyAction, KeyMode, KeyShortcut};
+use crate::second_line::{text_copied_hint, system_clipboard_error};
 use crate::{action_key, action_key_group, color_elements, MORE_MSG, TO_NORMAL};
 use crate::{ColoredElements, LinePart};
 use unicode_width::UnicodeWidthStr;
@@ -19,7 +20,15 @@ pub fn one_line_ui(
     mut max_len: usize,
     separator: &str,
     base_mode_is_locked: bool,
+    text_copied_to_clipboard_destination: Option<CopyDestination>,
+    clipboard_failure: bool,
 ) -> LinePart {
+    if let Some(text_copied_to_clipboard_destination) = text_copied_to_clipboard_destination {
+        return text_copied_hint(&help.style.colors, text_copied_to_clipboard_destination);
+    }
+    if clipboard_failure {
+        return system_clipboard_error(&help.style.colors);
+    }
     let mut line_part_to_render = LinePart::default();
     let mut append = |line_part: &LinePart, max_len: &mut usize| {
         line_part_to_render.append(line_part);


### PR DESCRIPTION
This includes two fixes:

1. Bring back the "copied to clipboard" indication to the new UI
2. Make is possible to scroll out of a scrolled pane without resetting the scroll (previously only possible with the mouse, now also with `Alt+<arrows>` or `Alt+<hjkl>`.