### PR TITLE
fix(input): refix ctrl-j

### DIFF
--- a/src/tests/e2e/cases.rs
+++ b/src/tests/e2e/cases.rs
@@ -20,7 +20,7 @@ use super::remote_runner::{RemoteRunner, RemoteTerminal, Step};
 
 pub const QUIT: [u8; 1] = [17]; // ctrl-q
 pub const ESC: [u8; 1] = [27];
-pub const ENTER: [u8; 1] = [10]; // char '\n'
+pub const ENTER: [u8; 2] = [10, 13]; // '\n\r'
 pub const SPACE: [u8; 1] = [32];
 pub const LOCK_MODE: [u8; 1] = [7]; // ctrl-g
 


### PR DESCRIPTION
The previous fix for differentiating `Ctrl j` from `Enter` happened before the re-architecture involved in reloading the configuration at runtime - so it no longer works for anything but the default config (which is now not a thing in itself since we make sure the config is written on first run).

This fixes it by moving the differentiation to the server side.