### PR TITLE
fix(ux): forward keys to pane in locked mode and base mode rather than hard-coded normal mode

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -314,12 +314,17 @@ impl SessionMetaData {
     pub fn get_client_keybinds_and_mode(
         &self,
         client_id: &ClientId,
-    ) -> Option<(Keybinds, &InputMode, InputMode)> { // (keybinds, current_input_mode,
-                                                     // default_input_mode)
+    ) -> Option<(Keybinds, &InputMode, InputMode)> {
+        // (keybinds, current_input_mode,
+        // default_input_mode)
         let client_keybinds = self.session_configuration.get_client_keybinds(client_id);
-        let default_input_mode = self.session_configuration.get_client_default_input_mode(client_id);
+        let default_input_mode = self
+            .session_configuration
+            .get_client_default_input_mode(client_id);
         match self.current_input_modes.get(client_id) {
-            Some(client_input_mode) => Some((client_keybinds, client_input_mode, default_input_mode)),
+            Some(client_input_mode) => {
+                Some((client_keybinds, client_input_mode, default_input_mode))
+            },
             _ => None,
         }
     }

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -203,6 +203,13 @@ impl SessionConfiguration {
             .map(|c| c.keybinds.clone())
             .unwrap_or_default()
     }
+    pub fn get_client_default_input_mode(&self, client_id: &ClientId) -> InputMode {
+        self.runtime_config
+            .get(client_id)
+            .or_else(|| self.saved_config.get(client_id))
+            .and_then(|c| c.options.default_mode.clone())
+            .unwrap_or_default()
+    }
     pub fn get_client_configuration(&self, client_id: &ClientId) -> Config {
         self.runtime_config
             .get(client_id)
@@ -307,10 +314,12 @@ impl SessionMetaData {
     pub fn get_client_keybinds_and_mode(
         &self,
         client_id: &ClientId,
-    ) -> Option<(Keybinds, &InputMode)> {
+    ) -> Option<(Keybinds, &InputMode, InputMode)> { // (keybinds, current_input_mode,
+                                                     // default_input_mode)
         let client_keybinds = self.session_configuration.get_client_keybinds(client_id);
+        let default_input_mode = self.session_configuration.get_client_default_input_mode(client_id);
         match self.current_input_modes.get(client_id) {
-            Some(client_input_mode) => Some((client_keybinds, client_input_mode)),
+            Some(client_input_mode) => Some((client_keybinds, client_input_mode, default_input_mode)),
             _ => None,
         }
     }

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -1015,12 +1015,13 @@ pub(crate) fn route_thread_main(
                         ClientToServerMsg::Key(key, raw_bytes, is_kitty_keyboard_protocol) => {
                             if let Some(rlocked_sessions) = rlocked_sessions.as_ref() {
                                 match rlocked_sessions.get_client_keybinds_and_mode(&client_id) {
-                                    Some((keybinds, input_mode)) => {
+                                    Some((keybinds, input_mode, default_input_mode)) => {
                                         for action in keybinds
                                             .get_actions_for_key_in_mode_or_default_action(
                                                 &input_mode,
                                                 &key,
                                                 raw_bytes,
+                                                default_input_mode,
                                                 is_kitty_keyboard_protocol,
                                             )
                                         {

--- a/zellij-utils/src/input/keybinds.rs
+++ b/zellij-utils/src/input/keybinds.rs
@@ -39,6 +39,7 @@ impl Keybinds {
         mode: &InputMode,
         key_with_modifier: &KeyWithModifier,
         raw_bytes: Vec<u8>,
+        default_input_mode: InputMode,
         key_is_kitty_protocol: bool,
     ) -> Vec<Action> {
         self.0
@@ -50,6 +51,7 @@ impl Keybinds {
                     mode,
                     Some(key_with_modifier),
                     raw_bytes,
+                    default_input_mode,
                     key_is_kitty_protocol,
                 )]
             })
@@ -65,12 +67,16 @@ impl Keybinds {
         mode: &InputMode,
         key_with_modifier: Option<&KeyWithModifier>,
         raw_bytes: Vec<u8>,
+        default_input_mode: InputMode,
         key_is_kitty_protocol: bool,
     ) -> Action {
         match *mode {
-            InputMode::Normal | InputMode::Locked => {
+            InputMode::Locked => {
                 Action::Write(key_with_modifier.cloned(), raw_bytes, key_is_kitty_protocol)
             },
+            mode if mode == default_input_mode => {
+                Action::Write(key_with_modifier.cloned(), raw_bytes, key_is_kitty_protocol)
+            }
             InputMode::RenameTab => Action::TabNameInput(raw_bytes),
             InputMode::RenamePane => Action::PaneNameInput(raw_bytes),
             InputMode::EnterSearch => Action::SearchInput(raw_bytes),

--- a/zellij-utils/src/input/keybinds.rs
+++ b/zellij-utils/src/input/keybinds.rs
@@ -76,7 +76,7 @@ impl Keybinds {
             },
             mode if mode == default_input_mode => {
                 Action::Write(key_with_modifier.cloned(), raw_bytes, key_is_kitty_protocol)
-            }
+            },
             InputMode::RenameTab => Action::TabNameInput(raw_bytes),
             InputMode::RenamePane => Action::PaneNameInput(raw_bytes),
             InputMode::EnterSearch => Action::SearchInput(raw_bytes),


### PR DESCRIPTION
This fixes an issue where keys would be forwarded to panes only in locked mode and hard-coded normal mode. Which is alright for the default preset, but not so much for unlocked-first (because then they would also be forwarded when the interface is unlocked and one must press single-letter aliases to enter the different modes).

This fixes it by forwarding the keys in locked mode always and also in the base mode (in unlocked-first the base mode is locked mode, so this works fine).