### PR TITLE
Fix Synchronized Output (mode 2026) reporting

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -2745,7 +2745,7 @@ impl Perform for Grid {
                 for param in params_iter.map(|param| param[0]) {
                     match param {
                         2026 => {
-                            let response = "\u{1b}[2026;2$y";
+                            let response = "\u{1b}[?2026;2$y";
                             self.pending_messages_to_pty
                                 .push(response.as_bytes().to_vec());
                         },


### PR DESCRIPTION
Hi, thank you for Zellij!

I help maintain [Textual](https://github.com/textualize/textual/) and some dependent TUI apps like [Posting](https://github.com/darrenburns/posting) which make use of mode 2026.

I started using Zellij yesterday (loving it!) and noticed that the mode 2026 query response was not being parsed as expected and so the output could not be synchronized.

Looking into the code of Zellij, I think the response is missing a `?` character. If I'm understanding correctly, response should be of the format `CSI ? 2026 ; N $ y` where N can be any value in the range 0-4 (inclusive).

References:

- https://gist.github.com/christianparpart/d8a62cc1ab659194337d73e399004036
- https://vt100.net/docs/vt510-rm/DECRPM.html

## Before

Notice the tearing effect as the cursor moves through the list. It's particularly noticeable as the cursor moves over `PATCH`.

https://github.com/user-attachments/assets/332aaae5-2844-4ac5-a5f6-894df26871f4

## After

On a build containing this fix I cannot reproduce the tearing effect:

https://github.com/user-attachments/assets/d228626d-94c8-40a6-b3ed-becda0662285

Possibly fixes https://github.com/zellij-org/zellij/issues/2794

