### PR TITLE
(fix) show more realistic serialization_interval

### DIFF
--- a/src/tests/fixtures/configs/load_background_plugins.kdl
+++ b/src/tests/fixtures/configs/load_background_plugins.kdl
@@ -372,8 +372,8 @@ default_mode "locked"
  
 // How often in seconds sessions are serialized
 // 
-// serialization_interval 10000
- 
+// serialization_interval 60
+
 // Enable or disable writing of session metadata to disk (if disabled, other sessions might not know
 // metadata info on this session)
 // Default: false

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__bare_config_from_default_assets_to_string_with_comments.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__bare_config_from_default_assets_to_string_with_comments.snap
@@ -425,9 +425,9 @@ load_plugins {
 // styled_underlines false
  
 // How often in seconds sessions are serialized
-// 
-// serialization_interval 10000
  
+//
+// serialization_interval 60
 // Enable or disable writing of session metadata to disk (if disabled, other sessions might not know
 // metadata info on this session)
 // (Requires restart)


### PR DESCRIPTION
This value is in seconds, not milliseconds.
