### PR TITLE
chore: add vendored-openssl feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ pkg-fmt = "tgz"
 [features]
 # See remarks in zellij_utils/Cargo.toml
 default = ["zellij-utils/plugins_from_target"]
+vendored-openssl = ["zellij-utils/vendored-openssl"]
 disable_automatic_asset_installation = ["zellij-utils/disable_automatic_asset_installation"]
 unstable = ["zellij-client/unstable", "zellij-utils/unstable"]
 singlepass = ["zellij-server/singlepass"]

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -56,7 +56,7 @@ async-std = { version = "1.3.0", features = ["unstable", "attributes"] }
 notify-debouncer-full = "0.1.0"
 humantime = "2.1.0"
 futures = "0.3.28"
-openssl-sys = { version = "0.9.93", features = ["vendored"] }
+openssl-sys = { version = "0.9.93" }
 isahc = "1.7.2"
 curl-sys = { version = "0.4", features = ["force-system-lib-on-osx"] }
 
@@ -75,3 +75,4 @@ prost-build = "0.11.9"
 disable_automatic_asset_installation = []
 unstable = []
 plugins_from_target = []
+vendored-openssl = ["openssl-sys/vendored"]


### PR DESCRIPTION
This allows using the system openssl installation. If you want me to I can make it vendored by default, with `--no-default-features` to disable it.