### PR TITLE
fix(plugins): rebind insert

### DIFF
--- a/default-plugins/configuration/src/presets_screen.rs
+++ b/default-plugins/configuration/src/presets_screen.rs
@@ -85,7 +85,7 @@ impl PresetsScreen {
                 self.reset_selected_index();
             }
             should_render = true;
-        } else if key.bare_key == BareKey::Insert && key.has_no_modifiers() {
+        } else if key.bare_key == BareKey::Char('s') && key.has_modifiers(&[KeyModifier::Ctrl]) {
             if let Some(selected_index) = self.take_selected_index() {
                 let write_to_disk = true;
                 self.reconfigure(selected_index, write_to_disk);
@@ -788,16 +788,16 @@ impl PresetsScreen {
         }
     }
     fn render_help_text_main(&self, rows: usize, cols: usize) {
-        let full_help_text = "Help: <↓↑> - navigate, <ENTER> - apply, <INS> - apply & save, <l> - leaders, <ESC> - close";
-        let short_help_text = "Help: <↓↑> / <ENTER> / <INS> / <l> / <ESC>";
+        let full_help_text = "Help: <↓↑> - navigate, <ENTER> - apply, <Ctrl s> - apply & save, <l> - leaders, <ESC> - close";
+        let short_help_text = "Help: <↓↑> / <ENTER> / <Ctrl s> / <l> / <ESC>";
         if cols >= full_help_text.chars().count() {
             print_text_with_coordinates(
                 Text::new(full_help_text)
                     .color_range(2, 6..10)
                     .color_range(2, 23..30)
-                    .color_range(2, 40..45)
-                    .color_range(2, 62..65)
-                    .color_range(2, 77..82),
+                    .color_range(2, 40..48)
+                    .color_range(2, 65..68)
+                    .color_range(2, 80..85),
                 0,
                 rows,
                 None,
@@ -808,9 +808,9 @@ impl PresetsScreen {
                 Text::new(short_help_text)
                     .color_range(2, 6..10)
                     .color_range(2, 13..20)
-                    .color_range(2, 23..28)
-                    .color_range(2, 31..34)
-                    .color_range(2, 37..42),
+                    .color_range(2, 23..31)
+                    .color_range(2, 34..37)
+                    .color_range(2, 40..45),
                 0,
                 rows,
                 None,

--- a/default-plugins/configuration/src/rebind_leaders_screen.rs
+++ b/default-plugins/configuration/src/rebind_leaders_screen.rs
@@ -558,10 +558,10 @@ impl RebindLeadersScreen {
         if self.is_rebinding_for_presets {
             return self.render_help_text_for_presets_rebinding(rows, cols);
         }
-        let help_text_long = "Help: <←↓↑→> - navigate, <SPACE> - select, <ENTER> - apply, <INSERT> - save, <Ctrl c> - reset, <ESC> - close";
-        let help_text_medium = "Help: <←↓↑→/SPACE> - navigate/select, <ENTER/INS> - apply/save, <Ctrl c> - reset, <ESC> - close";
-        let help_text_short = "Help: <←↓↑→>/<SPACE>/<ENTER> select/<INS> save/<Ctrl c> reset/<ESC>";
-        let help_text_minimum = "<←↓↑→>/<SPACE>/<ENTER>/<INS>/<Ctrl c>/<ESC>";
+        let help_text_long = "Help: <←↓↑→> - navigate, <SPACE> - select, <ENTER> - apply, <Ctrl s> - save, <Ctrl c> - reset, <ESC> - close";
+        let help_text_medium = "Help: <←↓↑→/SPACE> - navigate/select, <ENTER/Ctrl s> - apply/save, <Ctrl c> - reset, <ESC> - close";
+        let help_text_short = "Help: <←↓↑→>/<SPACE>/<ENTER> select/<Ctrl s> save/<Ctrl c> reset/<ESC>";
+        let help_text_minimum = "<←↓↑→>/<SPACE>/<ENTER>/<Ctrl s>/<Ctrl c>/<ESC>";
         if cols >= help_text_long.chars().count() {
             print_text_with_coordinates(
                 Text::new(help_text_long)
@@ -580,9 +580,9 @@ impl RebindLeadersScreen {
             print_text_with_coordinates(
                 Text::new(help_text_medium)
                     .color_range(2, 6..=17)
-                    .color_range(2, 38..=48)
-                    .color_range(2, 64..=72)
-                    .color_range(2, 82..=86),
+                    .color_range(2, 38..=51)
+                    .color_range(2, 67..=75)
+                    .color_range(2, 85..=89),
                 0,
                 rows,
                 None,
@@ -594,9 +594,9 @@ impl RebindLeadersScreen {
                     .color_range(2, 6..=11)
                     .color_range(2, 13..=19)
                     .color_range(2, 21..=27)
-                    .color_range(2, 36..=40)
-                    .color_range(2, 47..=54)
-                    .color_range(2, 62..=66),
+                    .color_range(2, 36..=43)
+                    .color_range(2, 50..=57)
+                    .color_range(2, 65..=69),
                 0,
                 rows,
                 None,
@@ -608,9 +608,9 @@ impl RebindLeadersScreen {
                     .color_range(2, ..=5)
                     .color_range(2, 7..=13)
                     .color_range(2, 15..=21)
-                    .color_range(2, 23..=27)
-                    .color_range(2, 29..=36)
-                    .color_range(2, 38..=42),
+                    .color_range(2, 23..=30)
+                    .color_range(2, 32..=39)
+                    .color_range(2, 41..=45),
                 0,
                 rows,
                 None,
@@ -1194,8 +1194,8 @@ impl RebindLeadersScreen {
         self.is_rebinding_for_presets = is_rebinding_for_presets;
     }
     fn handle_unlock_first_key(&mut self, key: KeyWithModifier) -> bool {
-        if key.bare_key == BareKey::Insert
-            && key.has_no_modifiers()
+        if key.bare_key == BareKey::Char('s')
+            && key.has_modifiers(&[KeyModifier::Ctrl])
             && !self.is_rebinding_for_presets
         {
             let write_to_disk = true;

--- a/default-plugins/configuration/src/rebind_leaders_screen.rs
+++ b/default-plugins/configuration/src/rebind_leaders_screen.rs
@@ -560,7 +560,8 @@ impl RebindLeadersScreen {
         }
         let help_text_long = "Help: <←↓↑→> - navigate, <SPACE> - select, <ENTER> - apply, <Ctrl s> - save, <Ctrl c> - reset, <ESC> - close";
         let help_text_medium = "Help: <←↓↑→/SPACE> - navigate/select, <ENTER/Ctrl s> - apply/save, <Ctrl c> - reset, <ESC> - close";
-        let help_text_short = "Help: <←↓↑→>/<SPACE>/<ENTER> select/<Ctrl s> save/<Ctrl c> reset/<ESC>";
+        let help_text_short =
+            "Help: <←↓↑→>/<SPACE>/<ENTER> select/<Ctrl s> save/<Ctrl c> reset/<ESC>";
         let help_text_minimum = "<←↓↑→>/<SPACE>/<ENTER>/<Ctrl s>/<Ctrl c>/<ESC>";
         if cols >= help_text_long.chars().count() {
             print_text_with_coordinates(

--- a/default-plugins/plugin-manager/src/main.rs
+++ b/default-plugins/plugin-manager/src/main.rs
@@ -841,29 +841,32 @@ impl State {
         tab_line
     }
     pub fn render_help(&self, y: usize, cols: usize) {
-        let full_text = "Help: <←↓↑→> - Navigate/Expand, <ENTER> - focus, <TAB> - Reload, <Del> - Close, <INSERT> - New";
+        let full_text = "Help: <←↓↑→> - Navigate/Expand, <ENTER> - focus, <TAB> - Reload, <Del> - Close, <Ctrl a> - New, <ESC> - Exit";
         let middle_text =
-            "Help: <←↓↑→/ENTER> - Navigate, <TAB> - Reload, <Del> - Close, <INSERT> - New";
-        let short_text = "<←↓↑→/ENTER/TAB/Del> - Navigate/Expand/Reload/Close, <INSERT> - New";
+            "Help: <←↓↑→/ENTER> - Navigate, <TAB> - Reload, <Del> - Close, <Ctrl a> - New, <ESC> - Exit";
+        let short_text = "<←↓↑→/ENTER/TAB/Del> - Navigate/Expand/Reload/Close, <Ctrl a> - New, <ESC> - Exit";
         if cols >= full_text.chars().count() {
             let text = Text::new(full_text)
                 .color_range(3, 5..=11)
                 .color_range(3, 32..=38)
                 .color_range(3, 49..=53)
                 .color_range(3, 65..=69)
-                .color_range(3, 80..=87);
+                .color_range(3, 80..=87)
+                .color_range(3, 96..=100);
             print_text_with_coordinates(text, 0, y, Some(cols), None);
         } else if cols >= middle_text.chars().count() {
             let text = Text::new(middle_text)
                 .color_range(3, 6..=17)
                 .color_range(3, 31..=35)
                 .color_range(3, 47..=51)
-                .color_range(3, 62..=69);
+                .color_range(3, 62..=69)
+                .color_range(3, 78..=82);
             print_text_with_coordinates(text, 0, y, Some(cols), None);
         } else {
             let text = Text::new(short_text)
                 .color_range(3, ..=21)
-                .color_range(3, 53..=60);
+                .color_range(3, 53..=60)
+                .color_range(3, 69..=73);
             print_text_with_coordinates(text, 0, y, Some(cols), None);
         }
     }
@@ -989,7 +992,7 @@ impl State {
             BareKey::Tab if key.has_no_modifiers() => {
                 self.reload_selected();
             },
-            BareKey::Insert if key.has_no_modifiers() => {
+            BareKey::Char('a') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
                 self.new_plugin_screen = Some(Default::default());
                 should_render = true;
             },
@@ -997,9 +1000,13 @@ impl State {
                 self.close_selected();
             },
             BareKey::Esc if key.has_no_modifiers() => {
-                self.search_term.clear();
-                self.update_search_term();
-                should_render = true;
+                if !self.search_term.is_empty() {
+                    self.search_term.clear();
+                    self.update_search_term();
+                    should_render = true;
+                } else {
+                    close_self();
+                }
             },
             _ => {},
         }

--- a/default-plugins/plugin-manager/src/main.rs
+++ b/default-plugins/plugin-manager/src/main.rs
@@ -844,7 +844,8 @@ impl State {
         let full_text = "Help: <←↓↑→> - Navigate/Expand, <ENTER> - focus, <TAB> - Reload, <Del> - Close, <Ctrl a> - New, <ESC> - Exit";
         let middle_text =
             "Help: <←↓↑→/ENTER> - Navigate, <TAB> - Reload, <Del> - Close, <Ctrl a> - New, <ESC> - Exit";
-        let short_text = "<←↓↑→/ENTER/TAB/Del> - Navigate/Expand/Reload/Close, <Ctrl a> - New, <ESC> - Exit";
+        let short_text =
+            "<←↓↑→/ENTER/TAB/Del> - Navigate/Expand/Reload/Close, <Ctrl a> - New, <ESC> - Exit";
         if cols >= full_text.chars().count() {
             let text = Text::new(full_text)
                 .color_range(3, 5..=11)

--- a/zellij-server/src/panes/active_panes.rs
+++ b/zellij-server/src/panes/active_panes.rs
@@ -9,7 +9,7 @@ pub struct ActivePanes {
     os_api: Box<dyn ServerOsApi>,
 }
 
-impl std::fmt::Debug for ActivePanes{
+impl std::fmt::Debug for ActivePanes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.active_panes)
     }

--- a/zellij-server/src/panes/active_panes.rs
+++ b/zellij-server/src/panes/active_panes.rs
@@ -9,6 +9,12 @@ pub struct ActivePanes {
     os_api: Box<dyn ServerOsApi>,
 }
 
+impl std::fmt::Debug for ActivePanes{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.active_panes)
+    }
+}
+
 impl ActivePanes {
     pub fn new(os_api: &Box<dyn ServerOsApi>) -> Self {
         let os_api = os_api.clone();

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -1569,7 +1569,11 @@ impl TiledPanes {
             closed_pane
         } else {
             let closed_pane = self.panes.remove(&pane_id);
-            if closed_pane.as_ref().map(|p| p.selectable()).unwrap_or(false) {
+            if closed_pane
+                .as_ref()
+                .map(|p| p.selectable())
+                .unwrap_or(false)
+            {
                 // this is a bit of a roundabout way to say: this is the last pane and so the tab
                 // should be destroyed
                 self.active_panes.clear(&mut self.panes);

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -1569,9 +1569,11 @@ impl TiledPanes {
             closed_pane
         } else {
             let closed_pane = self.panes.remove(&pane_id);
-            // this is a bit of a roundabout way to say: this is the last pane and so the tab
-            // should be destroyed
-            self.active_panes.clear(&mut self.panes);
+            if closed_pane.as_ref().map(|p| p.selectable()).unwrap_or(false) {
+                // this is a bit of a roundabout way to say: this is the last pane and so the tab
+                // should be destroyed
+                self.active_panes.clear(&mut self.panes);
+            }
             closed_pane
         }
     }


### PR DESCRIPTION
Rebind insert key in the plugin manager and configuration, since it doesn't exist on macOS (thanks @dj95 !)

This also fixes an issue where if the tab-bar or status-bar were closed through the plugin manager, the UI would get stuck. Right now, due to the built-in swap layouts, another pane fills their place - but this will be fixed at another time. Right now I preferred to leave this option open in order to empower users to make this decision on their own.