### PR TITLE
fix(break-pane): strip logical position when inserting pane to new tab

### DIFF
--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -216,8 +216,13 @@ impl TiledPanes {
             })
             .copied()
         {
-            if let Some(pane) = self.panes.remove(&pane_id) {
-                self.add_pane(pane.pid(), pane, true, None);
+            if let Some(mut pane) = self.panes.remove(&pane_id) {
+                // we must strip the logical position here because it's likely a straggler from
+                // this pane's previous tab and would cause chaos if considered in the new one
+                let mut pane_geom = pane.position_and_size();
+                pane_geom.logical_position = None;
+                pane.set_geom(pane_geom);
+                self.add_pane_with_existing_geom(pane.pid(), pane);
             }
         }
     }


### PR DESCRIPTION
This fixes an issue with the yet-to-be-released logical position refactor where panes broken into a new tab under certain conditions would crash or disappear.

The issue was that the logical position from the previous tab was kept and cause chaos. This fixes it by stripping it before adding the pane to the new tab.