### PR TITLE
fix(terminal): recover from partial line drop

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -705,9 +705,17 @@ impl Grid {
             let line_to_push_up = if line_to_push_up.is_canonical {
                 line_to_push_up
             } else {
-                let mut last_line_above = self.lines_above.pop_back().unwrap();
-                last_line_above.append(&mut line_to_push_up.columns);
-                last_line_above
+                match self.lines_above.pop_back() {
+                    Some(mut last_line_above) => {
+                        last_line_above.append(&mut line_to_push_up.columns);
+                        last_line_above
+                    },
+                    None => {
+                        // in this case, this line was not canonical but its beginning line was
+                        // dropped out of scope, so we make it canonical and push it up
+                        line_to_push_up.canonical()
+                    },
+                }
             };
 
             let dropped_line_width =


### PR DESCRIPTION
This is a fix for https://github.com/zellij-org/zellij/issues/3525

The issue that was happening here is that a canonical line exceeded the scrollback size and was only partially dropped. Then when scrolling back down we were trying to connect its non-canonical edge to it. This should not have happened, but my guess is that due to some recent algorithm changes in this area this situation became possible.

For this reason we now recover from this situation by making the partial line canonical (which is probably nicer anyway).