### PR TITLE
fix(plugins): cwd and usability fixes

### DIFF
--- a/default-plugins/plugin-manager/src/main.rs
+++ b/default-plugins/plugin-manager/src/main.rs
@@ -49,7 +49,7 @@ impl Default for NewPluginScreen {
             entering_config_val: false,
             selected_config_index: None,
             request_ids: vec![],
-            load_in_background: true,
+            load_in_background: false,
             colors: Palette::default(),
         }
     }
@@ -353,7 +353,7 @@ impl NewPluginScreen {
         let (mut should_render, mut should_close) = (false, false);
 
         match key.bare_key {
-            BareKey::Char(character) if key.has_no_modifiers() && character != ' ' => {
+            BareKey::Char(character) if key.has_no_modifiers() => {
                 if let Some(field) = self.get_field_being_edited_mut() {
                     field.push(character);
                 }
@@ -965,7 +965,7 @@ impl State {
     pub fn handle_main_screen_key(&mut self, key: KeyWithModifier) -> bool {
         let mut should_render = false;
         match key.bare_key {
-            BareKey::Char(character) if key.has_no_modifiers() && character != ' ' => {
+            BareKey::Char(character) if key.has_no_modifiers() => {
                 self.search_term.push(character);
                 self.update_search_term();
                 self.reset_selection();

--- a/zellij-server/src/plugins/plugin_loader.rs
+++ b/zellij-server/src/plugins/plugin_loader.rs
@@ -109,7 +109,7 @@ impl<'a> PluginLoader<'a> {
             engine,
             &plugin_dir,
             path_to_default_shell,
-            zellij_cwd,
+            Some(zellij_cwd),
             capabilities,
             client_attributes,
             default_shell,
@@ -275,7 +275,6 @@ impl<'a> PluginLoader<'a> {
         connected_clients: Arc<Mutex<Vec<ClientId>>>,
         loading_indication: &mut LoadingIndication,
         path_to_default_shell: PathBuf,
-        zellij_cwd: PathBuf,
         capabilities: PluginCapabilities,
         client_attributes: ClientAttributes,
         default_shell: Option<TerminalAction>,
@@ -301,7 +300,7 @@ impl<'a> PluginLoader<'a> {
             engine,
             &plugin_dir,
             path_to_default_shell,
-            zellij_cwd,
+            None,
             capabilities,
             client_attributes,
             default_shell,
@@ -382,7 +381,7 @@ impl<'a> PluginLoader<'a> {
         engine: Engine,
         plugin_dir: &'a PathBuf,
         path_to_default_shell: PathBuf,
-        zellij_cwd: PathBuf,
+        cwd: Option<PathBuf>,
         capabilities: PluginCapabilities,
         client_attributes: ClientAttributes,
         default_shell: Option<TerminalAction>,
@@ -405,6 +404,10 @@ impl<'a> PluginLoader<'a> {
         let keybinds = running_plugin.store.data().keybinds.clone();
         let default_mode = running_plugin.store.data().default_mode;
         let plugin_config = running_plugin.store.data().plugin.clone();
+        // prefer the explicitly given cwd, otherwise copy it from the running plugin
+        // (when reloading a plugin, we want to copy it, when starting a new plugin instance from
+        // meomory, we want to reset it)
+        let zellij_cwd = cwd.unwrap_or_else(|| running_plugin.store.data().plugin_cwd.clone());
         loading_indication.set_name(running_plugin.store.data().name());
         PluginLoader::new(
             plugin_cache,

--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -363,7 +363,6 @@ impl WasmBridge {
             let plugin_map = self.plugin_map.clone();
             let connected_clients = self.connected_clients.clone();
             let path_to_default_shell = self.path_to_default_shell.clone();
-            let zellij_cwd = self.zellij_cwd.clone();
             let capabilities = self.capabilities.clone();
             let client_attributes = self.client_attributes.clone();
             let default_shell = self.default_shell.clone();
@@ -380,7 +379,6 @@ impl WasmBridge {
                     connected_clients.clone(),
                     &mut loading_indication,
                     path_to_default_shell.clone(),
-                    zellij_cwd.clone(),
                     capabilities.clone(),
                     client_attributes.clone(),
                     default_shell.clone(),
@@ -456,7 +454,6 @@ impl WasmBridge {
                     connected_clients.clone(),
                     &mut loading_indication,
                     path_to_default_shell.clone(),
-                    zellij_cwd.clone(),
                     capabilities.clone(),
                     client_attributes.clone(),
                     default_shell.clone(),


### PR DESCRIPTION
This includes a few fixes:
1. Maintain plugin cwd when reloading it (eg. through the plugin manager)
2. Default to loading plugins in the foreground through the plugin manager
3. Allow sending space in configuration parameters when starting plugins through the plugin manager