### PR TITLE
fix(grid): out of bounds removal when app does not update its scroll region on resize

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1283,7 +1283,9 @@ impl Grid {
             let mut pad_character = EMPTY_TERMINAL_CHARACTER;
             pad_character.styles = self.cursor.pending_styles.clone();
             for _ in 0..count {
-                self.viewport.remove(scroll_region_top);
+                if scroll_region_top < self.viewport.len() {
+                    self.viewport.remove(scroll_region_top);
+                }
                 let columns = VecDeque::from(vec![pad_character.clone(); self.width]);
                 self.viewport
                     .insert(scroll_region_bottom, Row::from_columns(columns).canonical());


### PR DESCRIPTION
This fixes a minor issue where some apps using scroll region rotate would try to clear the scroll region bounds before they updated them to the terminal window size (eg. after a resize). While this is an error on the app side (I think it comes from ncurses), we should be able to handle this without crashing. This fixes that!