### PR TITLE
fix(screen): off by 1 error when focusing layout tab

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -3485,7 +3485,7 @@ pub(crate) fn screen_thread_main(
                 pending_tab_ids.remove(&tab_index);
                 if pending_tab_ids.is_empty() {
                     for (tab_index, client_id) in pending_tab_switches.drain() {
-                        screen.go_to_tab(tab_index as usize, client_id)?;
+                        screen.go_to_tab(tab_index as usize + 1, client_id)?;
                     }
                     if should_change_focus_to_new_tab {
                         screen.go_to_tab(tab_index as usize + 1, client_id)?;


### PR DESCRIPTION
This is a fix for https://github.com/zellij-org/zellij/issues/3786

The `focus` directive in this case trickled down into an off-by-one error which was causing this (position vs. index). It's now fixed!