### PR TITLE
style(fmt): various cleanups

### DIFF
--- a/default-plugins/configuration/src/rebind_leaders_screen.rs
+++ b/default-plugins/configuration/src/rebind_leaders_screen.rs
@@ -294,7 +294,7 @@ impl RebindLeadersScreen {
             WIDTH_BREAKPOINTS.1
         };
         let base_x = cols.saturating_sub(screen_width) / 2;
-        let base_y = rows.saturating_sub(7) / 2;
+        let base_y = rows.saturating_sub(10) / 2;
         let primary_modifier_key_text = self.primary_modifier_text();
         let (primary_modifier_text, primary_modifier_start_position) =
             if cols >= WIDTH_BREAKPOINTS.0 {
@@ -305,7 +305,7 @@ impl RebindLeadersScreen {
         print_text_with_coordinates(
             Text::new(primary_modifier_text).color_range(3, primary_modifier_start_position..),
             base_x,
-            base_y + 4,
+            base_y + 5,
             None,
             None,
         );
@@ -327,7 +327,7 @@ impl RebindLeadersScreen {
                 })
                 .collect(),
             base_x,
-            base_y + 5,
+            base_y + 6,
             Some(screen_width / 2),
             None,
         );

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -51,7 +51,7 @@ use zellij_utils::{
         config::Config,
         get_mode_info,
         keybinds::Keybinds,
-        layout::{FloatingPaneLayout, Layout, PercentOrFixed, PluginAlias, Run, RunPluginOrAlias},
+        layout::{FloatingPaneLayout, Layout, PluginAlias, Run, RunPluginOrAlias},
         options::Options,
         plugins::PluginAliases,
     },
@@ -1169,7 +1169,7 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                     .unwrap()
                     .propagate_configuration_changes(changes);
             },
