### PR TITLE
fix(about): Correct typo.

### DIFF
--- a/default-plugins/about/src/tips.rs
+++ b/default-plugins/about/src/tips.rs
@@ -323,7 +323,7 @@ impl Page {
                             }
                     )),
                     ActiveComponent::new(TextOrCustomRender::Text(
-                            Text::new("Press TAB to go to Chagne Mode Behavior")
+                            Text::new("Press TAB to go to Change Mode Behavior")
                                 .color_range(3, 6..=9)
                     )),
                     ActiveComponent::new(TextOrCustomRender::Text(


### PR DESCRIPTION
Corrects apparent typo in about plugin - "Chagne" vs "Change"

My first contribution here, as meager as it is. Happy for any feedback.