### PR TITLE
fix(output-buffer): truncate grid height when not rendering it fully

### DIFF
--- a/zellij-server/src/output/mod.rs
+++ b/zellij-server/src/output/mod.rs
@@ -941,9 +941,13 @@ impl OutputBuffer {
             }
             changed_chunks
         } else {
-            let mut line_changes: Vec<_> = self.changed_lines.iter().copied().collect();
+            let mut line_changes: Vec<_> = self
+                .changed_lines
+                .iter()
+                .filter(|i| *i < &viewport_height)
+                .copied()
+                .collect();
             line_changes.sort_unstable();
-            line_changes.truncate(viewport_height);
             let mut changed_chunks = Vec::new();
             for line_index in line_changes {
                 let terminal_characters =

--- a/zellij-server/src/output/mod.rs
+++ b/zellij-server/src/output/mod.rs
@@ -943,6 +943,7 @@ impl OutputBuffer {
         } else {
             let mut line_changes: Vec<_> = self.changed_lines.iter().copied().collect();
             line_changes.sort_unstable();
+            line_changes.truncate(viewport_height);
             let mut changed_chunks = Vec::new();
             for line_index in line_changes {
                 let terminal_characters =


### PR DESCRIPTION
This fixes a rendering issue where sometimes when terminals would render themselves multiple times while being resized, their output would "spill" onto other panes. This is now fixed by always truncating the rendered buffer to the grid sized, even when it's cached and only partially rendered.