### PR TITLE
fix(ux): change plugin manager shortcut

### DIFF
--- a/default-plugins/plugin-manager/src/main.rs
+++ b/default-plugins/plugin-manager/src/main.rs
@@ -99,7 +99,7 @@ impl NewPluginScreen {
         };
         print_text_with_coordinates(url_field, 0, 2, None, None);
         let url_helper =
-            NestedListItem::new(format!("<Ctrl d> - Load from Disk")).color_range(3, ..=8);
+            NestedListItem::new(format!("<Ctrl f> - Load from Disk")).color_range(3, ..=8);
         print_nested_list_with_coordinates(vec![url_helper], 0, 3, None, None);
     }
     fn render_configuration_title(&self) {
@@ -457,7 +457,7 @@ impl NewPluginScreen {
                     should_render = true;
                 }
             },
-            BareKey::Char('d') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
+            BareKey::Char('f') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
                 let mut args = BTreeMap::new();
                 let request_id = Uuid::new_v4();
                 self.request_ids.push(request_id.to_string());


### PR DESCRIPTION
This changes `Ctrl d` to `Ctrl f` in the plugin manager for loading a new plugin from disk. This is so that there will be consistency with other built-in plugins (eg. the session-manager) for opening the filepicker.