### PR TITLE
feat(plugins): send info about $EDITOR and $SHELL

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -364,6 +364,7 @@ impl SessionMetaData {
                     rounded_corners: new_config.ui.pane_frames.rounded_corners,
                     hide_session_name: new_config.ui.pane_frames.hide_session_name,
                     stacked_resize: new_config.options.stacked_resize.unwrap_or(true),
+                    default_editor: new_config.options.scrollback_editor.clone(),
                 })
                 .unwrap();
             self.senders

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__switch_to_mode_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__switch_to_mode_plugin_command.snap
@@ -1,6 +1,6 @@
 ---
 source: zellij-server/src/plugins/./unit/plugin_tests.rs
-assertion_line: 1043
+assertion_line: 1143
 expression: "format!(\"{:#?}\", switch_to_mode_event)"
 ---
 Some(
@@ -76,6 +76,8 @@ Some(
             session_name: Some(
                 "zellij-test",
             ),
+            editor: None,
+            shell: None,
         },
         1,
     ),

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -251,11 +251,12 @@ fn create_new_tab(size: Size, default_mode: ModeInfo) -> Tab {
         terminal_emulator_colors,
         terminal_emulator_color_codes,
         (vec![], vec![]),
-        None,
+        PathBuf::from("my_default_shell"),
         debug,
         arrow_fonts,
         styled_underlines,
         explicitly_disable_kitty_keyboard_protocol,
+        None,
     );
     tab.apply_layout(
         TiledPaneLayout::default(),
@@ -333,11 +334,12 @@ fn create_new_tab_with_swap_layouts(
         terminal_emulator_colors,
         terminal_emulator_color_codes,
         swap_layouts,
-        None,
+        PathBuf::from("my_default_shell"),
         debug,
         arrow_fonts,
         styled_underlines,
         explicitly_disable_kitty_keyboard_protocol,
+        None,
     );
     let (
         base_layout,
@@ -416,11 +418,12 @@ fn create_new_tab_with_os_api(
         terminal_emulator_colors,
         terminal_emulator_color_codes,
         (vec![], vec![]), // swap layouts
-        None,
+        PathBuf::from("my_default_shell"),
         debug,
         arrow_fonts,
         styled_underlines,
         explicitly_disable_kitty_keyboard_protocol,
+        None,
     );
     tab.apply_layout(
         TiledPaneLayout::default(),
@@ -485,11 +488,12 @@ fn create_new_tab_with_layout(size: Size, default_mode: ModeInfo, layout: &str) 
         terminal_emulator_colors,
         terminal_emulator_color_codes,
         (vec![], vec![]), // swap layouts
-        None,
+        PathBuf::from("my_default_shell"),
         debug,
         arrow_fonts,
         styled_underlines,
         explicitly_disable_kitty_keyboard_protocol,
+        None,
     );
     let pane_ids = tab_layout
         .extract_run_instructions()
@@ -568,11 +572,12 @@ fn create_new_tab_with_mock_pty_writer(
         terminal_emulator_colors,
         terminal_emulator_color_codes,
         (vec![], vec![]), // swap layouts
-        None,
+        PathBuf::from("my_default_shell"),
         debug,
         arrow_fonts,
         styled_underlines,
         explicitly_disable_kitty_keyboard_protocol,
+        None,
     );
     tab.apply_layout(
         TiledPaneLayout::default(),
@@ -642,11 +647,12 @@ fn create_new_tab_with_sixel_support(
         terminal_emulator_colors,
         terminal_emulator_color_codes,
         (vec![], vec![]), // swap layouts
-        None,
+        PathBuf::from("my_default_shell"),
         debug,
         arrow_fonts,
         styled_underlines,
         explicitly_disable_kitty_keyboard_protocol,
+        None,
     );
     tab.apply_layout(
         TiledPaneLayout::default(),

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -191,11 +191,12 @@ fn create_new_tab(size: Size, stacked_resize: bool) -> Tab {
         terminal_emulator_colors,
         terminal_emulator_color_codes,
         (vec![], vec![]), // swap layouts
-        None,
+        PathBuf::from("my_default_shell"),
         debug,
         arrow_fonts,
         styled_underlines,
         explicitly_disable_kitty_keyboard_protocol,
+        None,
     );
     tab.apply_layout(
         TiledPaneLayout::default(),
@@ -257,11 +258,12 @@ fn create_new_tab_with_layout(size: Size, layout: TiledPaneLayout) -> Tab {
         terminal_emulator_colors,
         terminal_emulator_color_codes,
         (vec![], vec![]), // swap layouts
-        None,
+        PathBuf::from("my_default_shell"),
         debug,
         arrow_fonts,
         styled_underlines,
         explicitly_disable_kitty_keyboard_protocol,
+        None,
     );
     let mut new_terminal_ids = vec![];
     for i in 0..layout.extract_run_instructions().len() {
@@ -329,11 +331,12 @@ fn create_new_tab_with_cell_size(
         terminal_emulator_colors,
         terminal_emulator_color_codes,
         (vec![], vec![]), // swap layouts
-        None,
+        PathBuf::from("my_default_shell"),
         debug,
         arrow_fonts,
         styled_underlines,
         explicitly_disable_kitty_keyboard_protocol,
+        None,
     );
     tab.apply_layout(
         TiledPaneLayout::default(),

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -261,7 +261,7 @@ fn create_new_screen(size: Size) -> Screen {
     let copy_options = CopyOptions::default();
     let default_layout = Box::new(Layout::default());
     let default_layout_name = None;
-    let default_shell = None;
+    let default_shell = PathBuf::from("my_default_shell");
     let session_serialization = true;
     let serialize_pane_viewport = false;
     let scrollback_lines_to_serialize = None;
@@ -293,6 +293,7 @@ fn create_new_screen(size: Size) -> Screen {
         layout_dir,
         explicitly_disable_kitty_keyboard_protocol,
         stacked_resize,
+        None,
     );
     screen
 }

--- a/zellij-utils/assets/prost/api.event.rs
+++ b/zellij-utils/assets/prost/api.event.rs
@@ -438,6 +438,10 @@ pub struct ModeUpdatePayload {
     pub session_name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(enumeration = "super::input_mode::InputMode", optional, tag = "6")]
     pub base_mode: ::core::option::Option<i32>,
+    #[prost(string, optional, tag = "7")]
+    pub editor: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "8")]
+    pub shell: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -1150,6 +1150,8 @@ pub struct ModeInfo {
     pub style: Style,
     pub capabilities: PluginCapabilities,
     pub session_name: Option<String>,
+    pub editor: Option<PathBuf>,
+    pub shell: Option<PathBuf>,
 }
 
 impl ModeInfo {

--- a/zellij-utils/src/input/mod.rs
+++ b/zellij-utils/src/input/mod.rs
@@ -43,6 +43,8 @@ mod not_wasm {
             style: attributes.style,
             capabilities,
             session_name,
+            editor: None,
+            shell: None,
         }
     }
 

--- a/zellij-utils/src/plugin_api/event.proto
+++ b/zellij-utils/src/plugin_api/event.proto
@@ -322,6 +322,8 @@ message ModeUpdatePayload {
   bool arrow_fonts_support = 4;
   optional string session_name = 5;
   optional input_mode.InputMode base_mode = 6;
+  optional string editor = 7;
+  optional string shell = 8;
 }
 
 message InputModeKeybinds {

--- a/zellij-utils/src/plugin_api/event.rs
+++ b/zellij-utils/src/plugin_api/event.rs
@@ -1157,6 +1157,10 @@ impl TryFrom<ProtobufModeUpdatePayload> for ModeInfo {
             .and_then(|m| m.try_into().ok())
             .ok_or("malformed payload for mode_info")?;
         let session_name = protobuf_mode_update_payload.session_name;
+        let editor = protobuf_mode_update_payload
+            .editor
+            .map(|e| PathBuf::from(e));
+        let shell = protobuf_mode_update_payload.shell.map(|s| PathBuf::from(s));
         let capabilities = PluginCapabilities {
             arrow_fonts: protobuf_mode_update_payload.arrow_fonts_support,
         };
@@ -1167,6 +1171,8 @@ impl TryFrom<ProtobufModeUpdatePayload> for ModeInfo {
             capabilities,
             session_name,
             base_mode,
+            editor,
+            shell,
         };
         Ok(mode_info)
     }
@@ -1182,6 +1188,8 @@ impl TryFrom<ModeInfo> for ProtobufModeUpdatePayload {
         let style: ProtobufStyle = mode_info.style.try_into()?;
         let arrow_fonts_support: bool = mode_info.capabilities.arrow_fonts;
         let session_name = mode_info.session_name;
+        let editor = mode_info.editor.map(|e| e.display().to_string());
+        let shell = mode_info.shell.map(|s| s.display().to_string());
         let mut protobuf_input_mode_keybinds: Vec<ProtobufInputModeKeybinds> = vec![];
         for (input_mode, input_mode_keybinds) in mode_info.keybinds {
             let mode: ProtobufInputMode = input_mode.try_into()?;
@@ -1213,6 +1221,8 @@ impl TryFrom<ModeInfo> for ProtobufModeUpdatePayload {
             arrow_fonts_support,
             session_name,
             base_mode: base_mode.map(|b_m| b_m as i32),
+            editor,
+            shell,
         })
     }
 }
@@ -1455,6 +1465,8 @@ fn serialize_mode_update_event_with_non_default_values() {
         capabilities: PluginCapabilities { arrow_fonts: false },
         session_name: Some("my awesome test session".to_owned()),
         base_mode: Some(InputMode::Locked),
+        editor: Some(PathBuf::from("my_awesome_editor")),
+        shell: Some(PathBuf::from("my_awesome_shell")),
     });
     let protobuf_event: ProtobufEvent = mode_update_event.clone().try_into().unwrap();
     let serialized_protobuf_event = protobuf_event.encode_to_vec();


### PR DESCRIPTION
This adds an `editor` and `shell` optional fields to the `ModeInfo` sent on `ModeUpdate` to plugins.
Meaning plugins would be able to (for example) use the user's default shell to launch commands and shell aliases (if they have permission). Also to display helpful information to the user about which program would be used to edit files in the built-in editor.