### PR TITLE
fix(utils): use correct `MIN_TERMINAL_HEIGHT`

### DIFF
--- a/zellij-server/src/panes/floating_panes/floating_pane_grid.rs
+++ b/zellij-server/src/panes/floating_panes/floating_pane_grid.rs
@@ -1,10 +1,12 @@
-use crate::tab::{MIN_TERMINAL_HEIGHT, MIN_TERMINAL_WIDTH};
 use crate::{panes::PaneId, tab::Pane};
 use std::cmp::Ordering;
 use std::collections::HashMap;
-use zellij_utils::data::{Direction, ResizeStrategy};
-use zellij_utils::errors::prelude::*;
-use zellij_utils::pane_size::{Dimension, PaneGeom, Size, Viewport};
+use zellij_utils::{
+    consts::{MIN_TERMINAL_HEIGHT, MIN_TERMINAL_WIDTH},
+    data::{Direction, ResizeStrategy},
+    errors::prelude::*,
+    pane_size::{Dimension, PaneGeom, Size, Viewport},
+};
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     output::Output,
     panes::{ActivePanes, PaneId},
     plugins::PluginInstruction,
-    tab::{pane_info_for_pane, Pane, MIN_TERMINAL_HEIGHT, MIN_TERMINAL_WIDTH},
+    tab::{pane_info_for_pane, Pane},
     thread_bus::ThreadSenders,
     ui::boundaries::Boundaries,
     ui::pane_contents_and_ui::PaneContentsAndUi,
@@ -18,6 +18,7 @@ use crate::{
 };
 use stacked_panes::StackedPanes;
 use zellij_utils::{
+    consts::{MIN_TERMINAL_HEIGHT, MIN_TERMINAL_WIDTH},
     data::{Direction, ModeInfo, PaneInfo, Resize, ResizeStrategy, Style, Styling},
     errors::prelude::*,
     input::{

--- a/zellij-server/src/panes/tiled_panes/stacked_panes.rs
+++ b/zellij-server/src/panes/tiled_panes/stacked_panes.rs
@@ -1,11 +1,9 @@
-use crate::{
-    panes::PaneId,
-    tab::{Pane, MIN_TERMINAL_HEIGHT},
-};
+use crate::{panes::PaneId, tab::Pane};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use zellij_utils::{
+    consts::MIN_TERMINAL_HEIGHT,
     errors::prelude::*,
     pane_size::{Dimension, PaneGeom},
 };

--- a/zellij-server/src/panes/tiled_panes/tiled_pane_grid.rs
+++ b/zellij-server/src/panes/tiled_panes/tiled_pane_grid.rs
@@ -1,12 +1,12 @@
 use super::is_inside_viewport;
 use super::pane_resizer::PaneResizer;
 use super::stacked_panes::StackedPanes;
-use crate::tab::{MIN_TERMINAL_HEIGHT, MIN_TERMINAL_WIDTH};
 use crate::{panes::PaneId, tab::Pane};
 use std::cmp::{Ordering, Reverse};
 use std::collections::{HashMap, HashSet};
 use zellij_utils::data::{Direction, Resize, ResizeStrategy};
 use zellij_utils::{
+    consts::{MIN_TERMINAL_HEIGHT, MIN_TERMINAL_WIDTH},
     errors::prelude::*,
     input::layout::SplitDirection,
     pane_size::{Dimension, PaneGeom, Size, Viewport},

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -10,15 +10,20 @@ use copy_command::CopyCommand;
 use std::env::temp_dir;
 use std::path::PathBuf;
 use uuid::Uuid;
-use zellij_utils::data::{
-    Direction, KeyWithModifier, PaneInfo, PermissionStatus, PermissionType, PluginPermission,
-    ResizeStrategy,
+use zellij_utils::{
+    consts::{MIN_TERMINAL_HEIGHT, MIN_TERMINAL_WIDTH},
+    data::{
+        Direction, KeyWithModifier, PaneInfo, PermissionStatus, PermissionType, PluginPermission,
+        ResizeStrategy,
+    },
+    errors::prelude::*,
+    input::{
+        command::RunCommand,
+        mouse::{MouseEvent, MouseEventType},
+    },
+    position::{Column, Line, Position},
+    serde,
 };
-use zellij_utils::errors::prelude::*;
-use zellij_utils::input::command::RunCommand;
-use zellij_utils::input::mouse::{MouseEvent, MouseEventType};
-use zellij_utils::position::{Column, Line};
-use zellij_utils::{position::Position, serde};
 
 use crate::background_jobs::BackgroundJob;
 use crate::pty_writer::PtyWriteInstruction;
@@ -131,10 +136,6 @@ macro_rules! resize_pty {
         }
     }};
 }
-
-// FIXME: This should be replaced by `RESIZE_PERCENT` at some point
-pub const MIN_TERMINAL_HEIGHT: usize = 5;
-pub const MIN_TERMINAL_WIDTH: usize = 5;
 
 const MAX_PENDING_VTE_EVENTS: usize = 7000;
 

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -13,6 +13,11 @@ pub const ZELLIJ_CONFIG_DIR_ENV: &str = "ZELLIJ_CONFIG_DIR";
 pub const ZELLIJ_LAYOUT_DIR_ENV: &str = "ZELLIJ_LAYOUT_DIR";
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const DEFAULT_SCROLL_BUFFER_SIZE: usize = 10_000;
+
+// FIXME: This should be replaced by `RESIZE_PERCENT` at some point
+pub const MIN_TERMINAL_HEIGHT: usize = 5;
+pub const MIN_TERMINAL_WIDTH: usize = 5;
+
 pub static SCROLL_BUFFER_SIZE: OnceCell<usize> = OnceCell::new();
 pub static DEBUG_MODE: OnceCell<bool> = OnceCell::new();
 

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -11,6 +11,7 @@
 #[cfg(not(target_family = "wasm"))]
 use crate::downloader::Downloader;
 use crate::{
+    consts::MIN_TERMINAL_HEIGHT,
     data::{Direction, LayoutInfo},
     home::{default_layout_dir, find_default_config_dir},
     input::{
@@ -1631,8 +1632,12 @@ fn split_space(
         } else if let Some(last_size) = sizes.last_mut() {
             *last_size = None;
         }
-        if sizes.len() > space_to_split.rows.as_usize().saturating_sub(4) {
-            // 4 is MIN_TERMINAL_HEIGHT
+        if sizes.len()
+            > space_to_split
+                .rows
+                .as_usize()
+                .saturating_sub(MIN_TERMINAL_HEIGHT)
+        {
             return Err("Not enough room for stacked panes in this layout");
         }
         sizes


### PR DESCRIPTION
Pulls out `MIN_TERMINAL_*` constants from `zellij-server` into `zellij-utils` so that they can be used everywhere, without relying on comments to keep magic numbers in sync!