### PR TITLE
chore: add vendored_curl feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,8 +80,10 @@ pkg-fmt = "tgz"
 
 [features]
 # See remarks in zellij_utils/Cargo.toml
-default = ["zellij-utils/plugins_from_target"]
+default = ["plugins_from_target", "vendored_curl"]
+plugins_from_target = ["zellij-utils/plugins_from_target"]
 disable_automatic_asset_installation = ["zellij-utils/disable_automatic_asset_installation"]
+vendored_curl = ["zellij-utils/vendored_curl"]
 unstable = ["zellij-client/unstable", "zellij-utils/unstable"]
 singlepass = ["zellij-server/singlepass"]
 

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -56,9 +56,9 @@ async-std = { version = "1.3.0", features = ["unstable", "attributes"] }
 notify-debouncer-full = "0.1.0"
 humantime = "2.1.0"
 futures = "0.3.28"
-openssl-sys = { version = "0.9.93", features = ["vendored"] }
-isahc = "1.7.2"
-curl-sys = { version = "0.4", features = ["force-system-lib-on-osx"] }
+openssl-sys = { version = "0.9.93", features = ["vendored"], optional = true }
+isahc = { version = "1.7.2", default-features = false, features = ["http2", "text-decoding"] }
+curl-sys = { version = "0.4", features = ["force-system-lib-on-osx"], optional = true }
 
 [dev-dependencies]
 insta = { version = "1.6.0", features = ["backtrace"] }
@@ -75,3 +75,4 @@ prost-build = "0.11.9"
 disable_automatic_asset_installation = []
 unstable = []
 plugins_from_target = []
+vendored_curl = ["isahc/static-curl", "dep:openssl-sys", "dep:curl-sys"]


### PR DESCRIPTION
Closes #3720
Supersedes #3745

The additive and by-default nature of the `vendored-curl` feature is the cleanest way I could come up with to retain the old vendored behavior and also achieve the "off switch" that I talk about in the issue above.