### PR TITLE
Ctrl + p, Ctrl + n to lnavigate lists in sesssion manager up and down, and shift + tab to navigate session manager tabs backwards

### DIFF
--- a/default-plugins/session-manager/src/main.rs
+++ b/default-plugins/session-manager/src/main.rs
@@ -197,11 +197,19 @@ impl State {
     fn handle_new_session_key(&mut self, key: KeyWithModifier) -> bool {
         let mut should_render = false;
         match key.bare_key {
+            BareKey::Char('n') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
+                self.new_session_info.handle_key(key);
+                should_render = true;
+            },
             BareKey::Down if key.has_no_modifiers() => {
                 self.new_session_info.handle_key(key);
                 should_render = true;
             },
             BareKey::Up if key.has_no_modifiers() => {
+                self.new_session_info.handle_key(key);
+                should_render = true;
+            },
+            BareKey::Char('p') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
                 self.new_session_info.handle_key(key);
                 should_render = true;
             },
@@ -227,6 +235,10 @@ impl State {
             },
             BareKey::Tab if key.has_no_modifiers() => {
                 self.toggle_active_screen();
+                should_render = true;
+            },
+            BareKey::Tab if key.has_modifiers(&[KeyModifier::Shift]) => {
+                self.toggle_active_screen_backwards();
                 should_render = true;
             },
             BareKey::Char('f') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
@@ -301,7 +313,15 @@ impl State {
                     self.sessions.move_selection_down();
                     should_render = true;
                 },
+                BareKey::Char('n') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
+                    self.sessions.move_selection_down();
+                    should_render = true;
+                },
                 BareKey::Up if key.has_no_modifiers() => {
+                    self.sessions.move_selection_up();
+                    should_render = true;
+                },
+                BareKey::Char('p') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
                     self.sessions.move_selection_up();
                     should_render = true;
                 },
@@ -383,6 +403,10 @@ impl State {
                     self.toggle_active_screen();
                     should_render = true;
                 },
+                BareKey::Tab if key.has_modifiers(&[KeyModifier::Shift]) => {
+                    self.toggle_active_screen_backwards();
+                    should_render = true;
+                },
                 BareKey::Esc if key.has_no_modifiers() => {
                     if self.renaming_session_name.is_some() {
                         self.renaming_session_name = None;
@@ -403,7 +427,15 @@ impl State {
                 self.resurrectable_sessions.move_selection_down();
                 should_render = true;
             },
+            BareKey::Char('n') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
+                self.resurrectable_sessions.move_selection_down();
+                should_render = true;
+            },
             BareKey::Up if key.has_no_modifiers() => {
+                self.resurrectable_sessions.move_selection_up();
+                should_render = true;
+            },
+            BareKey::Char('p') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
                 self.resurrectable_sessions.move_selection_up();
                 should_render = true;
             },
@@ -429,6 +461,10 @@ impl State {
             },
             BareKey::Tab if key.has_no_modifiers() => {
                 self.toggle_active_screen();
+                should_render = true;
+            },
+            BareKey::Tab if key.has_modifiers(&[KeyModifier::Shift]) => {
+                self.toggle_active_screen_backwards();
                 should_render = true;
             },
             BareKey::Delete if key.has_no_modifiers() => {
@@ -534,6 +570,13 @@ impl State {
             ActiveScreen::NewSession => ActiveScreen::AttachToSession,
             ActiveScreen::AttachToSession => ActiveScreen::ResurrectSession,
             ActiveScreen::ResurrectSession => ActiveScreen::NewSession,
+        };
+    }
+    fn toggle_active_screen_backwards(&mut self) {
+        self.active_screen = match self.active_screen {
+            ActiveScreen::NewSession => ActiveScreen::ResurrectSession,
+            ActiveScreen::ResurrectSession => ActiveScreen::AttachToSession,
+            ActiveScreen::AttachToSession => ActiveScreen::NewSession,
         };
     }
     fn show_error(&mut self, error_text: &str) {

--- a/default-plugins/session-manager/src/new_session_info.rs
+++ b/default-plugins/session-manager/src/new_session_info.rs
@@ -87,7 +87,13 @@ impl NewSessionInfo {
             BareKey::Up if key.has_no_modifiers() => {
                 self.move_selection_up();
             },
+            BareKey::Char('p') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
+                self.move_selection_up();
+            },
             BareKey::Down if key.has_no_modifiers() => {
+                self.move_selection_down();
+            },
+            BareKey::Char('n') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
                 self.move_selection_down();
             },
             _ => {},


### PR DESCRIPTION
Allows navigation of lists in session manager wiht Ctrl+p and Ctrl+n (these keyshortcuts are used by default by vim, nvim, helix, zsh and fish, for similar purposes, such as navigating lists of suggested completions, these are established keyshortcuts) which can be more ergonimical than using the up and down arrow keys, and allows using Shift+Tab to navigate the tab bar backwards.