### PR TITLE
Add a --size parameter to `zellij run`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ fn main() {
             y,
             width,
             height,
+            size,
         })) = opts.command
         {
             let cwd = cwd.or_else(|| std::env::current_dir().ok());
@@ -57,6 +58,7 @@ fn main() {
                 y,
                 width,
                 height,
+                size,
             };
             commands::send_action_to_session(command_cli_action, opts.session, config);
             std::process::exit(0);
@@ -71,6 +73,7 @@ fn main() {
             y,
             width,
             height,
+            size,
         })) = opts.command
         {
             let cwd = None;
@@ -90,6 +93,7 @@ fn main() {
                 y,
                 width,
                 height,
+                size,
             };
             commands::send_action_to_session(command_cli_action, opts.session, config);
             std::process::exit(0);

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -22,7 +22,7 @@ use zellij_utils::{
     errors::prelude::*,
     input::{
         command::RunCommand,
-        layout::{Run, RunPluginOrAlias, SplitDirection},
+        layout::{Run, RunPluginOrAlias, SplitDirection, SplitSize},
     },
     pane_size::{Offset, PaneGeom, Size, SizeInPixels, Viewport},
 };
@@ -202,7 +202,7 @@ impl TiledPanes {
                 // this unwrap is safe because floating panes should not be visible if there are no floating panes
                 let pane_to_split = self.panes.get_mut(&pane_id_to_split).unwrap();
                 let size_of_both_panes = pane_to_split.position_and_size();
-                if let Some((first_geom, second_geom)) = split(split_direction, &size_of_both_panes)
+                if let Some((first_geom, second_geom)) = split(split_direction, &size_of_both_panes, None)
                 {
                     pane_to_split.set_geom(first_geom);
                     pane.set_geom(second_geom);
@@ -349,7 +349,7 @@ impl TiledPanes {
                 {
                     return false;
                 } else {
-                    return split(SplitDirection::Horizontal, &full_pane_size).is_some();
+                    return split(SplitDirection::Horizontal, &full_pane_size, None).is_some();
                 }
             }
         }
@@ -364,7 +364,7 @@ impl TiledPanes {
                 {
                     return false;
                 }
-                return split(SplitDirection::Vertical, &full_pane_size).is_some();
+                return split(SplitDirection::Vertical, &full_pane_size, None).is_some();
             }
         }
         false
@@ -376,7 +376,7 @@ impl TiledPanes {
         if full_pane_size.rows.is_fixed() || full_pane_size.is_stacked {
             return false;
         }
-        if split(SplitDirection::Horizontal, &full_pane_size).is_some() {
+        if split(SplitDirection::Horizontal, &full_pane_size, None).is_some() {
             true
         } else {
             false
@@ -387,12 +387,13 @@ impl TiledPanes {
         pid: PaneId,
         mut new_pane: Box<dyn Pane>,
         client_id: ClientId,
+        size: Option<SplitSize>,
     ) {
         let active_pane_id = &self.active_panes.get(&client_id).unwrap();
         let active_pane = self.panes.get_mut(active_pane_id).unwrap();
         let full_pane_size = active_pane.position_and_size();
         if let Some((top_winsize, bottom_winsize)) =
-            split(SplitDirection::Horizontal, &full_pane_size)
+            split(SplitDirection::Horizontal, &full_pane_size, size)
         {
             active_pane.set_geom(top_winsize);
             new_pane.set_geom(bottom_winsize);
@@ -407,7 +408,7 @@ impl TiledPanes {
         if full_pane_size.cols.is_fixed() || full_pane_size.is_stacked {
             return false;
         }
-        if split(SplitDirection::Vertical, &full_pane_size).is_some() {
+        if split(SplitDirection::Vertical, &full_pane_size, None).is_some() {
             true
         } else {
             false
@@ -418,12 +419,13 @@ impl TiledPanes {
         pid: PaneId,
         mut new_pane: Box<dyn Pane>,
         client_id: ClientId,
+        size: Option<SplitSize>,
     ) {
         let active_pane_id = &self.active_panes.get(&client_id).unwrap();
         let active_pane = self.panes.get_mut(active_pane_id).unwrap();
         let full_pane_size = active_pane.position_and_size();
         if let Some((left_winsize, right_winsize)) =
-            split(SplitDirection::Vertical, &full_pane_size)
+            split(SplitDirection::Vertical, &full_pane_size, size)
         {
             active_pane.set_geom(left_winsize);
             new_pane.set_geom(right_winsize);

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -202,7 +202,8 @@ impl TiledPanes {
                 // this unwrap is safe because floating panes should not be visible if there are no floating panes
                 let pane_to_split = self.panes.get_mut(&pane_id_to_split).unwrap();
                 let size_of_both_panes = pane_to_split.position_and_size();
-                if let Some((first_geom, second_geom)) = split(split_direction, &size_of_both_panes, None)
+                if let Some((first_geom, second_geom)) =
+                    split(split_direction, &size_of_both_panes, None, false)
                 {
                     pane_to_split.set_geom(first_geom);
                     pane.set_geom(second_geom);
@@ -349,7 +350,8 @@ impl TiledPanes {
                 {
                     return false;
                 } else {
-                    return split(SplitDirection::Horizontal, &full_pane_size, None).is_some();
+                    return split(SplitDirection::Horizontal, &full_pane_size, None, false)
+                        .is_some();
                 }
             }
         }
@@ -364,7 +366,7 @@ impl TiledPanes {
                 {
                     return false;
                 }
-                return split(SplitDirection::Vertical, &full_pane_size, None).is_some();
+                return split(SplitDirection::Vertical, &full_pane_size, None, false).is_some();
             }
         }
         false
@@ -376,7 +378,7 @@ impl TiledPanes {
         if full_pane_size.rows.is_fixed() || full_pane_size.is_stacked {
             return false;
         }
-        if split(SplitDirection::Horizontal, &full_pane_size, None).is_some() {
+        if split(SplitDirection::Horizontal, &full_pane_size, None, false).is_some() {
             true
         } else {
             false
@@ -388,12 +390,13 @@ impl TiledPanes {
         mut new_pane: Box<dyn Pane>,
         client_id: ClientId,
         size: Option<SplitSize>,
+        up: bool,
     ) {
         let active_pane_id = &self.active_panes.get(&client_id).unwrap();
         let active_pane = self.panes.get_mut(active_pane_id).unwrap();
         let full_pane_size = active_pane.position_and_size();
         if let Some((top_winsize, bottom_winsize)) =
-            split(SplitDirection::Horizontal, &full_pane_size, size)
+            split(SplitDirection::Horizontal, &full_pane_size, size, up)
         {
             active_pane.set_geom(top_winsize);
             new_pane.set_geom(bottom_winsize);
@@ -408,7 +411,7 @@ impl TiledPanes {
         if full_pane_size.cols.is_fixed() || full_pane_size.is_stacked {
             return false;
         }
-        if split(SplitDirection::Vertical, &full_pane_size, None).is_some() {
+        if split(SplitDirection::Vertical, &full_pane_size, None, false).is_some() {
             true
         } else {
             false
@@ -420,12 +423,13 @@ impl TiledPanes {
         mut new_pane: Box<dyn Pane>,
         client_id: ClientId,
         size: Option<SplitSize>,
+        left: bool,
     ) {
         let active_pane_id = &self.active_panes.get(&client_id).unwrap();
         let active_pane = self.panes.get_mut(active_pane_id).unwrap();
         let full_pane_size = active_pane.position_and_size();
         if let Some((left_winsize, right_winsize)) =
-            split(SplitDirection::Vertical, &full_pane_size, size)
+            split(SplitDirection::Vertical, &full_pane_size, size, left)
         {
             active_pane.set_geom(left_winsize);
             new_pane.set_geom(right_winsize);

--- a/zellij-server/src/panes/tiled_panes/tiled_pane_grid.rs
+++ b/zellij-server/src/panes/tiled_panes/tiled_pane_grid.rs
@@ -1388,6 +1388,7 @@ pub fn split(
     direction: SplitDirection,
     rect: &PaneGeom,
     size: Option<SplitSize>,
+    swap: bool,
 ) -> Option<(PaneGeom, PaneGeom)> {
     let space = match direction {
         SplitDirection::Vertical => rect.cols,
@@ -1398,6 +1399,7 @@ pub fn split(
         SplitSize::Percent(x) => x as f64 / 100.0,
         SplitSize::Fixed(x) => (x as f64 / space.as_usize() as f64).clamp(0.0, 1.0),
     };
+    let size = if swap { 1.0 - size } else { size };
     if let Some(p) = space.as_percent() {
         let dim1 = Dimension::percent(p * (1.0 - size));
         let dim2 = Dimension::percent(p * size);
@@ -1423,7 +1425,11 @@ pub fn split(
                 ..*rect
             },
         };
-        Some((first_rect, second_rect))
+        if swap {
+            Some((second_rect, first_rect))
+        } else {
+            Some((first_rect, second_rect))
+        }
     } else {
         None
     }

--- a/zellij-server/src/panes/tiled_panes/tiled_pane_grid.rs
+++ b/zellij-server/src/panes/tiled_panes/tiled_pane_grid.rs
@@ -6,6 +6,7 @@ use crate::{panes::PaneId, tab::Pane};
 use std::cmp::{Ordering, Reverse};
 use std::collections::{HashMap, HashSet};
 use zellij_utils::data::{Direction, Resize, ResizeStrategy};
+use zellij_utils::input::layout::SplitSize;
 use zellij_utils::{
     errors::prelude::*,
     input::layout::SplitDirection,
@@ -1383,31 +1384,42 @@ impl<'a> TiledPaneGrid<'a> {
     }
 }
 
-pub fn split(direction: SplitDirection, rect: &PaneGeom) -> Option<(PaneGeom, PaneGeom)> {
+pub fn split(
+    direction: SplitDirection,
+    rect: &PaneGeom,
+    size: Option<SplitSize>,
+) -> Option<(PaneGeom, PaneGeom)> {
     let space = match direction {
         SplitDirection::Vertical => rect.cols,
         SplitDirection::Horizontal => rect.rows,
     };
+    let size = size.unwrap_or(SplitSize::Percent(50));
+    let size = match size {
+        SplitSize::Percent(x) => x as f64 / 100.0,
+        SplitSize::Fixed(x) => (x as f64 / space.as_usize() as f64).clamp(0.0, 1.0),
+    };
     if let Some(p) = space.as_percent() {
+        let dim1 = Dimension::percent(p * (1.0 - size));
+        let dim2 = Dimension::percent(p * size);
         let first_rect = match direction {
             SplitDirection::Vertical => PaneGeom {
-                cols: Dimension::percent(p / 2.0),
+                cols: dim1,
                 ..*rect
             },
             SplitDirection::Horizontal => PaneGeom {
-                rows: Dimension::percent(p / 2.0),
+                rows: dim1,
                 ..*rect
             },
         };
         let second_rect = match direction {
             SplitDirection::Vertical => PaneGeom {
                 x: first_rect.x + 1,
-                cols: first_rect.cols,
+                cols: dim2,
                 ..*rect
             },
             SplitDirection::Horizontal => PaneGeom {
                 y: first_rect.y + 1,
-                rows: first_rect.rows,
+                rows: dim2,
                 ..*rect
             },
         };

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -591,7 +591,7 @@ fn open_terminal(env: &PluginEnv, cwd: PathBuf) {
         TerminalAction::RunCommand(run_command) => Some(run_command.into()),
         _ => None,
     };
-    let action = Action::NewTiledPane(None, run_command_action, None);
+    let action = Action::NewTiledPane(None, run_command_action, None, None);
     apply_action!(action, error_msg, env);
 }
 
@@ -661,7 +661,7 @@ fn open_command_pane(
             context,
         )),
     };
-    let action = Action::NewTiledPane(direction, Some(run_command_action), name);
+    let action = Action::NewTiledPane(direction, Some(run_command_action), name, None);
     apply_action!(action, error_msg, env);
 }
 

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -9,6 +9,7 @@ use crate::{
     ClientId, ServerInstruction,
 };
 use async_std::task::{self, JoinHandle};
+use zellij_utils::input::layout::SplitSize;
 use std::sync::Arc;
 use std::{collections::HashMap, os::unix::io::RawFd, path::PathBuf};
 use zellij_utils::nix::unistd::Pid;
@@ -48,11 +49,11 @@ pub enum PtyInstruction {
     ), // bool (if Some) is
     // should_float, String is an optional pane name
     OpenInPlaceEditor(PathBuf, Option<usize>, ClientTabIndexOrPaneId), // Option<usize> is the optional line number
-    SpawnTerminalVertically(Option<TerminalAction>, Option<String>, ClientId), // String is an
+    SpawnTerminalVertically(Option<TerminalAction>, Option<String>, ClientId, Option<SplitSize>), // String is an
     // optional pane
     // name
     // bool is start_suppressed
-    SpawnTerminalHorizontally(Option<TerminalAction>, Option<String>, ClientId), // String is an
+    SpawnTerminalHorizontally(Option<TerminalAction>, Option<String>, ClientId, Option<SplitSize>), // String is an
     // optional pane
     // name
     UpdateActivePane(Option<PaneId>, ClientId),
@@ -385,7 +386,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                     },
                 }
             },
-            PtyInstruction::SpawnTerminalVertically(terminal_action, name, client_id) => {
+            PtyInstruction::SpawnTerminalVertically(terminal_action, name, client_id, size) => {
                 let err_context =
                     || format!("failed to spawn terminal vertically for client {client_id}");
 
@@ -410,6 +411,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                 pane_title,
                                 hold_for_command,
                                 client_id,
+                                size,
                             ))
                             .with_context(err_context)?;
                     },
@@ -424,6 +426,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                         pane_title,
                                         hold_for_command,
                                         client_id,
+                                        size,
                                     ))
                                     .with_context(err_context)?;
                                 if let Some(run_command) = run_command {
@@ -456,7 +459,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                     },
                 }
             },
-            PtyInstruction::SpawnTerminalHorizontally(terminal_action, name, client_id) => {
+            PtyInstruction::SpawnTerminalHorizontally(terminal_action, name, client_id, size) => {
                 let err_context =
                     || format!("failed to spawn terminal horizontally for client {client_id}");
 
@@ -481,6 +484,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                 pane_title,
                                 hold_for_command,
                                 client_id,
+                                size,
                             ))
                             .with_context(err_context)?;
                     },
@@ -495,6 +499,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                         pane_title,
                                         hold_for_command,
                                         client_id,
+                                        size
                                     ))
                                     .with_context(err_context)?;
                                 if let Some(run_command) = run_command {

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -9,9 +9,9 @@ use crate::{
     ClientId, ServerInstruction,
 };
 use async_std::task::{self, JoinHandle};
-use zellij_utils::input::layout::SplitSize;
 use std::sync::Arc;
 use std::{collections::HashMap, os::unix::io::RawFd, path::PathBuf};
+use zellij_utils::input::layout::SplitSize;
 use zellij_utils::nix::unistd::Pid;
 use zellij_utils::{
     async_std,
@@ -49,13 +49,20 @@ pub enum PtyInstruction {
     ), // bool (if Some) is
     // should_float, String is an optional pane name
     OpenInPlaceEditor(PathBuf, Option<usize>, ClientTabIndexOrPaneId), // Option<usize> is the optional line number
-    SpawnTerminalVertically(Option<TerminalAction>, Option<String>, ClientId, Option<SplitSize>), // String is an
-    // optional pane
-    // name
-    // bool is start_suppressed
-    SpawnTerminalHorizontally(Option<TerminalAction>, Option<String>, ClientId, Option<SplitSize>), // String is an
-    // optional pane
-    // name
+    SpawnTerminalVertically(
+        Option<TerminalAction>,
+        Option<String>,
+        ClientId,
+        Option<SplitSize>,
+        bool,
+    ), // String is an optional pane name, bool is left
+    SpawnTerminalHorizontally(
+        Option<TerminalAction>,
+        Option<String>,
+        ClientId,
+        Option<SplitSize>,
+        bool,
+    ), // String is an optional pane name, bool is up
     UpdateActivePane(Option<PaneId>, ClientId),
     GoToTab(TabIndex, ClientId),
     NewTab(
@@ -386,7 +393,13 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                     },
                 }
             },
-            PtyInstruction::SpawnTerminalVertically(terminal_action, name, client_id, size) => {
+            PtyInstruction::SpawnTerminalVertically(
+                terminal_action,
+                name,
+                client_id,
+                size,
+                left,
+            ) => {
                 let err_context =
                     || format!("failed to spawn terminal vertically for client {client_id}");
 
@@ -412,6 +425,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                 hold_for_command,
                                 client_id,
                                 size,
+                                left,
                             ))
                             .with_context(err_context)?;
                     },
@@ -427,6 +441,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                         hold_for_command,
                                         client_id,
                                         size,
+                                        left,
                                     ))
                                     .with_context(err_context)?;
                                 if let Some(run_command) = run_command {
@@ -459,7 +474,13 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                     },
                 }
             },
-            PtyInstruction::SpawnTerminalHorizontally(terminal_action, name, client_id, size) => {
+            PtyInstruction::SpawnTerminalHorizontally(
+                terminal_action,
+                name,
+                client_id,
+                size,
+                up,
+            ) => {
                 let err_context =
                     || format!("failed to spawn terminal horizontally for client {client_id}");
 
@@ -485,6 +506,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                 hold_for_command,
                                 client_id,
                                 size,
+                                up,
                             ))
                             .with_context(err_context)?;
                     },
@@ -499,7 +521,8 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                         pane_title,
                                         hold_for_command,
                                         client_id,
-                                        size
+                                        size,
+                                        up
                                     ))
                                     .with_context(err_context)?;
                                 if let Some(run_command) = run_command {

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -263,16 +263,16 @@ pub(crate) fn route_action(
             let shell = default_shell.clone();
             let pty_instr = match direction {
                 Some(Direction::Left) => {
-                    PtyInstruction::SpawnTerminalVertically(shell, name, client_id)
+                    PtyInstruction::SpawnTerminalVertically(shell, name, client_id, None)
                 },
                 Some(Direction::Right) => {
-                    PtyInstruction::SpawnTerminalVertically(shell, name, client_id)
+                    PtyInstruction::SpawnTerminalVertically(shell, name, client_id, None)
                 },
                 Some(Direction::Up) => {
-                    PtyInstruction::SpawnTerminalHorizontally(shell, name, client_id)
+                    PtyInstruction::SpawnTerminalHorizontally(shell, name, client_id, None)
                 },
                 Some(Direction::Down) => {
-                    PtyInstruction::SpawnTerminalHorizontally(shell, name, client_id)
+                    PtyInstruction::SpawnTerminalHorizontally(shell, name, client_id, None)
                 },
                 // No direction specified - try to put it in the biggest available spot
                 None => PtyInstruction::SpawnTerminal(
@@ -298,20 +298,22 @@ pub(crate) fn route_action(
             let open_file = TerminalAction::OpenFile(open_file_payload);
             let pty_instr = match (split_direction, should_float, should_open_in_place) {
                 (Some(Direction::Left), false, false) => {
-                    PtyInstruction::SpawnTerminalVertically(Some(open_file), Some(title), client_id)
+                    PtyInstruction::SpawnTerminalVertically(Some(open_file), Some(title), client_id, None)
                 },
                 (Some(Direction::Right), false, false) => {
-                    PtyInstruction::SpawnTerminalVertically(Some(open_file), Some(title), client_id)
+                    PtyInstruction::SpawnTerminalVertically(Some(open_file), Some(title), client_id, None)
                 },
                 (Some(Direction::Up), false, false) => PtyInstruction::SpawnTerminalHorizontally(
                     Some(open_file),
                     Some(title),
                     client_id,
+                    None,
                 ),
                 (Some(Direction::Down), false, false) => PtyInstruction::SpawnTerminalHorizontally(
                     Some(open_file),
                     Some(title),
                     client_id,
+                    None,
                 ),
                 // open terminal in place
                 (_, _, true) => match pane_id {
@@ -410,23 +412,23 @@ pub(crate) fn route_action(
                 },
             }
         },
-        Action::NewTiledPane(direction, run_command, name) => {
+        Action::NewTiledPane(direction, run_command, name, size) => {
             let should_float = false;
             let run_cmd = run_command
                 .map(|cmd| TerminalAction::RunCommand(cmd.into()))
                 .or_else(|| default_shell.clone());
             let pty_instr = match direction {
                 Some(Direction::Left) => {
-                    PtyInstruction::SpawnTerminalVertically(run_cmd, name, client_id)
+                    PtyInstruction::SpawnTerminalVertically(run_cmd, name, client_id, size)
                 },
                 Some(Direction::Right) => {
-                    PtyInstruction::SpawnTerminalVertically(run_cmd, name, client_id)
+                    PtyInstruction::SpawnTerminalVertically(run_cmd, name, client_id, size)
                 },
                 Some(Direction::Up) => {
-                    PtyInstruction::SpawnTerminalHorizontally(run_cmd, name, client_id)
+                    PtyInstruction::SpawnTerminalHorizontally(run_cmd, name, client_id, size)
                 },
                 Some(Direction::Down) => {
-                    PtyInstruction::SpawnTerminalHorizontally(run_cmd, name, client_id)
+                    PtyInstruction::SpawnTerminalHorizontally(run_cmd, name, client_id, size)
                 },
                 // No direction specified - try to put it in the biggest available spot
                 None => PtyInstruction::SpawnTerminal(
@@ -467,16 +469,16 @@ pub(crate) fn route_action(
             let run_cmd = Some(TerminalAction::RunCommand(command.clone().into()));
             let pty_instr = match command.direction {
                 Some(Direction::Left) => {
-                    PtyInstruction::SpawnTerminalVertically(run_cmd, None, client_id)
+                    PtyInstruction::SpawnTerminalVertically(run_cmd, None, client_id, None)
                 },
                 Some(Direction::Right) => {
-                    PtyInstruction::SpawnTerminalVertically(run_cmd, None, client_id)
+                    PtyInstruction::SpawnTerminalVertically(run_cmd, None, client_id, None)
                 },
                 Some(Direction::Up) => {
-                    PtyInstruction::SpawnTerminalHorizontally(run_cmd, None, client_id)
+                    PtyInstruction::SpawnTerminalHorizontally(run_cmd, None, client_id, None)
                 },
                 Some(Direction::Down) => {
-                    PtyInstruction::SpawnTerminalHorizontally(run_cmd, None, client_id)
+                    PtyInstruction::SpawnTerminalHorizontally(run_cmd, None, client_id, None)
                 },
                 // No direction specified - try to put it in the biggest available spot
                 None => PtyInstruction::SpawnTerminal(

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -263,16 +263,16 @@ pub(crate) fn route_action(
             let shell = default_shell.clone();
             let pty_instr = match direction {
                 Some(Direction::Left) => {
-                    PtyInstruction::SpawnTerminalVertically(shell, name, client_id, None)
+                    PtyInstruction::SpawnTerminalVertically(shell, name, client_id, None, true)
                 },
                 Some(Direction::Right) => {
-                    PtyInstruction::SpawnTerminalVertically(shell, name, client_id, None)
+                    PtyInstruction::SpawnTerminalVertically(shell, name, client_id, None, false)
                 },
                 Some(Direction::Up) => {
-                    PtyInstruction::SpawnTerminalHorizontally(shell, name, client_id, None)
+                    PtyInstruction::SpawnTerminalHorizontally(shell, name, client_id, None, true)
                 },
                 Some(Direction::Down) => {
-                    PtyInstruction::SpawnTerminalHorizontally(shell, name, client_id, None)
+                    PtyInstruction::SpawnTerminalHorizontally(shell, name, client_id, None, false)
                 },
                 // No direction specified - try to put it in the biggest available spot
                 None => PtyInstruction::SpawnTerminal(
@@ -298,22 +298,24 @@ pub(crate) fn route_action(
             let open_file = TerminalAction::OpenFile(open_file_payload);
             let pty_instr = match (split_direction, should_float, should_open_in_place) {
                 (Some(Direction::Left), false, false) => {
-                    PtyInstruction::SpawnTerminalVertically(Some(open_file), Some(title), client_id, None)
+                    PtyInstruction::SpawnTerminalVertically(Some(open_file), Some(title), client_id, None, true)
                 },
                 (Some(Direction::Right), false, false) => {
-                    PtyInstruction::SpawnTerminalVertically(Some(open_file), Some(title), client_id, None)
+                    PtyInstruction::SpawnTerminalVertically(Some(open_file), Some(title), client_id, None, false)
                 },
                 (Some(Direction::Up), false, false) => PtyInstruction::SpawnTerminalHorizontally(
                     Some(open_file),
                     Some(title),
                     client_id,
                     None,
+                    true,
                 ),
                 (Some(Direction::Down), false, false) => PtyInstruction::SpawnTerminalHorizontally(
                     Some(open_file),
                     Some(title),
                     client_id,
                     None,
+                    false,
                 ),
                 // open terminal in place
                 (_, _, true) => match pane_id {
@@ -419,16 +421,16 @@ pub(crate) fn route_action(
                 .or_else(|| default_shell.clone());
             let pty_instr = match direction {
                 Some(Direction::Left) => {
-                    PtyInstruction::SpawnTerminalVertically(run_cmd, name, client_id, size)
+                    PtyInstruction::SpawnTerminalVertically(run_cmd, name, client_id, size, true)
                 },
                 Some(Direction::Right) => {
-                    PtyInstruction::SpawnTerminalVertically(run_cmd, name, client_id, size)
+                    PtyInstruction::SpawnTerminalVertically(run_cmd, name, client_id, size, false)
                 },
                 Some(Direction::Up) => {
-                    PtyInstruction::SpawnTerminalHorizontally(run_cmd, name, client_id, size)
+                    PtyInstruction::SpawnTerminalHorizontally(run_cmd, name, client_id, size, true)
                 },
                 Some(Direction::Down) => {
-                    PtyInstruction::SpawnTerminalHorizontally(run_cmd, name, client_id, size)
+                    PtyInstruction::SpawnTerminalHorizontally(run_cmd, name, client_id, size, false)
                 },
                 // No direction specified - try to put it in the biggest available spot
                 None => PtyInstruction::SpawnTerminal(
@@ -469,16 +471,16 @@ pub(crate) fn route_action(
             let run_cmd = Some(TerminalAction::RunCommand(command.clone().into()));
             let pty_instr = match command.direction {
                 Some(Direction::Left) => {
-                    PtyInstruction::SpawnTerminalVertically(run_cmd, None, client_id, None)
+                    PtyInstruction::SpawnTerminalVertically(run_cmd, None, client_id, None, true)
                 },
                 Some(Direction::Right) => {
-                    PtyInstruction::SpawnTerminalVertically(run_cmd, None, client_id, None)
+                    PtyInstruction::SpawnTerminalVertically(run_cmd, None, client_id, None, false)
                 },
                 Some(Direction::Up) => {
-                    PtyInstruction::SpawnTerminalHorizontally(run_cmd, None, client_id, None)
+                    PtyInstruction::SpawnTerminalHorizontally(run_cmd, None, client_id, None, true)
                 },
                 Some(Direction::Down) => {
-                    PtyInstruction::SpawnTerminalHorizontally(run_cmd, None, client_id, None)
+                    PtyInstruction::SpawnTerminalHorizontally(run_cmd, None, client_id, None, false)
                 },
                 // No direction specified - try to put it in the biggest available spot
                 None => PtyInstruction::SpawnTerminal(

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -166,6 +166,7 @@ pub enum ScreenInstruction {
         HoldForCommand,
         ClientId,
         Option<SplitSize>,
+        bool,
     ),
     VerticalSplit(
         PaneId,
@@ -173,6 +174,7 @@ pub enum ScreenInstruction {
         HoldForCommand,
         ClientId,
         Option<SplitSize>,
+        bool,
     ),
     WriteCharacter(Option<KeyWithModifier>, Vec<u8>, bool, ClientId), // bool ->
     // is_kitty_keyboard_protocol
@@ -2888,11 +2890,12 @@ pub(crate) fn screen_thread_main(
                 hold_for_command,
                 client_id,
                 size,
+                up,
             ) => {
                 active_tab_and_connected_client_id!(
                     screen,
                     client_id,
-                    |tab: &mut Tab, client_id: ClientId| tab.horizontal_split(pid, initial_pane_title, client_id, size),
+                    |tab: &mut Tab, client_id: ClientId| tab.horizontal_split(pid, initial_pane_title, client_id, size, up),
                     ?
                 );
                 if let Some(hold_for_command) = hold_for_command {
@@ -2918,11 +2921,12 @@ pub(crate) fn screen_thread_main(
                 hold_for_command,
                 client_id,
                 size,
+                left,
             ) => {
                 active_tab_and_connected_client_id!(
                     screen,
                     client_id,
-                    |tab: &mut Tab, client_id: ClientId| tab.vertical_split(pid, initial_pane_title, client_id, size),
+                    |tab: &mut Tab, client_id: ClientId| tab.vertical_split(pid, initial_pane_title, client_id, size, left),
                     ?
                 );
                 if let Some(hold_for_command) = hold_for_command {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -15,6 +15,7 @@ use zellij_utils::errors::prelude::*;
 use zellij_utils::input::command::RunCommand;
 use zellij_utils::input::config::Config;
 use zellij_utils::input::keybinds::Keybinds;
+use zellij_utils::input::layout::SplitSize;
 use zellij_utils::input::options::Clipboard;
 use zellij_utils::pane_size::{Size, SizeInPixels};
 use zellij_utils::{
@@ -159,8 +160,20 @@ pub enum ScreenInstruction {
     OpenInPlaceEditor(PaneId, ClientTabIndexOrPaneId),
     TogglePaneEmbedOrFloating(ClientId),
     ToggleFloatingPanes(ClientId, Option<TerminalAction>),
-    HorizontalSplit(PaneId, Option<InitialTitle>, HoldForCommand, ClientId),
-    VerticalSplit(PaneId, Option<InitialTitle>, HoldForCommand, ClientId),
+    HorizontalSplit(
+        PaneId,
+        Option<InitialTitle>,
+        HoldForCommand,
+        ClientId,
+        Option<SplitSize>,
+    ),
+    VerticalSplit(
+        PaneId,
+        Option<InitialTitle>,
+        HoldForCommand,
+        ClientId,
+        Option<SplitSize>,
+    ),
     WriteCharacter(Option<KeyWithModifier>, Vec<u8>, bool, ClientId), // bool ->
     // is_kitty_keyboard_protocol
     Resize(ClientId, ResizeStrategy),
@@ -2874,11 +2887,12 @@ pub(crate) fn screen_thread_main(
                 initial_pane_title,
                 hold_for_command,
                 client_id,
+                size,
             ) => {
                 active_tab_and_connected_client_id!(
                     screen,
                     client_id,
-                    |tab: &mut Tab, client_id: ClientId| tab.horizontal_split(pid, initial_pane_title, client_id),
+                    |tab: &mut Tab, client_id: ClientId| tab.horizontal_split(pid, initial_pane_title, client_id, size),
                     ?
                 );
                 if let Some(hold_for_command) = hold_for_command {
@@ -2903,11 +2917,12 @@ pub(crate) fn screen_thread_main(
                 initial_pane_title,
                 hold_for_command,
                 client_id,
+                size,
             ) => {
                 active_tab_and_connected_client_id!(
                     screen,
                     client_id,
-                    |tab: &mut Tab, client_id: ClientId| tab.vertical_split(pid, initial_pane_title, client_id),
+                    |tab: &mut Tab, client_id: ClientId| tab.vertical_split(pid, initial_pane_title, client_id, size),
                     ?
                 );
                 if let Some(hold_for_command) = hold_for_command {

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1441,6 +1441,7 @@ impl Tab {
         initial_pane_title: Option<String>,
         client_id: ClientId,
         size: Option<SplitSize>,
+        up: bool,
     ) -> Result<()> {
         let err_context =
             || format!("failed to split pane {pid:?} horizontally for client {client_id}");
@@ -1474,7 +1475,7 @@ impl Tab {
                     self.explicitly_disable_kitty_keyboard_protocol,
                 );
                 self.tiled_panes
-                    .split_pane_horizontally(pid, Box::new(new_terminal), client_id, size);
+                    .split_pane_horizontally(pid, Box::new(new_terminal), client_id, size, up);
                 self.should_clear_display_before_rendering = true;
                 self.tiled_panes.focus_pane(pid, client_id);
                 self.swap_layouts.set_is_tiled_damaged();
@@ -1502,6 +1503,7 @@ impl Tab {
         initial_pane_title: Option<String>,
         client_id: ClientId,
         size: Option<SplitSize>,
+        left: bool,
     ) -> Result<()> {
         let err_context =
             || format!("failed to split pane {pid:?} vertically for client {client_id}");
@@ -1535,7 +1537,7 @@ impl Tab {
                     self.explicitly_disable_kitty_keyboard_protocol,
                 );
                 self.tiled_panes
-                    .split_pane_vertically(pid, Box::new(new_terminal), client_id, size);
+                    .split_pane_vertically(pid, Box::new(new_terminal), client_id, size, left);
                 self.should_clear_display_before_rendering = true;
                 self.tiled_panes.focus_pane(pid, client_id);
                 self.swap_layouts.set_is_tiled_damaged();

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -7,6 +7,7 @@ mod layout_applier;
 mod swap_layouts;
 
 use copy_command::CopyCommand;
+use zellij_utils::input::layout::SplitSize;
 use std::env::temp_dir;
 use std::path::PathBuf;
 use uuid::Uuid;
@@ -1439,6 +1440,7 @@ impl Tab {
         pid: PaneId,
         initial_pane_title: Option<String>,
         client_id: ClientId,
+        size: Option<SplitSize>,
     ) -> Result<()> {
         let err_context =
             || format!("failed to split pane {pid:?} horizontally for client {client_id}");
@@ -1472,7 +1474,7 @@ impl Tab {
                     self.explicitly_disable_kitty_keyboard_protocol,
                 );
                 self.tiled_panes
-                    .split_pane_horizontally(pid, Box::new(new_terminal), client_id);
+                    .split_pane_horizontally(pid, Box::new(new_terminal), client_id, size);
                 self.should_clear_display_before_rendering = true;
                 self.tiled_panes.focus_pane(pid, client_id);
                 self.swap_layouts.set_is_tiled_damaged();
@@ -1499,6 +1501,7 @@ impl Tab {
         pid: PaneId,
         initial_pane_title: Option<String>,
         client_id: ClientId,
+        size: Option<SplitSize>,
     ) -> Result<()> {
         let err_context =
             || format!("failed to split pane {pid:?} vertically for client {client_id}");
@@ -1532,7 +1535,7 @@ impl Tab {
                     self.explicitly_disable_kitty_keyboard_protocol,
                 );
                 self.tiled_panes
-                    .split_pane_vertically(pid, Box::new(new_terminal), client_id);
+                    .split_pane_vertically(pid, Box::new(new_terminal), client_id, size);
                 self.should_clear_display_before_rendering = true;
                 self.tiled_panes.focus_pane(pid, client_id);
                 self.swap_layouts.set_is_tiled_damaged();

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -246,6 +246,9 @@ pub enum Sessions {
         /// The height if the pane is floating as a bare integer (eg. 1) or percent (eg. 10%)
         #[clap(long, requires("floating"))]
         height: Option<String>,
+        /// The size if the pane is tiled as a bare integer (eg. 1) or percent (eg. 10%)
+        #[clap(long, conflicts_with("floating"))]
+        size: Option<String>,
     },
     /// Load a plugin
     #[clap(visible_alias = "p")]
@@ -288,6 +291,9 @@ pub enum Sessions {
         /// The height if the pane is floating as a bare integer (eg. 1) or percent (eg. 10%)
         #[clap(long, requires("floating"))]
         height: Option<String>,
+        /// The size if the pane is tiled as a bare integer (eg. 1) or percent (eg. 10%)
+        #[clap(long, conflicts_with("floating"))]
+        size: Option<String>,
     },
     /// Edit file with default $EDITOR / $VISUAL
     #[clap(visible_alias = "e")]
@@ -526,6 +532,9 @@ pub enum CliAction {
         /// The height if the pane is floating as a bare integer (eg. 1) or percent (eg. 10%)
         #[clap(long, requires("floating"))]
         height: Option<String>,
+        /// The size if the pane is tiled as a bare integer (eg. 1) or percent (eg. 10%)
+        #[clap(long, conflicts_with("floating"))]
+        size: Option<String>,
     },
     /// Open the specified file in a new zellij pane with your default EDITOR
     Edit {

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -275,9 +275,10 @@ impl TryFrom<ProtobufAction> for Action {
                             direction,
                             Some(run_command_action),
                             pane_name,
+                            None,
                         ))
                     } else {
-                        Ok(Action::NewTiledPane(direction, None, None))
+                        Ok(Action::NewTiledPane(direction, None, None, None))
                     }
                 },
                 _ => Err("Wrong payload for Action::NewTiledPane"),
@@ -937,7 +938,7 @@ impl TryFrom<Action> for ProtobufAction {
                     )),
                 })
             },
-            Action::NewTiledPane(direction, run_command_action, pane_name) => {
+            Action::NewTiledPane(direction, run_command_action, pane_name, _size) => {
                 let direction = direction.and_then(|direction| {
                     let protobuf_direction: ProtobufResizeDirection = direction.try_into().ok()?;
                     Some(protobuf_direction as i32)


### PR DESCRIPTION
This has been an important thing missing for me in automating zellij with [kakoune](https://github.com/mawww/kakoune).

Currently, the `--size` parameter allows either a percentage or an initial row/column count. Importantly, this row/column count does not result in a fixed-size pane, but is just an initial size, that is translated to percentage constraint. This is more useful in my case, but maybe that should be added as a separate SplitSize type instead.

Architecture-wise, this required passing the flag down through a lot of layers, and im unsure if there are better ways to do it.

Additionally, `--direction left` and `--direction up` have been fixed, which should close https://github.com/zellij-org/zellij/issues/3332