### PR TITLE
Refactor Pane

### DIFF
--- a/zellij-server/src/panes/active_panes.rs
+++ b/zellij-server/src/panes/active_panes.rs
@@ -1,4 +1,4 @@
-use crate::tab::Pane;
+use crate::tab::PaneTrait;
 
 use crate::{os_input_output::ServerOsApi, panes::PaneId, ClientId};
 use std::collections::{BTreeMap, HashMap};
@@ -30,13 +30,13 @@ impl ActivePanes {
         &mut self,
         client_id: ClientId,
         pane_id: PaneId,
-        panes: &mut BTreeMap<PaneId, Box<dyn Pane>>,
+        panes: &mut BTreeMap<PaneId, Box<dyn PaneTrait>>,
     ) {
         self.unfocus_pane_for_client(client_id, panes);
         self.active_panes.insert(client_id, pane_id);
         self.focus_pane(pane_id, panes);
     }
-    pub fn clear(&mut self, panes: &mut BTreeMap<PaneId, Box<dyn Pane>>) {
+    pub fn clear(&mut self, panes: &mut BTreeMap<PaneId, Box<dyn PaneTrait>>) {
         for pane_id in self.active_panes.values() {
             self.unfocus_pane(*pane_id, panes);
         }
@@ -54,19 +54,19 @@ impl ActivePanes {
     pub fn remove(
         &mut self,
         client_id: &ClientId,
-        panes: &mut BTreeMap<PaneId, Box<dyn Pane>>,
+        panes: &mut BTreeMap<PaneId, Box<dyn PaneTrait>>,
     ) -> Option<PaneId> {
         if let Some(pane_id_to_unfocus) = self.active_panes.get(&client_id) {
             self.unfocus_pane(*pane_id_to_unfocus, panes);
         }
         self.active_panes.remove(client_id)
     }
-    pub fn unfocus_all_panes(&self, panes: &mut BTreeMap<PaneId, Box<dyn Pane>>) {
+    pub fn unfocus_all_panes(&self, panes: &mut BTreeMap<PaneId, Box<dyn PaneTrait>>) {
         for (_client_id, pane_id) in &self.active_panes {
             self.unfocus_pane(*pane_id, panes);
         }
     }
-    pub fn focus_all_panes(&self, panes: &mut BTreeMap<PaneId, Box<dyn Pane>>) {
+    pub fn focus_all_panes(&self, panes: &mut BTreeMap<PaneId, Box<dyn PaneTrait>>) {
         for (_client_id, pane_id) in &self.active_panes {
             self.focus_pane(*pane_id, panes);
         }
@@ -80,13 +80,13 @@ impl ActivePanes {
     fn unfocus_pane_for_client(
         &self,
         client_id: ClientId,
-        panes: &mut BTreeMap<PaneId, Box<dyn Pane>>,
+        panes: &mut BTreeMap<PaneId, Box<dyn PaneTrait>>,
     ) {
         if let Some(pane_id_to_unfocus) = self.active_panes.get(&client_id) {
             self.unfocus_pane(*pane_id_to_unfocus, panes);
         }
     }
-    fn unfocus_pane(&self, pane_id: PaneId, panes: &mut BTreeMap<PaneId, Box<dyn Pane>>) {
+    fn unfocus_pane(&self, pane_id: PaneId, panes: &mut BTreeMap<PaneId, Box<dyn PaneTrait>>) {
         if let PaneId::Terminal(terminal_id) = pane_id {
             if let Some(focus_event) = panes.get(&pane_id).and_then(|p| p.unfocus_event()) {
                 let _ = self
@@ -95,7 +95,7 @@ impl ActivePanes {
             }
         }
     }
-    fn focus_pane(&self, pane_id: PaneId, panes: &mut BTreeMap<PaneId, Box<dyn Pane>>) {
+    fn focus_pane(&self, pane_id: PaneId, panes: &mut BTreeMap<PaneId, Box<dyn PaneTrait>>) {
         if let PaneId::Terminal(terminal_id) = pane_id {
             if let Some(focus_event) = panes.get(&pane_id).and_then(|p| p.focus_event()) {
                 let _ = self

--- a/zellij-server/src/panes/floating_panes/floating_pane_grid.rs
+++ b/zellij-server/src/panes/floating_panes/floating_pane_grid.rs
@@ -1,5 +1,5 @@
 use crate::tab::{MIN_TERMINAL_HEIGHT, MIN_TERMINAL_WIDTH};
-use crate::{panes::PaneId, tab::Pane};
+use crate::{panes::PaneId, tab::PaneTrait};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use zellij_utils::data::{Direction, ResizeStrategy};
@@ -20,7 +20,7 @@ fn no_pane_id(pane_id: &PaneId) -> String {
 }
 
 pub struct FloatingPaneGrid<'a> {
-    panes: Rc<RefCell<HashMap<PaneId, &'a mut Box<dyn Pane>>>>,
+    panes: Rc<RefCell<HashMap<PaneId, &'a mut Box<dyn PaneTrait>>>>,
     desired_pane_positions: Rc<RefCell<&'a mut HashMap<PaneId, PaneGeom>>>,
     display_area: Size, // includes all panes (including eg. the status bar and tab bar in the default layout)
     viewport: Viewport, // includes all non-UI panes
@@ -28,7 +28,7 @@ pub struct FloatingPaneGrid<'a> {
 
 impl<'a> FloatingPaneGrid<'a> {
     pub fn new(
-        panes: impl IntoIterator<Item = (&'a PaneId, &'a mut Box<dyn Pane>)>,
+        panes: impl IntoIterator<Item = (&'a PaneId, &'a mut Box<dyn PaneTrait>)>,
         desired_pane_positions: &'a mut HashMap<PaneId, PaneGeom>,
         display_area: Size,
         viewport: Viewport,
@@ -602,7 +602,7 @@ impl<'a> FloatingPaneGrid<'a> {
     pub fn next_selectable_pane_id_to_the_left(&self, current_pane_id: &PaneId) -> Option<PaneId> {
         let panes = self.panes.borrow();
         let current_pane = panes.get(current_pane_id)?;
-        let panes: Vec<(PaneId, &&mut Box<dyn Pane>)> = panes
+        let panes: Vec<(PaneId, &&mut Box<dyn PaneTrait>)> = panes
             .iter()
             .filter(|(_, p)| p.selectable())
             .map(|(p_id, p)| (*p_id, p))
@@ -627,7 +627,7 @@ impl<'a> FloatingPaneGrid<'a> {
     }
     pub fn pane_id_on_edge(&self, direction: Direction) -> Option<PaneId> {
         let panes = self.panes.borrow();
-        let panes: Vec<(PaneId, &&mut Box<dyn Pane>)> = panes
+        let panes: Vec<(PaneId, &&mut Box<dyn PaneTrait>)> = panes
             .iter()
             .filter(|(_, p)| p.selectable())
             .map(|(p_id, p)| (*p_id, p))
@@ -672,7 +672,7 @@ impl<'a> FloatingPaneGrid<'a> {
     pub fn next_selectable_pane_id_below(&self, current_pane_id: &PaneId) -> Option<PaneId> {
         let panes = self.panes.borrow();
         let current_pane = panes.get(current_pane_id)?;
-        let panes: Vec<(PaneId, &&mut Box<dyn Pane>)> = panes
+        let panes: Vec<(PaneId, &&mut Box<dyn PaneTrait>)> = panes
             .iter()
             .filter(|(_, p)| p.selectable())
             .map(|(p_id, p)| (*p_id, p))
@@ -698,7 +698,7 @@ impl<'a> FloatingPaneGrid<'a> {
     pub fn next_selectable_pane_id_above(&self, current_pane_id: &PaneId) -> Option<PaneId> {
         let panes = self.panes.borrow();
         let current_pane = panes.get(current_pane_id)?;
-        let panes: Vec<(PaneId, &&mut Box<dyn Pane>)> = panes
+        let panes: Vec<(PaneId, &&mut Box<dyn PaneTrait>)> = panes
             .iter()
             .filter(|(_, p)| p.selectable())
             .map(|(p_id, p)| (*p_id, p))
@@ -724,7 +724,7 @@ impl<'a> FloatingPaneGrid<'a> {
     pub fn next_selectable_pane_id_to_the_right(&self, current_pane_id: &PaneId) -> Option<PaneId> {
         let panes = self.panes.borrow();
         let current_pane = panes.get(current_pane_id)?;
-        let panes: Vec<(PaneId, &&mut Box<dyn Pane>)> = panes
+        let panes: Vec<(PaneId, &&mut Box<dyn PaneTrait>)> = panes
             .iter()
             .filter(|(_, p)| p.selectable())
             .map(|(p_id, p)| (*p_id, p))
@@ -749,7 +749,7 @@ impl<'a> FloatingPaneGrid<'a> {
     }
     pub fn next_selectable_pane_id(&self, current_pane_id: &PaneId) -> Option<PaneId> {
         let panes = self.panes.borrow();
-        let mut panes: Vec<(PaneId, &&mut Box<dyn Pane>)> = panes
+        let mut panes: Vec<(PaneId, &&mut Box<dyn PaneTrait>)> = panes
             .iter()
             .filter(|(_, p)| p.selectable())
             .map(|(p_id, p)| (*p_id, p))
@@ -775,7 +775,7 @@ impl<'a> FloatingPaneGrid<'a> {
     }
     pub fn previous_selectable_pane_id(&self, current_pane_id: &PaneId) -> Option<PaneId> {
         let panes = self.panes.borrow();
-        let mut panes: Vec<(PaneId, &&mut Box<dyn Pane>)> = panes
+        let mut panes: Vec<(PaneId, &&mut Box<dyn PaneTrait>)> = panes
             .iter()
             .filter(|(_, p)| p.selectable())
             .map(|(p_id, p)| (*p_id, p))

--- a/zellij-server/src/panes/mod.rs
+++ b/zellij-server/src/panes/mod.rs
@@ -12,6 +12,8 @@ mod search;
 mod terminal_pane;
 mod tiled_panes;
 
+use std::ops::Deref;
+
 pub use active_panes::*;
 pub use alacritty_functions::*;
 pub use floating_panes::*;
@@ -22,3 +24,22 @@ pub use sixel::*;
 pub(crate) use terminal_character::*;
 pub use terminal_pane::*;
 pub use tiled_panes::*;
+
+use crate::tab::PaneTrait;
+
+enum Pane {
+    TerminalPane(TerminalPane),
+    PluginPane(PluginPane),
+}
+
+// Deref trait for Lazy use of common methods as defined in the trait
+impl Deref for Pane {
+    type Target = impl PaneTrait;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Pane::TerminalPane(term) => term,
+            Pane::PluginPane(plugin) => plugin,
+        }
+    }
+}

--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -10,7 +10,7 @@ use crate::panes::{
 };
 use crate::plugins::PluginInstruction;
 use crate::pty::VteBytes;
-use crate::tab::{AdjustedInput, Pane};
+use crate::tab::{AdjustedInput, PaneTrait};
 use crate::ui::{
     loading_indication::LoadingIndication,
     pane_boundaries_frame::{FrameParams, PaneFrame},
@@ -162,7 +162,7 @@ impl PluginPane {
     }
 }
 
-impl Pane for PluginPane {
+impl PaneTrait for PluginPane {
     // FIXME: These position and size things should all be moved to default trait implementations,
     // with something like a get_pos_and_sz() method underpinning all of them. Alternatively and
     // preferably, just use an enum and not a trait object

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -6,7 +6,7 @@ use crate::panes::{
     terminal_character::{render_first_run_banner, TerminalCharacter, EMPTY_TERMINAL_CHARACTER},
 };
 use crate::pty::VteBytes;
-use crate::tab::{AdjustedInput, Pane};
+use crate::tab::{AdjustedInput, PaneTrait};
 use crate::ClientId;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
@@ -141,7 +141,7 @@ pub struct TerminalPane {
     arrow_fonts: bool,
 }
 
-impl Pane for TerminalPane {
+impl PaneTrait for TerminalPane {
     fn x(&self) -> usize {
         self.get_x()
     }

--- a/zellij-server/src/panes/tiled_panes/pane_resizer.rs
+++ b/zellij-server/src/panes/tiled_panes/pane_resizer.rs
@@ -1,5 +1,5 @@
 use super::stacked_panes::StackedPanes;
-use crate::{panes::PaneId, tab::Pane};
+use crate::{panes::PaneId, tab::PaneTrait};
 use cassowary::{
     strength::{REQUIRED, STRONG},
     Expression, Solver, Variable,
@@ -15,7 +15,7 @@ use zellij_utils::{
 };
 
 pub struct PaneResizer<'a> {
-    panes: Rc<RefCell<HashMap<PaneId, &'a mut Box<dyn Pane>>>>,
+    panes: Rc<RefCell<HashMap<PaneId, &'a mut Box<dyn PaneTrait>>>>,
     vars: HashMap<PaneId, Variable>,
     solver: Solver,
 }
@@ -34,7 +34,7 @@ struct Span {
 type Grid = Vec<Vec<Span>>;
 
 impl<'a> PaneResizer<'a> {
-    pub fn new(panes: Rc<RefCell<HashMap<PaneId, &'a mut Box<dyn Pane>>>>) -> Self {
+    pub fn new(panes: Rc<RefCell<HashMap<PaneId, &'a mut Box<dyn PaneTrait>>>>) -> Self {
         let mut vars = HashMap::new();
         for &pane_id in panes.borrow().keys() {
             vars.insert(pane_id, Variable::new());
@@ -245,7 +245,7 @@ impl<'a> PaneResizer<'a> {
         spans
     }
 
-    fn get_span(&self, direction: SplitDirection, pane: &dyn Pane) -> Option<Span> {
+    fn get_span(&self, direction: SplitDirection, pane: &dyn PaneTrait) -> Option<Span> {
         let position_and_size = {
             let pas = pane.current_geom();
             if pas.is_stacked && pas.rows.is_percent() {

--- a/zellij-server/src/panes/tiled_panes/stacked_panes.rs
+++ b/zellij-server/src/panes/tiled_panes/stacked_panes.rs
@@ -1,4 +1,4 @@
-use crate::{panes::PaneId, tab::Pane};
+use crate::{panes::PaneId, tab::PaneTrait};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
@@ -8,15 +8,15 @@ use zellij_utils::{
 };
 
 pub struct StackedPanes<'a> {
-    panes: Rc<RefCell<HashMap<PaneId, &'a mut Box<dyn Pane>>>>,
+    panes: Rc<RefCell<HashMap<PaneId, &'a mut Box<dyn PaneTrait>>>>,
 }
 
 impl<'a> StackedPanes<'a> {
-    pub fn new(panes: Rc<RefCell<HashMap<PaneId, &'a mut Box<dyn Pane>>>>) -> Self {
+    pub fn new(panes: Rc<RefCell<HashMap<PaneId, &'a mut Box<dyn PaneTrait>>>>) -> Self {
         StackedPanes { panes }
     }
     pub fn new_from_btreemap(
-        panes: impl IntoIterator<Item = (&'a PaneId, &'a mut Box<dyn Pane>)>,
+        panes: impl IntoIterator<Item = (&'a PaneId, &'a mut Box<dyn PaneTrait>)>,
         panes_to_hide: &HashSet<PaneId>,
     ) -> Self {
         let panes: HashMap<_, _> = panes
@@ -368,7 +368,7 @@ impl<'a> StackedPanes<'a> {
     fn position_of_current_pane(
         &self,
         all_stacked_pane_positions: &Vec<(PaneId, PaneGeom)>,
-        pane_to_close: &Box<dyn Pane>,
+        pane_to_close: &Box<dyn PaneTrait>,
     ) -> Result<usize> {
         let err_context = || format!("Failed to find position of current pane");
         all_stacked_pane_positions

--- a/zellij-server/src/panes/unit/search_in_pane_tests.rs
+++ b/zellij-server/src/panes/unit/search_in_pane_tests.rs
@@ -1,7 +1,7 @@
 use super::super::TerminalPane;
 use crate::panes::sixel::SixelImageStore;
 use crate::panes::LinkHandler;
-use crate::tab::Pane;
+use crate::tab::PaneTrait;
 use insta::assert_snapshot;
 use std::cell::RefCell;
 use std::collections::HashMap;

--- a/zellij-server/src/panes/unit/terminal_pane_tests.rs
+++ b/zellij-server/src/panes/unit/terminal_pane_tests.rs
@@ -1,7 +1,7 @@
 use super::super::TerminalPane;
 use crate::panes::sixel::SixelImageStore;
 use crate::panes::LinkHandler;
-use crate::tab::Pane;
+use crate::tab::PaneTrait;
 use ::insta::assert_snapshot;
 use std::cell::RefCell;
 use std::collections::HashMap;

--- a/zellij-server/src/ui/boundaries.rs
+++ b/zellij-server/src/ui/boundaries.rs
@@ -2,7 +2,7 @@ use zellij_utils::pane_size::Viewport;
 
 use crate::output::CharacterChunk;
 use crate::panes::terminal_character::{TerminalCharacter, EMPTY_TERMINAL_CHARACTER, RESET_STYLES};
-use crate::tab::Pane;
+use crate::tab::PaneTrait;
 use ansi_term::Colour::{Fixed, RGB};
 use std::collections::HashMap;
 use zellij_utils::errors::prelude::*;
@@ -444,7 +444,7 @@ impl Boundaries {
             boundary_characters: HashMap::new(),
         }
     }
-    pub fn add_rect(&mut self, rect: &dyn Pane, color: Option<PaletteColor>) {
+    pub fn add_rect(&mut self, rect: &dyn PaneTrait, color: Option<PaletteColor>) {
         let pane_is_stacked = rect.current_geom().is_stacked;
         if !self.is_fully_inside_screen(rect) {
             return;
@@ -569,13 +569,13 @@ impl Boundaries {
         }
         Ok(character_chunks)
     }
-    fn rect_right_boundary_is_before_screen_edge(&self, rect: &dyn Pane) -> bool {
+    fn rect_right_boundary_is_before_screen_edge(&self, rect: &dyn PaneTrait) -> bool {
         rect.x() + rect.cols() < self.viewport.cols
     }
-    fn rect_bottom_boundary_is_before_screen_edge(&self, rect: &dyn Pane) -> bool {
+    fn rect_bottom_boundary_is_before_screen_edge(&self, rect: &dyn PaneTrait) -> bool {
         rect.y() + rect.rows() < self.viewport.y + self.viewport.rows
     }
-    fn rect_right_boundary_row_start(&self, rect: &dyn Pane) -> usize {
+    fn rect_right_boundary_row_start(&self, rect: &dyn PaneTrait) -> usize {
         let pane_is_stacked = rect.current_geom().is_stacked;
         let horizontal_frame_offset = if pane_is_stacked { 0 } else { 1 };
         if rect.y() > self.viewport.y {
@@ -584,20 +584,20 @@ impl Boundaries {
             self.viewport.y
         }
     }
-    fn rect_right_boundary_row_end(&self, rect: &dyn Pane) -> usize {
+    fn rect_right_boundary_row_end(&self, rect: &dyn PaneTrait) -> usize {
         rect.y() + rect.rows()
     }
-    fn rect_bottom_boundary_col_start(&self, rect: &dyn Pane) -> usize {
+    fn rect_bottom_boundary_col_start(&self, rect: &dyn PaneTrait) -> usize {
         if rect.x() == 0 {
             0
         } else {
             rect.x() - 1
         }
     }
-    fn rect_bottom_boundary_col_end(&self, rect: &dyn Pane) -> usize {
+    fn rect_bottom_boundary_col_end(&self, rect: &dyn PaneTrait) -> usize {
         rect.x() + rect.cols()
     }
-    fn is_fully_inside_screen(&self, rect: &dyn Pane) -> bool {
+    fn is_fully_inside_screen(&self, rect: &dyn PaneTrait) -> bool {
         rect.x() >= self.viewport.x
             && rect.x() + rect.cols() <= self.viewport.x + self.viewport.cols
             && rect.y() >= self.viewport.y

--- a/zellij-server/src/ui/pane_contents_and_ui.rs
+++ b/zellij-server/src/ui/pane_contents_and_ui.rs
@@ -1,6 +1,6 @@
 use crate::output::Output;
 use crate::panes::PaneId;
-use crate::tab::Pane;
+use crate::tab::PaneTrait;
 use crate::ui::boundaries::Boundaries;
 use crate::ui::pane_boundaries_frame::FrameParams;
 use crate::ClientId;
@@ -10,7 +10,7 @@ use zellij_utils::data::{
 };
 use zellij_utils::errors::prelude::*;
 pub struct PaneContentsAndUi<'a> {
-    pane: &'a mut Box<dyn Pane>,
+    pane: &'a mut Box<dyn PaneTrait>,
     output: &'a mut Output,
     style: Style,
     focused_clients: Vec<ClientId>,
@@ -23,7 +23,7 @@ pub struct PaneContentsAndUi<'a> {
 
 impl<'a> PaneContentsAndUi<'a> {
     pub fn new(
-        pane: &'a mut Box<dyn Pane>,
+        pane: &'a mut Box<dyn PaneTrait>,
         output: &'a mut Output,
         style: Style,
         active_panes: &HashMap<ClientId, PaneId>,


### PR DESCRIPTION
# Refactor Pane somewhat according to https://github.com/zellij-org/zellij/blob/1dbd14f277ceff89588adf6d8db10d856c310e69/zellij-server/src/tab/mod.rs#L206

As of now I've added a enum (`Pane`) which holds either a TerminalPane, or a PluginPane, and derefs to the `PaneTrait` (previously just `Pane`) trait.

## Things I need to know: 
- [ ] What methods from the `PaneTrait` trait to move to `PluginPane` and `TerminalPane` respectively
- [ ] Wether `zellij-server/src/panes/mod.rs` is an acceptable (new) home for both the `Pane` enum and the `PaneTrait` trait (`PaneTrait` seems kind of out of place in `zellij-server/src/tab/mod.rs`)
- [ ] Wether I should rename `PaneTrait` to something better (and what)

Other Ideas and suggestions are more than welcome

## Regarding the methods that should be moved

Here is a quick list of methods that I think might be better off outside of `PaneTrait`:

### Methods that I might be better off in `TerminalPane`
https://github.com/zellij-org/zellij/blob/1dbd14f277ceff89588adf6d8db10d856c310e69/zellij-server/src/tab/mod.rs#L483

https://github.com/zellij-org/zellij/blob/1dbd14f277ceff89588adf6d8db10d856c310e69/zellij-server/src/tab/mod.rs#L486

https://github.com/zellij-org/zellij/blob/1dbd14f277ceff89588adf6d8db10d856c310e69/zellij-server/src/tab/mod.rs#L493


### Methods that might be better off in `PluginPane`

https://github.com/zellij-org/zellij/blob/1dbd14f277ceff89588adf6d8db10d856c310e69/zellij-server/src/tab/mod.rs#L475-L477

## Q&A


### Q:  Why make this Draft instead of just coding away?
A:  Because I prefer gathering info and tips before doing a somewhat huge amount of changes over having to scrap 90% of my code because it doesnt conform to the general vision of the Maintainers

### Q: Why this?
A: Because Im currently working on another (smaller) change, and I dont want to have to write Spagetti Code to make it work. And Im sure the Maintainer(s) dont want me to either.