### PR TITLE
fix(grid): Clear sixels when clearing terminal

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -2637,6 +2637,9 @@ impl Perform for Grid {
                     }
                 } else if clear_type == 3 {
                     self.clear_lines_above();
+                    if let Some(images_to_reap) = self.sixel_grid.clear() {
+                        self.sixel_grid.reap_images(images_to_reap);
+                    }
                 }
             };
         } else if c == 'H' || c == 'f' {

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -2632,6 +2632,9 @@ impl Perform for Grid {
                 } else if clear_type == 2 {
                     self.set_scroll_region_to_viewport_size();
                     self.fill_viewport(char_to_replace);
+                    if let Some(images_to_reap) = self.sixel_grid.clear() {
+                        self.sixel_grid.reap_images(images_to_reap);
+                    }
                 } else if clear_type == 3 {
                     self.clear_lines_above();
                 }


### PR DESCRIPTION
No code paths existed to clear sixel images when handling csi dispatch for clear.

Fixes #3173 