### PR TITLE
fix(multiuser): properly clear fake cursors

### DIFF
--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -806,6 +806,20 @@ impl Pane for TerminalPane {
         self.style.rounded_corners = rounded_corners;
         self.frame.clear();
     }
+    fn drain_fake_cursors(&mut self) -> Option<HashSet<(usize, usize)>> {
+        if !self.fake_cursor_locations.is_empty() {
+            for (y, _x) in &self.fake_cursor_locations {
+                // we do this because once these fake_cursor_locations
+                // have been drained, we have to make sure to render the line
+                // they appeared on so that whatever clears their location
+                // won't leave a hole
+                self.grid.update_line_for_rendering(*y);
+            }
+            Some(self.fake_cursor_locations.drain().collect())
+        } else {
+            None
+        }
+    }
 }
 
 impl TerminalPane {

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -500,6 +500,9 @@ pub trait Pane {
     fn query_should_be_suppressed(&self) -> bool {
         false
     }
+    fn drain_fake_cursors(&mut self) -> Option<HashSet<(usize, usize)>> {
+        None
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/zellij-server/src/ui/pane_contents_and_ui.rs
+++ b/zellij-server/src/ui/pane_contents_and_ui.rs
@@ -57,6 +57,10 @@ impl<'a> PaneContentsAndUi<'a> {
     ) -> Result<()> {
         let err_context = "failed to render pane contents to multiple clients";
 
+        // here we drop the fake cursors so that their lines will be updated
+        // and we can clear them from the UI below
+        drop(self.pane.drain_fake_cursors());
+
         if let Some((character_chunks, raw_vte_output, sixel_image_chunks)) =
             self.pane.render(None).context(err_context)?
         {


### PR DESCRIPTION
This fixes an old bug where the fake cursors rendered for other players in multiplayer sessions would sometimes not be properly cleared when their line was not updated (this sometimes happened in older shells like bash or sh).