### PR TITLE
 Add fish shell completions for the `delete-session` subcommand

### DIFF
--- a/zellij-utils/assets/completions/comp.fish
+++ b/zellij-utils/assets/completions/comp.fish
@@ -3,6 +3,8 @@ function __fish_complete_sessions
 end
 complete -c zellij -n "__fish_seen_subcommand_from attach" -f -a "(__fish_complete_sessions)" -d "Session"
 complete -c zellij -n "__fish_seen_subcommand_from a" -f -a "(__fish_complete_sessions)" -d "Session"
+complete -c zellij -n "__fish_seen_subcommand_from delete-session" -f -a "(__fish_complete_sessions)" -d "Session"
+complete -c zellij -n "__fish_seen_subcommand_from d" -f -a "(__fish_complete_sessions)" -d "Session"
 complete -c zellij -n "__fish_seen_subcommand_from kill-session" -f -a "(__fish_complete_sessions)" -d "Session"
 complete -c zellij -n "__fish_seen_subcommand_from k" -f -a "(__fish_complete_sessions)" -d "Session"
 complete -c zellij -n "__fish_seen_subcommand_from setup" -l "generate-completion" -x -a "bash elvish fish zsh powershell" -d "Shell"


### PR DESCRIPTION
This PR partially addresses issue #3055 by adding fish shell completion for the `delete-session` subcommand.
It enables session name suggestions when typing `zellij d ` followed by `<tab>`.

The newly added `complete` commands are in the same order as the SUBCOMMANDS section in the `zellij --help` output.