### PR TITLE
fix error message in session name validation

### DIFF
--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -20,7 +20,7 @@ fn validate_session(name: &str) -> Result<String, String> {
         if socket_path.as_os_str().len() >= ZELLIJ_SOCK_MAX_LENGTH {
             // socket path must be less than 108 bytes
             let available_length = ZELLIJ_SOCK_MAX_LENGTH
-                .saturating_sub(socket_path.as_os_str().len())
+                .saturating_sub(crate::consts::ZELLIJ_SOCK_DIR.as_os_str().len())
                 .saturating_sub(1);
 
             return Err(format!(


### PR DESCRIPTION
The error message for session names, that are too long, was always claiming, that the maximum is 0. This was because it calculated the difference after the given session name was already applied.

Now only the path to the socket directory is considered and the error message displays the correct value. 