### PR TITLE
feat(plugins): add `PastedText` Event

### DIFF
--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -296,16 +296,17 @@ impl Pane for PluginPane {
             if let Some(text_being_pasted) = self.text_being_pasted.take() {
                 match String::from_utf8(text_being_pasted) {
                     Ok(pasted_text) => {
-                        let _ = self.send_plugin_instructions
+                        let _ = self
+                            .send_plugin_instructions
                             .send(PluginInstruction::Update(vec![(
                                 Some(self.pid),
                                 client_id,
-                                Event::PastedText(pasted_text)
+                                Event::PastedText(pasted_text),
                             )]));
                     },
                     Err(e) => {
                         log::error!("Failed to convert pasted bytes as utf8 {:?}", e);
-                    }
+                    },
                 }
             }
             None

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -213,6 +213,7 @@ impl Pane for TerminalPane {
         key_with_modifier: &Option<KeyWithModifier>,
         raw_input_bytes: Vec<u8>,
         raw_input_bytes_are_kitty: bool,
+        _client_id: Option<ClientId>,
     ) -> Option<AdjustedInput> {
         // there are some cases in which the terminal state means that input sent to it
         // needs to be adjusted.

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -229,6 +229,7 @@ pub trait Pane {
         _key_with_modifier: &Option<KeyWithModifier>,
         _raw_input_bytes: Vec<u8>,
         _raw_input_bytes_are_kitty: bool,
+        _client_id: Option<ClientId>,
     ) -> Option<AdjustedInput> {
         None
     }
@@ -1874,6 +1875,7 @@ impl Tab {
                     key_with_modifier,
                     raw_input_bytes,
                     raw_input_bytes_are_kitty,
+                    client_id,
                 ) {
                     Some(AdjustedInput::WriteBytesToTerminal(adjusted_input)) => {
                         self.senders
@@ -1916,6 +1918,7 @@ impl Tab {
                 key_with_modifier,
                 raw_input_bytes,
                 raw_input_bytes_are_kitty,
+                client_id,
             ) {
                 Some(AdjustedInput::WriteKeyToPlugin(key_with_modifier)) => {
                     self.senders

--- a/zellij-utils/assets/prost/api.event.rs
+++ b/zellij-utils/assets/prost/api.event.rs
@@ -11,7 +11,7 @@ pub struct Event {
     pub name: i32,
     #[prost(
         oneof = "event::Payload",
-        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25"
+        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26"
     )]
     pub payload: ::core::option::Option<event::Payload>,
 }
@@ -68,7 +68,15 @@ pub mod event {
         HostFolderChangedPayload(super::HostFolderChangedPayload),
         #[prost(message, tag = "25")]
         FailedToChangeHostFolderPayload(super::FailedToChangeHostFolderPayload),
+        #[prost(message, tag = "26")]
+        PastedTextPayload(super::PastedTextPayload),
     }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PastedTextPayload {
+    #[prost(string, tag = "1")]
+    pub pasted_text: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -486,6 +494,7 @@ pub enum EventType {
     ListClients = 26,
     HostFolderChanged = 27,
     FailedToChangeHostFolder = 28,
+    PastedText = 29,
 }
 impl EventType {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -523,6 +532,7 @@ impl EventType {
             EventType::ListClients => "ListClients",
             EventType::HostFolderChanged => "HostFolderChanged",
             EventType::FailedToChangeHostFolder => "FailedToChangeHostFolder",
+            EventType::PastedText => "PastedText",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -557,6 +567,7 @@ impl EventType {
             "ListClients" => Some(Self::ListClients),
             "HostFolderChanged" => Some(Self::HostFolderChanged),
             "FailedToChangeHostFolder" => Some(Self::FailedToChangeHostFolder),
+            "PastedText" => Some(Self::PastedText),
             _ => None,
         }
     }

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -914,6 +914,7 @@ pub enum Event {
     ListClients(Vec<ClientInfo>),
     HostFolderChanged(PathBuf),               // PathBuf -> new host folder
     FailedToChangeHostFolder(Option<String>), // String -> the error we got when changing
+    PastedText(String),
 }
 
 #[derive(

--- a/zellij-utils/src/plugin_api/event.proto
+++ b/zellij-utils/src/plugin_api/event.proto
@@ -52,6 +52,7 @@ enum EventType {
     ListClients = 26;
     HostFolderChanged = 27;
     FailedToChangeHostFolder = 28;
+    PastedText = 29;
 }
 
 message EventNameList {
@@ -85,7 +86,12 @@ message Event {
     ListClientsPayload list_clients_payload = 23;
     HostFolderChangedPayload host_folder_changed_payload = 24;
     FailedToChangeHostFolderPayload failed_to_change_host_folder_payload = 25;
+    PastedTextPayload pasted_text_payload = 26;
   }
+}
+
+message PastedTextPayload {
+  string pasted_text = 1;
 }
 
 message FailedToChangeHostFolderPayload {

--- a/zellij-utils/src/plugin_api/event.rs
+++ b/zellij-utils/src/plugin_api/event.rs
@@ -349,6 +349,14 @@ impl TryFrom<ProtobufEvent> for Event {
                 )),
                 _ => Err("Malformed payload for the FailedToChangeHostFolder Event"),
             },
+            Some(ProtobufEventType::PastedText) => match protobuf_event.payload {
+                Some(ProtobufEventPayload::PastedTextPayload(
+                    pasted_text_payload,
+                )) => Ok(Event::PastedText(
+                    pasted_text_payload.pasted_text,
+                )),
+                _ => Err("Malformed payload for the PastedText Event"),
+            },
             None => Err("Unknown Protobuf Event"),
         }
     }
@@ -711,6 +719,12 @@ impl TryFrom<Event> for ProtobufEvent {
                 name: ProtobufEventType::FailedToChangeHostFolder as i32,
                 payload: Some(event::Payload::FailedToChangeHostFolderPayload(
                     FailedToChangeHostFolderPayload { error_message },
+                )),
+            }),
+            Event::PastedText(pasted_text) => Ok(ProtobufEvent {
+                name: ProtobufEventType::PastedText as i32,
+                payload: Some(event::Payload::PastedTextPayload(
+                    PastedTextPayload { pasted_text },
                 )),
             }),
         }
