### PR TITLE
fix(stacked): stacked panes can't resize status-bar

### DIFF
--- a/default-plugins/about/src/tips.rs
+++ b/default-plugins/about/src/tips.rs
@@ -323,7 +323,7 @@ impl Page {
                             }
                     )),
                     ActiveComponent::new(TextOrCustomRender::Text(
-                            Text::new("Press TAB to go to Chagne Mode Behavior")
+                            Text::new("Press TAB to go to Change Mode Behavior")
                                 .color_range(3, 6..=9)
                     )),
                     ActiveComponent::new(TextOrCustomRender::Text(

--- a/src/tests/e2e/cases.rs
+++ b/src/tests/e2e/cases.rs
@@ -1799,7 +1799,9 @@ pub fn multiple_users_in_different_panes_and_same_tab() {
             name: "take snapshot after",
             instruction: |remote_terminal: RemoteTerminal| -> bool {
                 let mut step_is_complete = false;
-                if remote_terminal.cursor_position_is(63, 2) && remote_terminal.status_bar_appears()
+                if remote_terminal.cursor_position_is(63, 2)
+                    && remote_terminal.status_bar_appears()
+                    && remote_terminal.snapshot_contains("LOCK")
                 {
                     // cursor is in the newly opened second pane
                     step_is_complete = true;

--- a/zellij-server/src/panes/tiled_panes/stacked_panes.rs
+++ b/zellij-server/src/panes/tiled_panes/stacked_panes.rs
@@ -309,7 +309,7 @@ impl<'a> StackedPanes<'a> {
         Ok(())
     }
     fn pane_is_one_liner(&self, id: &PaneId) -> Result<bool> {
-        let err_context = || format!("Cannot determin if pane is one liner or not");
+        let err_context = || format!("Cannot determine if pane is one liner or not");
         let panes = self.panes.borrow();
         let pane_to_close = panes.get(id).with_context(err_context)?;
         Ok(pane_to_close.position_and_size().rows.is_fixed())

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -1157,10 +1157,7 @@ impl Layout {
             .or_else(|| default_layout_dir())
             .and_then(|layout_dir| match std::fs::read_dir(layout_dir) {
                 Ok(layout_files) => Some(layout_files),
-                Err(e) => {
-                    log::error!("Failed to read layout dir: {:?}", e);
-                    None
-                },
+                Err(_) => None,
             })
             .map(|layout_files| {
                 let mut available_layouts = vec![];


### PR DESCRIPTION
Fixed a number of other typos and issues I came across, but the last commit is the one that actually solves the resize issue!

There is another experiment on `tll-pane-resizer-with-stackinfo` for the future when we have <N panes above / below>

I might need @imsnif's help to write a test if one is wanted!