### PR TITLE
fix(floating-panes): reset swap floating layouts when closing last floating pane

### DIFF
--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -2786,6 +2786,7 @@ impl Tab {
             let _closed_pane = self.floating_panes.remove_pane(id);
             self.floating_panes.move_clients_out_of_pane(id);
             if !self.floating_panes.has_panes() {
+                self.swap_layouts.reset_floating_damage();
                 self.hide_floating_panes();
             }
             self.set_force_render();
@@ -2846,6 +2847,7 @@ impl Tab {
             let mut closed_pane = self.floating_panes.remove_pane(id);
             self.floating_panes.move_clients_out_of_pane(id);
             if !self.floating_panes.has_panes() {
+                self.swap_layouts.reset_floating_damage();
                 self.hide_floating_panes();
             }
             self.set_force_render();

--- a/zellij-server/src/tab/swap_layouts.rs
+++ b/zellij-server/src/tab/swap_layouts.rs
@@ -61,6 +61,12 @@ impl SwapLayouts {
     pub fn set_is_tiled_damaged(&mut self) {
         self.is_tiled_damaged = true;
     }
+    pub fn reset_floating_damage(&mut self) {
+        self.is_floating_damaged = false;
+    }
+    pub fn reset_tiled_damage(&mut self) {
+        self.is_tiled_damaged = false;
+    }
     pub fn is_floating_damaged(&self) -> bool {
         self.is_floating_damaged
     }


### PR DESCRIPTION
This fixes an issue where the swap layouts would remain "damaged" after closing the last floating pane (if they were damaged beforehand).