### PR TITLE
fix(panes): handle various invalid state situations

### DIFF
--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -1620,8 +1620,9 @@ impl TiledPanes {
                 viewport_pane.reset_size_and_position_override();
             }
             self.panes_to_hide.clear();
-            let fullscreen_pane = self.get_pane_mut(fullscreen_pane_id).unwrap();
-            fullscreen_pane.reset_size_and_position_override();
+            if let Some(fullscreen_pane) = self.get_pane_mut(fullscreen_pane_id) {
+                fullscreen_pane.reset_size_and_position_override();
+            }
             self.set_force_render();
             let display_area = *self.display_area.borrow();
             self.resize(display_area);

--- a/zellij-server/src/panes/tiled_panes/tiled_pane_grid.rs
+++ b/zellij-server/src/panes/tiled_panes/tiled_pane_grid.rs
@@ -557,7 +557,7 @@ impl<'a> TiledPaneGrid<'a> {
     }
 
     fn reduce_pane_height(&mut self, id: &PaneId, percent: f64) {
-        if self.can_reduce_pane_height(id, percent).unwrap() {
+        if self.can_reduce_pane_height(id, percent).unwrap_or(false) {
             let current_pane_is_stacked = self
                 .panes
                 .borrow()
@@ -1292,7 +1292,9 @@ impl<'a> TiledPaneGrid<'a> {
         // false => didn't succeed, so didn't do anything
         let (freed_width, freed_height, pane_to_close_is_stacked) = {
             let panes = self.panes.borrow_mut();
-            let pane_to_close = panes.get(&id).unwrap();
+            let Some(pane_to_close) = panes.get(&id) else {
+                return false;
+            };
             let freed_space = pane_to_close.position_and_size();
             let freed_width = freed_space.cols.as_percent();
             let freed_height = freed_space.rows.as_percent();
@@ -1350,7 +1352,9 @@ impl<'a> TiledPaneGrid<'a> {
             },
         );
         pane_id_to_split.and_then(|t_id_to_split| {
-            let pane_to_split = panes.get(t_id_to_split).unwrap();
+            let Some(pane_to_split) = panes.get(t_id_to_split) else {
+                return None;
+            };
             let direction = if pane_to_split.rows()
                 * cursor_height_width_ratio.unwrap_or(DEFAULT_CURSOR_HEIGHT_WIDTH_RATIO)
                 > pane_to_split.cols()


### PR DESCRIPTION
This fixes various situations in which due to invalid state, Zellij would crash.

These situations were likely exposed due to our recent wasm runtime change.