### PR TITLE
Add focus-pane-with-id CLI action

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -4320,7 +4320,14 @@ pub(crate) fn screen_thread_main(
                 screen.log_and_report_session_state()?;
             },
             ScreenInstruction::FocusPaneWithId(pane_id, should_float_if_hidden, client_id) => {
+                let client_id = if screen.get_active_tab(client_id).is_ok() {
+                    client_id
+                } else {
+                    screen.get_first_client_id().unwrap_or(client_id)
+                };
                 screen.focus_pane_with_id(pane_id, should_float_if_hidden, client_id)?;
+                screen.render(None)?;
+                screen.unblock_input()?;
                 screen.log_and_report_session_state()?;
             },
             ScreenInstruction::RenamePane(pane_id, new_name) => {

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -405,6 +405,13 @@ pub enum CliAction {
     MoveFocus {
         direction: Direction,
     },
+    /// Focus the pane with the specified ID
+    FocusPaneWithId {
+        id: u32,
+        /// Whether the pane should float if it was hidden
+        #[clap(short, long, value_parser, default_value("false"), takes_value(false))]
+        floating: bool,
+    },
     /// Move focus to the pane or tab (if on screen edge) in the specified direction
     /// [right|left|up|down]
     MoveFocusOrTab {

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -325,6 +325,9 @@ impl Action {
             CliAction::FocusNextPane => Ok(vec![Action::FocusNextPane]),
             CliAction::FocusPreviousPane => Ok(vec![Action::FocusPreviousPane]),
             CliAction::MoveFocus { direction } => Ok(vec![Action::MoveFocus(direction)]),
+            CliAction::FocusPaneWithId { id, floating } => {
+                Ok(vec![Action::FocusTerminalPaneWithId(id, floating)])
+            },
             CliAction::MoveFocusOrTab { direction } => Ok(vec![Action::MoveFocusOrTab(direction)]),
             CliAction::MovePane { direction } => Ok(vec![Action::MovePane(direction)]),
             CliAction::MovePaneBackwards => Ok(vec![Action::MovePaneBackwards]),


### PR DESCRIPTION
Allows scripts to better control the pane focus. My use case is to avoid this horrible hack used in the kakoune zellij integration:
https://github.com/mawww/kakoune/blob/8c49c8ee404fecc110338c08eeed515b63caa93c/rc/windowing/zellij.kak#L46-L59

Instead, a pane can now be focused from its `$ZELLIJ_PANE_ID` environment variable.
Possibly a fix for https://github.com/zellij-org/zellij/issues/3190