### PR TITLE
fix(terminal): reset kitty keyboard support when resetting terminal state

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1727,6 +1727,7 @@ impl Grid {
         self.mouse_tracking = MouseTracking::Off;
         self.focus_event_tracking = false;
         self.cursor_is_hidden = false;
+        self.supports_kitty_keyboard_protocol = false;
         if let Some(images_to_reap) = self.sixel_grid.clear() {
             self.sixel_grid.reap_images(images_to_reap);
         }


### PR DESCRIPTION
Minor fix to make sure the kitty keyboard support is reset when resetting the terminal state (eg. using the `reset` command).