### PR TITLE
fix(input): remove support for extra modifiers

### DIFF
--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -135,10 +135,6 @@ impl Into<Modifiers> for &KeyModifier {
             KeyModifier::Alt => Modifiers::ALT,
             KeyModifier::Ctrl => Modifiers::CTRL,
             KeyModifier::Super => Modifiers::SUPER,
-            KeyModifier::Hyper => Modifiers::NONE,
-            KeyModifier::Meta => Modifiers::NONE,
-            KeyModifier::CapsLock => Modifiers::NONE,
-            KeyModifier::NumLock => Modifiers::NONE,
         }
     }
 }
@@ -256,10 +252,6 @@ pub enum KeyModifier {
     Alt,
     Shift,
     Super,
-    Hyper,
-    Meta,
-    CapsLock,
-    NumLock,
 }
 
 impl FromStr for KeyModifier {
@@ -367,6 +359,8 @@ bitflags::bitflags! {
         const ALT     = 0b0000_0010;
         const CONTROL = 0b0000_0100;
         const SUPER   = 0b0000_1000;
+        // we don't actually use the below, left here for completeness in case we want to add them
+        // later
         const HYPER = 0b0001_0000;
         const META = 0b0010_0000;
         const CAPS_LOCK = 0b0100_0000;
@@ -389,10 +383,6 @@ impl KeyModifier {
                     ModifierFlags::ALT => key_modifiers.insert(KeyModifier::Alt),
                     ModifierFlags::CONTROL => key_modifiers.insert(KeyModifier::Ctrl),
                     ModifierFlags::SUPER => key_modifiers.insert(KeyModifier::Super),
-                    ModifierFlags::HYPER => key_modifiers.insert(KeyModifier::Hyper),
-                    ModifierFlags::META => key_modifiers.insert(KeyModifier::Meta),
-                    ModifierFlags::CAPS_LOCK => key_modifiers.insert(KeyModifier::CapsLock),
-                    ModifierFlags::NUM_LOCK => key_modifiers.insert(KeyModifier::NumLock),
                     _ => false,
                 };
             }


### PR DESCRIPTION
Implementation of the Kitty Keyboard protocol, especially in regards to the more unusual modifiers such as `NumLock`, `Capslock` etc. varies wildly between terminal emulators. This causes some odd bugs such as keybindings not being recognized when `NumLock` is pressed - but only in some terminals!

To remove the confusion, I removed these keys from Zellij's internal representation. We will still forward them to terminal panes that request them (since we forward the STDIN buffer verbatim) but will not interpret them or send them to plugins.