### PR TITLE
build: Don't use default features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 * refactor(terminal): track scroll_region as tuple rather than Option (https://github.com/zellij-org/zellij/pull/4082)
 * chore(deps): Use workspace dependencies (https://github.com/zellij-org/zellij/pull/4085)
+* build: Don't use default features (https://github.com/zellij-org/zellij/pull/4086)
 
 ## [0.42.1] - 2025-03-21
 * fix(mouse): fix mouse handling in windows terminal (https://github.com/zellij-org/zellij/pull/4076)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,12 +1006,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "destructure_traitobject"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c877555693c14d2f84191cfd3ad8582790fc52b5e2274b40b59cf5f5cea25c7"
-
-[[package]]
 name = "dialoguer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,7 +1314,6 @@ checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1344,17 +1337,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
-name = "futures-executor"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1376,17 +1358,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-macro"
-version = "0.3.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,16 +1375,11 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -1777,25 +1743,12 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f2533f3be42fffe3b5e63b71aeca416c1c3bc33e4e27be018521e76b1f38fb"
 dependencies = [
- "blocking",
  "cfg-if",
- "futures-core",
- "futures-io",
- "intmap",
  "libc",
- "once_cell",
  "rustc_version",
- "spinning",
- "thiserror 1.0.61",
  "to_method",
  "winapi",
 ]
-
-[[package]]
-name = "intmap"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae52f28f45ac2bc96edb7714de995cffc174a395fb0abf5bff453587c980d7b9"
 
 [[package]]
 name = "inventory"
@@ -2094,7 +2047,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
- "serde",
  "value-bag",
 ]
 
@@ -2115,19 +2067,11 @@ dependencies = [
  "chrono",
  "derivative",
  "fnv",
- "humantime",
- "libc",
  "log",
  "log-mdc",
  "parking_lot 0.12.1",
- "serde",
- "serde-value",
- "serde_json",
- "serde_yaml",
  "thiserror 1.0.61",
  "thread-id",
- "typemap-ors",
- "winapi",
 ]
 
 [[package]]
@@ -2356,7 +2300,6 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4812c1eb49be776fb8df4961623bdc01ec9dfdc1abe8211ceb09150a2e64219"
 dependencies = [
- "crossbeam-channel",
  "file-id",
  "notify",
  "parking_lot 0.12.1",
@@ -2462,15 +2405,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "ordered-float"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "ordered-float"
@@ -3164,16 +3098,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float 2.10.0",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3370,15 +3294,6 @@ checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "spinning"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d4f0e86297cad2658d92a707320d87bf4e6ae1050287f51d19b67ef3f153a7b"
-dependencies = [
- "lock_api",
 ]
 
 [[package]]
@@ -3657,7 +3572,7 @@ dependencies = [
  "nix 0.29.0",
  "num-derive",
  "num-traits",
- "ordered-float 4.2.0",
+ "ordered-float",
  "pest",
  "pest_derive",
  "phf",
@@ -3885,15 +3800,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typemap-ors"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68c24b707f02dd18f1e4ccceb9d49f2058c2fb86384ef9972592904d7a28867"
-dependencies = [
- "unsafe-any-ors",
-]
-
-[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3982,15 +3888,6 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
-name = "unsafe-any-ors"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a303d30665362d9680d7d91d78b23f5f899504d4f08b3c4cf08d055d87c0ad"
-dependencies = [
- "destructure_traitobject",
-]
 
 [[package]]
 name = "url"
@@ -4611,7 +4508,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
- "ordered-float 4.2.0",
+ "ordered-float",
  "strsim 0.11.1",
  "thiserror 1.0.61",
  "wezterm-dynamic-derive",
@@ -5175,7 +5072,6 @@ dependencies = [
  "curl-sys",
  "directories",
  "expect-test",
- "futures",
  "humantime",
  "include_dir",
  "insta",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,8 +1019,6 @@ checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
 dependencies = [
  "console",
  "shell-words",
- "tempfile",
- "zeroize",
 ]
 
 [[package]]
@@ -3550,7 +3548,6 @@ dependencies = [
  "libc",
  "ntapi",
  "once_cell",
- "rayon",
  "winapi",
 ]
 
@@ -5254,12 +5251,6 @@ dependencies = [
  "quote",
  "syn 2.0.96",
 ]
-
-[[package]]
-name = "zeroize"
-version = "1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94693807d016b2f2d2e14420eb3bfcca689311ff775dcf113d74ea624b7cdf07"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5189,7 +5189,6 @@ dependencies = [
  "miette",
  "nix 0.23.1",
  "notify-debouncer-full",
- "once_cell",
  "openssl-sys",
  "percent-encoding",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ members = [
 [workspace.dependencies]
 ansi_term = { version = "0.12.1", default-features = false }
 anyhow = { version = "1.0.70", default-features = false, features = ["backtrace", "std"] }
-clap = { version = "3.2.2", features = ["env", "derive"] }
+clap = { version = "3.2.2", default-features = false, features = ["env", "derive", "color", "std", "suggestions"] }
 log = { version = "0.4.17", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ rust-version = "1.84"
 zellij-client = { path = "zellij-client/", version = "0.43.0" }
 zellij-server = { path = "zellij-server/", version = "0.43.0" }
 zellij-utils = { workspace = true }
-dialoguer = "0.10.4"
+dialoguer = { version = "0.10.4", default-features = false }
 log = { workspace = true }
 names = { version = "0.14.0", default-features = false }
-suggest = "0.4.0"
+suggest = { version = "0.4.0", default-features = false }
 thiserror = { workspace = true }
 
 [dev-dependencies]
@@ -50,18 +50,18 @@ members = [
 ]
 
 [workspace.dependencies]
-ansi_term = "0.12.1"
-anyhow = { version = "1.0.70", features = ["backtrace"] }
-clap = { version = "3.2.2", features = ["derive", "env"] }
-log = "0.4.17"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-strum = "0.20.0"
-strum_macros = "0.20.0"
-thiserror = "1.0.40"
-unicode-width = "0.1.8"
-url = { version = "2.2.2", features = ["serde"] }
-uuid = { version = "1.4.1", features = ["serde", "v4"] }
+ansi_term = { version = "0.12.1", default-features = false }
+anyhow = { version = "1.0.70", default-features = false, features = ["backtrace", "std"] }
+clap = { version = "3.2.2", features = ["env", "derive"] }
+log = { version = "0.4.17", default-features = false }
+serde = { version = "1.0", default-features = false, features = ["derive", "std"] }
+serde_json = { version = "1.0", default-features = false, features = ["std"] }
+strum = { version = "0.20.0", default-features = false }
+strum_macros = { version = "0.20.0", default-features = false }
+thiserror = { version = "1.0.40", default-features = false }
+unicode-width = { version = "0.1.8", default-features = false }
+url = { version = "2.2.2", default-features = false, features = ["serde"] }
+uuid = { version = "1.4.1", default-features = false, features = ["serde", "v4", "std"] }
 zellij-utils = { path = "zellij-utils/", version = "0.43.0" }
 
 [profile.dev-opt]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 
 [dependencies]
 anyhow = { workspace = true }
-prost-build = "0.11.9"
-toml = "0.5"
-which = "4.2"
-xflags = "0.3.2"
+prost-build = { version = "0.11.9", default-features = false }
+toml = { version = "0.5", default-features = false }
+which = { version = "4.2", default-features = false }
+xflags = { version = "0.3.2", default-features = false }
 # TODO(hartan): Update this once we get a new release. See:
 #   <https://github.com/matklad/xshell/issues/63>
-xshell = "= 0.2.2"
+xshell = { version = "= 0.2.2", default-features = false }
 
 [lints.rust]
 # Only required because we need to fix `xshell` to `=0.2.2`

--- a/zellij-client/Cargo.toml
+++ b/zellij-client/Cargo.toml
@@ -10,10 +10,10 @@ license = "MIT"
 
 [dependencies]
 log = { workspace = true }
-mio = { version = "0.7.11", features = ['os-ext'] }
+mio = { version = "0.7.11", default-features = false, features = ['os-ext'] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = "0.8"
+serde_yaml = { version = "0.8", default-features = false }
 url = { workspace = true }
 zellij-utils = { workspace = true }
 

--- a/zellij-server/Cargo.toml
+++ b/zellij-server/Cargo.toml
@@ -10,44 +10,41 @@ license = "MIT"
 
 [dependencies]
 ansi_term = { workspace = true }
-arrayvec = "0.7.2"
-async-trait = "0.1.50"
-base64 = "0.13.0"
-byteorder = "1.4.3"
-bytes = "1.6.0"
-cassowary = "0.3.0"
-chrono = "0.4.19"
-close_fds = "0.3.2"
-daemonize = "0.5"
-highway = "0.6.4"
+arrayvec = { version = "0.7.2", default-features = false, features = ["std"] }
+async-trait = { version = "0.1.50", default-features = false }
+base64 = { version = "0.13.0", default-features = false, features = ["std"] }
+byteorder = { version = "1.4.3", default-features = false, features = ["std"] }
+bytes = { version = "1.6.0", default-features = false, features = ["std"] }
+cassowary = { version = "0.3.0", default-features = false }
+chrono = { version = "0.4.19", default-features = false, features = ["std", "clock"] }
+close_fds = { version = "0.3.2", default-features = false }
+daemonize = { version = "0.5", default-features = false }
+highway = { version = "0.6.4", default-features = false, features = ["std"] }
 log = { workspace = true }
-semver = "0.11.0"
+semver = { version = "0.11.0", default-features = false }
 serde_json = { workspace = true }
-sixel-image = "0.1.0"
-sixel-tokenizer = "0.1.0"
-sysinfo = "0.22.5"
-typetag = "0.1.7"
+sixel-image = { version = "0.1.0", default-features = false }
+sixel-tokenizer = { version = "0.1.0", default-features = false }
+sysinfo = { version = "0.22.5", default-features = false }
+typetag = { version = "0.1.7", default-features = false }
 unicode-width = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
-wasmtime-wasi = "29.0.1" # Keep in sync with wasmtime
+wasmtime-wasi = { version = "29.0.1", default-features = false, features = ["preview1"] } # Keep in sync with wasmtime
 zellij-utils = { workspace = true }
+
 [dependencies.wasmtime]
 version = "29.0.1" # Keep in sync with wasmtime-wasi
 default-features = false
 features = [
-  'async',
-  'cache',
-  'parallel-compilation',
+  'addr2line',
   'cranelift',
   'demangle',
-  'addr2line',
-  'debug-builtins',
-  'runtime',
-  'component-model',
-  'std',
   'gc',
   'gc-drc',
+  'parallel-compilation',
+  'runtime',
+  'std',
 ]
 
 [dev-dependencies]

--- a/zellij-server/src/logging_pipe.rs
+++ b/zellij-server/src/logging_pipe.rs
@@ -4,7 +4,6 @@ use crate::plugins::PluginId;
 use log::{debug, error};
 use zellij_utils::{errors::prelude::*, serde};
 
-use chrono::prelude::*;
 use serde::{Deserialize, Serialize};
 
 // 16kB log buffer
@@ -30,7 +29,7 @@ impl LoggingPipe {
         debug!(
             "|{:<25.25}| {} [{:<10.15}] {}",
             self.plugin_name,
-            Local::now().format("%Y-%m-%d %H:%M:%S.%3f"),
+            chrono::Local::now().format("%Y-%m-%d %H:%M:%S.%3f"),
             format!("id: {}", self.plugin_id),
             message
         );

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -27,7 +27,6 @@ libc = "0.2"
 log = { workspace = true }
 miette = { version = "5.7.0", features = ["fancy"] }
 nix = "0.23.1"
-once_cell = "1.8.0"
 percent-encoding = "2.1.0"
 prost = "0.11.9"
 regex = "1.5.5"

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -11,49 +11,47 @@ include = ["src/**/*", "assets/"]
 
 [dependencies]
 anyhow = { workspace = true }
-async-channel = "1.8.0"
-backtrace = "0.3.55"
-bitflags = "2.5.0"
+async-channel = { version = "1.8.0", default-features = false }
+backtrace = { version = "0.3.55", default-features = false, features = ["std"] }
+bitflags = { version = "2.5.0", default-features = false }
 clap = { workspace = true }
-clap_complete = "3.2.1"
-colored = "2.0.0"
-colorsys = "0.6.5"
-crossbeam = "0.8.1"
-directories = "5.0"
-include_dir = "0.7.3"
-kdl = { version = "4.5.0", features = ["span"] }
-lazy_static = "1.4.0"
-libc = "0.2"
+clap_complete = { version = "3.2.1", default-features = false }
+colored = { version = "2.0.0", default-features = false }
+colorsys = { version = "0.6.5", default-features = false, features = ["std"] }
+crossbeam = { version = "0.8.1", default-features = false, features = ["alloc", "std"] }
+directories = { version = "5.0", default-features = false }
+include_dir = { version = "0.7.3", default-features = false }
+kdl = { version = "4.5.0", default-features = false, features = ["span"] }
+lazy_static = { version = "1.4.0", default-features = false }
+libc = { version = "0.2", default-features = false, features = ["std"] }
 log = { workspace = true }
 miette = { version = "5.7.0", features = ["fancy"] }
-nix = "0.23.1"
-percent-encoding = "2.1.0"
-prost = "0.11.9"
-regex = "1.5.5"
-rmp-serde = "1.1.0"
+nix = { version = "0.23.1", default-features = false }
+percent-encoding = { version = "2.1.0", default-features = false, features = ["std"] }
+prost = { version = "0.11.9", default-features = false, features = ["std", "prost-derive"] }
+regex = { version = "1.5.5", default-features = false, features = ["perf", "std"] }
+rmp-serde = { version = "1.1.0", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
-shellexpand = "3.0.0"
-strip-ansi-escapes = "0.1.0"
+shellexpand = { version = "3.0.0", default-features = false, features = ["base-0", "tilde"] }
+strip-ansi-escapes = { version = "0.1.0", default-features = false }
 strum = { workspace = true }
 strum_macros = { workspace = true }
-tempfile = "3.2.0"
+tempfile = { version = "3.2.0", default-features = false }
 thiserror = { workspace = true }
 unicode-width = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
 vte = { version = "0.11.0", default-features = false }
 
-#[cfg(not(target_family = "wasm"))]
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-termwiz = "0.23.2"
-log4rs = "1.2.0"
-signal-hook = "0.3"
-interprocess = "1.2.1"
-async-std = { version = "1.3.0", features = ["unstable", "attributes"] }
-notify-debouncer-full = "0.1.0"
-humantime = "2.1.0"
-futures = "0.3.28"
+termwiz = { version = "0.23.2", default-features = false }
+log4rs = { version = "1.2.0", default-features = false, features = ["pattern_encoder", "rolling_file_appender", "compound_policy", "fixed_window_roller", "size_trigger"] }
+notify-debouncer-full = { version = "0.1.0", default-features = false }
+signal-hook = { version = "0.3", default-features = false, features = ["iterator"] }
+interprocess = { version = "1.2.1", default-features = false }
+async-std = { version = "1.3.0", default-features = false, features = ["attributes", "default", "std", "unstable"] }
+humantime = { version = "2.1.0", default-features = false }
 openssl-sys = { version = "0.9.93", features = ["vendored"], optional = true }
 isahc = { version = "1.7.2", default-features = false, features = ["http2", "text-decoding"] }
 curl-sys = { version = "0.4", features = ["force-system-lib-on-osx"], optional = true }

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -25,7 +25,7 @@ kdl = { version = "4.5.0", default-features = false, features = ["span"] }
 lazy_static = { version = "1.4.0", default-features = false }
 libc = { version = "0.2", default-features = false, features = ["std"] }
 log = { workspace = true }
-miette = { version = "5.7.0", features = ["fancy"] }
+miette = { version = "5.7.0", default-features = false, features = ["fancy"] }
 nix = { version = "0.23.1", default-features = false }
 percent-encoding = { version = "2.1.0", default-features = false, features = ["std"] }
 prost = { version = "0.11.9", default-features = false, features = ["std", "prost-derive"] }
@@ -52,9 +52,9 @@ signal-hook = { version = "0.3", default-features = false, features = ["iterator
 interprocess = { version = "1.2.1", default-features = false }
 async-std = { version = "1.3.0", default-features = false, features = ["attributes", "default", "std", "unstable"] }
 humantime = { version = "2.1.0", default-features = false }
-openssl-sys = { version = "0.9.93", features = ["vendored"], optional = true }
+openssl-sys = { version = "0.9.93", default-features = false, features = ["vendored"], optional = true }
 isahc = { version = "1.7.2", default-features = false, features = ["http2", "text-decoding"] }
-curl-sys = { version = "0.4", features = ["force-system-lib-on-osx"], optional = true }
+curl-sys = { version = "0.4", default-features = false, features = ["force-system-lib-on-osx", "ssl"], optional = true }
 
 [dev-dependencies]
 insta = { version = "1.6.0", features = ["backtrace"] }

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -4,8 +4,7 @@ use crate::home::find_default_config_dir;
 use directories::ProjectDirs;
 use include_dir::{include_dir, Dir};
 use lazy_static::lazy_static;
-use once_cell::sync::OnceCell;
-use std::path::PathBuf;
+use std::{sync::OnceLock, path::PathBuf};
 use uuid::Uuid;
 
 pub const ZELLIJ_CONFIG_FILE_ENV: &str = "ZELLIJ_CONFIG_FILE";
@@ -13,8 +12,8 @@ pub const ZELLIJ_CONFIG_DIR_ENV: &str = "ZELLIJ_CONFIG_DIR";
 pub const ZELLIJ_LAYOUT_DIR_ENV: &str = "ZELLIJ_LAYOUT_DIR";
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const DEFAULT_SCROLL_BUFFER_SIZE: usize = 10_000;
-pub static SCROLL_BUFFER_SIZE: OnceCell<usize> = OnceCell::new();
-pub static DEBUG_MODE: OnceCell<bool> = OnceCell::new();
+pub static SCROLL_BUFFER_SIZE: OnceLock<usize> = OnceLock::new();
+pub static DEBUG_MODE: OnceLock<bool> = OnceLock::new();
 
 pub const SYSTEM_DEFAULT_CONFIG_DIR: &str = "/etc/zellij";
 pub const SYSTEM_DEFAULT_DATA_DIR_PREFIX: &str = system_default_data_dir();

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -4,7 +4,7 @@ use crate::home::find_default_config_dir;
 use directories::ProjectDirs;
 use include_dir::{include_dir, Dir};
 use lazy_static::lazy_static;
-use std::{sync::OnceLock, path::PathBuf};
+use std::{path::PathBuf, sync::OnceLock};
 use uuid::Uuid;
 
 pub const ZELLIJ_CONFIG_FILE_ENV: &str = "ZELLIJ_CONFIG_FILE";


### PR DESCRIPTION
but instead specify all the dependency features we need/want explicitly. This cuts down the number of dependencies in the compilation from 587 to 565 and also makes our code more robust against unexpected changes in upstream default features.