-            ServerInstruction::FailedToWriteConfigToDisk(client_id, file_path) => {
+            ServerInstruction::FailedToWriteConfigToDisk(_client_id, file_path) => {
                 session_data
                     .write()
                     .unwrap()

--- a/zellij-server/src/plugins/mod.rs
+++ b/zellij-server/src/plugins/mod.rs
@@ -14,7 +14,6 @@ use std::{
 };
 use wasmtime::Engine;
 
-use crate::background_jobs::BackgroundJob;
 use crate::panes::PaneId;
 use crate::screen::ScreenInstruction;
 use crate::session_layout_metadata::SessionLayoutMetadata;
@@ -34,7 +33,7 @@ use zellij_utils::{
         command::TerminalAction,
         keybinds::Keybinds,
         layout::{FloatingPaneLayout, Layout, Run, RunPlugin, RunPluginOrAlias, TiledPaneLayout},
-        plugins::{PluginAliases, PluginConfig},
+        plugins::PluginAliases,
     },
     ipc::ClientAttributes,
     pane_size::Size,
@@ -254,7 +253,7 @@ pub(crate) fn plugin_thread_main(
         default_keybinds,
     );
 
-    for mut run_plugin_or_alias in background_plugins {
+    for run_plugin_or_alias in background_plugins {
         load_background_plugin(
             run_plugin_or_alias,
             &mut wasm_bridge,

--- a/zellij-server/src/plugins/plugin_loader.rs
+++ b/zellij-server/src/plugins/plugin_loader.rs
@@ -90,8 +90,6 @@ impl<'a> PluginLoader<'a> {
         default_shell: Option<TerminalAction>,
         default_layout: Box<Layout>,
         layout_dir: Option<PathBuf>,
-        base_modes: &HashMap<ClientId, InputMode>,
-        keybinds: &HashMap<ClientId, Keybinds>,
     ) -> Result<()> {
         let err_context = || format!("failed to reload plugin {plugin_id} from memory");
         let mut connected_clients: Vec<ClientId> =
@@ -100,11 +98,6 @@ impl<'a> PluginLoader<'a> {
             return Err(anyhow!("No connected clients, cannot reload plugin"));
         }
         let first_client_id = connected_clients.remove(0);
-        let keybinds = keybinds.get(&first_client_id).cloned().unwrap_or_default();
-        let default_mode = base_modes
-            .get(&first_client_id)
-            .cloned()
-            .unwrap_or_default();
 
         let mut plugin_loader = PluginLoader::new_from_existing_plugin_attributes(
             &plugin_cache,
@@ -122,8 +115,6 @@ impl<'a> PluginLoader<'a> {
             default_shell,
             default_layout,
             layout_dir,
-            default_mode,
-            keybinds,
         )?;
         plugin_loader
             .load_module_from_memory()
@@ -290,8 +281,6 @@ impl<'a> PluginLoader<'a> {
         default_shell: Option<TerminalAction>,
         default_layout: Box<Layout>,
         layout_dir: Option<PathBuf>,
-        base_modes: &HashMap<ClientId, InputMode>,
-        keybinds: &HashMap<ClientId, Keybinds>,
     ) -> Result<()> {
         let err_context = || format!("failed to reload plugin id {plugin_id}");
 
@@ -301,11 +290,6 @@ impl<'a> PluginLoader<'a> {
             return Err(anyhow!("No connected clients, cannot reload plugin"));
         }
         let first_client_id = connected_clients.remove(0);
-        let keybinds = keybinds.get(&first_client_id).cloned().unwrap_or_default();
-        let default_mode = base_modes
-            .get(&first_client_id)
-            .cloned()
-            .unwrap_or_default();
 
         let mut plugin_loader = PluginLoader::new_from_existing_plugin_attributes(
             &plugin_cache,
@@ -323,8 +307,6 @@ impl<'a> PluginLoader<'a> {
             default_shell,
             default_layout,
             layout_dir,
-            default_mode,
-            keybinds,
         )?;
         plugin_loader
             .compile_module()
@@ -406,8 +388,6 @@ impl<'a> PluginLoader<'a> {
         default_shell: Option<TerminalAction>,
         default_layout: Box<Layout>,
         layout_dir: Option<PathBuf>,
-        default_mode: InputMode,
-        keybinds: Keybinds,
     ) -> Result<Self> {
         let err_context = || "Failed to find existing plugin";
         let (running_plugin, _subscriptions, _workers) = {
@@ -833,11 +813,11 @@ impl<'a> PluginLoader<'a> {
                 self.plugin_id,
             )))));
         let wasi_ctx = wasi_ctx_builder.build_p1();
-        let mut mut_plugin = self.plugin.clone();
+        let plugin = self.plugin.clone();
         let plugin_env = PluginEnv {
             plugin_id: self.plugin_id,
             client_id: self.client_id,
-            plugin: mut_plugin,
+            plugin,
             permissions: Arc::new(Mutex::new(None)),
             senders: self.senders.clone(),
             wasi_ctx,

--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -369,8 +369,6 @@ impl WasmBridge {
             let default_shell = self.default_shell.clone();
             let default_layout = self.default_layout.clone();
             let layout_dir = self.layout_dir.clone();
-            let base_modes = self.base_modes.clone();
-            let keybinds = self.keybinds.clone();
             async move {
                 match PluginLoader::reload_plugin(
                     plugin_id,
@@ -388,8 +386,6 @@ impl WasmBridge {
                     default_shell.clone(),
                     default_layout.clone(),
                     layout_dir.clone(),
-                    &base_modes,
-                    &keybinds,
                 ) {
                     Ok(_) => {
                         let plugin_list = plugin_map.lock().unwrap().list_plugins();
@@ -449,8 +445,6 @@ impl WasmBridge {
             let default_shell = self.default_shell.clone();
             let default_layout = self.default_layout.clone();
             let layout_dir = self.layout_dir.clone();
-            let base_modes = self.base_modes.clone();
-            let keybinds = self.keybinds.clone();
             async move {
                 match PluginLoader::reload_plugin(
                     first_plugin_id,
@@ -468,8 +462,6 @@ impl WasmBridge {
                     default_shell.clone(),
                     default_layout.clone(),
                     layout_dir.clone(),
-                    &base_modes,
-                    &keybinds,
                 ) {
                     Ok(_) => {
                         let plugin_list = plugin_map.lock().unwrap().list_plugins();
@@ -496,8 +488,6 @@ impl WasmBridge {
                                 default_shell.clone(),
                                 default_layout.clone(),
                                 layout_dir.clone(),
-                                &base_modes,
-                                &keybinds,
                             ) {
                                 Ok(_) => {
                                     let plugin_list = plugin_map.lock().unwrap().list_plugins();

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -793,7 +793,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
             },
             PtyInstruction::Reconfigure {
                 default_editor,
-                client_id,
+                client_id: _,
             } => {
                 pty.reconfigure(default_editor);
             },
@@ -931,7 +931,6 @@ impl Pty {
                     None,
                     open_file_payload.originating_plugin.clone(),
                 ),
-                _ => (false, false, None, None),
             };
 
         if hold_on_start {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -2124,7 +2124,7 @@ impl Screen {
         let mut found = false;
         for tab in self.tabs.values_mut() {
             if tab.has_pane_with_pid(&pane_id) {
-                tab.resize_pane_with_id(resize, pane_id);
+                tab.resize_pane_with_id(resize, pane_id).non_fatal();
                 found = true;
                 break;
             }
@@ -2232,7 +2232,7 @@ impl Screen {
         } else {
             self.new_tab(tab_index, swap_layouts, None, None)?;
         }
-        let mut tab = self.tabs.get_mut(&tab_index).with_context(err_context)?;
+        let tab = self.tabs.get_mut(&tab_index).with_context(err_context)?;
         if let Some(new_tab_name) = new_tab_name {
             tab.name = new_tab_name.clone();
         }
@@ -2828,7 +2828,7 @@ pub(crate) fn screen_thread_main(
                         screen.unblock_input()?;
                         screen.log_and_report_session_state()?;
                     },
-                    ClientTabIndexOrPaneId::TabIndex(tab_index) => {
+                    ClientTabIndexOrPaneId::TabIndex(_tab_index) => {
                         log::error!("Cannot OpenInPlaceEditor with a TabIndex");
                     },
                     ClientTabIndexOrPaneId::PaneId(pane_id_to_replace) => {
@@ -2836,7 +2836,7 @@ pub(crate) fn screen_thread_main(
                         let all_tabs = screen.get_tabs_mut();
                         for tab in all_tabs.values_mut() {
                             if tab.has_pane_with_pid(&pane_id_to_replace) {
-                                tab.replace_pane_with_editor_pane(pid, pane_id_to_replace);
+                                tab.replace_pane_with_editor_pane(pid, pane_id_to_replace).non_fatal();
                                 found = true;
                                 break;
                             }

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -2836,7 +2836,8 @@ pub(crate) fn screen_thread_main(
                         let all_tabs = screen.get_tabs_mut();
                         for tab in all_tabs.values_mut() {
                             if tab.has_pane_with_pid(&pane_id_to_replace) {
-                                tab.replace_pane_with_editor_pane(pid, pane_id_to_replace).non_fatal();
+                                tab.replace_pane_with_editor_pane(pid, pane_id_to_replace)
+                                    .non_fatal();
                                 found = true;
                                 break;
                             }

--- a/zellij-server/src/tab/layout_applier.rs
+++ b/zellij-server/src/tab/layout_applier.rs
@@ -109,14 +109,12 @@ impl<'a> LayoutApplier<'a> {
         client_id: ClientId,
     ) -> Result<bool> {
         // true => should_show_floating_panes
-        let layout_name = layout.name.clone();
         let hide_floating_panes = layout.hide_floating_panes;
         self.apply_tiled_panes_layout(layout, new_terminal_ids, &mut new_plugin_ids, client_id)?;
         let layout_has_floating_panes = self.apply_floating_panes_layout(
             floating_panes_layout,
             new_floating_terminal_ids,
             &mut new_plugin_ids,
-            layout_name,
         )?;
         let should_show_floating_panes = layout_has_floating_panes && !hide_floating_panes;
         return Ok(should_show_floating_panes);
@@ -379,7 +377,6 @@ impl<'a> LayoutApplier<'a> {
         floating_panes_layout: Vec<FloatingPaneLayout>,
         new_floating_terminal_ids: Vec<(u32, HoldForCommand)>,
         new_plugin_ids: &mut HashMap<RunPluginOrAlias, Vec<u32>>,
-        layout_name: Option<String>,
     ) -> Result<bool> {
         // true => has floating panes
         let err_context = || format!("Failed to apply_floating_panes_layout");

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1297,7 +1297,8 @@ impl Tab {
                             self.os_api,
                             self.senders,
                             self.character_cell_size
-                        ).non_fatal();
+                        )
+                        .non_fatal();
                         self.insert_scrollback_editor_replaced_pane(replaced_pane, pid);
                     },
                     None => {
@@ -4096,7 +4097,8 @@ impl Tab {
         match self.suppressed_panes.remove(&pane_id) {
             Some(pane) => {
                 self.show_floating_panes();
-                self.add_floating_pane(pane.1, pane_id, None, None).non_fatal();
+                self.add_floating_pane(pane.1, pane_id, None, None)
+                    .non_fatal();
                 self.floating_panes.focus_pane_for_all_clients(pane_id);
             },
             None => {

--- a/zellij-utils/src/input/config.rs
+++ b/zellij-utils/src/input/config.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 use std::convert::TryFrom;
 
 use super::keybinds::Keybinds;
-use super::layout::{RunPluginOrAlias};
+use super::layout::RunPluginOrAlias;
 use super::options::Options;
 use super::plugins::{PluginAliases, PluginsConfigError};
 use super::theme::{Themes, UiConfig};

--- a/zellij-utils/src/input/config.rs
+++ b/zellij-utils/src/input/config.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 use std::convert::TryFrom;
 
 use super::keybinds::Keybinds;
-use super::layout::{RunPlugin, RunPluginOrAlias};
+use super::layout::{RunPluginOrAlias};
 use super::options::Options;
 use super::plugins::{PluginAliases, PluginsConfigError};
 use super::theme::{Themes, UiConfig};
@@ -402,10 +402,9 @@ impl Config {
 #[cfg(test)]
 mod config_test {
     use super::*;
-    use crate::data::{InputMode, Palette, PaletteColor, PluginTag};
-    use crate::input::layout::{RunPlugin, RunPluginLocation};
+    use crate::data::{InputMode, Palette, PaletteColor};
+    use crate::input::layout::RunPlugin;
     use crate::input::options::{Clipboard, OnForceClose};
-    use crate::input::plugins::PluginConfig;
     use crate::input::theme::{FrameConfig, Theme, Themes, UiConfig};
     use std::collections::{BTreeMap, HashMap};
     use std::io::Write;

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -4,7 +4,6 @@ use crate::{
     data::{ClientId, ConnectToSession, KeyWithModifier, Style},
     errors::{get_current_ctx, prelude::*, ErrorContext},
     input::config::Config,
-    input::keybinds::Keybinds,
     input::{actions::Action, layout::Layout, options::Options, plugins::PluginAliases},
     pane_size::{Size, SizeInPixels},
 };

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -1030,13 +1030,13 @@ impl Action {
             Action::KeybindPipe {
                 name,
                 payload,
-                args,
+                args: _, // currently unsupported
                 plugin,
                 configuration,
                 launch_new,
                 skip_cache,
                 floating,
-                in_place,
+                in_place: _, // currently unsupported
                 cwd,
                 pane_title,
                 plugin_id,

--- a/zellij-utils/src/session_serialization.rs
+++ b/zellij-utils/src/session_serialization.rs
@@ -3,10 +3,9 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use crate::{
-    input::command::RunCommand,
     input::layout::PluginUserConfiguration,
     input::layout::{
-        FloatingPaneLayout, Layout, LayoutConstraint, PercentOrFixed, Run, RunPlugin,
+        FloatingPaneLayout, Layout, LayoutConstraint, PercentOrFixed, Run,
         RunPluginOrAlias, SplitDirection, SplitSize, SwapFloatingLayout, SwapTiledLayout,
         TiledPaneLayout,
     },
@@ -1263,6 +1262,8 @@ mod tests {
     }
     #[test]
     fn can_serialize_tab_with_tiled_panes() {
+        use crate::input::command::RunCommand;
+        use crate::input::layout::RunPlugin;
         let mut plugin_configuration = BTreeMap::new();
         plugin_configuration.insert("key 1\"\\".to_owned(), "val 1\"\\".to_owned());
         plugin_configuration.insert("key 2\"\\".to_owned(), "val 2\"\\".to_owned());
@@ -1401,6 +1402,8 @@ mod tests {
     }
     #[test]
     fn can_serialize_tab_with_floating_panes() {
+        use crate::input::command::RunCommand;
+        use crate::input::layout::RunPlugin;
         let mut plugin_configuration = BTreeMap::new();
         plugin_configuration.insert("key 1\"\\".to_owned(), "val 1\"\\".to_owned());
         plugin_configuration.insert("key 2\"\\".to_owned(), "val 2\"\\".to_owned());

--- a/zellij-utils/src/session_serialization.rs
+++ b/zellij-utils/src/session_serialization.rs
@@ -5,9 +5,8 @@ use std::path::PathBuf;
 use crate::{
     input::layout::PluginUserConfiguration,
     input::layout::{
-        FloatingPaneLayout, Layout, LayoutConstraint, PercentOrFixed, Run,
-        RunPluginOrAlias, SplitDirection, SplitSize, SwapFloatingLayout, SwapTiledLayout,
-        TiledPaneLayout,
+        FloatingPaneLayout, Layout, LayoutConstraint, PercentOrFixed, Run, RunPluginOrAlias,
+        SplitDirection, SplitSize, SwapFloatingLayout, SwapTiledLayout, TiledPaneLayout,
     },
     pane_size::{Constraint, PaneGeom},
 };


### PR DESCRIPTION
This addresses the cargo warnings as well as fixes a minor rounding error in the configuration UI