### PR TITLE
fix(ux): some filepicker improvements

### DIFF
--- a/default-plugins/strider/src/file_list_view.rs
+++ b/default-plugins/strider/src/file_list_view.rs
@@ -46,7 +46,11 @@ impl FileListView {
         self.path = path;
         self.path_is_dir = is_dir;
         self.files.clear();
-        self.reset_selected();
+        self.clear_selected(); // TODO: better naming between clear and reset
+        // self.reset_selected();
+    }
+    pub fn clear_selected(&mut self) {
+        self.cursor_hist.remove(&self.path);
     }
     pub fn reset_selected(&mut self) {
         *self.selected_mut() = self.selected().unwrap_or(0);

--- a/default-plugins/strider/src/file_list_view.rs
+++ b/default-plugins/strider/src/file_list_view.rs
@@ -30,14 +30,14 @@ impl FileListView {
         self.path.pop();
         self.path_is_dir = true;
         self.files.clear();
-        self.reset_selected();
+        self.clear_selected();
         refresh_directory(&self.path);
     }
     pub fn descend_to_root_path(&mut self) {
         self.path.clear();
         self.path_is_dir = true;
         self.files.clear();
-        self.reset_selected();
+        self.clear_selected();
         refresh_directory(&self.path);
     }
     pub fn enter_dir(&mut self, entry: &FsEntry) {
@@ -46,14 +46,10 @@ impl FileListView {
         self.path = path;
         self.path_is_dir = is_dir;
         self.files.clear();
-        self.clear_selected(); // TODO: better naming between clear and reset
-        // self.reset_selected();
+        self.clear_selected();
     }
     pub fn clear_selected(&mut self) {
         self.cursor_hist.remove(&self.path);
-    }
-    pub fn reset_selected(&mut self) {
-        *self.selected_mut() = self.selected().unwrap_or(0);
     }
     pub fn update_files(
         &mut self,

--- a/default-plugins/strider/src/main.rs
+++ b/default-plugins/strider/src/main.rs
@@ -73,7 +73,12 @@ impl ZellijPlugin for State {
                     should_render = true;
                 },
                 BareKey::Esc if key.has_no_modifiers() => {
-                    self.clear_search_term_or_descend();
+                    if self.is_searching {
+                        // self.clear_search_term_or_descend();
+                        self.clear_search_term();
+                    } else {
+                        self.file_list_view.clear_selected();
+                    }
                     should_render = true;
                 },
                 BareKey::Char('c') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
@@ -87,15 +92,20 @@ impl ZellijPlugin for State {
                     self.move_selection_down();
                     should_render = true;
                 },
-                BareKey::Enter
-                    if key.has_no_modifiers() && self.handling_filepick_request_from.is_some() =>
-                {
-                    self.send_filepick_response();
-                },
-                BareKey::Enter if key.has_no_modifiers() => {
+                //                 TODO: handle send_filepick_response case
+//                 BareKey::Enter
+//                     if key.has_no_modifiers() && self.handling_filepick_request_from.is_some() =>
+//                 {
+//                     self.send_filepick_response();
+//                 },
+//                 BareKey::Enter if key.has_no_modifiers() => {
+//                     self.open_selected_path();
+//                 },
+                BareKey::Enter if key.has_no_modifiers() && self.has_no_selected_entry() => {
                     self.open_selected_path();
+                    should_render = true;
                 },
-                BareKey::Right | BareKey::Tab if key.has_no_modifiers() => {
+                BareKey::Right | BareKey::Tab | BareKey::Enter if key.has_no_modifiers() => {
                     self.traverse_dir();
                     should_render = true;
                 },
@@ -122,6 +132,12 @@ impl ZellijPlugin for State {
                 Mouse::LeftClick(line, _) => {
                     self.handle_left_click(line);
                     should_render = true;
+                },
+                Mouse::Hover(line, _) => {
+                    if line >= 0 {
+                        self.handle_mouse_hover(line);
+                        should_render = true;
+                    }
                 },
                 _ => {},
             },

--- a/default-plugins/strider/src/main.rs
+++ b/default-plugins/strider/src/main.rs
@@ -32,7 +32,7 @@ impl ZellijPlugin for State {
             EventType::Timer,
             EventType::FileSystemUpdate,
         ]);
-        self.file_list_view.reset_selected();
+        self.file_list_view.clear_selected();
         // the caller_cwd might be different from the initial_cwd if this plugin was defined as an
         // alias, with access to a certain part of the file system (often broader) and was called
         // from an individual pane somewhere inside this broad scope - in this case, we want to
@@ -92,23 +92,14 @@ impl ZellijPlugin for State {
                     self.move_selection_down();
                     should_render = true;
                 },
-                //                 TODO: handle send_filepick_response case
-//                 BareKey::Enter
-//                     if key.has_no_modifiers() && self.handling_filepick_request_from.is_some() =>
-//                 {
-//                     self.send_filepick_response();
-//                 },
-//                 BareKey::Enter if key.has_no_modifiers() => {
-//                     self.open_selected_path();
-//                 },
-                BareKey::Enter if key.has_no_modifiers() && self.has_no_selected_entry() => {
-                    self.open_selected_path();
-                    should_render = true;
-                },
                 BareKey::Right | BareKey::Tab | BareKey::Enter if key.has_no_modifiers() => {
                     self.traverse_dir();
                     should_render = true;
                 },
+                BareKey::Right if key.has_no_modifiers() => {
+                    self.traverse_dir();
+                    should_render = true;
+                }
                 BareKey::Left if key.has_no_modifiers() => {
                     self.descend_to_previous_path();
                     should_render = true;

--- a/default-plugins/strider/src/main.rs
+++ b/default-plugins/strider/src/main.rs
@@ -74,7 +74,6 @@ impl ZellijPlugin for State {
                 },
                 BareKey::Esc if key.has_no_modifiers() => {
                     if self.is_searching {
-                        // self.clear_search_term_or_descend();
                         self.clear_search_term();
                     } else {
                         self.file_list_view.clear_selected();
@@ -99,7 +98,7 @@ impl ZellijPlugin for State {
                 BareKey::Right if key.has_no_modifiers() => {
                     self.traverse_dir();
                     should_render = true;
-                }
+                },
                 BareKey::Left if key.has_no_modifiers() => {
                     self.descend_to_previous_path();
                     should_render = true;

--- a/default-plugins/strider/src/state.rs
+++ b/default-plugins/strider/src/state.rs
@@ -202,7 +202,11 @@ impl State {
                 }
             } else {
                 if self.close_on_selection {
-                    open_file_in_place_of_plugin(FileToOpen::new(&self.file_list_view.path), true, BTreeMap::new());
+                    open_file_in_place_of_plugin(
+                        FileToOpen::new(&self.file_list_view.path),
+                        true,
+                        BTreeMap::new(),
+                    );
                 } else {
                     open_file(FileToOpen::new(&self.file_list_view.path), BTreeMap::new());
                 }

--- a/default-plugins/strider/src/state.rs
+++ b/default-plugins/strider/src/state.rs
@@ -146,20 +146,48 @@ impl State {
             .update_files(paths, self.hide_hidden_files);
     }
     pub fn open_selected_path(&mut self) {
+//         if self.file_list_view.path_is_dir {
+//             open_terminal(&self.file_list_view.path);
+//         } else {
+//             if let Some(parent_folder) = self.file_list_view.path.parent() {
+//                 open_file(
+//                     FileToOpen::new(&self.file_list_view.path).with_cwd(parent_folder.into()),
+//                     BTreeMap::new(),
+//                 );
+//             } else {
+//                 open_file(FileToOpen::new(&self.file_list_view.path), BTreeMap::new());
+//             }
+//         }
+//         if self.close_on_selection {
+//             close_self();
+//         }
         if self.file_list_view.path_is_dir {
-            open_terminal(&self.file_list_view.path);
+            if self.close_on_selection {
+                open_terminal_in_place_of_plugin(&self.file_list_view.path, true);
+            } else {
+                open_terminal(&self.file_list_view.path);
+            }
         } else {
             if let Some(parent_folder) = self.file_list_view.path.parent() {
-                open_file(
-                    FileToOpen::new(&self.file_list_view.path).with_cwd(parent_folder.into()),
-                    BTreeMap::new(),
-                );
+                if self.close_on_selection {
+                    open_file_in_place_of_plugin(
+                        FileToOpen::new(&self.file_list_view.path).with_cwd(parent_folder.into()),
+                        true,
+                        BTreeMap::new(),
+                    );
+                } else {
+                    open_file(
+                        FileToOpen::new(&self.file_list_view.path).with_cwd(parent_folder.into()),
+                        BTreeMap::new(),
+                    );
+                }
             } else {
-                open_file(FileToOpen::new(&self.file_list_view.path), BTreeMap::new());
+                if self.close_on_selection {
+                    open_file_in_place_of_plugin(FileToOpen::new(&self.file_list_view.path), true, BTreeMap::new());
+                } else {
+                    open_file(FileToOpen::new(&self.file_list_view.path), BTreeMap::new());
+                }
             }
-        }
-        if self.close_on_selection {
-            close_self();
         }
     }
     pub fn send_filepick_response(&mut self) {

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -257,14 +257,25 @@ fn host_run_plugin_command(caller: Caller<'_, PluginEnv>) {
                         open_terminal_in_place(env, cwd.path.try_into()?)
                     },
                     PluginCommand::OpenTerminalInPlaceOfPlugin(cwd, close_plugin_after_replace) => {
-                        open_terminal_in_place_of_plugin(env, cwd.path.try_into()?, close_plugin_after_replace)
+                        open_terminal_in_place_of_plugin(
+                            env,
+                            cwd.path.try_into()?,
+                            close_plugin_after_replace,
+                        )
                     },
                     PluginCommand::OpenCommandPaneInPlace(command_to_run, context) => {
                         open_command_pane_in_place(env, command_to_run, context)
                     },
-                    PluginCommand::OpenCommandPaneInPlaceOfPlugin(command_to_run, close_plugin_after_replace, context) => {
-                        open_command_pane_in_place_of_plugin(env, command_to_run, close_plugin_after_replace, context)
-                    },
+                    PluginCommand::OpenCommandPaneInPlaceOfPlugin(
+                        command_to_run,
+                        close_plugin_after_replace,
+                        context,
+                    ) => open_command_pane_in_place_of_plugin(
+                        env,
+                        command_to_run,
+                        close_plugin_after_replace,
+                        context,
+                    ),
                     PluginCommand::RenameSession(new_session_name) => {
                         rename_session(env, new_session_name)
                     },
@@ -413,9 +424,16 @@ fn host_run_plugin_command(caller: Caller<'_, PluginEnv>) {
                         floating_pane_coordinates,
                         context,
                     ),
-                    PluginCommand::OpenFileInPlaceOfPlugin(file_to_open, close_plugin_after_replace, context) => {
-                        open_file_in_place_of_plugin(env, file_to_open, close_plugin_after_replace, context)
-                    },
+                    PluginCommand::OpenFileInPlaceOfPlugin(
+                        file_to_open,
+                        close_plugin_after_replace,
+                        context,
+                    ) => open_file_in_place_of_plugin(
+                        env,
+                        file_to_open,
+                        close_plugin_after_replace,
+                        context,
+                    ),
                 },
                 (PermissionStatus::Denied, permission) => {
                     log::error!(
@@ -830,7 +848,11 @@ fn open_terminal_in_place(env: &PluginEnv, cwd: PathBuf) {
     apply_action!(action, error_msg, env);
 }
 
-fn open_terminal_in_place_of_plugin(env: &PluginEnv, cwd: PathBuf, close_plugin_after_replace: bool) {
+fn open_terminal_in_place_of_plugin(
+    env: &PluginEnv,
+    cwd: PathBuf,
+    close_plugin_after_replace: bool,
+) {
     let cwd = env.plugin_cwd.join(cwd);
     let mut default_shell = env.default_shell.clone().unwrap_or_else(|| {
         TerminalAction::RunCommand(RunCommand {

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -78,6 +78,7 @@ pub enum PtyInstruction {
     SpawnInPlaceTerminal(
         Option<TerminalAction>,
         Option<String>,
+        bool, // close replaced pane
         ClientTabIndexOrPaneId,
     ), // String is an optional pane name
     DumpLayout(SessionLayoutMetadata, ClientId),
@@ -278,6 +279,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
             PtyInstruction::SpawnInPlaceTerminal(
                 terminal_action,
                 name,
+                close_replaced_pane,
                 client_id_tab_index_or_pane_id,
             ) => {
                 let err_context = || {
@@ -318,6 +320,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                 hold_for_command,
                                 pane_title,
                                 invoked_with,
+                                close_replaced_pane,
                                 client_id_tab_index_or_pane_id,
                             ))
                             .with_context(err_context)?;
@@ -333,6 +336,7 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                                         hold_for_command,
                                         pane_title,
                                         invoked_with,
+                                        close_replaced_pane,
                                         client_id_tab_index_or_pane_id,
                                     ))
                                     .with_context(err_context)?;

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -312,11 +312,13 @@ pub(crate) fn route_action(
                     Some(pane_id) => PtyInstruction::SpawnInPlaceTerminal(
                         Some(open_file),
                         Some(title),
+                        false,
                         ClientTabIndexOrPaneId::PaneId(pane_id),
                     ),
                     None => PtyInstruction::SpawnInPlaceTerminal(
                         Some(open_file),
                         Some(title),
+                        false,
                         ClientTabIndexOrPaneId::ClientId(client_id),
                     ),
                 },
@@ -389,6 +391,7 @@ pub(crate) fn route_action(
                         .send_to_pty(PtyInstruction::SpawnInPlaceTerminal(
                             run_cmd,
                             name,
+                            false,
                             ClientTabIndexOrPaneId::PaneId(pane_id),
                         ))
                         .with_context(err_context)?;
@@ -398,6 +401,7 @@ pub(crate) fn route_action(
                         .send_to_pty(PtyInstruction::SpawnInPlaceTerminal(
                             run_cmd,
                             name,
+                            false,
                             ClientTabIndexOrPaneId::ClientId(client_id),
                         ))
                         .with_context(err_context)?;

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -2394,7 +2394,12 @@ impl Screen {
         client_id_tab_index_or_pane_id: ClientTabIndexOrPaneId,
     ) -> Result<()> {
         let suppress_pane = |tab: &mut Tab, pane_id: PaneId, new_pane_id: PaneId| {
-            let _ = tab.suppress_pane_and_replace_with_pid(pane_id, new_pane_id, close_replaced_pane, run);
+            let _ = tab.suppress_pane_and_replace_with_pid(
+                pane_id,
+                new_pane_id,
+                close_replaced_pane,
+                run,
+            );
             if let Some(pane_title) = pane_title {
                 let _ = tab.rename_pane(pane_title.as_bytes().to_vec(), new_pane_id);
             }

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -4513,7 +4513,6 @@ pub(crate) fn screen_thread_main(
                 close_replaced_pane,
                 client_id_tab_index_or_pane_id,
             ) => {
-                log::info!("ScreenInstruction::ReplacePane");
                 screen.replace_pane(
                     new_pane_id,
                     hold_for_command,

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1358,6 +1358,11 @@ impl Tab {
                         .replace_pane(old_pane_id, Box::new(new_pane))
                 };
                 if close_replaced_pane {
+                    if let Some(pid) = replaced_pane.as_ref().map(|p| p.pid()) {
+                        self.senders
+                            .send_to_pty(PtyInstruction::ClosePane(pid))
+                            .with_context(err_context)?;
+                    }
                     drop(replaced_pane);
                 } else {
                     match replaced_pane {

--- a/zellij-server/src/ui/components/text.rs
+++ b/zellij-server/src/ui/components/text.rs
@@ -58,7 +58,11 @@ pub fn stringify_text(
             break;
         }
         text_width += character_width;
-        if !text.indices.is_empty() {
+
+        // TODO: does this break stuff?
+        stringified.push_str(&format!("{}", base_text_style));
+
+        if !text.indices.is_empty() || text.selected {
             let character_with_styling =
                 color_index_character(character, i, &text, style, base_text_style);
             stringified.push_str(&character_with_styling);

--- a/zellij-server/src/ui/components/text.rs
+++ b/zellij-server/src/ui/components/text.rs
@@ -59,8 +59,11 @@ pub fn stringify_text(
         }
         text_width += character_width;
 
-        // TODO: does this break stuff?
-        stringified.push_str(&format!("{}", base_text_style));
+        if text.selected {
+            // we do this so that selected text will appear selected
+            // even if it does not have color indices
+            stringified.push_str(&format!("{}", base_text_style));
+        }
 
         if !text.indices.is_empty() || text.selected {
             let character_with_styling =

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -126,8 +126,8 @@ pub fn open_file_floating_near_plugin(
 }
 
 /// Open a file in the user's default `$EDITOR`, replacing the plugin pane
-pub fn open_file_in_place_of_plugin(file_to_open: FileToOpen, context: BTreeMap<String, String>) {
-    let plugin_command = PluginCommand::OpenFileInPlaceOfPlugin(file_to_open, context);
+pub fn open_file_in_place_of_plugin(file_to_open: FileToOpen, close_plugin_after_replace: bool, context: BTreeMap<String, String>) {
+    let plugin_command = PluginCommand::OpenFileInPlaceOfPlugin(file_to_open, close_plugin_after_replace, context);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
     unsafe { host_run_plugin_command() };
@@ -190,9 +190,9 @@ pub fn open_terminal_in_place<P: AsRef<Path>>(path: P) {
 
 /// Open a new terminal pane to the specified location on the host filesystem, temporarily
 /// replacing the plugin pane
-pub fn open_terminal_in_place_of_plugin<P: AsRef<Path>>(path: P) {
+pub fn open_terminal_in_place_of_plugin<P: AsRef<Path>>(path: P, close_plugin_after_replace: bool) {
     let file_to_open = FileToOpen::new(path.as_ref().to_path_buf());
-    let plugin_command = PluginCommand::OpenTerminalInPlaceOfPlugin(file_to_open);
+    let plugin_command = PluginCommand::OpenTerminalInPlaceOfPlugin(file_to_open, close_plugin_after_replace);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
     unsafe { host_run_plugin_command() };
@@ -260,9 +260,10 @@ pub fn open_command_pane_in_place(command_to_run: CommandToRun, context: BTreeMa
 /// plugin pane rather than whichever pane the user is focused on
 pub fn open_command_pane_in_place_of_plugin(
     command_to_run: CommandToRun,
+    close_plugin_after_replace: bool,
     context: BTreeMap<String, String>,
 ) {
-    let plugin_command = PluginCommand::OpenCommandPaneInPlaceOfPlugin(command_to_run, context);
+    let plugin_command = PluginCommand::OpenCommandPaneInPlaceOfPlugin(command_to_run, close_plugin_after_replace, context);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
     unsafe { host_run_plugin_command() };

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -126,8 +126,13 @@ pub fn open_file_floating_near_plugin(
 }
 
 /// Open a file in the user's default `$EDITOR`, replacing the plugin pane
-pub fn open_file_in_place_of_plugin(file_to_open: FileToOpen, close_plugin_after_replace: bool, context: BTreeMap<String, String>) {
-    let plugin_command = PluginCommand::OpenFileInPlaceOfPlugin(file_to_open, close_plugin_after_replace, context);
+pub fn open_file_in_place_of_plugin(
+    file_to_open: FileToOpen,
+    close_plugin_after_replace: bool,
+    context: BTreeMap<String, String>,
+) {
+    let plugin_command =
+        PluginCommand::OpenFileInPlaceOfPlugin(file_to_open, close_plugin_after_replace, context);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
     unsafe { host_run_plugin_command() };
@@ -192,7 +197,8 @@ pub fn open_terminal_in_place<P: AsRef<Path>>(path: P) {
 /// replacing the plugin pane
 pub fn open_terminal_in_place_of_plugin<P: AsRef<Path>>(path: P, close_plugin_after_replace: bool) {
     let file_to_open = FileToOpen::new(path.as_ref().to_path_buf());
-    let plugin_command = PluginCommand::OpenTerminalInPlaceOfPlugin(file_to_open, close_plugin_after_replace);
+    let plugin_command =
+        PluginCommand::OpenTerminalInPlaceOfPlugin(file_to_open, close_plugin_after_replace);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
     unsafe { host_run_plugin_command() };
@@ -263,7 +269,11 @@ pub fn open_command_pane_in_place_of_plugin(
     close_plugin_after_replace: bool,
     context: BTreeMap<String, String>,
 ) {
-    let plugin_command = PluginCommand::OpenCommandPaneInPlaceOfPlugin(command_to_run, close_plugin_after_replace, context);
+    let plugin_command = PluginCommand::OpenCommandPaneInPlaceOfPlugin(
+        command_to_run,
+        close_plugin_after_replace,
+        context,
+    );
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
     unsafe { host_run_plugin_command() };

--- a/zellij-utils/assets/prost/api.plugin_command.rs
+++ b/zellij-utils/assets/prost/api.plugin_command.rs
@@ -219,6 +219,8 @@ pub struct OpenFileInPlaceOfPluginPayload {
     pub floating_pane_coordinates: ::core::option::Option<FloatingPaneCoordinates>,
     #[prost(message, repeated, tag = "3")]
     pub context: ::prost::alloc::vec::Vec<ContextItem>,
+    #[prost(bool, tag = "4")]
+    pub close_plugin_after_replace: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -247,6 +249,8 @@ pub struct OpenCommandPaneInPlaceOfPluginPayload {
     pub command_to_run: ::core::option::Option<super::command::Command>,
     #[prost(message, repeated, tag = "3")]
     pub context: ::prost::alloc::vec::Vec<ContextItem>,
+    #[prost(bool, tag = "4")]
+    pub close_plugin_after_replace: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -265,6 +269,8 @@ pub struct OpenTerminalInPlaceOfPluginPayload {
     pub file_to_open: ::core::option::Option<super::file::File>,
     #[prost(message, repeated, tag = "3")]
     pub context: ::prost::alloc::vec::Vec<ContextItem>,
+    #[prost(bool, tag = "4")]
+    pub close_plugin_after_replace: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -2295,10 +2295,11 @@ pub enum PluginCommand {
     OpenCommandPaneNearPlugin(CommandToRun, Context),
     OpenTerminalNearPlugin(FileToOpen),
     OpenTerminalFloatingNearPlugin(FileToOpen, Option<FloatingPaneCoordinates>),
-    OpenTerminalInPlaceOfPlugin(FileToOpen),
+    OpenTerminalInPlaceOfPlugin(FileToOpen, bool), // bool -> close_plugin_after_replace
     OpenCommandPaneFloatingNearPlugin(CommandToRun, Option<FloatingPaneCoordinates>, Context),
-    OpenCommandPaneInPlaceOfPlugin(CommandToRun, Context),
+    OpenCommandPaneInPlaceOfPlugin(CommandToRun, bool, Context), // bool ->
+                                                                 // close_plugin_after_replace
     OpenFileNearPlugin(FileToOpen, Context),
     OpenFileFloatingNearPlugin(FileToOpen, Option<FloatingPaneCoordinates>, Context),
-    OpenFileInPlaceOfPlugin(FileToOpen, Context),
+    OpenFileInPlaceOfPlugin(FileToOpen, bool, Context), // bool -> close_plugin_after_replace
 }

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -2298,7 +2298,7 @@ pub enum PluginCommand {
     OpenTerminalInPlaceOfPlugin(FileToOpen, bool), // bool -> close_plugin_after_replace
     OpenCommandPaneFloatingNearPlugin(CommandToRun, Option<FloatingPaneCoordinates>, Context),
     OpenCommandPaneInPlaceOfPlugin(CommandToRun, bool, Context), // bool ->
-                                                                 // close_plugin_after_replace
+    // close_plugin_after_replace
     OpenFileNearPlugin(FileToOpen, Context),
     OpenFileFloatingNearPlugin(FileToOpen, Option<FloatingPaneCoordinates>, Context),
     OpenFileInPlaceOfPlugin(FileToOpen, bool, Context), // bool -> close_plugin_after_replace

--- a/zellij-utils/src/plugin_api/plugin_command.proto
+++ b/zellij-utils/src/plugin_api/plugin_command.proto
@@ -243,6 +243,7 @@ message OpenFileInPlaceOfPluginPayload {
   file.File file_to_open = 1;
   optional FloatingPaneCoordinates floating_pane_coordinates = 2;
   repeated ContextItem context = 3;
+  bool close_plugin_after_replace = 4;
 }
 
 message OpenFileFloatingNearPluginPayload {
@@ -260,6 +261,7 @@ message OpenFileNearPluginPayload {
 message OpenCommandPaneInPlaceOfPluginPayload {
   command.Command command_to_run = 1;
   repeated ContextItem context = 3;
+  bool close_plugin_after_replace = 4;
 }
 
 message OpenCommandPaneFloatingNearPluginPayload {
@@ -271,6 +273,7 @@ message OpenCommandPaneFloatingNearPluginPayload {
 message OpenTerminalInPlaceOfPluginPayload {
   file.File file_to_open = 1;
   repeated ContextItem context = 3;
+  bool close_plugin_after_replace = 4;
 }
 
 message OpenTerminalFloatingNearPluginPayload {

--- a/zellij-utils/src/plugin_api/plugin_command.rs
+++ b/zellij-utils/src/plugin_api/plugin_command.rs
@@ -1422,6 +1422,7 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
                 )) => match open_terminal_in_place_of_plugin_payload.file_to_open {
                     Some(file_to_open) => Ok(PluginCommand::OpenTerminalInPlaceOfPlugin(
                         file_to_open.try_into()?,
+                        open_terminal_in_place_of_plugin_payload.close_plugin_after_replace,
                     )),
                     None => Err("Malformed open terminal in place of plugin payload"),
                 },
@@ -1467,6 +1468,7 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
                                     .collect();
                             Ok(PluginCommand::OpenCommandPaneInPlaceOfPlugin(
                                 command_to_run.try_into()?,
+                                open_command_pane_in_place_of_plugin_payload.close_plugin_after_replace,
                                 context,
                             ))
                         },
@@ -1528,6 +1530,7 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
                                 .collect();
                             Ok(PluginCommand::OpenFileInPlaceOfPlugin(
                                 file_to_open.try_into()?,
+                                file_to_open_payload.close_plugin_after_replace,
                                 context,
                             ))
                         },
@@ -2467,16 +2470,17 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
                     )),
                 })
             },
-            PluginCommand::OpenTerminalInPlaceOfPlugin(cwd) => Ok(ProtobufPluginCommand {
+            PluginCommand::OpenTerminalInPlaceOfPlugin(cwd, close_plugin_after_replace) => Ok(ProtobufPluginCommand {
                 name: CommandName::OpenTerminalInPlaceOfPlugin as i32,
                 payload: Some(Payload::OpenTerminalInPlaceOfPluginPayload(
                     OpenTerminalInPlaceOfPluginPayload {
                         file_to_open: Some(cwd.try_into()?),
+                        close_plugin_after_replace,
                         context: vec![], // will be added in the future
                     },
                 )),
             }),
-            PluginCommand::OpenCommandPaneInPlaceOfPlugin(command_to_run, context) => {
+            PluginCommand::OpenCommandPaneInPlaceOfPlugin(command_to_run, close_plugin_after_replace, context) => {
                 let context: Vec<_> = context
                     .into_iter()
                     .map(|(name, value)| ContextItem { name, value })
@@ -2486,6 +2490,7 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
                     payload: Some(Payload::OpenCommandPaneInPlaceOfPluginPayload(
                         OpenCommandPaneInPlaceOfPluginPayload {
                             command_to_run: Some(command_to_run.try_into()?),
+                            close_plugin_after_replace,
                             context,
                         },
                     )),
@@ -2521,13 +2526,14 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
                     },
                 )),
             }),
-            PluginCommand::OpenFileInPlaceOfPlugin(file_to_open, context) => {
+            PluginCommand::OpenFileInPlaceOfPlugin(file_to_open, close_plugin_after_replace, context) => {
                 Ok(ProtobufPluginCommand {
                     name: CommandName::OpenFileInPlaceOfPlugin as i32,
                     payload: Some(Payload::OpenFileInPlaceOfPluginPayload(
                         OpenFileInPlaceOfPluginPayload {
                             file_to_open: Some(file_to_open.try_into()?),
                             floating_pane_coordinates: None,
+                            close_plugin_after_replace,
                             context: context
                                 .into_iter()
                                 .map(|(name, value)| ContextItem { name, value })

--- a/zellij-utils/src/plugin_api/plugin_command.rs
+++ b/zellij-utils/src/plugin_api/plugin_command.rs
@@ -1468,7 +1468,8 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
                                     .collect();
                             Ok(PluginCommand::OpenCommandPaneInPlaceOfPlugin(
                                 command_to_run.try_into()?,
-                                open_command_pane_in_place_of_plugin_payload.close_plugin_after_replace,
+                                open_command_pane_in_place_of_plugin_payload
+                                    .close_plugin_after_replace,
                                 context,
                             ))
                         },
@@ -2470,17 +2471,23 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
                     )),
                 })
             },
-            PluginCommand::OpenTerminalInPlaceOfPlugin(cwd, close_plugin_after_replace) => Ok(ProtobufPluginCommand {
-                name: CommandName::OpenTerminalInPlaceOfPlugin as i32,
-                payload: Some(Payload::OpenTerminalInPlaceOfPluginPayload(
-                    OpenTerminalInPlaceOfPluginPayload {
-                        file_to_open: Some(cwd.try_into()?),
-                        close_plugin_after_replace,
-                        context: vec![], // will be added in the future
-                    },
-                )),
-            }),
-            PluginCommand::OpenCommandPaneInPlaceOfPlugin(command_to_run, close_plugin_after_replace, context) => {
+            PluginCommand::OpenTerminalInPlaceOfPlugin(cwd, close_plugin_after_replace) => {
+                Ok(ProtobufPluginCommand {
+                    name: CommandName::OpenTerminalInPlaceOfPlugin as i32,
+                    payload: Some(Payload::OpenTerminalInPlaceOfPluginPayload(
+                        OpenTerminalInPlaceOfPluginPayload {
+                            file_to_open: Some(cwd.try_into()?),
+                            close_plugin_after_replace,
+                            context: vec![], // will be added in the future
+                        },
+                    )),
+                })
+            },
+            PluginCommand::OpenCommandPaneInPlaceOfPlugin(
+                command_to_run,
+                close_plugin_after_replace,
+                context,
+            ) => {
                 let context: Vec<_> = context
                     .into_iter()
                     .map(|(name, value)| ContextItem { name, value })
@@ -2526,22 +2533,24 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
                     },
                 )),
             }),
-            PluginCommand::OpenFileInPlaceOfPlugin(file_to_open, close_plugin_after_replace, context) => {
-                Ok(ProtobufPluginCommand {
-                    name: CommandName::OpenFileInPlaceOfPlugin as i32,
-                    payload: Some(Payload::OpenFileInPlaceOfPluginPayload(
-                        OpenFileInPlaceOfPluginPayload {
-                            file_to_open: Some(file_to_open.try_into()?),
-                            floating_pane_coordinates: None,
-                            close_plugin_after_replace,
-                            context: context
-                                .into_iter()
-                                .map(|(name, value)| ContextItem { name, value })
-                                .collect(),
-                        },
-                    )),
-                })
-            },
+            PluginCommand::OpenFileInPlaceOfPlugin(
+                file_to_open,
+                close_plugin_after_replace,
+                context,
+            ) => Ok(ProtobufPluginCommand {
+                name: CommandName::OpenFileInPlaceOfPlugin as i32,
+                payload: Some(Payload::OpenFileInPlaceOfPluginPayload(
+                    OpenFileInPlaceOfPluginPayload {
+                        file_to_open: Some(file_to_open.try_into()?),
+                        floating_pane_coordinates: None,
+                        close_plugin_after_replace,
+                        context: context
+                            .into_iter()
+                            .map(|(name, value)| ContextItem { name, value })
+                            .collect(),
+                    },
+                )),
+            }),
         }
     }
 }


### PR DESCRIPTION
This improves the filepicker (strider) UI somewhat, and also adds the ability to close a plugin once it has replaced itself with another pane.

In Strider this is used when opening a file in place of strider, or when using the "open terminal here" functionality.