### PR TITLE
session-manager: ctrl-k keybinding to kill selected session

### DIFF
--- a/default-plugins/session-manager/src/main.rs
+++ b/default-plugins/session-manager/src/main.rs
@@ -343,7 +343,7 @@ impl State {
                     self.renaming_session_name = Some(String::new());
                     should_render = true;
                 },
-                BareKey::Delete if key.has_no_modifiers() => {
+                BareKey::Char('k') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
                     if let Some(selected_session_name) = self.sessions.get_selected_session_name() {
                         kill_sessions(&[selected_session_name]);
                         self.reset_selected_index();
@@ -431,7 +431,7 @@ impl State {
                 self.toggle_active_screen();
                 should_render = true;
             },
-            BareKey::Delete if key.has_no_modifiers() => {
+            BareKey::Char('k') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
                 self.resurrectable_sessions.delete_selected_session();
                 should_render = true;
             },

--- a/default-plugins/session-manager/src/ui/components.rs
+++ b/default-plugins/session-manager/src/ui/components.rs
@@ -941,7 +941,7 @@ pub fn render_controls_line(
             let rename_text = colors.bold("Rename");
             let disconnect = colors.shortcuts("<Ctrl x>");
             let disconnect_text = colors.bold("Disconnect others");
-            let kill = colors.shortcuts("<Del>");
+            let kill = colors.shortcuts("<Ctrl k>");
             let kill_text = colors.bold("Kill");
             let kill_all = colors.shortcuts("<Ctrl d>");
             let kill_all_text = colors.bold("Kill all");


### PR DESCRIPTION
i love zellij, but it doesn't love my rather obscure keyboard. on some small keyboards like mine delete key is absent. i can add it to my keyboard using QMK on a different layer, but i don't have any space left for an additional key

to me it seems a great idea to replace `Delete` with more keyboard-friendly `Ctrl-k`, as it is available on every keyboard and in my opinion better *feels* with other `Ctrl` prefixed bindings of session manager

extremely unrelated to this but i've figured there's no way to use system clipboard by selecting text in shell panes/tabs on Kitty terminal without disabling mouse mode first. i am able to copy to system clipboard from helix, but not using `Ctrl-Shift-C` from my shell panes. don't know if it's a but or not. configuring `copy_command`/`copy_clipboard` doesn't help too

meow