### PR TITLE
Styling fixes in the "about" plugin 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix(plugins): prevent paging plugins from cache at runtime (https://github.com/zellij-org/zellij/pull/4044)
 * fix(ui): add split right/down shortcut hints to the status-bar (https://github.com/zellij-org/zellij/pull/4046)
 * chore(repo): remove compile warnings (https://github.com/zellij-org/zellij/pull/4026)
+* fix(plugins): fix styling in "about" (https://github.com/zellij-org/zellij/pull/4062)
 
 ## [0.41.2] - 2024-11-19
 * fix(input): keypresses not being identified properly with kitty keyboard protocol in some terminals (https://github.com/zellij-org/zellij/pull/3725)

--- a/default-plugins/about/src/pages.rs
+++ b/default-plugins/about/src/pages.rs
@@ -144,9 +144,9 @@ impl Page {
                                 .color_range(3, 6..=10)
                     )),
                     ActiveComponent::new(TextOrCustomRender::Text(
-                            Text::new("5. You can always snap back to the built-in swap layouts with Alt <[]>")
-                                .color_range(3, 62..=64)
-                                .color_range(3, 67..=68)
+                            Text::new("You can always snap back to the built-in swap layouts with Alt <[]>")
+                                .color_range(3, 59..=61)
+                                .color_range(3, 64..=65)
                     )),
                 ])
             )

--- a/default-plugins/about/src/tips.rs
+++ b/default-plugins/about/src/tips.rs
@@ -430,7 +430,7 @@ impl Page {
                             .color_range(0, 34..=36)
                             .color_range(2, 40..=45)
                             .color_range(0, 50..=52)
-                            .color_range(2, 56..=60)
+                            .color_range(2, 56..=61)
                     ))
                 ]),
                 ComponentLine::new(vec![


### PR DESCRIPTION
Hey @imsnif,

in preparation for the next release I had a glance at the startup tips and feature highlights (nice job, btw). I noticed some minor "bugs" so here are the fixes for that (see first two commits).

While reading through the tips in the "about" plugin I also noticed that keybindings aren't formatted nor painted consistently. Before I go about fixing that I wanted to know: Was that a deliberate choice, or may I go ahead and bring them in line with how we format keys in e.g. the status-bar plugin?