### PR TITLE
fix(terminal): restore dim after resetting bold

### DIFF
--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -368,6 +368,14 @@ impl CharacterStyles {
         if self.dim != new_styles.dim {
             diff.dim = new_styles.dim;
         }
+        // Bold and dim share a reset code.
+        // If we reset one we need to
+        // reapply the other.
+        match (diff.bold, diff.dim) {
+            (Some(AnsiCode::Reset), None) => diff.dim = self.dim,
+            (None, Some(AnsiCode::Reset)) => diff.bold = self.bold,
+            _ => {}
+        };
         if self.italic != new_styles.italic {
             diff.italic = new_styles.italic;
         }


### PR DESCRIPTION
Dim and bold have the same ansi reset code [22m, so when resetting bold
we must explicitly send [2m to re-enable dim.

Fixes #4088
