### PR TITLE
fix(screen): send PaneClosed event to plugins also when closing the whole tab

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1081,6 +1081,14 @@ impl Screen {
             pane_ids.retain(|p| p != suppressed_pane_id);
         }
 
+        let _ = self.bus.senders.send_to_plugin(PluginInstruction::Update(
+            pane_ids
+                .iter()
+                .copied()
+                .map(|p_id| (None, None, Event::PaneClosed(p_id.into())))
+                .collect(),
+        ));
+
         // below we don't check the result of sending the CloseTab instruction to the pty thread
         // because this might be happening when the app is closing, at which point the pty thread
         // has already closed and this would result in an error


### PR DESCRIPTION
The `PaneClosed` event was not being sent to plugins when the pane was closed as a result of closing an entire tab. This fixes it.