### PR TITLE
fix(plugins): prevent paging plugins from cache at runtime

### DIFF
--- a/zellij-server/src/plugins/plugin_loader.rs
+++ b/zellij-server/src/plugins/plugin_loader.rs
@@ -529,7 +529,8 @@ impl<'a> PluginLoader<'a> {
         );
         let (_wasm_bytes, cached_path) = self.plugin_bytes_and_cache_path()?;
         let timer = std::time::Instant::now();
-        let module = unsafe { Module::deserialize_file(&self.engine, &cached_path)? };
+        let file_in_cache = std::fs::read(&cached_path)?;
+        let module = unsafe { Module::deserialize(&self.engine, file_in_cache)? };
         log::info!(
             "Loaded plugin '{}' from cache folder at '{}' in {:?}",
             self.plugin_path.display(),


### PR DESCRIPTION
This is a fix for an issue where if one would run a development instance of Zellij that shared cache with a release instance, plugins would sometimes be paged from the HD, causing segfaults. More info here: https://github.com/bytecodealliance/wasmtime/issues/10283#issuecomment-2692084111