### PR TITLE
also force the window title to rerender when reattaching

### DIFF
--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -659,6 +659,9 @@ impl TiledPanes {
         }
         self.reset_boundaries();
     }
+    pub fn set_force_window_title_update(&mut self) {
+        self.window_title = None;
+    }
     pub fn has_active_panes(&self) -> bool {
         !self.active_panes.is_empty()
     }

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -913,6 +913,7 @@ impl Tab {
             );
         }
         self.set_force_render();
+        self.set_force_window_title_update();
         Ok(())
     }
 
@@ -2062,6 +2063,9 @@ impl Tab {
     pub fn set_force_render(&mut self) {
         self.tiled_panes.set_force_render();
         self.floating_panes.set_force_render();
+    }
+    pub fn set_force_window_title_update(&mut self) {
+        self.tiled_panes.set_force_window_title_update();
     }
     pub fn set_should_clear_display_before_rendering(&mut self) {
         self.should_clear_display_before_rendering = true;


### PR DESCRIPTION
currently if you detach from a session and then reattach, the terminal that zellij is running in doesn't restore the correct terminal title until the pane name changes (because it thinks there's no reason to if it hasn't changed). this forces the terminal title to be reapplied any time a client reconnects to a session.