### PR TITLE
fix(plugins): derive hash and ord for PaneId

### DIFF
--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -1503,7 +1503,7 @@ pub struct NewPluginArgs {
     pub skip_cache: bool,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum PaneId {
     Terminal(u32),
     Plugin(u32),


### PR DESCRIPTION
This is a minor fix to the plugin API - namely adding the `Hash` and `Ord` derives for the exported `PaneId` type to make it easier to use this type as a key in a `HashMap` and `BTreeMap` in plugins.