### PR TITLE
fix(tabs): maintain event order for MoveTab

### DIFF
--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -262,7 +262,6 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                         pty.bus.senders.clone(),
                                         *terminal_id,
                                         run_command.clone(),
-                                        None,
                                     )
                                     .with_context(err_context)?;
                                 }
@@ -342,7 +341,6 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                         pty.bus.senders.clone(),
                                         *terminal_id,
                                         run_command.clone(),
-                                        None,
                                     )
                                     .with_context(err_context)?;
                                 }
@@ -445,8 +443,6 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                             PaneId::Terminal(*terminal_id),
                                             Some(2), // exit status
                                             run_command,
-                                            None,
-                                            None,
                                         ))
                                         .with_context(err_context)?;
                                 }
@@ -516,8 +512,6 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                             PaneId::Terminal(*terminal_id),
                                             Some(2), // exit status
                                             run_command,
-                                            None,
-                                            None,
                                         ))
                                         .with_context(err_context)?;
                                 }
@@ -614,8 +608,6 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                         PaneId::Terminal(*terminal_id),
                                         Some(2), // exit status
                                         run_command,
-                                        None,
-                                        None,
                                     ))
                                     .with_context(err_context)?;
                             }
@@ -667,8 +659,6 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                         PaneId::Terminal(*terminal_id),
                                         Some(2), // exit status
                                         run_command,
-                                        None,
-                                        None,
                                     ))
                                     .with_context(err_context)?;
                             }
@@ -985,8 +975,6 @@ impl Pty {
                         pane_id,
                         exit_status,
                         command,
-                        None,
-                        None,
                     ));
                 } else {
                     let _ = senders.send_to_screen(ScreenInstruction::ClosePane(pane_id, None));
@@ -1059,14 +1047,14 @@ impl Pty {
                     // new_pane_pids
         for run_instruction in extracted_run_instructions {
             if let Some(new_pane_data) =
-                self.apply_run_instruction(run_instruction, default_shell.clone(), tab_index)?
+                self.apply_run_instruction(run_instruction, default_shell.clone())?
             {
                 new_pane_pids.push(new_pane_data);
             }
         }
         for run_instruction in extracted_floating_run_instructions {
             if let Some(new_pane_data) =
-                self.apply_run_instruction(run_instruction, default_shell.clone(), tab_index)?
+                self.apply_run_instruction(run_instruction, default_shell.clone())?
             {
                 new_floating_panes_pids.push(new_pane_data);
             }
@@ -1147,7 +1135,6 @@ impl Pty {
                                 self.bus.senders.clone(),
                                 terminal_id,
                                 run_command.clone(),
-                                Some(tab_index),
                             )
                             .with_context(err_context)?;
                         } else {
@@ -1168,7 +1155,6 @@ impl Pty {
         &mut self,
         run_instruction: Option<Run>,
         default_shell: TerminalAction,
-        tab_index: usize,
     ) -> Result<Option<(u32, bool, Option<RunCommand>, Result<i32>)>> {
         // terminal_id,
         // starts_held,
@@ -1193,8 +1179,6 @@ impl Pty {
                                 pane_id,
                                 exit_status,
                                 command,
-                                Some(tab_index),
-                                None,
                             ));
                         } else {
                             let _ =
@@ -1425,8 +1409,6 @@ impl Pty {
                                 pane_id,
                                 exit_status,
                                 command,
-                                None,
-                                None,
                             ));
                         } else {
                             let _ =
@@ -1598,7 +1580,6 @@ fn send_command_not_found_to_screen(
     senders: ThreadSenders,
     terminal_id: u32,
     run_command: RunCommand,
-    tab_index: Option<usize>,
 ) -> Result<()> {
     let err_context = || format!("failed to send command_not_fount for terminal {terminal_id}");
     senders
@@ -1614,8 +1595,6 @@ fn send_command_not_found_to_screen(
             PaneId::Terminal(terminal_id),
             Some(2),
             run_command.clone(),
-            tab_index,
-            None,
         ))
         .with_context(err_context)?;
     Ok(())

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -202,11 +202,7 @@ pub enum ScreenInstruction {
     TogglePaneFrames,
     SetSelectable(PaneId, bool),
     ClosePane(PaneId, Option<ClientId>),
-    HoldPane(
-        PaneId,
-        Option<i32>,
-        RunCommand,
-    ),
+    HoldPane(PaneId, Option<i32>, RunCommand),
     UpdatePaneName(Vec<u8>, ClientId),
     UndoRenamePane(ClientId),
     NewTab(
@@ -3618,8 +3614,7 @@ pub(crate) fn screen_thread_main(
                     screen.move_active_tab_to_left(client_id)?;
                     screen.render(None)?;
                 } else {
-                    pending_events_waiting_for_tab
-                        .push(ScreenInstruction::MoveTabLeft(client_id));
+                    pending_events_waiting_for_tab.push(ScreenInstruction::MoveTabLeft(client_id));
                 }
                 screen.unblock_input()?;
             },
@@ -3628,8 +3623,7 @@ pub(crate) fn screen_thread_main(
                     screen.move_active_tab_to_right(client_id)?;
                     screen.render(None)?;
                 } else {
-                    pending_events_waiting_for_tab
-                        .push(ScreenInstruction::MoveTabRight(client_id));
+                    pending_events_waiting_for_tab.push(ScreenInstruction::MoveTabRight(client_id));
                 }
                 screen.unblock_input()?;
             },


### PR DESCRIPTION
This is a fix for some out-of-order events that happened due to our recent wasm runtime change.

Namely, `MoveTab` now doesn't happen when there's a pending tab being populated and `HoldPane` explicitly looks for the tab containing the relevant pane id in all cases.