### PR TITLE
fix(selection): add proper multi-click dragging options

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1836,7 +1836,8 @@ impl Grid {
         let old_selection = self.selection;
         if &old_selection.end != to {
             if self.click.is_double_click() {
-                let Some((word_start_position, word_end_position)) = self.word_around_position(&to) else {
+                let Some((word_start_position, word_end_position)) = self.word_around_position(&to)
+                else {
                     // no-op
                     return;
                 };

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1834,10 +1834,29 @@ impl Grid {
     }
     pub fn update_selection(&mut self, to: &Position) {
         let old_selection = self.selection;
+        // TODO:
+        // 1. if self.click.is_double_click
+        //  * self.selection.add_word_to_selection(word_around_to)
+        // 2. if self.click.is_triple_click
+        //  * self.selection.add_line_to_selection(canonical_line_around_position)
         if &old_selection.end != to {
-            self.selection.to(*to);
-            self.update_selected_lines(&old_selection, &self.selection.clone());
-            self.mark_for_rerender();
+            if self.click.is_double_click() {
+                let Some((word_start_position, word_end_position)) = self.word_around_position(&to) else {
+                    // no-op
+                    return;
+                };
+                self.selection
+                    .add_word_to_position(word_start_position, word_end_position);
+                let current_selection = self.selection;
+                self.update_selected_lines(&old_selection, &current_selection);
+                self.mark_for_rerender();
+            } else if self.click.is_triple_click() {
+                log::info!("can has triple click drag");
+            } else {
+                self.selection.to(*to);
+                self.update_selected_lines(&old_selection, &self.selection.clone());
+                self.mark_for_rerender();
+            }
         }
     }
 

--- a/zellij-server/src/panes/selection.rs
+++ b/zellij-server/src/panes/selection.rs
@@ -50,14 +50,23 @@ impl Selection {
     }
     pub fn add_word_to_position(&mut self, word_start: Position, word_end: Position) {
         // here we assume word_start is smaller or equal to word_end
-        let already_added = self.last_added_word_position.map(|(last_word_start, last_word_end)| {
-            last_word_start == word_start && last_word_end == word_end
-        }).unwrap_or(false);
+        let already_added = self
+            .last_added_word_position
+            .map(|(last_word_start, last_word_end)| {
+                last_word_start == word_start && last_word_end == word_end
+            })
+            .unwrap_or(false);
         if already_added {
             return;
         }
-        let word_is_above_last_added_word = self.last_added_word_position.map(|(l_start, _l_end)| word_start.line < l_start.line).unwrap_or(false);
-        let word_is_below_last_added_word = self.last_added_word_position.map(|(_l_start, l_end)| word_end.line > l_end.line).unwrap_or(false);
+        let word_is_above_last_added_word = self
+            .last_added_word_position
+            .map(|(l_start, _l_end)| word_start.line < l_start.line)
+            .unwrap_or(false);
+        let word_is_below_last_added_word = self
+            .last_added_word_position
+            .map(|(_l_start, l_end)| word_end.line > l_end.line)
+            .unwrap_or(false);
         if word_is_above_last_added_word && word_start.line < self.start.line {
             // extend line above
             self.start = word_start;
@@ -71,18 +80,37 @@ impl Selection {
             // reduce from below
             self.end = word_end;
         } else {
-            let word_end_is_to_the_left_of_last_word_start = self.last_added_word_position.map(|(l_start, _l_end)| word_end.column <= l_start.column).unwrap_or(false);
-            let word_start_is_to_the_right_of_last_word_end = self.last_added_word_position.map(|(_l_start, l_end)| word_start.column >= l_end.column).unwrap_or(false);
-            let last_word_start_equals_word_end = self.last_added_word_position.map(|(l_start, _l_end)| l_start.column == word_end.column).unwrap_or(false);
-            let last_word_end_equals_word_start = self.last_added_word_position.map(|(_l_start, l_end)| l_end.column == word_start.column).unwrap_or(false);
-            let selection_start_column_is_to_the_right_of_word_start = self.start.column > word_start.column;
+            let word_end_is_to_the_left_of_last_word_start = self
+                .last_added_word_position
+                .map(|(l_start, _l_end)| word_end.column <= l_start.column)
+                .unwrap_or(false);
+            let word_start_is_to_the_right_of_last_word_end = self
+                .last_added_word_position
+                .map(|(_l_start, l_end)| word_start.column >= l_end.column)
+                .unwrap_or(false);
+            let last_word_start_equals_word_end = self
+                .last_added_word_position
+                .map(|(l_start, _l_end)| l_start.column == word_end.column)
+                .unwrap_or(false);
+            let last_word_end_equals_word_start = self
+                .last_added_word_position
+                .map(|(_l_start, l_end)| l_end.column == word_start.column)
+                .unwrap_or(false);
+            let selection_start_column_is_to_the_right_of_word_start =
+                self.start.column > word_start.column;
             let selection_start_is_on_same_line_as_word_start = self.start.line == word_start.line;
             let selection_end_is_to_the_left_of_word_end = self.end.column < word_end.column;
             let selection_end_is_on_same_line_as_word_end = self.end.line == word_end.line;
-            if word_end_is_to_the_left_of_last_word_start && selection_start_column_is_to_the_right_of_word_start && selection_start_is_on_same_line_as_word_start {
+            if word_end_is_to_the_left_of_last_word_start
+                && selection_start_column_is_to_the_right_of_word_start
+                && selection_start_is_on_same_line_as_word_start
+            {
                 // extend selection left
                 self.start.column = word_start.column;
-            } else if word_start_is_to_the_right_of_last_word_end && selection_end_is_to_the_left_of_word_end && selection_end_is_on_same_line_as_word_end {
+            } else if word_start_is_to_the_right_of_last_word_end
+                && selection_end_is_to_the_left_of_word_end
+                && selection_end_is_on_same_line_as_word_end
+            {
                 // extend selection right
                 self.end.column = word_end.column;
             } else if last_word_start_equals_word_end {
@@ -96,14 +124,21 @@ impl Selection {
         self.last_added_word_position = Some((word_start, word_end));
     }
     pub fn add_line_to_position(&mut self, line_index: isize, last_index_in_line: usize) {
-        let already_added = self.last_added_line_index.map(|last_added_line_index| {
-            last_added_line_index == line_index
-        }).unwrap_or(false);
+        let already_added = self
+            .last_added_line_index
+            .map(|last_added_line_index| last_added_line_index == line_index)
+            .unwrap_or(false);
         if already_added {
             return;
         }
-        let line_index_is_smaller_than_last_added_line_index = self.last_added_line_index.map(|last| line_index < last).unwrap_or(false);
-        let line_index_is_larger_than_last_added_line_index = self.last_added_line_index.map(|last| line_index > last).unwrap_or(false);
+        let line_index_is_smaller_than_last_added_line_index = self
+            .last_added_line_index
+            .map(|last| line_index < last)
+            .unwrap_or(false);
+        let line_index_is_larger_than_last_added_line_index = self
+            .last_added_line_index
+            .map(|last| line_index > last)
+            .unwrap_or(false);
 
         if line_index_is_smaller_than_last_added_line_index && self.start.line.0 > line_index {
             // extend selection one line upwards
@@ -114,13 +149,13 @@ impl Selection {
         } else if line_index_is_smaller_than_last_added_line_index && self.end.line.0 > line_index {
             // reduce selection one line from below
             self.end = Position::new(line_index as i32, last_index_in_line as u16);
-        } else if line_index_is_larger_than_last_added_line_index && self.start.line.0 < line_index {
+        } else if line_index_is_larger_than_last_added_line_index && self.start.line.0 < line_index
+        {
             // reduce selection one line from above
             self.start = Position::new(line_index as i32, 0);
         }
 
         self.last_added_line_index = Some(line_index);
-
     }
 
     pub fn contains(&self, row: usize, col: usize) -> bool {

--- a/zellij-server/src/panes/selection.rs
+++ b/zellij-server/src/panes/selection.rs
@@ -42,6 +42,7 @@ impl Selection {
     }
 
     pub fn set_start_and_end_positions(&mut self, start: Position, end: Position) {
+        self.active = true;
         self.start = start;
         self.end = end;
         self.last_added_word_position = Some((start, end));

--- a/zellij-server/src/panes/selection.rs
+++ b/zellij-server/src/panes/selection.rs
@@ -9,6 +9,7 @@ pub struct Selection {
     pub start: Position,
     pub end: Position,
     active: bool, // used to handle moving the selection up and down
+    last_added_word_position: Option<(Position, Position)>, // (start / end)
 }
 
 impl Default for Selection {
@@ -17,6 +18,7 @@ impl Default for Selection {
             start: Position::new(0, 0),
             end: Position::new(0, 0),
             active: false,
+            last_added_word_position: None,
         }
     }
 }
@@ -40,6 +42,54 @@ impl Selection {
     pub fn set_start_and_end_positions(&mut self, start: Position, end: Position) {
         self.start = start;
         self.end = end;
+        self.last_added_word_position = Some((start, end));
+    }
+    pub fn add_word_to_position(&mut self, word_start: Position, word_end: Position) {
+        // here we assume word_start is smaller or equal to word_end
+        let already_added = self.last_added_word_position.map(|(last_word_start, last_word_end)| {
+            last_word_start == word_start && last_word_end == word_end
+        }).unwrap_or(false);
+        if already_added {
+            return;
+        }
+        let word_is_above_last_added_word = self.last_added_word_position.map(|(l_start, _l_end)| word_start.line < l_start.line).unwrap_or(false);
+        let word_is_below_last_added_word = self.last_added_word_position.map(|(_l_start, l_end)| word_end.line > l_end.line).unwrap_or(false);
+        if word_is_above_last_added_word && word_start.line < self.start.line {
+            // extend line above
+            self.start = word_start;
+        } else if word_is_below_last_added_word && word_end.line > self.end.line {
+            // extend line below
+            self.end = word_end;
+        } else if word_is_below_last_added_word && word_start.line > self.start.line {
+            // reduce from above
+            self.start = word_start;
+        } else if word_is_above_last_added_word && word_end.line < self.end.line {
+            // reduce from below
+            self.end = word_end;
+        } else {
+            let word_end_is_to_the_left_of_last_word_start = self.last_added_word_position.map(|(l_start, _l_end)| word_end.column <= l_start.column).unwrap_or(false);
+            let word_start_is_to_the_right_of_last_word_end = self.last_added_word_position.map(|(_l_start, l_end)| word_start.column >= l_end.column).unwrap_or(false);
+            let last_word_start_equals_word_end = self.last_added_word_position.map(|(l_start, _l_end)| l_start.column == word_end.column).unwrap_or(false);
+            let last_word_end_equals_word_start = self.last_added_word_position.map(|(_l_start, l_end)| l_end.column == word_start.column).unwrap_or(false);
+            let selection_start_column_is_to_the_right_of_word_start = self.start.column > word_start.column;
+            let selection_start_is_on_same_line_as_word_start = self.start.line == word_start.line;
+            let selection_end_is_to_the_left_of_word_end = self.end.column < word_end.column;
+            let selection_end_is_on_same_line_as_word_end = self.end.line == word_end.line;
+            if word_end_is_to_the_left_of_last_word_start && selection_start_column_is_to_the_right_of_word_start && selection_start_is_on_same_line_as_word_start {
+                // extend selection left
+                self.start.column = word_start.column;
+            } else if word_start_is_to_the_right_of_last_word_end && selection_end_is_to_the_left_of_word_end && selection_end_is_on_same_line_as_word_end {
+                // extend selection right
+                self.end.column = word_end.column;
+            } else if last_word_start_equals_word_end {
+                // reduce selection from the right
+                self.end.column = word_end.column;
+            } else if last_word_end_equals_word_start {
+                // reduce selection from the left
+                self.start.column = word_start.column;
+            }
+        }
+        self.last_added_word_position = Some((word_start, word_end));
     }
 
     pub fn contains(&self, row: usize, col: usize) -> bool {
@@ -91,6 +141,7 @@ impl Selection {
             start,
             end,
             active: self.active,
+            last_added_word_position: self.last_added_word_position,
         }
     }
 

--- a/zellij-server/src/panes/unit/selection_tests.rs
+++ b/zellij-server/src/panes/unit/selection_tests.rs
@@ -44,6 +44,7 @@ fn contains() {
         end: Position::new(40, 20),
         active: false,
         last_added_word_position: None,
+        last_added_line_index: None,
     };
 
     let test_cases = vec![
@@ -95,6 +96,7 @@ fn sorted() {
         end: Position::new(10, 2),
         active: false,
         last_added_word_position: None,
+        last_added_line_index: None,
     };
     let sorted_selection = selection.sorted();
     assert_eq!(selection.start, sorted_selection.start);
@@ -105,6 +107,7 @@ fn sorted() {
         end: Position::new(1, 1),
         active: false,
         last_added_word_position: None,
+        last_added_line_index: None,
     };
     let sorted_selection = selection.sorted();
     assert_eq!(selection.end, sorted_selection.start);
@@ -118,6 +121,7 @@ fn line_indices() {
         end: Position::new(10, 2),
         active: false,
         last_added_word_position: None,
+        last_added_line_index: None,
     };
 
     assert_eq!(selection.line_indices(), (1..=10))
@@ -132,6 +136,7 @@ fn move_up_inactive() {
         end,
         active: false,
         last_added_word_position: None,
+        last_added_line_index: None,
     };
 
     inactive_selection.move_up(2);
@@ -151,6 +156,7 @@ fn move_up_active() {
         end,
         active: true,
         last_added_word_position: None,
+        last_added_line_index: None,
     };
 
     inactive_selection.move_up(2);
@@ -167,6 +173,7 @@ fn move_down_inactive() {
         end,
         active: false,
         last_added_word_position: None,
+        last_added_line_index: None,
     };
 
     inactive_selection.move_down(2);
@@ -186,6 +193,7 @@ fn move_down_active() {
         end,
         active: true,
         last_added_word_position: None,
+        last_added_line_index: None,
     };
 
     inactive_selection.move_down(2);
@@ -204,6 +212,7 @@ fn add_word_to_position_extend_line_above() {
         end: selection_end,
         active: true,
         last_added_word_position: Some((last_word_start, last_word_end)),
+        last_added_line_index: None,
     };
     let word_start = Position::new(9, 5);
     let word_end = Position::new(9, 6);
@@ -224,6 +233,7 @@ fn add_word_to_position_extend_line_below() {
         end: selection_end,
         active: true,
         last_added_word_position: Some((last_word_start, last_word_end)),
+        last_added_line_index: None,
     };
     let word_start = Position::new(21, 5);
     let word_end = Position::new(21, 6);
@@ -244,6 +254,7 @@ fn add_word_to_position_reduce_from_above() {
         end: selection_end,
         active: true,
         last_added_word_position: Some((last_word_start, last_word_end)),
+        last_added_line_index: None,
     };
     let word_start = Position::new(11, 5);
     let word_end = Position::new(11, 6);
@@ -264,6 +275,7 @@ fn add_word_to_position_reduce_from_below() {
         end: selection_end,
         active: true,
         last_added_word_position: Some((last_word_start, last_word_end)),
+        last_added_line_index: None,
     };
     let word_start = Position::new(19, 5);
     let word_end = Position::new(19, 6);
@@ -284,6 +296,7 @@ fn add_word_to_position_extend_right() {
         end: selection_end,
         active: true,
         last_added_word_position: Some((last_word_start, last_word_end)),
+        last_added_line_index: None,
     };
     let word_start = Position::new(20, 21);
     let word_end = Position::new(20, 23);
@@ -304,6 +317,7 @@ fn add_word_to_position_extend_left() {
         end: selection_end,
         active: true,
         last_added_word_position: Some((last_word_start, last_word_end)),
+        last_added_line_index: None,
     };
     let word_start = Position::new(10, 5);
     let word_end = Position::new(10, 9);
@@ -324,6 +338,7 @@ fn add_word_to_position_reduce_from_left() {
         end: selection_end,
         active: true,
         last_added_word_position: Some((last_word_start, last_word_end)),
+        last_added_line_index: None,
     };
     let word_start = Position::new(10, 20);
     let word_end = Position::new(10, 30);
@@ -344,6 +359,7 @@ fn add_word_to_position_reduce_from_right() {
         end: selection_end,
         active: true,
         last_added_word_position: Some((last_word_start, last_word_end)),
+        last_added_line_index: None,
     };
     let word_start = Position::new(20, 5);
     let word_end = Position::new(20, 10);
@@ -351,4 +367,84 @@ fn add_word_to_position_reduce_from_right() {
 
     assert_eq!(selection.start, selection_start);
     assert_eq!(selection.end, word_end);
+}
+
+#[test]
+fn add_line_to_position_extend_upwards() {
+    let selection_start = Position::new(10, 10);
+    let selection_end = Position::new(20, 20);
+    let last_added_line_index = 10;
+    let mut selection = Selection {
+        start: selection_start,
+        end: selection_end,
+        active: true,
+        last_added_word_position: None,
+        last_added_line_index: Some(last_added_line_index),
+    };
+    let line_index_to_add = 9;
+    let last_index_in_line = 21;
+    selection.add_line_to_position(line_index_to_add, last_index_in_line);
+
+    assert_eq!(selection.start, Position::new(line_index_to_add as i32, 0));
+    assert_eq!(selection.end, selection_end);
+}
+
+#[test]
+fn add_line_to_position_extend_downwards() {
+    let selection_start = Position::new(10, 10);
+    let selection_end = Position::new(20, 20);
+    let last_added_line_index = 20;
+    let mut selection = Selection {
+        start: selection_start,
+        end: selection_end,
+        active: true,
+        last_added_word_position: None,
+        last_added_line_index: Some(last_added_line_index),
+    };
+    let line_index_to_add = 21;
+    let last_index_in_line = 21;
+    selection.add_line_to_position(line_index_to_add, last_index_in_line);
+
+    assert_eq!(selection.start, selection_start);
+    assert_eq!(selection.end, Position::new(line_index_to_add as i32, last_index_in_line as u16));
+}
+
+#[test]
+fn add_line_to_position_reduce_from_below() {
+    let selection_start = Position::new(10, 10);
+    let selection_end = Position::new(20, 20);
+    let last_added_line_index = 20;
+    let mut selection = Selection {
+        start: selection_start,
+        end: selection_end,
+        active: true,
+        last_added_word_position: None,
+        last_added_line_index: Some(last_added_line_index),
+    };
+    let line_index_to_add = 19;
+    let last_index_in_line = 21;
+    selection.add_line_to_position(line_index_to_add, last_index_in_line);
+
+    assert_eq!(selection.start, selection_start);
+    assert_eq!(selection.end, Position::new(line_index_to_add as i32, last_index_in_line as u16));
+}
+
+#[test]
+fn add_line_to_position_reduce_from_above() {
+    let selection_start = Position::new(10, 10);
+    let selection_end = Position::new(20, 20);
+    let last_added_line_index = 10;
+    let mut selection = Selection {
+        start: selection_start,
+        end: selection_end,
+        active: true,
+        last_added_word_position: None,
+        last_added_line_index: Some(last_added_line_index),
+    };
+    let line_index_to_add = 9;
+    let last_index_in_line = 21;
+    selection.add_line_to_position(line_index_to_add, last_index_in_line);
+
+    assert_eq!(selection.start, Position::new(line_index_to_add as i32, 0));
+    assert_eq!(selection.end, selection_end);
 }

--- a/zellij-server/src/panes/unit/selection_tests.rs
+++ b/zellij-server/src/panes/unit/selection_tests.rs
@@ -406,7 +406,10 @@ fn add_line_to_position_extend_downwards() {
     selection.add_line_to_position(line_index_to_add, last_index_in_line);
 
     assert_eq!(selection.start, selection_start);
-    assert_eq!(selection.end, Position::new(line_index_to_add as i32, last_index_in_line as u16));
+    assert_eq!(
+        selection.end,
+        Position::new(line_index_to_add as i32, last_index_in_line as u16)
+    );
 }
 
 #[test]
@@ -426,7 +429,10 @@ fn add_line_to_position_reduce_from_below() {
     selection.add_line_to_position(line_index_to_add, last_index_in_line);
 
     assert_eq!(selection.start, selection_start);
-    assert_eq!(selection.end, Position::new(line_index_to_add as i32, last_index_in_line as u16));
+    assert_eq!(
+        selection.end,
+        Position::new(line_index_to_add as i32, last_index_in_line as u16)
+    );
 }
 
 #[test]


### PR DESCRIPTION
This fixes some issues with the new multiple-mouse-click feature for marking word/line boundaries on double-triple click. Namely, the selection is now properly taken into account on mouse drag in these scenarios.