### PR TITLE
chore: Introduce workspace dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 * refactor(terminal): track scroll_region as tuple rather than Option (https://github.com/zellij-org/zellij/pull/4082)
+* chore(deps): Use workspace dependencies (https://github.com/zellij-org/zellij/pull/4085)
 
 ## [0.42.1] - 2025-03-21
 * fix(mouse): fix mouse handling in windows terminal (https://github.com/zellij-org/zellij/pull/4076)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ rust-version = "1.84"
 [dependencies]
 zellij-client = { path = "zellij-client/", version = "0.43.0" }
 zellij-server = { path = "zellij-server/", version = "0.43.0" }
-zellij-utils = { path = "zellij-utils/", version = "0.43.0" }
-thiserror = "1.0.40"
-names = { version = "0.14.0", default-features = false }
-log = "0.4.17"
+zellij-utils = { workspace = true }
 dialoguer = "0.10.4"
+log = { workspace = true }
+names = { version = "0.14.0", default-features = false }
 suggest = "0.4.0"
+thiserror = { workspace = true }
 
 [dev-dependencies]
 insta = { version = "1.6.0", features = ["backtrace"] }
@@ -48,6 +48,21 @@ members = [
     "xtask",
     ".",
 ]
+
+[workspace.dependencies]
+ansi_term = "0.12.1"
+anyhow = { version = "1.0.70", features = ["backtrace"] }
+clap = { version = "3.2.2", features = ["derive", "env"] }
+log = "0.4.17"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+strum = "0.20.0"
+strum_macros = "0.20.0"
+thiserror = "1.0.40"
+unicode-width = "0.1.8"
+url = { version = "2.2.2", features = ["serde"] }
+uuid = { version = "1.4.1", features = ["serde", "v4"] }
+zellij-utils = { path = "zellij-utils/", version = "0.43.0" }
 
 [profile.dev-opt]
 inherits = "dev"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,14 +5,14 @@ edition = "2021"
 
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
+prost-build = "0.11.9"
+toml = "0.5"
+which = "4.2"
+xflags = "0.3.2"
 # TODO(hartan): Update this once we get a new release. See:
 #   <https://github.com/matklad/xshell/issues/63>
 xshell = "= 0.2.2"
-xflags = "0.3.2"
-which = "4.2"
-toml = "0.5"
-prost-build = "0.11.9"
 
 [lints.rust]
 # Only required because we need to fix `xshell` to `=0.2.2`

--- a/zellij-client/Cargo.toml
+++ b/zellij-client/Cargo.toml
@@ -9,13 +9,13 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+log = { workspace = true }
 mio = { version = "0.7.11", features = ['os-ext'] }
-serde = { version = "1.0", features = ["derive"] }
-url = { version = "2.2.2", features = ["serde"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
 serde_yaml = "0.8"
-serde_json = "1.0"
-zellij-utils = { path = "../zellij-utils/", version = "0.43.0" }
-log = "0.4.17"
+url = { workspace = true }
+zellij-utils = { workspace = true }
 
 [dev-dependencies]
 insta = "1.6.0"

--- a/zellij-server/Cargo.toml
+++ b/zellij-server/Cargo.toml
@@ -9,30 +9,29 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-highway = "0.6.4"
-ansi_term = "0.12.1"
+ansi_term = { workspace = true }
+arrayvec = "0.7.2"
 async-trait = "0.1.50"
 base64 = "0.13.0"
 byteorder = "1.4.3"
 bytes = "1.6.0"
-daemonize = "0.5"
-serde_json = "1.0"
-unicode-width = "0.1.8"
-url = "2.2.2"
-wasmtime-wasi = "29.0.1" # Keep in sync with wasmtime
 cassowary = "0.3.0"
-zellij-utils = { path = "../zellij-utils/", version = "0.43.0" }
-log = "0.4.17"
-typetag = "0.1.7"
 chrono = "0.4.19"
 close_fds = "0.3.2"
-sysinfo = "0.22.5"
-sixel-tokenizer = "0.1.0"
-sixel-image = "0.1.0"
-arrayvec = "0.7.2"
-uuid = { version = "1.4.1", features = ["serde", "v4"] }
+daemonize = "0.5"
+highway = "0.6.4"
+log = { workspace = true }
 semver = "0.11.0"
-
+serde_json = { workspace = true }
+sixel-image = "0.1.0"
+sixel-tokenizer = "0.1.0"
+sysinfo = "0.22.5"
+typetag = "0.1.7"
+unicode-width = { workspace = true }
+url = { workspace = true }
+uuid = { workspace = true }
+wasmtime-wasi = "29.0.1" # Keep in sync with wasmtime
+zellij-utils = { workspace = true }
 [dependencies.wasmtime]
 version = "29.0.1" # Keep in sync with wasmtime-wasi
 default-features = false

--- a/zellij-tile-utils/Cargo.toml
+++ b/zellij-tile-utils/Cargo.toml
@@ -9,4 +9,4 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ansi_term = "0.12.1"
+ansi_term = { workspace = true }

--- a/zellij-tile/Cargo.toml
+++ b/zellij-tile/Cargo.toml
@@ -7,9 +7,9 @@ description = "A small client-side library for writing Zellij plugins"
 license = "MIT"
 
 [dependencies]
-clap = { version = "3.0", features = ["derive"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-strum = "0.20.0"
-strum_macros = "0.20.0"
-zellij-utils = { path = "../zellij-utils/", version = "0.43.0" }
+clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+zellij-utils = { workspace = true }

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -10,10 +10,11 @@ include = ["src/**/*", "assets/"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = { version = "1.0.70", features = ["backtrace"] }
+anyhow = { workspace = true }
 async-channel = "1.8.0"
 backtrace = "0.3.55"
-clap = { version = "3.2.2", features = ["derive", "env"] }
+bitflags = "2.5.0"
+clap = { workspace = true }
 clap_complete = "3.2.1"
 colored = "2.0.0"
 colorsys = "0.6.5"
@@ -23,7 +24,7 @@ include_dir = "0.7.3"
 kdl = { version = "4.5.0", features = ["span"] }
 lazy_static = "1.4.0"
 libc = "0.2"
-log = "0.4.17"
+log = { workspace = true }
 miette = { version = "5.7.0", features = ["fancy"] }
 nix = "0.23.1"
 once_cell = "1.8.0"
@@ -31,18 +32,17 @@ percent-encoding = "2.1.0"
 prost = "0.11.9"
 regex = "1.5.5"
 rmp-serde = "1.1.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 shellexpand = "3.0.0"
 strip-ansi-escapes = "0.1.0"
-strum = "0.20.0"
-strum_macros = "0.20.1"
+strum = { workspace = true }
+strum_macros = { workspace = true }
 tempfile = "3.2.0"
-thiserror = "1.0.30"
-unicode-width = "0.1.8"
-url = { version = "2.2.2", features = ["serde"] }
-uuid = { version = "1.4.1", features = ["serde", "v4"] }
-bitflags = "2.5.0"
+thiserror = { workspace = true }
+unicode-width = { workspace = true }
+url = { workspace = true }
+uuid = { workspace = true }
 vte = { version = "0.11.0", default-features = false }
 
 #[cfg(not(target_family = "wasm"))]


### PR DESCRIPTION
and deduplicate dependency entries across all non-plugin workspace members. In the future this hopefully makes dependency upgrade easier since shared dependencies need only be touched in one location.