### PR TITLE
fix(panes): when focusing pane off the tab edge, break ties with active_at instead of y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * chore(repo): update some dependencies (https://github.com/zellij-org/zellij/pull/4019)
 * fix(grid): reap sixel images on clear (https://github.com/zellij-org/zellij/pull/3982)
 * fix(panes): properly render stacked panes when pane frames are disabled (https://github.com/zellij-org/zellij/pull/4035)
+* fix(panes): break ties by last focus time when focusing panes on screen edge (https://github.com/zellij-org/zellij/pull/4037)
 
 ## [0.41.2] - 2024-11-19
 * fix(input): keypresses not being identified properly with kitty keyboard protocol in some terminals (https://github.com/zellij-org/zellij/pull/3725)

--- a/zellij-server/src/panes/tiled_panes/tiled_pane_grid.rs
+++ b/zellij-server/src/panes/tiled_panes/tiled_pane_grid.rs
@@ -1044,28 +1044,28 @@ impl<'a> TiledPaneGrid<'a> {
                 Direction::Left => {
                     let x_comparison = a.x().cmp(&b.x());
                     match x_comparison {
-                        Ordering::Equal => b.y().cmp(&a.y()),
+                        Ordering::Equal => a.active_at().cmp(&b.active_at()),
                         _ => x_comparison,
                     }
                 },
                 Direction::Right => {
                     let x_comparison = b.x().cmp(&a.x());
                     match x_comparison {
-                        Ordering::Equal => b.y().cmp(&a.y()),
+                        Ordering::Equal => a.active_at().cmp(&b.active_at()),
                         _ => x_comparison,
                     }
                 },
                 Direction::Up => {
                     let y_comparison = a.y().cmp(&b.y());
                     match y_comparison {
-                        Ordering::Equal => a.x().cmp(&b.x()),
+                        Ordering::Equal => a.active_at().cmp(&b.active_at()),
                         _ => y_comparison,
                     }
                 },
                 Direction::Down => {
                     let y_comparison = b.y().cmp(&a.y());
                     match y_comparison {
-                        Ordering::Equal => b.x().cmp(&a.x()),
+                        Ordering::Equal => a.active_at().cmp(&b.active_at()),
                         _ => y_comparison,
                     }
                 },


### PR DESCRIPTION
This fixes an annoying UX issue where when focusing panes off the screen edge using `Alt <arrows>`, the selectable pane with the lowest x would be focused on the relevant edge regardless of which one was previously active. Now these ties will be broken with `active_at` instead of the opposite direction, which is a much better user experience.