### PR TITLE
fix(terminal): Support kitty keyboard protocol setting with "="

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -2992,6 +2992,17 @@ impl Perform for Grid {
                 "\u{1b}[?0u"
             };
             self.pending_messages_to_pty.push(reply.as_bytes().to_vec());
+        } else if c == 'u' && intermediates == &[b'='] {
+            // kitty keyboard protocol without the stack, just setting.
+            // 0 disables, everything else enables.
+            let count = next_param_or(0);
+            if !self.explicitly_disable_kitty_keyboard_protocol {
+                if count > 0 {
+                    self.supports_kitty_keyboard_protocol = true;
+                } else {
+                    self.supports_kitty_keyboard_protocol = false;
+                }
+            }
         } else if c == 'u' {
             self.restore_cursor_position();
         } else if c == '@' {


### PR DESCRIPTION
From
https://sw.kovidgoyal.net/kitty/keyboard-protocol/#progressive-enhancement:

> The escape code for requesting enhancements is:

> CSI = flags ; mode u

That means it can be *set* with CSI =, not just pushed/popped onto the stack with CSI < and CSI >.

This is important because otherwise zellij would interpret this as restore_cursor_position, which would move the cursor.

This would be hit by the next fish-shell release, which sends CSI = 5 u and CSI = 0 u to enable/disable the kitty keyboard enhancements unconditionally,
so if you used any program that saved the cursor position it would constantly move your cursor back on every prompt.

Fixes #3852