### PR TITLE
fix(floating-panes): when changing coordinates, if a pane is not floating - make it floating

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -2067,6 +2067,7 @@ impl Screen {
                     plugin_pane_to_move_to_active_tab,
                     pane_id,
                     None,
+                    true,
                 )?;
             } else {
                 new_active_tab.hide_floating_panes();
@@ -2180,7 +2181,7 @@ impl Screen {
             let (mut tiled_panes_layout, mut floating_panes_layout) = default_layout.new_tab();
             if pane_to_break_is_floating {
                 tab.show_floating_panes();
-                tab.add_floating_pane(active_pane, active_pane_id, None)?;
+                tab.add_floating_pane(active_pane, active_pane_id, None, true)?;
                 if let Some(already_running_layout) = floating_panes_layout
                     .iter_mut()
                     .find(|i| i.run == active_pane_run_instruction)
@@ -2304,7 +2305,7 @@ impl Screen {
 
             if pane_to_break_is_floating {
                 new_active_tab.show_floating_panes();
-                new_active_tab.add_floating_pane(active_pane, active_pane_id, None)?;
+                new_active_tab.add_floating_pane(active_pane, active_pane_id, None, true)?;
             } else {
                 new_active_tab.hide_floating_panes();
                 new_active_tab.add_tiled_pane(active_pane, active_pane_id, Some(client_id))?;

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -4190,7 +4190,8 @@ impl Tab {
         match self.suppressed_panes.remove(&pane_id) {
             Some(pane) => {
                 self.show_floating_panes();
-                self.add_floating_pane(pane.1, pane_id, None, true).non_fatal();
+                self.add_floating_pane(pane.1, pane_id, None, true)
+                    .non_fatal();
                 self.floating_panes.focus_pane_for_all_clients(pane_id);
             },
             None => {
@@ -4526,7 +4527,10 @@ impl Tab {
         if !self.floating_panes.panes_contain(pane_id) {
             // if these panes are not floating, we make them floating (assuming doing so wouldn't
             // be removing the last selectable tiled pane in the tab, which would close it)
-            if (self.tiled_panes.panes_contain(&pane_id) && self.get_selectable_tiled_panes().count() <= 1) || self.suppressed_panes.contains_key(pane_id) {
+            if (self.tiled_panes.panes_contain(&pane_id)
+                && self.get_selectable_tiled_panes().count() <= 1)
+                || self.suppressed_panes.contains_key(pane_id)
+            {
                 if let Some(pane) = self.extract_pane(*pane_id, true) {
                     self.add_floating_pane(pane, *pane_id, None, false)?;
                 }


### PR DESCRIPTION
This is a small fix to the recent change-floating-panes plugin API, to make it so that if a pane is tiled or suppressed - changing its floating coordinates would make it floating.