### PR TITLE
Set hide_floating_panes in parse_tab_node_with_template

### DIFF
--- a/zellij-utils/src/kdl/kdl_layout_parser.rs
+++ b/zellij-utils/src/kdl/kdl_layout_parser.rs
@@ -1590,6 +1590,7 @@ impl<'a> KdlLayoutParser<'a> {
                 floating_pane.add_cwd_to_layout(&cwd_prefix);
             }
         }
+        tab_layout.hide_floating_panes = kdl_get_bool_property_or_child_value!(kdl_node, "hide_floating_panes").unwrap_or(false);
         tab_layout.external_children_index = None;
         Ok((
             is_focused,


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/2974

When the layout uses `default_tab_template`, the `hide_floating_panes` option on the `tab` was ignored. With this change the user can hide floating panes while using `default_tab_template`.