### PR TITLE
fix(config): crash if unable to watch config folder

### DIFF
--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -707,10 +707,13 @@ fn report_changes_in_config_file(
             })
             .unwrap();
             if let Some(config_file_parent_folder) = config_file_path.parent() {
-                watcher
-                    .watch(&config_file_parent_folder, RecursiveMode::Recursive)
-                    .unwrap();
-                Some(Box::new(watcher))
+                match watcher.watch(&config_file_parent_folder, RecursiveMode::Recursive) {
+                    Ok(_) => Some(Box::new(watcher)),
+                    Err(e) => {
+                        log::error!("Failed to watch config file folder: {}", e);
+                        None
+                    },
+                }
             } else {
                 log::error!("Could not find config parent folder");
                 None


### PR DESCRIPTION
This fixes a crash that happened on startup when Zellij did not have read permissions to the config parent folder - ouch!