### PR TITLE
stop truncating characters passed through the plugin api

### DIFF
--- a/zellij-utils/src/plugin_api/key.rs
+++ b/zellij-utils/src/plugin_api/key.rs
@@ -141,7 +141,7 @@ fn fn_index_to_main_key(index: u8) -> Result<ProtobufMainKey, &'static str> {
 }
 
 fn char_index_to_char(char_index: i32) -> char {
-    char_index as u8 as char
+    char::from_u32(char_index as u32).unwrap()
 }
 
 fn named_key_to_bare_key(named_key: ProtobufNamedKey) -> BareKey {


### PR DESCRIPTION
currently receiving input in plugins via Event::Key is broken for characters that don't fit into a u8 because this line is truncating them