### PR TITLE
fix(plugins): properly focus pane after tab was closed

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -2414,10 +2414,10 @@ impl Screen {
                     .map(|(_tab_index, tab)| tab.position);
                 match tab_index {
                     Some(tab_index) => {
-                        if let Some(tab) = self.tabs
-                            .iter_mut()
-                            .find(|(_, t)| t.position == tab_index) {
-                                suppress_pane(tab.1, pane_id, new_pane_id);
+                        if let Some(tab) =
+                            self.tabs.iter_mut().find(|(_, t)| t.position == tab_index)
+                        {
+                            suppress_pane(tab.1, pane_id, new_pane_id);
                         }
                     },
                     None => {


### PR DESCRIPTION
This fixes a minor issue where the `focus_pane_with_id` and `suppress_pane` plugin API commands would not work properly if a tab was closed.

The issue was that the tab was being focused by its index and not by its position.