### PR TITLE
fix(configuration): leave notification up when base mode changes

### DIFF
--- a/default-plugins/configuration/src/main.rs
+++ b/default-plugins/configuration/src/main.rs
@@ -32,8 +32,16 @@ impl Screen {
             Screen::new_reset_keybindings_screen(Some(0));
         } else {
             match self {
-                Screen::RebindLeaders(r) => *r = Default::default(),
-                Screen::Presets(r) => *r = Default::default(),
+                Screen::RebindLeaders(r) => {
+                    let notification = r.drain_notification();
+                    *r = Default::default();
+                    r.set_notification(notification);
+                },
+                Screen::Presets(r) => {
+                    let notification = r.drain_notification();
+                    *r = Default::default();
+                    r.set_notification(notification);
+                },
             }
         }
     }

--- a/default-plugins/configuration/src/presets_screen.rs
+++ b/default-plugins/configuration/src/presets_screen.rs
@@ -190,6 +190,12 @@ impl PresetsScreen {
     pub fn reset_selected_index(&mut self) {
         self.selected_index = Some(0);
     }
+    pub fn drain_notification(&mut self) -> Option<String> {
+        self.notification.take()
+    }
+    pub fn set_notification(&mut self, notification: Option<String>) {
+        self.notification = notification;
+    }
     fn reconfigure(&self, selected: usize, write_to_disk: bool) {
         if selected == 0 {
             // TODO: these should be part of a "transaction" when they are

--- a/default-plugins/configuration/src/rebind_leaders_screen.rs
+++ b/default-plugins/configuration/src/rebind_leaders_screen.rs
@@ -680,6 +680,12 @@ impl RebindLeadersScreen {
             self.handle_default_preset_key(key)
         }
     }
+    pub fn drain_notification(&mut self) -> Option<String> {
+        self.notification.take()
+    }
+    pub fn set_notification(&mut self, notification: Option<String>) {
+        self.notification = notification;
+    }
     fn currently_in_unlock_first(&self) -> bool {
         if self.is_rebinding_for_presets {
             false


### PR DESCRIPTION
This is a minor fix for the new configuration plugin that prevents the "configuration applies to current session" notification from disappearing when the base input mode changes (eg. from `normal` to `locked`).