### PR TITLE
fix(clipboard): clipboard message

### DIFF
--- a/default-plugins/compact-bar/src/main.rs
+++ b/default-plugins/compact-bar/src/main.rs
@@ -24,6 +24,8 @@ struct State {
     active_tab_idx: usize,
     mode_info: ModeInfo,
     tab_line: Vec<LinePart>,
+    text_copy_destination: Option<CopyDestination>,
+    display_system_clipboard_failure: bool,
 }
 
 static ARROW_SEPARATOR: &str = "";
@@ -37,6 +39,9 @@ impl ZellijPlugin for State {
             EventType::TabUpdate,
             EventType::ModeUpdate,
             EventType::Mouse,
+            EventType::CopyToClipboard,
+            EventType::InputReceived,
+            EventType::SystemClipboardFailure,
         ]);
     }
 
@@ -77,6 +82,32 @@ impl ZellijPlugin for State {
                 },
                 _ => {},
             },
+            Event::CopyToClipboard(copy_destination) => {
+                match self.text_copy_destination {
+                    Some(text_copy_destination) => {
+                        if text_copy_destination != copy_destination {
+                            should_render = true;
+                        }
+                    },
+                    None => {
+                        should_render = true;
+                    },
+                }
+                self.text_copy_destination = Some(copy_destination);
+            },
+            Event::SystemClipboardFailure => {
+                should_render = true;
+                self.display_system_clipboard_failure = true;
+            },
+            Event::InputReceived => {
+                if self.text_copy_destination.is_some()
+                    || self.display_system_clipboard_failure == true
+                {
+                    should_render = true;
+                }
+                self.text_copy_destination = None;
+                self.display_system_clipboard_failure = false;
+            },
             _ => {
                 eprintln!("Got unrecognized event: {:?}", event);
             },
