### PR TITLE
fix(terminal): cursor overflow

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1144,7 +1144,7 @@ impl Grid {
         )));
     }
     pub fn cursor_coordinates(&self) -> Option<(usize, usize)> {
-        if self.cursor_is_hidden {
+        if self.cursor_is_hidden || self.cursor.x >= self.width || self.cursor.y >= self.height {
             None
         } else {
             Some((self.cursor.x, self.cursor.y))

--- a/zellij-utils/assets/layouts/default.swap.kdl
+++ b/zellij-utils/assets/layouts/default.swap.kdl
@@ -31,7 +31,7 @@ swap_tiled_layout name="vertical" {
 }
 
 swap_tiled_layout name="horizontal" {
-    ui max_panes=5 {
+    ui max_panes=4 {
         pane
         pane
     }

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-2.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-2.snap
@@ -808,7 +808,7 @@ Layout {
         (
             {
                 MaxPanes(
-                    5,
+                    4,
                 ): TiledPaneLayout {
                     children_split_direction: Horizontal,
                     name: None,


### PR DESCRIPTION
This fixes a small issue where in some cases where the application running inside a terminal pane would report an out-of-bounds cursor position, we would render the cursor on the pane border. This was likely introduced during some changes in the past months.

This fixes it as well as one minor issue introduced in a recent PR regarding swap layout placement.