### PR TITLE
feat(plugins): Allow opening panes near plugin

### DIFF
--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -823,7 +823,7 @@ impl FloatingPanes {
                 if let Some(first_pane_id) = self.panes.iter().next().map(|(p_id, _)| *p_id) {
                     self.focus_pane(first_pane_id, client_id);
                 }
-            }
+            },
         }
     }
     pub fn defocus_pane(&mut self, pane_id: PaneId, client_id: ClientId) {

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -816,6 +816,16 @@ impl FloatingPanes {
             None => self.focus_pane(pane_id, client_id),
         }
     }
+    pub fn focus_first_pane_if_client_not_focused(&mut self, client_id: ClientId) {
+        match self.active_panes.get(&client_id) {
+            Some(already_focused_pane_id) => self.focus_pane(*already_focused_pane_id, client_id),
+            None => {
+                if let Some(first_pane_id) = self.panes.iter().next().map(|(p_id, _)| *p_id) {
+                    self.focus_pane(first_pane_id, client_id);
+                }
+            }
+        }
+    }
     pub fn defocus_pane(&mut self, pane_id: PaneId, client_id: ClientId) {
         self.z_indices.retain(|p_id| *p_id != pane_id);
         self.active_panes.remove(&client_id, &mut self.panes);

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -2946,7 +2946,10 @@ pub(crate) fn screen_thread_main(
                             }
                         }
                         if !found {
-                            log::error!("Failed to find tab containing pane with id: {:?}", pane_id);
+                            log::error!(
+                                "Failed to find tab containing pane with id: {:?}",
+                                pane_id
+                            );
                         }
                     },
                 };

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -2923,8 +2923,31 @@ pub(crate) fn screen_thread_main(
                             log::error!("Tab index not found: {:?}", tab_index);
                         }
                     },
-                    ClientTabIndexOrPaneId::PaneId(_pane_id) => {
-                        log::error!("cannot open a pane with a pane id??");
+                    ClientTabIndexOrPaneId::PaneId(pane_id) => {
+                        let mut found = false;
+                        let all_tabs = screen.get_tabs_mut();
+                        for tab in all_tabs.values_mut() {
+                            if tab.has_pane_with_pid(&pane_id) {
+                                tab.new_pane(
+                                    pid,
+                                    initial_pane_title,
+                                    should_float,
+                                    invoked_with,
+                                    floating_pane_coordinates,
+                                    start_suppressed,
+                                    None,
+                                )?;
+                                if let Some(hold_for_command) = hold_for_command {
+                                    let is_first_run = true;
+                                    tab.hold_pane(pid, None, is_first_run, hold_for_command);
+                                }
+                                found = true;
+                                break;
+                            }
+                        }
+                        if !found {
+                            log::error!("Failed to find tab containing pane with id: {:?}", pane_id);
+                        }
                     },
                 };
                 screen.unblock_input()?;

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -928,6 +928,7 @@ impl Tab {
             };
             self.tiled_panes
                 .focus_pane_if_client_not_focused(focus_pane_id, client_id);