@@ -85,60 +116,110 @@ impl ZellijPlugin for State {
     }
 
     fn render(&mut self, _rows: usize, cols: usize) {
-        if self.tabs.is_empty() {
-            return;
-        }
-        let mut all_tabs: Vec<LinePart> = vec![];
-        let mut active_tab_index = 0;
-        let mut active_swap_layout_name = None;
-        let mut is_swap_layout_dirty = false;
-        let mut is_alternate_tab = false;
-        for t in &mut self.tabs {
-            let mut tabname = t.name.clone();
-            if t.active && self.mode_info.mode == InputMode::RenameTab {
-                if tabname.is_empty() {
-                    tabname = String::from("Enter name...");
-                }
-                active_tab_index = t.position;
-            } else if t.active {
-                active_tab_index = t.position;
-                is_swap_layout_dirty = t.is_swap_layout_dirty;
-                active_swap_layout_name = t.active_swap_layout_name.clone();
+        if let Some(copy_destination) = self.text_copy_destination {
+            let hint = text_copied_hint(copy_destination).part;
+
+            let background = self.mode_info.style.colors.text_unselected.background;
+            match background {
+                PaletteColor::Rgb((r, g, b)) => {
+                    print!("{}\u{1b}[48;2;{};{};{}m\u{1b}[0K", hint, r, g, b);
+                },
+                PaletteColor::EightBit(color) => {
+                    print!("{}\u{1b}[48;5;{}m\u{1b}[0K", hint, color);
+                },
             }
-            let tab = tab_style(
-                tabname,
-                t,
-                is_alternate_tab,
+        } else if self.display_system_clipboard_failure {
+            let hint = system_clipboard_error().part;
+            let background = self.mode_info.style.colors.text_unselected.background;
+            match background {
+                PaletteColor::Rgb((r, g, b)) => {
+                    print!("{}\u{1b}[48;2;{};{};{}m\u{1b}[0K", hint, r, g, b);
+                },
+                PaletteColor::EightBit(color) => {
+                    print!("{}\u{1b}[48;5;{}m\u{1b}[0K", hint, color);
+                },
+            }
+        } else {
+            if self.tabs.is_empty() {
+                return;
+            }
+            let mut all_tabs: Vec<LinePart> = vec![];
+            let mut active_tab_index = 0;
+            let mut active_swap_layout_name = None;
+            let mut is_swap_layout_dirty = false;
+            let mut is_alternate_tab = false;
+            for t in &mut self.tabs {
+                let mut tabname = t.name.clone();
+                if t.active && self.mode_info.mode == InputMode::RenameTab {
+                    if tabname.is_empty() {
+                        tabname = String::from("Enter name...");
+                    }
+                    active_tab_index = t.position;
+                } else if t.active {
+                    active_tab_index = t.position;
+                    is_swap_layout_dirty = t.is_swap_layout_dirty;
+                    active_swap_layout_name = t.active_swap_layout_name.clone();
+                }
+                let tab = tab_style(
+                    tabname,
+                    t,
+                    is_alternate_tab,
+                    self.mode_info.style.colors,
+                    self.mode_info.capabilities,
+                );
+                is_alternate_tab = !is_alternate_tab;
+                all_tabs.push(tab);
+            }
+            self.tab_line = tab_line(
+                self.mode_info.session_name.as_deref(),
+                all_tabs,
+                active_tab_index,
+                cols.saturating_sub(1),
                 self.mode_info.style.colors,
                 self.mode_info.capabilities,
+                self.mode_info.style.hide_session_name,
+                self.mode_info.mode,
+                &active_swap_layout_name,
+                is_swap_layout_dirty,
             );
-            is_alternate_tab = !is_alternate_tab;
-            all_tabs.push(tab);
+            let output = self
+                .tab_line
+                .iter()
+                .fold(String::new(), |output, part| output + &part.part);
+            let background = self.mode_info.style.colors.text_unselected.background;
+            match background {
+                PaletteColor::Rgb((r, g, b)) => {
+                    print!("{}\u{1b}[48;2;{};{};{}m\u{1b}[0K", output, r, g, b);
+                },
+                PaletteColor::EightBit(color) => {
+                    print!("{}\u{1b}[48;5;{}m\u{1b}[0K", output, color);
+                },
+            }
         }
-        self.tab_line = tab_line(
-            self.mode_info.session_name.as_deref(),
-            all_tabs,
-            active_tab_index,
-            cols.saturating_sub(1),
-            self.mode_info.style.colors,
-            self.mode_info.capabilities,
-            self.mode_info.style.hide_session_name,
-            self.mode_info.mode,
-            &active_swap_layout_name,
-            is_swap_layout_dirty,
-        );
-        let output = self
-            .tab_line
-            .iter()
-            .fold(String::new(), |output, part| output + &part.part);
-        let background = self.mode_info.style.colors.text_unselected.background;
-        match background {
-            PaletteColor::Rgb((r, g, b)) => {
-                print!("{}\u{1b}[48;2;{};{};{}m\u{1b}[0K", output, r, g, b);
-            },
-            PaletteColor::EightBit(color) => {
-                print!("{}\u{1b}[48;5;{}m\u{1b}[0K", output, color);
-            },
-        }
+    }
+}
+
+pub fn text_copied_hint(copy_destination: CopyDestination) -> LinePart {
+    let hint = match copy_destination {
+        CopyDestination::Command => "Text piped to external command",
+        #[cfg(not(target_os = "macos"))]
+        CopyDestination::Primary => "Text copied to system primary selection",
+        #[cfg(target_os = "macos")] // primary selection does not exist on macos
+        CopyDestination::Primary => "Text copied to system clipboard",
+        CopyDestination::System => "Text copied to system clipboard",
+    };
+    LinePart {
+        part: serialize_text(&Text::new(&hint).color_range(2, ..).opaque()),
+        len: hint.len(),
+        tab_index: None,
+    }
+}
+
+pub fn system_clipboard_error() -> LinePart {
+    let hint = " Error using the system clipboard.";
+    LinePart {
+        part: serialize_text(&Text::new(&hint).color_range(2, ..).opaque()),
+        len: hint.len(),
+        tab_index: None,
     }
 }

--- a/default-plugins/status-bar/src/main.rs
+++ b/default-plugins/status-bar/src/main.rs
@@ -329,7 +329,7 @@ impl State {
         let active_tab = self.tabs.iter().find(|t| t.active);
 
         if let Some(copy_destination) = self.text_copy_destination {
-            text_copied_hint(&self.mode_info.style.colors, copy_destination)
+            text_copied_hint(copy_destination)
         } else if self.display_system_clipboard_failure {
             system_clipboard_error(&self.mode_info.style.colors)
         } else if let Some(active_tab) = active_tab {

--- a/default-plugins/status-bar/src/one_line_ui.rs
+++ b/default-plugins/status-bar/src/one_line_ui.rs
@@ -24,7 +24,7 @@ pub fn one_line_ui(
     clipboard_failure: bool,
 ) -> LinePart {
     if let Some(text_copied_to_clipboard_destination) = text_copied_to_clipboard_destination {
-        return text_copied_hint(&help.style.colors, text_copied_to_clipboard_destination);
+        return text_copied_hint(text_copied_to_clipboard_destination);
     }
     if clipboard_failure {
         return system_clipboard_error(&help.style.colors);

--- a/default-plugins/status-bar/src/second_line.rs
+++ b/default-plugins/status-bar/src/second_line.rs
@@ -348,8 +348,7 @@ pub fn keybinds(help: &ModeInfo, tip_name: &str, max_width: usize) -> LinePart {
     best_effort_shortcut_list(help, tip_body.short, max_width)
 }
 
-pub fn text_copied_hint(palette: &Styling, copy_destination: CopyDestination) -> LinePart {
-    let green_color = palette_match!(palette.text_unselected.emphasis_2);
+pub fn text_copied_hint(copy_destination: CopyDestination) -> LinePart {
     let hint = match copy_destination {
         CopyDestination::Command => "Text piped to external command",
         #[cfg(not(target_os = "macos"))]
@@ -359,7 +358,7 @@ pub fn text_copied_hint(palette: &Styling, copy_destination: CopyDestination) ->
         CopyDestination::System => "Text copied to system clipboard",
     };
     LinePart {
-        part: Style::new().fg(green_color).bold().paint(hint).to_string(),
+        part: serialize_text(&Text::new(&hint).color_range(2, ..).opaque()),
         len: hint.len(),
     }
 }

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -47,7 +47,9 @@ pub(crate) fn route_action(
     let mut should_break = false;
     let err_context = || format!("failed to route action for client {client_id}");
 
-    if !action.is_mouse_motion() {
+    if !action.is_mouse_action() {
+        // mouse actions should only send InputReceived to plugins
+        // if they do not result in text being marked, this is handled in Tab
         senders
             .send_to_plugin(PluginInstruction::Update(vec![(
                 None,

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -3851,11 +3851,19 @@ pub(crate) fn screen_thread_main(
                 screen.unblock_input()?;
             },
             ScreenInstruction::MouseEvent(event, client_id) => {
-                let state_changed = screen
+                let mouse_effect = screen
                     .get_active_tab_mut(client_id)
                     .and_then(|tab| tab.handle_mouse_event(&event, client_id))?;
-                if state_changed {
+                if mouse_effect.state_changed {
                     screen.log_and_report_session_state()?;
+                }
+                if !mouse_effect.leave_clipboard_message {
+                    let _ = screen.bus.senders
+                        .send_to_plugin(PluginInstruction::Update(vec![(
+                            None,
+                            Some(client_id),
+                            Event::InputReceived,
+                        )]));
                 }
                 screen.render(None)?;
             },

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -3858,7 +3858,9 @@ pub(crate) fn screen_thread_main(
                     screen.log_and_report_session_state()?;
                 }
                 if !mouse_effect.leave_clipboard_message {
-                    let _ = screen.bus.senders
+                    let _ = screen
+                        .bus
+                        .senders
                         .send_to_plugin(PluginInstruction::Update(vec![(
                             None,
                             Some(client_id),

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -3366,7 +3366,11 @@ impl Tab {
 
     // returns true if the mouse event caused some sort of tab/pane state change that needs to be
     // reported to plugins
-    pub fn handle_mouse_event(&mut self, event: &MouseEvent, client_id: ClientId) -> Result<MouseEffect> {
+    pub fn handle_mouse_event(
+        &mut self,
+        event: &MouseEvent,
+        client_id: ClientId,
+    ) -> Result<MouseEffect> {
         let err_context =
             || format!("failed to handle mouse event {event:?} for client {client_id}");
 
@@ -3655,7 +3659,11 @@ impl Tab {
         }
     }
 
-    pub fn handle_right_click(&mut self, event: &MouseEvent, client_id: ClientId) -> Result<MouseEffect> {
+    pub fn handle_right_click(
+        &mut self,
+        event: &MouseEvent,
+        client_id: ClientId,
+    ) -> Result<MouseEffect> {
         let err_context = || format!("failed to handle mouse right click for client {client_id}");
 
         let absolute_position = event.position;
@@ -3689,7 +3697,11 @@ impl Tab {
         Ok(MouseEffect::default())
     }
 
-    fn handle_middle_click(&mut self, event: &MouseEvent, client_id: ClientId) -> Result<MouseEffect> {
+    fn handle_middle_click(
+        &mut self,
+        event: &MouseEvent,
+        client_id: ClientId,
+    ) -> Result<MouseEffect> {
         let err_context = || format!("failed to handle mouse middle click for client {client_id}");
         let absolute_position = event.position;
 
@@ -3721,7 +3733,11 @@ impl Tab {
         Ok(MouseEffect::default())
     }
 
-    fn handle_mouse_no_click(&mut self, event: &MouseEvent, client_id: ClientId) -> Result<MouseEffect> {
+    fn handle_mouse_no_click(
+        &mut self,
+        event: &MouseEvent,
+        client_id: ClientId,
+    ) -> Result<MouseEffect> {
         let err_context = || format!("failed to handle mouse no click for client {client_id}");
         let absolute_position = event.position;
 

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -10,7 +10,7 @@ use crate::data::{Direction, KeyWithModifier, PaneId, Resize};
 use crate::data::{FloatingPaneCoordinates, InputMode};
 use crate::home::{find_default_config_dir, get_layout_dir};
 use crate::input::config::{Config, ConfigError, KdlError};
-use crate::input::mouse::{MouseEvent, MouseEventType};
+use crate::input::mouse::MouseEvent;
 use crate::input::options::OnForceClose;
 use miette::{NamedSource, Report};
 use serde::{Deserialize, Serialize};
@@ -800,11 +800,9 @@ impl Action {
             _ => false,
         }
     }
-    pub fn is_mouse_motion(&self) -> bool {
-        if let Action::MouseEvent(mouse_event) = self {
-            if let MouseEventType::Motion = mouse_event.event_type {
-                return true;
-            }
+    pub fn is_mouse_action(&self) -> bool {
+        if let Action::MouseEvent(_mouse_event) = self {
+            return true;
         }
         false
     }


### PR DESCRIPTION
This fixes some issues with the "Text copied to clipboard" message:
1. The message now properly appears with an opaque background
2. The message now also appears in the compact layout
3. The message does not jitter when double-clicking a word to copy it