### PR TITLE
fix(plugins): properly focus plugin after it was hidden

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -2035,7 +2035,7 @@ impl Screen {
                 tab_index_and_plugin_pane_id = Some((*tab_index, plugin_pane_id));
                 if move_to_focused_tab && focused_tab_index != *tab_index {
                     plugin_pane_to_move_to_active_tab =
-                        tab.extract_pane(plugin_pane_id, false, Some(client_id));
+                        tab.extract_pane(plugin_pane_id, true, Some(client_id));
                 }
 
                 break;

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -2760,10 +2760,11 @@ impl Tab {
     pub fn extract_pane(
         &mut self,
         id: PaneId,
-        ignore_suppressed_panes: bool,
+        dont_swap_if_suppressed: bool,
         client_id: Option<ClientId>,
     ) -> Option<Box<dyn Pane>> {
-        if !ignore_suppressed_panes && self.suppressed_panes.contains_key(&id) {
+        if !dont_swap_if_suppressed && self.suppressed_panes.contains_key(&id) {
+            // this is done for the scrollback editor
             return match self.replace_pane_with_suppressed_pane(id) {
                 Ok(pane) => pane,
                 Err(e) => {


### PR DESCRIPTION
This is a fix for https://github.com/zellij-org/zellij/issues/3834 (among other issues).

What was happening here is that `LaunchOrFocusPlugin` was unintentionally going through the logic for switching back to a normal pane after having edited its scrollback with the scrollback editor. The relevant parameter in the function had an outdated name (my bad!) which caused this confusion when implementing this feature in the first place.

Now opening the session-manager properly brings it to the focused tab.
