### PR TITLE
fix(tab): focus largest pane instead of topmost

### DIFF
--- a/zellij-server/src/panes/tiled_panes/tiled_pane_grid.rs
+++ b/zellij-server/src/panes/tiled_panes/tiled_pane_grid.rs
@@ -1039,14 +1039,14 @@ impl<'a> TiledPaneGrid<'a> {
                 Direction::Left => {
                     let x_comparison = a.x().cmp(&b.x());
                     match x_comparison {
-                        Ordering::Equal => b.y().cmp(&a.y()),
+                        Ordering::Equal => a.rows().cmp(&b.rows()).then(b.y().cmp(&a.y())),
                         _ => x_comparison,
                     }
                 },
                 Direction::Right => {
                     let x_comparison = b.x().cmp(&a.x());
                     match x_comparison {
-                        Ordering::Equal => b.y().cmp(&a.y()),
+                        Ordering::Equal => a.rows().cmp(&b.rows()).then(b.y().cmp(&a.y())),
                         _ => x_comparison,
                     }
                 },


### PR DESCRIPTION
When multiple Panes have the same x coord in a `MoveTabOrFocus` event that switches tabs, instead of picking the pane at the top to focus, choose the one biggest one. This ensures that in stacked layouts, the focused pane is opened again when moving, instead of always focusing the top pane.

## Current Behaviour
When switching tabs in `MoveTabOrFocus`, pick the one at the border, if multiple, pick the topmost.

## Fixed Behaviour
When switching tabs in `MoveTabOrFocus`, pick the one at the border, if multiple, pick the *largest*, then the topmost.

This ensures that when stacked panes are used, the previously focused is once again focused instead of always using the first.


## Considerations
This should not influence existing workflows using normal tiled panes all to much, since the previous implementation was quite arbitrary anyway, but is a big fix for stacked layouts, since this "keeps the layout" instead of resetting.


closes #3006
