### PR TITLE
fix(serialization): stacked panes fixes

### DIFF
--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -737,7 +737,7 @@ impl Tab {
     ) -> Result<()> {
         self.swap_layouts
             .set_base_layout((layout.clone(), floating_panes_layout.clone()));
-        if let Ok(should_show_floating_panes) = LayoutApplier::new(
+        match LayoutApplier::new(
             &self.viewport,
             &self.senders,
             &self.sixel_image_store,
@@ -766,17 +766,25 @@ impl Tab {
             new_plugin_ids,
             client_id,
         ) {
-            #[allow(clippy::if_same_then_else)]
-            if should_show_floating_panes && !self.floating_panes.panes_are_visible() {
-                self.toggle_floating_panes(Some(client_id), None)
-                    .non_fatal();
-            } else if !should_show_floating_panes && self.floating_panes.panes_are_visible() {
-                self.toggle_floating_panes(Some(client_id), None)
-                    .non_fatal();
+            Ok(should_show_floating_panes) => {
+                if should_show_floating_panes && !self.floating_panes.panes_are_visible() {
+                    self.toggle_floating_panes(Some(client_id), None)
+                        .non_fatal();
+                } else if !should_show_floating_panes && self.floating_panes.panes_are_visible() {
+                    self.toggle_floating_panes(Some(client_id), None)
+                        .non_fatal();
+                }
+                self.tiled_panes.reapply_pane_frames();
+                self.is_pending = false;
+                self.apply_buffered_instructions().non_fatal();
+            },
+            Err(e) => {
+                // TODO: this should only happen due to an erroneous layout created by user
+                // configuration that was somehow not caught in our KDL layout parser
+                // we should still be able to properly recover from this with a useful error
+                // message though
+                log::error!("Failed to apply layout: {}", e);
             }
-            self.tiled_panes.reapply_pane_frames();
-            self.is_pending = false;
-            self.apply_buffered_instructions().non_fatal();
         }
         Ok(())
     }

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -784,7 +784,7 @@ impl Tab {
                 // we should still be able to properly recover from this with a useful error
                 // message though
                 log::error!("Failed to apply layout: {}", e);
-            }
+            },
         }
         Ok(())
     }

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -925,8 +925,14 @@ impl TiledPaneLayout {
             },
             None => {
                 let mut stack_id = 0;
-                split_space(space, self, space, ignore_percent_split_sizes, &mut stack_id)?
-            }
+                split_space(
+                    space,
+                    self,
+                    space,
+                    ignore_percent_split_sizes,
+                    &mut stack_id,
+                )?
+            },
         };
         for (_pane_layout, pane_geom) in layouts.iter() {
             if !pane_geom.is_at_least_minimum_size() {

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -1642,8 +1642,9 @@ fn split_space(
         } else if let Some(last_size) = sizes.last_mut() {
             *last_size = None;
         }
-        if sizes.len() > space_to_split.rows.as_usize().saturating_sub(4) {
-            // 4 is MIN_TERMINAL_HEIGHT
+        if sizes.len() > space_to_split.rows.as_usize().saturating_sub(3) {
+            // 4 is MIN_TERMINAL_HEIGHT, minus 1 because sizes also includes the expanded pane in
+            // the stack
             return Err("Not enough room for stacked panes in this layout");
         }
         sizes

--- a/zellij-utils/src/session_serialization.rs
+++ b/zellij-utils/src/session_serialization.rs
@@ -669,12 +669,15 @@ fn serialize_floating_pane(
 
 fn stack_layout_from_manifest(
     geoms: &Vec<PaneLayoutManifest>,
-    split_size: Option<SplitSize>
+    split_size: Option<SplitSize>,
 ) -> Option<TiledPaneLayout> {
     let mut children_stacks: HashMap<usize, Vec<PaneLayoutManifest>> = HashMap::new();
     for p in geoms {
         if let Some(stack_id) = p.geom.stacked {
-            children_stacks.entry(stack_id).or_insert_with(Default::default).push(p.clone());
+            children_stacks
+                .entry(stack_id)
+                .or_insert_with(Default::default)
+                .push(p.clone());
         }
     }
     let mut stack_nodes = vec![];
@@ -754,7 +757,7 @@ fn get_tiled_panes_layout_from_panegeoms(
                 return Some(tiled_pane_layout_from_manifest(
                     geoms.iter().next(),
                     split_size,
-                ))
+                ));
             }
         },
     };
@@ -795,7 +798,6 @@ fn get_tiled_panes_layout_from_panegeoms(
     }
 
     let new_split_sizes = get_split_sizes(&new_constraints);
-
 
     for (subgeoms, subsplit_size) in new_geoms.iter().zip(new_split_sizes) {
         match get_tiled_panes_layout_from_panegeoms(&subgeoms, subsplit_size) {
@@ -954,15 +956,21 @@ fn get_row_splits(
     let mut all_geoms = vec![];
     for pane_layout_manifest in sorted_geoms.drain(..) {
         if let Some(stack_id) = pane_layout_manifest.geom.stacked {
-            stack_geoms.entry(stack_id).or_insert_with(Default::default).push(pane_layout_manifest)
-        }  else {
+            stack_geoms
+                .entry(stack_id)
+                .or_insert_with(Default::default)
+                .push(pane_layout_manifest)
+        } else {
             all_geoms.push(pane_layout_manifest);
         }
     }
     for (_stack_id, mut geoms_in_stack) in stack_geoms.into_iter() {
         let mut geom_of_whole_stack = geoms_in_stack.remove(0);
         if let Some(last_geom) = geoms_in_stack.last() {
-            geom_of_whole_stack.geom.rows.set_inner(last_geom.geom.y + last_geom.geom.rows.as_usize())
+            geom_of_whole_stack
+                .geom
+                .rows
+                .set_inner(last_geom.geom.y + last_geom.geom.rows.as_usize())
         }
         all_geoms.push(geom_of_whole_stack);
     }

--- a/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_tab_with_multiple_stacked_panes_in_the_same_node.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_tab_with_multiple_stacked_panes_in_the_same_node.snap
@@ -1,0 +1,21 @@
+---
+source: zellij-utils/src/session_serialization.rs
+assertion_line: 1812
+expression: kdl.0
+---
+layout {
+    tab name="Tab with \"stacked panes\"" {
+        pane stacked=true {
+            pane
+            pane expanded=true
+            pane
+        }
+        pane size=10
+        pane stacked=true {
+            pane
+            pane expanded=true
+            pane
+        }
+    }
+}
+

--- a/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_tab_with_multiple_stacked_panes_in_the_same_node.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_tab_with_multiple_stacked_panes_in_the_same_node.snap
@@ -1,17 +1,17 @@
 ---
 source: zellij-utils/src/session_serialization.rs
-assertion_line: 1812
+assertion_line: 1899
 expression: kdl.0
 ---
 layout {
     tab name="Tab with \"stacked panes\"" {
-        pane stacked=true {
+        pane size=12 stacked=true {
             pane
             pane expanded=true
             pane
         }
         pane size=10
-        pane stacked=true {
+        pane size=12 stacked=true {
             pane
             pane expanded=true
             pane

--- a/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_tab_with_multiple_stacks_next_to_eachother.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__session_serialization__tests__can_serialize_tab_with_multiple_stacks_next_to_eachother.snap
@@ -1,0 +1,38 @@
+---
+source: zellij-utils/src/session_serialization.rs
+assertion_line: 2081
+expression: kdl.0
+---
+layout {
+    tab name="Tab with \"stacked panes\"" {
+        pane size=12 split_direction="vertical" {
+            pane size=10 stacked=true {
+                pane
+                pane expanded=true
+                pane
+            }
+            pane size=10 stacked=true {
+                pane
+                pane expanded=true
+                pane
+            }
+        }
+        pane size=10 split_direction="vertical" {
+            pane size=10
+            pane size=10
+        }
+        pane size=12 split_direction="vertical" {
+            pane size=10 stacked=true {
+                pane
+                pane expanded=true
+                pane
+            }
+            pane size=10 stacked=true {
+                pane
+                pane expanded=true
+                pane
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
This includes various fixes for serializing stacked panes. These issues were mainly spotted when using the `zellij action dump-layout` and when using session serialization. These now work properly with multiple stacks in various configurations.