### PR TITLE
fix(cli): fix the detach message

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -1219,7 +1219,7 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                     let _ = os_input.send_to_client(
                         *client_id,
                         ServerToClientMsg::Exit {
-                            exit_reason: ExitReason::Normal,
+                            exit_reason: ExitReason::NormalDetached,
                         },
                     );
                     remove_client!(*client_id, os_input, session_state);


### PR DESCRIPTION
Keys are interpreted on the server after commit 5a437b79aac5 ("refactor(server): interpret keys on server so they can be rebound").

Since the server exits with "ExitReason::Normal" instead of "ExitReason::NormalDetached" when detaching a session, the detach message becomes "Bye from Zellij!" instead of "Session detached".

Correct the exit reason to fix this.

Fixes: #3798