### PR TITLE
fix(plugins): do not open extra instances of aliases

### DIFF
--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -186,7 +186,11 @@ impl RunPluginOrAlias {
                         // configuration (i.e. None)
                         .and_then(|c| if c.inner().is_empty() { None } else { Some(c) })
                         == run_alias.configuration.as_ref().and_then(|c| {
-                            if c.inner().is_empty() {
+                            let mut to_compare = c.inner().clone();
+                            // caller_cwd is a special attribute given to alias and should not be
+                            // considered when weighing configuration equivalency
+                            to_compare.remove("caller_cwd");
+                            if to_compare.is_empty() {
                                 None
                             } else {
                                 Some(c)


### PR DESCRIPTION
This is a fix for `LaunchOrFocusPlugin` (which is used in the default configuration to launch the session-manager, plugin manager and configuration screen) which would previously not work well with plugin aliases (which all the aforementioned use).

This fix makes it so that when launching the session-manager, it will always be the same session-manager.