@@ -1260,6 +1274,7 @@ impl TryFrom<ProtobufEventType> for EventType {
             ProtobufEventType::ListClients => EventType::ListClients,
             ProtobufEventType::HostFolderChanged => EventType::HostFolderChanged,
             ProtobufEventType::FailedToChangeHostFolder => EventType::FailedToChangeHostFolder,
+            ProtobufEventType::PastedText => EventType::PastedText,
         })
     }
 }
@@ -1297,6 +1312,7 @@ impl TryFrom<EventType> for ProtobufEventType {
             EventType::ListClients => ProtobufEventType::ListClients,
             EventType::HostFolderChanged => ProtobufEventType::HostFolderChanged,
             EventType::FailedToChangeHostFolder => ProtobufEventType::FailedToChangeHostFolder,
+            EventType::PastedText => ProtobufEventType::PastedText,
         })
     }
 }

--- a/zellij-utils/src/plugin_api/event.rs
+++ b/zellij-utils/src/plugin_api/event.rs
@@ -350,11 +350,9 @@ impl TryFrom<ProtobufEvent> for Event {
                 _ => Err("Malformed payload for the FailedToChangeHostFolder Event"),
             },
             Some(ProtobufEventType::PastedText) => match protobuf_event.payload {
-                Some(ProtobufEventPayload::PastedTextPayload(
-                    pasted_text_payload,
-                )) => Ok(Event::PastedText(
-                    pasted_text_payload.pasted_text,
-                )),
+                Some(ProtobufEventPayload::PastedTextPayload(pasted_text_payload)) => {
+                    Ok(Event::PastedText(pasted_text_payload.pasted_text))
+                },
                 _ => Err("Malformed payload for the PastedText Event"),
             },
             None => Err("Unknown Protobuf Event"),
@@ -723,9 +721,9 @@ impl TryFrom<Event> for ProtobufEvent {
             }),
             Event::PastedText(pasted_text) => Ok(ProtobufEvent {
                 name: ProtobufEventType::PastedText as i32,
-                payload: Some(event::Payload::PastedTextPayload(
-                    PastedTextPayload { pasted_text },
-                )),
+                payload: Some(event::Payload::PastedTextPayload(PastedTextPayload {
+                    pasted_text,
+                })),
             }),
         }
     }


### PR DESCRIPTION
This makes it so that if a user pastes text while focused on a plugin, the text will arrive in one go with the new `PastedText` event rather than character by character as before.

This should make it much easier to invite users to paste text into plugins and handle it as a whole rather than rendering on each keystroke and trying to figure out when the paste ended with debounces and other methods.