+            self.floating_panes.focus_first_pane_if_client_not_focused(client_id);
             self.connected_clients.borrow_mut().insert(client_id);
             self.mode_info.borrow_mut().insert(
                 client_id,

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -928,7 +928,8 @@ impl Tab {
             };
             self.tiled_panes
                 .focus_pane_if_client_not_focused(focus_pane_id, client_id);
-            self.floating_panes.focus_first_pane_if_client_not_focused(client_id);
+            self.floating_panes
+                .focus_first_pane_if_client_not_focused(client_id);
             self.connected_clients.borrow_mut().insert(client_id);
             self.mode_info.borrow_mut().insert(
                 client_id,

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -118,7 +118,8 @@ pub fn open_file_floating_near_plugin(
     coordinates: Option<FloatingPaneCoordinates>,
     context: BTreeMap<String, String>,
 ) {
-    let plugin_command = PluginCommand::OpenFileFloatingNearPlugin(file_to_open, coordinates, context);
+    let plugin_command =
+        PluginCommand::OpenFileFloatingNearPlugin(file_to_open, coordinates, context);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
     unsafe { host_run_plugin_command() };
@@ -208,7 +209,10 @@ pub fn open_command_pane(command_to_run: CommandToRun, context: BTreeMap<String,
 /// Open a new command pane with the specified command and args (this sort of pane allows the user to control the command, re-run it and see its exit status through the Zellij UI).
 /// This variant is the same as `open_command_pane` except it opens the pane in the same tab as the
 /// plugin regardless of whether the user is focused on it
-pub fn open_command_pane_near_plugin(command_to_run: CommandToRun, context: BTreeMap<String, String>) {
+pub fn open_command_pane_near_plugin(
+    command_to_run: CommandToRun,
+    context: BTreeMap<String, String>,
+) {
     let plugin_command = PluginCommand::OpenCommandPaneNearPlugin(command_to_run, context);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
@@ -254,7 +258,10 @@ pub fn open_command_pane_in_place(command_to_run: CommandToRun, context: BTreeMa
 /// Open a new in place command pane with the specified command and args (this sort of pane allows the user to control the command, re-run it and see its exit status through the Zellij UI).
 /// This variant is the same as open_command_pane_in_place, except that it always replaces the
 /// plugin pane rather than whichever pane the user is focused on
-pub fn open_command_pane_in_place_of_plugin(command_to_run: CommandToRun, context: BTreeMap<String, String>) {
+pub fn open_command_pane_in_place_of_plugin(
+    command_to_run: CommandToRun,
+    context: BTreeMap<String, String>,
+) {
     let plugin_command = PluginCommand::OpenCommandPaneInPlaceOfPlugin(command_to_run, context);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -104,6 +104,33 @@ pub fn open_file_in_place(file_to_open: FileToOpen, context: BTreeMap<String, St
     unsafe { host_run_plugin_command() };
 }
 
+/// Open a file in the user's default `$EDITOR` in a new pane near th eplugin
+pub fn open_file_near_plugin(file_to_open: FileToOpen, context: BTreeMap<String, String>) {
+    let plugin_command = PluginCommand::OpenFileNearPlugin(file_to_open, context);
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
+/// Open a file in the user's default `$EDITOR` in a new floating pane near the plugin
+pub fn open_file_floating_near_plugin(
+    file_to_open: FileToOpen,
+    coordinates: Option<FloatingPaneCoordinates>,
+    context: BTreeMap<String, String>,
+) {
+    let plugin_command = PluginCommand::OpenFileFloatingNearPlugin(file_to_open, coordinates, context);
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
+/// Open a file in the user's default `$EDITOR`, replacing the plugin pane
+pub fn open_file_in_place_of_plugin(file_to_open: FileToOpen, context: BTreeMap<String, String>) {
+    let plugin_command = PluginCommand::OpenFileInPlaceOfPlugin(file_to_open, context);
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
 /// Open a new terminal pane to the specified location on the host filesystem
 pub fn open_terminal<P: AsRef<Path>>(path: P) {
     let file_to_open = FileToOpen::new(path.as_ref().to_path_buf());

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -113,6 +113,17 @@ pub fn open_terminal<P: AsRef<Path>>(path: P) {
     unsafe { host_run_plugin_command() };
 }
 
+/// Open a new terminal pane to the specified location on the host filesystem
+/// This variant is identical to open_terminal, excpet it opens it near the plugin regardless of
+/// whether the user was focused on it or not
+pub fn open_terminal_near_plugin<P: AsRef<Path>>(path: P) {
+    let file_to_open = FileToOpen::new(path.as_ref().to_path_buf());
+    let plugin_command = PluginCommand::OpenTerminalNearPlugin(file_to_open);
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
 /// Open a new floating terminal pane to the specified location on the host filesystem
 pub fn open_terminal_floating<P: AsRef<Path>>(
     path: P,
@@ -120,6 +131,20 @@ pub fn open_terminal_floating<P: AsRef<Path>>(
 ) {
     let file_to_open = FileToOpen::new(path.as_ref().to_path_buf());
     let plugin_command = PluginCommand::OpenTerminalFloating(file_to_open, coordinates);
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
+/// Open a new floating terminal pane to the specified location on the host filesystem
+/// This variant is identical to open_terminal_floating, excpet it opens it near the plugin regardless of
+/// whether the user was focused on it or not
+pub fn open_terminal_floating_near_plugin<P: AsRef<Path>>(
+    path: P,
+    coordinates: Option<FloatingPaneCoordinates>,
+) {
+    let file_to_open = FileToOpen::new(path.as_ref().to_path_buf());
+    let plugin_command = PluginCommand::OpenTerminalFloatingNearPlugin(file_to_open, coordinates);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
     unsafe { host_run_plugin_command() };
@@ -135,9 +160,29 @@ pub fn open_terminal_in_place<P: AsRef<Path>>(path: P) {
     unsafe { host_run_plugin_command() };
 }
 
+/// Open a new terminal pane to the specified location on the host filesystem, temporarily
+/// replacing the plugin pane
+pub fn open_terminal_in_place_of_plugin<P: AsRef<Path>>(path: P) {
+    let file_to_open = FileToOpen::new(path.as_ref().to_path_buf());
+    let plugin_command = PluginCommand::OpenTerminalInPlaceOfPlugin(file_to_open);
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
 /// Open a new command pane with the specified command and args (this sort of pane allows the user to control the command, re-run it and see its exit status through the Zellij UI).
 pub fn open_command_pane(command_to_run: CommandToRun, context: BTreeMap<String, String>) {
     let plugin_command = PluginCommand::OpenCommandPane(command_to_run, context);
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
+/// Open a new command pane with the specified command and args (this sort of pane allows the user to control the command, re-run it and see its exit status through the Zellij UI).
+/// This variant is the same as `open_command_pane` except it opens the pane in the same tab as the
+/// plugin regardless of whether the user is focused on it
+pub fn open_command_pane_near_plugin(command_to_run: CommandToRun, context: BTreeMap<String, String>) {
+    let plugin_command = PluginCommand::OpenCommandPaneNearPlugin(command_to_run, context);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
     unsafe { host_run_plugin_command() };
@@ -156,9 +201,34 @@ pub fn open_command_pane_floating(
     unsafe { host_run_plugin_command() };
 }
 
+/// Open a new floating command pane with the specified command and args (this sort of pane allows the user to control the command, re-run it and see its exit status through the Zellij UI).
+/// This variant is the same as `open_command_pane_floating` except it opens the pane in the same tab as the
+/// plugin regardless of whether the user is focused on it
+pub fn open_command_pane_floating_near_plugin(
+    command_to_run: CommandToRun,
+    coordinates: Option<FloatingPaneCoordinates>,
+    context: BTreeMap<String, String>,
+) {
+    let plugin_command =
+        PluginCommand::OpenCommandPaneFloatingNearPlugin(command_to_run, coordinates, context);
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
 /// Open a new in place command pane with the specified command and args (this sort of pane allows the user to control the command, re-run it and see its exit status through the Zellij UI).
 pub fn open_command_pane_in_place(command_to_run: CommandToRun, context: BTreeMap<String, String>) {
     let plugin_command = PluginCommand::OpenCommandPaneInPlace(command_to_run, context);
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
+/// Open a new in place command pane with the specified command and args (this sort of pane allows the user to control the command, re-run it and see its exit status through the Zellij UI).
+/// This variant is the same as open_command_pane_in_place, except that it always replaces the
+/// plugin pane rather than whichever pane the user is focused on
+pub fn open_command_pane_in_place_of_plugin(command_to_run: CommandToRun, context: BTreeMap<String, String>) {
+    let plugin_command = PluginCommand::OpenCommandPaneInPlaceOfPlugin(command_to_run, context);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
     unsafe { host_run_plugin_command() };

--- a/zellij-utils/assets/prost/api.plugin_command.rs
+++ b/zellij-utils/assets/prost/api.plugin_command.rs
@@ -5,7 +5,7 @@ pub struct PluginCommand {
     pub name: i32,
     #[prost(
         oneof = "plugin_command::Payload",
-        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98"
+        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101"
     )]
     pub payload: ::core::option::Option<plugin_command::Payload>,
 }
@@ -202,7 +202,43 @@ pub mod plugin_command {
         OpenCommandPaneInPlaceOfPluginPayload(
             super::OpenCommandPaneInPlaceOfPluginPayload,
         ),
+        #[prost(message, tag = "99")]
+        OpenFileNearPluginPayload(super::OpenFileNearPluginPayload),
+        #[prost(message, tag = "100")]
+        OpenFileFloatingNearPluginPayload(super::OpenFileFloatingNearPluginPayload),
+        #[prost(message, tag = "101")]
+        OpenFileInPlaceOfPluginPayload(super::OpenFileInPlaceOfPluginPayload),
     }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OpenFileInPlaceOfPluginPayload {
+    #[prost(message, optional, tag = "1")]
+    pub file_to_open: ::core::option::Option<super::file::File>,
+    #[prost(message, optional, tag = "2")]
+    pub floating_pane_coordinates: ::core::option::Option<FloatingPaneCoordinates>,
+    #[prost(message, repeated, tag = "3")]
+    pub context: ::prost::alloc::vec::Vec<ContextItem>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OpenFileFloatingNearPluginPayload {
+    #[prost(message, optional, tag = "1")]
+    pub file_to_open: ::core::option::Option<super::file::File>,
+    #[prost(message, optional, tag = "2")]
+    pub floating_pane_coordinates: ::core::option::Option<FloatingPaneCoordinates>,
+    #[prost(message, repeated, tag = "3")]
+    pub context: ::prost::alloc::vec::Vec<ContextItem>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OpenFileNearPluginPayload {
+    #[prost(message, optional, tag = "1")]
+    pub file_to_open: ::core::option::Option<super::file::File>,
+    #[prost(message, optional, tag = "2")]
+    pub floating_pane_coordinates: ::core::option::Option<FloatingPaneCoordinates>,
+    #[prost(message, repeated, tag = "3")]
+    pub context: ::prost::alloc::vec::Vec<ContextItem>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -846,6 +882,9 @@ pub enum CommandName {
     OpenTerminalInPlaceOfPlugin = 121,
     OpenCommandPaneFloatingNearPlugin = 122,
     OpenCommandPaneInPlaceOfPlugin = 123,
+    OpenFileNearPlugin = 124,
+    OpenFileFloatingNearPlugin = 125,
+    OpenFileInPlaceOfPlugin = 126,
 }
 impl CommandName {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -988,6 +1027,9 @@ impl CommandName {
             CommandName::OpenCommandPaneInPlaceOfPlugin => {
                 "OpenCommandPaneInPlaceOfPlugin"
             }
+            CommandName::OpenFileNearPlugin => "OpenFileNearPlugin",
+            CommandName::OpenFileFloatingNearPlugin => "OpenFileFloatingNearPlugin",
+            CommandName::OpenFileInPlaceOfPlugin => "OpenFileInPlaceOfPlugin",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -1127,6 +1169,9 @@ impl CommandName {
             "OpenCommandPaneInPlaceOfPlugin" => {
                 Some(Self::OpenCommandPaneInPlaceOfPlugin)
             }
+            "OpenFileNearPlugin" => Some(Self::OpenFileNearPlugin),
+            "OpenFileFloatingNearPlugin" => Some(Self::OpenFileFloatingNearPlugin),
+            "OpenFileInPlaceOfPlugin" => Some(Self::OpenFileInPlaceOfPlugin),
             _ => None,
         }
     }

--- a/zellij-utils/assets/prost/api.plugin_command.rs
+++ b/zellij-utils/assets/prost/api.plugin_command.rs
@@ -5,7 +5,7 @@ pub struct PluginCommand {
     pub name: i32,
     #[prost(
         oneof = "plugin_command::Payload",
-        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92"
+        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98"
     )]
     pub payload: ::core::option::Option<plugin_command::Payload>,
 }
@@ -184,7 +184,79 @@ pub mod plugin_command {
         ChangeFloatingPanesCoordinatesPayload(
             super::ChangeFloatingPanesCoordinatesPayload,
         ),
+        #[prost(message, tag = "93")]
+        OpenCommandPaneNearPluginPayload(super::OpenCommandPaneNearPluginPayload),
+        #[prost(message, tag = "94")]
+        OpenTerminalNearPluginPayload(super::OpenTerminalNearPluginPayload),
+        #[prost(message, tag = "95")]
+        OpenTerminalFloatingNearPluginPayload(
+            super::OpenTerminalFloatingNearPluginPayload,
+        ),
+        #[prost(message, tag = "96")]
+        OpenTerminalInPlaceOfPluginPayload(super::OpenTerminalInPlaceOfPluginPayload),
+        #[prost(message, tag = "97")]
+        OpenCommandPaneFloatingNearPluginPayload(
+            super::OpenCommandPaneFloatingNearPluginPayload,
+        ),
+        #[prost(message, tag = "98")]
+        OpenCommandPaneInPlaceOfPluginPayload(
+            super::OpenCommandPaneInPlaceOfPluginPayload,
+        ),
     }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OpenCommandPaneInPlaceOfPluginPayload {
+    #[prost(message, optional, tag = "1")]
+    pub command_to_run: ::core::option::Option<super::command::Command>,
+    #[prost(message, repeated, tag = "3")]
+    pub context: ::prost::alloc::vec::Vec<ContextItem>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OpenCommandPaneFloatingNearPluginPayload {
+    #[prost(message, optional, tag = "1")]
+    pub command_to_run: ::core::option::Option<super::command::Command>,
+    #[prost(message, optional, tag = "2")]
+    pub floating_pane_coordinates: ::core::option::Option<FloatingPaneCoordinates>,
+    #[prost(message, repeated, tag = "3")]
+    pub context: ::prost::alloc::vec::Vec<ContextItem>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OpenTerminalInPlaceOfPluginPayload {
+    #[prost(message, optional, tag = "1")]
+    pub file_to_open: ::core::option::Option<super::file::File>,
+    #[prost(message, repeated, tag = "3")]
+    pub context: ::prost::alloc::vec::Vec<ContextItem>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OpenTerminalFloatingNearPluginPayload {
+    #[prost(message, optional, tag = "1")]
+    pub file_to_open: ::core::option::Option<super::file::File>,
+    #[prost(message, optional, tag = "2")]
+    pub floating_pane_coordinates: ::core::option::Option<FloatingPaneCoordinates>,
+    #[prost(message, repeated, tag = "3")]
+    pub context: ::prost::alloc::vec::Vec<ContextItem>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OpenTerminalNearPluginPayload {
+    #[prost(message, optional, tag = "1")]
+    pub file_to_open: ::core::option::Option<super::file::File>,
+    #[prost(message, repeated, tag = "3")]
+    pub context: ::prost::alloc::vec::Vec<ContextItem>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OpenCommandPaneNearPluginPayload {
+    #[prost(message, optional, tag = "1")]
+    pub command_to_run: ::core::option::Option<super::command::Command>,
+    #[prost(message, optional, tag = "2")]
+    pub floating_pane_coordinates: ::core::option::Option<FloatingPaneCoordinates>,
+    #[prost(message, repeated, tag = "3")]
+    pub context: ::prost::alloc::vec::Vec<ContextItem>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -768,6 +840,12 @@ pub enum CommandName {
     SetFloatingPanePinned = 115,
     StackPanes = 116,
     ChangeFloatingPanesCoordinates = 117,
+    OpenCommandPaneNearPlugin = 118,
+    OpenTerminalNearPlugin = 119,
+    OpenTerminalFloatingNearPlugin = 120,
+    OpenTerminalInPlaceOfPlugin = 121,
+    OpenCommandPaneFloatingNearPlugin = 122,
+    OpenCommandPaneInPlaceOfPlugin = 123,
 }
 impl CommandName {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -898,6 +976,18 @@ impl CommandName {
             CommandName::ChangeFloatingPanesCoordinates => {
                 "ChangeFloatingPanesCoordinates"
             }
+            CommandName::OpenCommandPaneNearPlugin => "OpenCommandPaneNearPlugin",
+            CommandName::OpenTerminalNearPlugin => "OpenTerminalNearPlugin",
+            CommandName::OpenTerminalFloatingNearPlugin => {
+                "OpenTerminalFloatingNearPlugin"
+            }
+            CommandName::OpenTerminalInPlaceOfPlugin => "OpenTerminalInPlaceOfPlugin",
+            CommandName::OpenCommandPaneFloatingNearPlugin => {
+                "OpenCommandPaneFloatingNearPlugin"
+            }
+            CommandName::OpenCommandPaneInPlaceOfPlugin => {
+                "OpenCommandPaneInPlaceOfPlugin"
+            }
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -1024,6 +1114,18 @@ impl CommandName {
             "StackPanes" => Some(Self::StackPanes),
             "ChangeFloatingPanesCoordinates" => {
                 Some(Self::ChangeFloatingPanesCoordinates)
+            }
+            "OpenCommandPaneNearPlugin" => Some(Self::OpenCommandPaneNearPlugin),
+            "OpenTerminalNearPlugin" => Some(Self::OpenTerminalNearPlugin),
+            "OpenTerminalFloatingNearPlugin" => {
+                Some(Self::OpenTerminalFloatingNearPlugin)
+            }
+            "OpenTerminalInPlaceOfPlugin" => Some(Self::OpenTerminalInPlaceOfPlugin),
+            "OpenCommandPaneFloatingNearPlugin" => {
+                Some(Self::OpenCommandPaneFloatingNearPlugin)
+            }
+            "OpenCommandPaneInPlaceOfPlugin" => {
+                Some(Self::OpenCommandPaneInPlaceOfPlugin)
             }
             _ => None,
         }

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -1939,4 +1939,7 @@ pub enum PluginCommand {
     OpenTerminalInPlaceOfPlugin(FileToOpen),
     OpenCommandPaneFloatingNearPlugin(CommandToRun, Option<FloatingPaneCoordinates>, Context),
     OpenCommandPaneInPlaceOfPlugin(CommandToRun, Context),
+    OpenFileNearPlugin(FileToOpen, Context),
+    OpenFileFloatingNearPlugin(FileToOpen, Option<FloatingPaneCoordinates>, Context),
+    OpenFileInPlaceOfPlugin(FileToOpen, Context),
 }

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -1933,4 +1933,10 @@ pub enum PluginCommand {
     SetFloatingPanePinned(PaneId, bool), // bool -> should be pinned
     StackPanes(Vec<PaneId>),
     ChangeFloatingPanesCoordinates(Vec<(PaneId, FloatingPaneCoordinates)>),
+    OpenCommandPaneNearPlugin(CommandToRun, Context),
+    OpenTerminalNearPlugin(FileToOpen),
+    OpenTerminalFloatingNearPlugin(FileToOpen, Option<FloatingPaneCoordinates>),
+    OpenTerminalInPlaceOfPlugin(FileToOpen),
+    OpenCommandPaneFloatingNearPlugin(CommandToRun, Option<FloatingPaneCoordinates>, Context),
+    OpenCommandPaneInPlaceOfPlugin(CommandToRun, Context),
 }

--- a/zellij-utils/src/plugin_api/plugin_command.proto
+++ b/zellij-utils/src/plugin_api/plugin_command.proto
@@ -137,6 +137,9 @@ enum CommandName {
   OpenTerminalInPlaceOfPlugin = 121;
   OpenCommandPaneFloatingNearPlugin = 122;
   OpenCommandPaneInPlaceOfPlugin = 123;
+  OpenFileNearPlugin = 124;
+  OpenFileFloatingNearPlugin = 125;
+  OpenFileInPlaceOfPlugin = 126;
 }
 
 message PluginCommand {
@@ -230,7 +233,28 @@ message PluginCommand {
     OpenTerminalInPlaceOfPluginPayload open_terminal_in_place_of_plugin_payload = 96;
     OpenCommandPaneFloatingNearPluginPayload open_command_pane_floating_near_plugin_payload = 97;
     OpenCommandPaneInPlaceOfPluginPayload open_command_pane_in_place_of_plugin_payload = 98;
+    OpenFileNearPluginPayload open_file_near_plugin_payload = 99;
+    OpenFileFloatingNearPluginPayload open_file_floating_near_plugin_payload = 100;
+    OpenFileInPlaceOfPluginPayload open_file_in_place_of_plugin_payload = 101;
   }
+}
+
+message OpenFileInPlaceOfPluginPayload {
+  file.File file_to_open = 1;
+  optional FloatingPaneCoordinates floating_pane_coordinates = 2;
+  repeated ContextItem context = 3;
+}
+
+message OpenFileFloatingNearPluginPayload {
+  file.File file_to_open = 1;
+  optional FloatingPaneCoordinates floating_pane_coordinates = 2;
+  repeated ContextItem context = 3;
+}
+
+message OpenFileNearPluginPayload {
+  file.File file_to_open = 1;
+  optional FloatingPaneCoordinates floating_pane_coordinates = 2;
+  repeated ContextItem context = 3;
 }
 
 message OpenCommandPaneInPlaceOfPluginPayload {

--- a/zellij-utils/src/plugin_api/plugin_command.proto
+++ b/zellij-utils/src/plugin_api/plugin_command.proto
@@ -131,6 +131,12 @@ enum CommandName {
   SetFloatingPanePinned = 115;
   StackPanes = 116;
   ChangeFloatingPanesCoordinates = 117;
+  OpenCommandPaneNearPlugin = 118;
+  OpenTerminalNearPlugin = 119;
+  OpenTerminalFloatingNearPlugin = 120;
+  OpenTerminalInPlaceOfPlugin = 121;
+  OpenCommandPaneFloatingNearPlugin = 122;
+  OpenCommandPaneInPlaceOfPlugin = 123;
 }
 
 message PluginCommand {
@@ -218,7 +224,46 @@ message PluginCommand {
     SetFloatingPanePinnedPayload set_floating_pane_pinned_payload = 90;
     StackPanesPayload stack_panes_payload = 91;
     ChangeFloatingPanesCoordinatesPayload change_floating_panes_coordinates_payload = 92;
+    OpenCommandPaneNearPluginPayload open_command_pane_near_plugin_payload = 93;
+    OpenTerminalNearPluginPayload open_terminal_near_plugin_payload = 94;
+    OpenTerminalFloatingNearPluginPayload open_terminal_floating_near_plugin_payload = 95;
+    OpenTerminalInPlaceOfPluginPayload open_terminal_in_place_of_plugin_payload = 96;
+    OpenCommandPaneFloatingNearPluginPayload open_command_pane_floating_near_plugin_payload = 97;
+    OpenCommandPaneInPlaceOfPluginPayload open_command_pane_in_place_of_plugin_payload = 98;
   }
+}
+
+message OpenCommandPaneInPlaceOfPluginPayload {
+  command.Command command_to_run = 1;
+  repeated ContextItem context = 3;
+}
+
+message OpenCommandPaneFloatingNearPluginPayload {
+  command.Command command_to_run = 1;
+  optional FloatingPaneCoordinates floating_pane_coordinates = 2;
+  repeated ContextItem context = 3;
+}
+
+message OpenTerminalInPlaceOfPluginPayload {
+  file.File file_to_open = 1;
+  repeated ContextItem context = 3;
+}
+
+message OpenTerminalFloatingNearPluginPayload {
+  file.File file_to_open = 1;
+  optional FloatingPaneCoordinates floating_pane_coordinates = 2;
+  repeated ContextItem context = 3;
+}
+
+message OpenTerminalNearPluginPayload {
+  file.File file_to_open = 1;
+  repeated ContextItem context = 3;
+}
+
+message OpenCommandPaneNearPluginPayload {
+  command.Command command_to_run = 1;
+  optional FloatingPaneCoordinates floating_pane_coordinates = 2;
+  repeated ContextItem context = 3;
 }
 
 message ChangeFloatingPanesCoordinatesPayload {

--- a/zellij-utils/src/plugin_api/plugin_command.rs
+++ b/zellij-utils/src/plugin_api/plugin_command.rs
@@ -13,7 +13,11 @@ pub use super::generated_api::api::{
         HttpVerb as ProtobufHttpVerb, IdAndNewName, KeyToRebind, KeyToUnbind, KillSessionsPayload,
         LoadNewPluginPayload, MessageToPluginPayload, MovePaneWithPaneIdInDirectionPayload,
         MovePaneWithPaneIdPayload, MovePayload, NewPluginArgs as ProtobufNewPluginArgs,
-        NewTabsWithLayoutInfoPayload, OpenCommandPanePayload, OpenFilePayload,
+        NewTabsWithLayoutInfoPayload, OpenCommandPaneFloatingNearPluginPayload,
+        OpenCommandPaneInPlaceOfPluginPayload, OpenCommandPaneNearPluginPayload,
+        OpenCommandPanePayload, OpenFileFloatingNearPluginPayload, OpenFileInPlaceOfPluginPayload,
+        OpenFileNearPluginPayload, OpenFilePayload, OpenTerminalFloatingNearPluginPayload,
+        OpenTerminalInPlaceOfPluginPayload, OpenTerminalNearPluginPayload,
         PageScrollDownInPaneIdPayload, PageScrollUpInPaneIdPayload, PaneId as ProtobufPaneId,
         PaneIdAndFloatingPaneCoordinates, PaneType as ProtobufPaneType,
         PluginCommand as ProtobufPluginCommand, PluginMessagePayload, RebindKeysPayload,
@@ -24,7 +28,7 @@ pub use super::generated_api::api::{
         SetTimeoutPayload, ShowPaneWithIdPayload, StackPanesPayload, SubscribePayload,
         SwitchSessionPayload, SwitchTabToPayload, TogglePaneEmbedOrEjectForPaneIdPayload,
         TogglePaneIdFullscreenPayload, UnsubscribePayload, WebRequestPayload,
-        WriteCharsToPaneIdPayload, WriteToPaneIdPayload, OpenCommandPaneNearPluginPayload, OpenCommandPaneFloatingNearPluginPayload, OpenTerminalNearPluginPayload, OpenTerminalFloatingNearPluginPayload, OpenTerminalInPlaceOfPluginPayload, OpenCommandPaneInPlaceOfPluginPayload, OpenFileNearPluginPayload, OpenFileFloatingNearPluginPayload, OpenFileInPlaceOfPluginPayload,
+        WriteCharsToPaneIdPayload, WriteToPaneIdPayload,
     },
     plugin_permission::PermissionType as ProtobufPermissionType,
     resize::ResizeAction as ProtobufResizeAction,
@@ -1384,53 +1388,57 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
             Some(CommandName::OpenTerminalNearPlugin) => match protobuf_plugin_command.payload {
                 Some(Payload::OpenTerminalNearPluginPayload(open_terminal_near_plugin_payload)) => {
                     match open_terminal_near_plugin_payload.file_to_open {
-                        Some(file_to_open) => {
-                            Ok(PluginCommand::OpenTerminalNearPlugin(file_to_open.try_into()?))
-                        },
+                        Some(file_to_open) => Ok(PluginCommand::OpenTerminalNearPlugin(
+                            file_to_open.try_into()?,
+                        )),
                         None => Err("Malformed open terminal near plugin payload"),
                     }
                 },
                 _ => Err("Mismatched payload for OpenTerminalNearPluginPayload"),
             },
-            Some(CommandName::OpenTerminalFloatingNearPlugin) => match protobuf_plugin_command.payload {
-                Some(Payload::OpenTerminalFloatingNearPluginPayload(open_terminal_floating_near_plugin_payload)) => {
+            Some(CommandName::OpenTerminalFloatingNearPlugin) => match protobuf_plugin_command
+                .payload
+            {
+                Some(Payload::OpenTerminalFloatingNearPluginPayload(
+                    open_terminal_floating_near_plugin_payload,
+                )) => {
                     let floating_pane_coordinates = open_terminal_floating_near_plugin_payload
                         .floating_pane_coordinates
                         .map(|f| f.into());
                     match open_terminal_floating_near_plugin_payload.file_to_open {
-                        Some(file_to_open) => {
-                            Ok(PluginCommand::OpenTerminalFloatingNearPlugin(
-                                file_to_open.try_into()?,
-                                floating_pane_coordinates
-                            ))
-                        },
+                        Some(file_to_open) => Ok(PluginCommand::OpenTerminalFloatingNearPlugin(
+                            file_to_open.try_into()?,
+                            floating_pane_coordinates,
+                        )),
                         None => Err("Malformed open terminal floating near plugin payload"),
                     }
                 },
                 _ => Err("Mismatched payload for OpenTerminalFloatingNearPlugin"),
             },
-            Some(CommandName::OpenTerminalInPlaceOfPlugin) => match protobuf_plugin_command.payload {
-                Some(Payload::OpenTerminalInPlaceOfPluginPayload(open_terminal_in_place_of_plugin_payload)) => {
-                    match open_terminal_in_place_of_plugin_payload.file_to_open {
-                        Some(file_to_open) => {
-                            Ok(PluginCommand::OpenTerminalInPlaceOfPlugin(
-                                file_to_open.try_into()?,
-                            ))
-                        },
-                        None => Err("Malformed open terminal in place of plugin payload"),
-                    }
+            Some(CommandName::OpenTerminalInPlaceOfPlugin) => match protobuf_plugin_command.payload
+            {
+                Some(Payload::OpenTerminalInPlaceOfPluginPayload(
+                    open_terminal_in_place_of_plugin_payload,
+                )) => match open_terminal_in_place_of_plugin_payload.file_to_open {
+                    Some(file_to_open) => Ok(PluginCommand::OpenTerminalInPlaceOfPlugin(
+                        file_to_open.try_into()?,
+                    )),
+                    None => Err("Malformed open terminal in place of plugin payload"),
                 },
                 _ => Err("Mismatched payload for OpenTerminalInPlaceOfPlugin"),
             },
-            Some(CommandName::OpenCommandPaneFloatingNearPlugin) => match protobuf_plugin_command.payload {
-                Some(Payload::OpenCommandPaneFloatingNearPluginPayload(open_command_pane_floating_near_plugin)) => {
-                    match open_command_pane_floating_near_plugin.command_to_run {
+            Some(CommandName::OpenCommandPaneFloatingNearPlugin) => {
+                match protobuf_plugin_command.payload {
+                    Some(Payload::OpenCommandPaneFloatingNearPluginPayload(
+                        open_command_pane_floating_near_plugin,
+                    )) => match open_command_pane_floating_near_plugin.command_to_run {
                         Some(command_to_run) => {
-                            let context: BTreeMap<String, String> = open_command_pane_floating_near_plugin
-                                .context
-                                .into_iter()
-                                .map(|e| (e.name, e.value))
-                                .collect();
+                            let context: BTreeMap<String, String> =
+                                open_command_pane_floating_near_plugin
+                                    .context
+                                    .into_iter()
+                                    .map(|e| (e.name, e.value))
+                                    .collect();
                             let floating_pane_coordinates = open_command_pane_floating_near_plugin
                                 .floating_pane_coordinates
                                 .map(|f| f.into());
@@ -1441,28 +1449,31 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
                             ))
                         },
                         None => Err("Malformed open command pane floating near plugin payload"),
-                    }
-                },
-                _ => Err("Mismatched payload for OpenCommandPaneFloatingNearPlugin"),
+                    },
+                    _ => Err("Mismatched payload for OpenCommandPaneFloatingNearPlugin"),
+                }
             },
-            Some(CommandName::OpenCommandPaneInPlaceOfPlugin) => match protobuf_plugin_command.payload {
-                Some(Payload::OpenCommandPaneInPlaceOfPluginPayload(open_command_pane_in_place_of_plugin_payload)) => {
-                    match open_command_pane_in_place_of_plugin_payload.command_to_run {
+            Some(CommandName::OpenCommandPaneInPlaceOfPlugin) => {
+                match protobuf_plugin_command.payload {
+                    Some(Payload::OpenCommandPaneInPlaceOfPluginPayload(
+                        open_command_pane_in_place_of_plugin_payload,
+                    )) => match open_command_pane_in_place_of_plugin_payload.command_to_run {
                         Some(command_to_run) => {
-                            let context: BTreeMap<String, String> = open_command_pane_in_place_of_plugin_payload
-                                .context
-                                .into_iter()
-                                .map(|e| (e.name, e.value))
-                                .collect();
+                            let context: BTreeMap<String, String> =
+                                open_command_pane_in_place_of_plugin_payload
+                                    .context
+                                    .into_iter()
+                                    .map(|e| (e.name, e.value))
+                                    .collect();
                             Ok(PluginCommand::OpenCommandPaneInPlaceOfPlugin(
                                 command_to_run.try_into()?,
                                 context,
                             ))
                         },
                         None => Err("Malformed open command pane in place of plugin payload"),
-                    }
-                },
-                _ => Err("Mismatched payload for OpenCommandPaneInPlaceOfPlugin"),
+                    },
+                    _ => Err("Mismatched payload for OpenCommandPaneInPlaceOfPlugin"),
+                }
             },
             Some(CommandName::OpenFileNearPlugin) => match protobuf_plugin_command.payload {
                 Some(Payload::OpenFileNearPluginPayload(file_to_open_payload)) => {
@@ -1473,33 +1484,38 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
                                 .into_iter()
                                 .map(|e| (e.name, e.value))
                                 .collect();
-                            Ok(PluginCommand::OpenFileNearPlugin(file_to_open.try_into()?, context))
+                            Ok(PluginCommand::OpenFileNearPlugin(
+                                file_to_open.try_into()?,
+                                context,
+                            ))
                         },
                         None => Err("Malformed open file payload"),
                     }
                 },
                 _ => Err("Mismatched payload for OpenFileNearPlugin"),
             },
-            Some(CommandName::OpenFileFloatingNearPlugin) => match protobuf_plugin_command.payload {
-                Some(Payload::OpenFileFloatingNearPluginPayload(file_to_open_payload)) => {
-                    let floating_pane_coordinates = file_to_open_payload
-                        .floating_pane_coordinates
-                        .map(|f| f.into());
-                    let context: BTreeMap<String, String> = file_to_open_payload
-                        .context
-                        .into_iter()
-                        .map(|e| (e.name, e.value))
-                        .collect();
-                    match file_to_open_payload.file_to_open {
-                        Some(file_to_open) => Ok(PluginCommand::OpenFileFloatingNearPlugin(
-                            file_to_open.try_into()?,
-                            floating_pane_coordinates,
-                            context,
-                        )),
-                        None => Err("Malformed open file payload"),
-                    }
-                },
-                _ => Err("Mismatched payload for OpenFileFloatingNearPlugin"),
+            Some(CommandName::OpenFileFloatingNearPlugin) => {
+                match protobuf_plugin_command.payload {
+                    Some(Payload::OpenFileFloatingNearPluginPayload(file_to_open_payload)) => {
+                        let floating_pane_coordinates = file_to_open_payload
+                            .floating_pane_coordinates
+                            .map(|f| f.into());
+                        let context: BTreeMap<String, String> = file_to_open_payload
+                            .context
+                            .into_iter()
+                            .map(|e| (e.name, e.value))
+                            .collect();
+                        match file_to_open_payload.file_to_open {
+                            Some(file_to_open) => Ok(PluginCommand::OpenFileFloatingNearPlugin(
+                                file_to_open.try_into()?,
+                                floating_pane_coordinates,
+                                context,
+                            )),
+                            None => Err("Malformed open file payload"),
+                        }
+                    },
+                    _ => Err("Mismatched payload for OpenFileFloatingNearPlugin"),
+                }
             },
             Some(CommandName::OpenFileInPlaceOfPlugin) => match protobuf_plugin_command.payload {
                 Some(Payload::OpenFileInPlaceOfPluginPayload(file_to_open_payload)) => {
@@ -2401,50 +2417,64 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
                     .collect();
                 Ok(ProtobufPluginCommand {
                     name: CommandName::OpenCommandPaneNearPlugin as i32,
-                    payload: Some(Payload::OpenCommandPaneNearPluginPayload(OpenCommandPaneNearPluginPayload {
-                        command_to_run: Some(command_to_run.try_into()?),
-                        floating_pane_coordinates: None,
-                        context,
-                    })),
+                    payload: Some(Payload::OpenCommandPaneNearPluginPayload(
+                        OpenCommandPaneNearPluginPayload {
+                            command_to_run: Some(command_to_run.try_into()?),
+                            floating_pane_coordinates: None,
+                            context,
+                        },
+                    )),
                 })
             },
-            PluginCommand::OpenCommandPaneFloatingNearPlugin(command_to_run, floating_pane_coordinates, context) => {
+            PluginCommand::OpenCommandPaneFloatingNearPlugin(
+                command_to_run,
+                floating_pane_coordinates,
+                context,
+            ) => {
                 let context: Vec<_> = context
                     .into_iter()
                     .map(|(name, value)| ContextItem { name, value })
                     .collect();
                 Ok(ProtobufPluginCommand {
                     name: CommandName::OpenCommandPaneFloatingNearPlugin as i32,
-                    payload: Some(Payload::OpenCommandPaneFloatingNearPluginPayload(OpenCommandPaneFloatingNearPluginPayload {
-                        command_to_run: Some(command_to_run.try_into()?),
-                        floating_pane_coordinates: floating_pane_coordinates.map(|f| f.into()),
-                        context,
-                    })),
+                    payload: Some(Payload::OpenCommandPaneFloatingNearPluginPayload(
+                        OpenCommandPaneFloatingNearPluginPayload {
+                            command_to_run: Some(command_to_run.try_into()?),
+                            floating_pane_coordinates: floating_pane_coordinates.map(|f| f.into()),
+                            context,
+                        },
+                    )),
                 })
             },
             PluginCommand::OpenTerminalNearPlugin(cwd) => Ok(ProtobufPluginCommand {
                 name: CommandName::OpenTerminalNearPlugin as i32,
-                payload: Some(Payload::OpenTerminalNearPluginPayload(OpenTerminalNearPluginPayload {
-                    file_to_open: Some(cwd.try_into()?),
-                    context: vec![], // will be added in the future
-                })),
+                payload: Some(Payload::OpenTerminalNearPluginPayload(
+                    OpenTerminalNearPluginPayload {
+                        file_to_open: Some(cwd.try_into()?),
+                        context: vec![], // will be added in the future
+                    },
+                )),
             }),
             PluginCommand::OpenTerminalFloatingNearPlugin(cwd, floating_pane_coordinates) => {
                 Ok(ProtobufPluginCommand {
                     name: CommandName::OpenTerminalFloatingNearPlugin as i32,
-                    payload: Some(Payload::OpenTerminalFloatingNearPluginPayload(OpenTerminalFloatingNearPluginPayload {
-                        file_to_open: Some(cwd.try_into()?),
-                        floating_pane_coordinates: floating_pane_coordinates.map(|f| f.into()),
-                        context: vec![], // will be added in the future
-                    })),
+                    payload: Some(Payload::OpenTerminalFloatingNearPluginPayload(
+                        OpenTerminalFloatingNearPluginPayload {
+                            file_to_open: Some(cwd.try_into()?),
+                            floating_pane_coordinates: floating_pane_coordinates.map(|f| f.into()),
+                            context: vec![], // will be added in the future
+                        },
+                    )),
                 })
             },
             PluginCommand::OpenTerminalInPlaceOfPlugin(cwd) => Ok(ProtobufPluginCommand {
                 name: CommandName::OpenTerminalInPlaceOfPlugin as i32,
-                payload: Some(Payload::OpenTerminalInPlaceOfPluginPayload(OpenTerminalInPlaceOfPluginPayload {
-                    file_to_open: Some(cwd.try_into()?),
-                    context: vec![], // will be added in the future
-                })),
+                payload: Some(Payload::OpenTerminalInPlaceOfPluginPayload(
+                    OpenTerminalInPlaceOfPluginPayload {
+                        file_to_open: Some(cwd.try_into()?),
+                        context: vec![], // will be added in the future
+                    },
+                )),
             }),
             PluginCommand::OpenCommandPaneInPlaceOfPlugin(command_to_run, context) => {
                 let context: Vec<_> = context
@@ -2463,39 +2493,49 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
             },
             PluginCommand::OpenFileNearPlugin(file_to_open, context) => Ok(ProtobufPluginCommand {
                 name: CommandName::OpenFileNearPlugin as i32,
-                payload: Some(Payload::OpenFileNearPluginPayload(OpenFileNearPluginPayload {
-                    file_to_open: Some(file_to_open.try_into()?),
-                    floating_pane_coordinates: None,
-                    context: context
-                        .into_iter()
-                        .map(|(name, value)| ContextItem { name, value })
-                        .collect(),
-                })),
+                payload: Some(Payload::OpenFileNearPluginPayload(
+                    OpenFileNearPluginPayload {
+                        file_to_open: Some(file_to_open.try_into()?),
+                        floating_pane_coordinates: None,
+                        context: context
+                            .into_iter()
+                            .map(|(name, value)| ContextItem { name, value })
+                            .collect(),
+                    },
+                )),
             }),
-            PluginCommand::OpenFileFloatingNearPlugin(file_to_open, floating_pane_coordinates, context) => {
-                Ok(ProtobufPluginCommand {
-                    name: CommandName::OpenFileFloatingNearPlugin as i32,
-                    payload: Some(Payload::OpenFileFloatingNearPluginPayload(OpenFileFloatingNearPluginPayload {
+            PluginCommand::OpenFileFloatingNearPlugin(
+                file_to_open,
+                floating_pane_coordinates,
+                context,
+            ) => Ok(ProtobufPluginCommand {
+                name: CommandName::OpenFileFloatingNearPlugin as i32,
+                payload: Some(Payload::OpenFileFloatingNearPluginPayload(
+                    OpenFileFloatingNearPluginPayload {
                         file_to_open: Some(file_to_open.try_into()?),
                         floating_pane_coordinates: floating_pane_coordinates.map(|f| f.into()),
                         context: context
                             .into_iter()
                             .map(|(name, value)| ContextItem { name, value })
                             .collect(),
-                    })),
+                    },
+                )),
+            }),
+            PluginCommand::OpenFileInPlaceOfPlugin(file_to_open, context) => {
+                Ok(ProtobufPluginCommand {
+                    name: CommandName::OpenFileInPlaceOfPlugin as i32,
+                    payload: Some(Payload::OpenFileInPlaceOfPluginPayload(
+                        OpenFileInPlaceOfPluginPayload {
+                            file_to_open: Some(file_to_open.try_into()?),
+                            floating_pane_coordinates: None,
+                            context: context
+                                .into_iter()
+                                .map(|(name, value)| ContextItem { name, value })
+                                .collect(),
+                        },
+                    )),
                 })
             },
-            PluginCommand::OpenFileInPlaceOfPlugin(file_to_open, context) => Ok(ProtobufPluginCommand {
-                name: CommandName::OpenFileInPlaceOfPlugin as i32,
-                payload: Some(Payload::OpenFileInPlaceOfPluginPayload(OpenFileInPlaceOfPluginPayload {
-                    file_to_open: Some(file_to_open.try_into()?),
-                    floating_pane_coordinates: None,
-                    context: context
-                        .into_iter()
-                        .map(|(name, value)| ContextItem { name, value })
-                        .collect(),
-                })),
-            }),
         }
     }
 }


### PR DESCRIPTION
Currently, plugins are only able to open new panes from the perspective of the user. For example, if a user is focused in a different tab than the plugin, the plugin could only open panes in that tab.

This adds new plugin API methods that allow a plugin to open new panes "near" it. So for example, if a plugin would use the new `open_terminal_near_plugin` command, the terminal will be opened near in its own tab regardless of whether the user is focused on it or not (and it will also not change the user focus).

The APIs that were added:
`open_terminal_near_plugin`
`open_terminal_floating_near_plugin`
`open_terminal_in_place_of_plugin` (will override the plugin pane with the terminal until the terminal is closed, at which point the plugin will reappear)

`open_command_pane_near_plugin`
`open_command_pane_floating_near_plugin`
`open_command_pane_in_place_of_plugin` (will override the plugin pane with the command pane until the command pane is closed, at which point the plugin will reappear)


`open_file_near_plugin`
`open_file_floating_near_plugin`
`open_file_in_place_of_plugin` (will override the plugin pane with the editor pane until the editor pane is closed, at which point the plugin will reappear)