### PR TITLE
fix(plugins): do not detach if using a slash in a session name

### DIFF
--- a/default-plugins/session-manager/src/main.rs
+++ b/default-plugins/session-manager/src/main.rs
@@ -462,6 +462,9 @@ impl State {
                     // through the package)
                     self.show_error("Session name must be shorter than 108 bytes");
                     return;
+                } else if self.new_session_info.name().contains('/') {
+                    self.show_error("Session name cannot contain '/'");
+                    return;
                 }
                 self.new_session_info.handle_selection(&self.session_name);
             },
@@ -483,6 +486,10 @@ impl State {
                         self.show_error("A resurrectable session by this name already exists.");
                         return; // s that we don't hide self
                     } else {
+                        if renaming_session_name.contains('/') {
+                            self.show_error("Session names cannot contain '/'");
+                            return;
+                        }
                         self.update_current_session_name_in_ui(&renaming_session_name);
                         rename_session(&renaming_session_name);
                         return; // s that we don't hide self

--- a/default-plugins/session-manager/src/ui/components.rs
+++ b/default-plugins/session-manager/src/ui/components.rs
@@ -891,6 +891,16 @@ pub fn render_renaming_session_screen(
         33 + new_session_name.width()..40 + new_session_name.width(),
     );
     print_text_with_coordinates(text, x, y, None, None);
+    if new_session_name.contains('/') {
+        let error_text = "Error: session name cannot contain '/'";
+        print_text_with_coordinates(
+            Text::new(error_text).color_range(3, ..),
+            x,
+            y + 2,
+            None,
+            None,
+        );
+    }
 }
 
 pub fn render_controls_line(


### PR DESCRIPTION
Session names cannot contain slashes. Previously, if trying to rename the session or start a new session with a slash in it - Zellij would detach (the check was only made on the client-side *after* detaching from the current session - yikes!)

This fixes the issue by verifying there's no slash in the session name both in the plugin API and in the session-manager plugin (so that it can show an informative error message).