### PR TITLE
feat(zellij-utils): Add source `client_id` to pipe messages

### DIFF
--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -80,7 +80,7 @@ pub fn build(sh: &Shell, flags: flags::Build) -> anyhow::Result<()> {
             if needs_regeneration {
                 prost
                     .compile_protos(&proto_files, &[protobuf_source_dir])
-                    .unwrap();
+                    .context("Failed to compile proto files")?;
             }
         }
 

--- a/zellij-server/src/plugins/mod.rs
+++ b/zellij-server/src/plugins/mod.rs
@@ -145,6 +145,7 @@ pub enum PluginInstruction {
     MessageFromPlugin {
         source_plugin_id: u32,
         message: MessageToPlugin,
+        source_client_id: ClientId,
     },
     UnblockCliPipes(Vec<PluginRenderAsset>),
     Reconfigure {
@@ -672,6 +673,7 @@ pub(crate) fn plugin_thread_main(
                         // send to specific plugin(s)
                         pipe_to_specific_plugins(
                             PipeSource::Cli(pipe_id.clone()),
+                            cli_client_id,
                             &plugin_url,
                             &configuration,
                             &cwd,
@@ -690,9 +692,11 @@ pub(crate) fn plugin_thread_main(
                         );
                     },
                     None => {
+                        log::warn!("PIPE MESSAGE TO ALL PLUGINS");
                         // no specific destination, send to all plugins
                         pipe_to_all_plugins(
                             PipeSource::Cli(pipe_id.clone()),
+                            cli_client_id,
                             &name,
                             &payload,
                             &args,
@@ -724,7 +728,14 @@ pub(crate) fn plugin_thread_main(
                     pipe_messages.push((
                         Some(plugin_id),
                         Some(client_id),
-                        PipeMessage::new(PipeSource::Keybind, name, &payload, &args, is_private),
+                        PipeMessage::new(
+                            PipeSource::Keybind,
+                            client_id,
+                            name,
+                            &payload,
+                            &args,
+                            is_private,
+                        ),
                     ));
                 } else {
                     match plugin {
@@ -732,6 +743,7 @@ pub(crate) fn plugin_thread_main(
                             // send to specific plugin(s)
                             pipe_to_specific_plugins(
                                 PipeSource::Keybind,
+                                cli_client_id,
                                 &plugin_url,
                                 &configuration,
                                 &cwd,
@@ -753,6 +765,7 @@ pub(crate) fn plugin_thread_main(
                             // no specific destination, send to all plugins
                             pipe_to_all_plugins(
                                 PipeSource::Keybind,
+                                cli_client_id,
                                 &name,
                                 &payload,
                                 &args,
@@ -768,6 +781,7 @@ pub(crate) fn plugin_thread_main(
                 wasm_bridge.cache_plugin_events(plugin_id);
             },
             PluginInstruction::MessageFromPlugin {
+                source_client_id,
                 source_plugin_id,
                 message,
             } => {
@@ -795,6 +809,7 @@ pub(crate) fn plugin_thread_main(
                         // send to specific plugin(s)
                         pipe_to_specific_plugins(
                             PipeSource::Plugin(source_plugin_id),
+                            source_client_id,
                             &plugin_url,
                             &Some(message.plugin_config),
                             &None,
@@ -819,6 +834,7 @@ pub(crate) fn plugin_thread_main(
                             None,
                             PipeMessage::new(
                                 PipeSource::Plugin(source_plugin_id),
+                                source_client_id,
                                 message.message_name,
                                 &message.message_payload,
                                 &Some(message.message_args),
@@ -834,6 +850,7 @@ pub(crate) fn plugin_thread_main(
                             None,
                             PipeMessage::new(
                                 PipeSource::Plugin(source_plugin_id),
+                                source_client_id,
                                 message.message_name,
                                 &message.message_payload,
                                 &Some(message.message_args),
@@ -845,6 +862,7 @@ pub(crate) fn plugin_thread_main(
                         // send to all plugins
                         pipe_to_all_plugins(
                             PipeSource::Plugin(source_plugin_id),
+                            source_client_id,
                             &message.message_name,
                             &message.message_payload,
                             &Some(message.message_args),
@@ -955,6 +973,7 @@ fn populate_session_layout_metadata(
 
 fn pipe_to_all_plugins(
     pipe_source: PipeSource,
+    from_client_id: u16,
     name: &str,
     payload: &Option<String>,
     args: &Option<BTreeMap<String, String>>,
@@ -967,13 +986,21 @@ fn pipe_to_all_plugins(
         pipe_messages.push((
             Some(plugin_id),
             Some(client_id),
-            PipeMessage::new(pipe_source.clone(), name, payload, &args, is_private),
+            PipeMessage::new(
+                pipe_source.clone(),
+                from_client_id,
+                name,
+                payload,
+                &args,
+                is_private,
+            ),
         ));
     }
 }
 
 fn pipe_to_specific_plugins(
     pipe_source: PipeSource,
+    from_client_id: u16,
     plugin_url: &str,
     configuration: &Option<BTreeMap<String, String>>,
     cwd: &Option<PathBuf>,
@@ -1015,7 +1042,14 @@ fn pipe_to_specific_plugins(
                 pipe_messages.push((
                     Some(plugin_id),
                     client_id,
-                    PipeMessage::new(pipe_source.clone(), name, payload, args, is_private),
+                    PipeMessage::new(
+                        pipe_source.clone(),
+                        from_client_id,
+                        name,
+                        payload,
+                        args,
+                        is_private,
+                    ),
                 ));
             }
         },

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -485,6 +485,7 @@ fn message_to_plugin(env: &PluginEnv, mut message_to_plugin: MessageToPlugin) ->
     }
     env.senders
         .send_to_plugin(PluginInstruction::MessageFromPlugin {
+            source_client_id: env.client_id,
             source_plugin_id: env.plugin_id,
             message: message_to_plugin,
         })

--- a/zellij-utils/assets/prost/api.pipe_message.rs
+++ b/zellij-utils/assets/prost/api.pipe_message.rs
@@ -15,6 +15,8 @@ pub struct PipeMessage {
     pub args: ::prost::alloc::vec::Vec<Arg>,
     #[prost(bool, tag = "7")]
     pub is_private: bool,
+    #[prost(uint32, tag = "8")]
+    pub client_id: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -2028,11 +2028,13 @@ pub struct PipeMessage {
     pub payload: Option<String>,
     pub args: BTreeMap<String, String>,
     pub is_private: bool,
+    pub client_id: ClientId,
 }
 
 impl PipeMessage {
     pub fn new(
         source: PipeSource,
+        client_id: ClientId,
         name: impl Into<String>,
         payload: &Option<String>,
         args: &Option<BTreeMap<String, String>>,
@@ -2040,6 +2042,7 @@ impl PipeMessage {
     ) -> Self {
         PipeMessage {
             source,
+            client_id,
             name: name.into(),
             payload: payload.clone(),
             args: args.clone().unwrap_or_else(|| Default::default()),

--- a/zellij-utils/src/plugin_api/pipe_message.proto
+++ b/zellij-utils/src/plugin_api/pipe_message.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+import "pane_id.proto";
+
 package api.pipe_message;
 
 message PipeMessage {
@@ -10,6 +12,7 @@ message PipeMessage {
     optional string payload = 5;
     repeated Arg args = 6;
     bool is_private = 7;
+    uint32 clientId = 8;
 }
 
 enum PipeSource {

--- a/zellij-utils/src/plugin_api/pipe_message.rs
+++ b/zellij-utils/src/plugin_api/pipe_message.rs
@@ -30,12 +30,14 @@ impl TryFrom<ProtobufPipeMessage> for PipeMessage {
             .map(|arg| (arg.key, arg.value))
             .collect();
         let is_private = protobuf_pipe_message.is_private;
+        let client_id = protobuf_pipe_message.client_id as u16;
         Ok(PipeMessage {
             source,
             name,
             payload,
             args,
             is_private,
+            client_id,
         })
     }
 }
@@ -60,6 +62,7 @@ impl TryFrom<PipeMessage> for ProtobufPipeMessage {
             .map(|(key, value)| ProtobufArg { key, value })
             .collect();
         let is_private = pipe_message.is_private;
+        let client_id = pipe_message.client_id as u32;
         Ok(ProtobufPipeMessage {
             source,
             cli_source_id,
@@ -68,6 +71,7 @@ impl TryFrom<PipeMessage> for ProtobufPipeMessage {
             payload,
             args,
             is_private,
+            client_id,
         })
     }
 }


### PR DESCRIPTION
# Proposal
## Description
Adds a the `client_id` of the client being the source of the pipe message.

## Problem

I want to create a plugin that allows to write chars to a specific pane based on it's name.
For this, I want my plugin to react to a pipe message (which can be sent from the CLI or a KeyBind), then tries to find a pane with a matching title in the focused tab.

But, since a pipe message is always sent to all clients, even when it is triggered by a KeyBind, I can't know which tab is focused by the client how sent the KeyBind.

# Solution

After a lot of trial and error, I think that adding the source `client_id` to the `PipeMessage` structure is the minimal way to fix my problem.

With the source `client_id`, my plugin can know from which tab the pipe message was sent by keeping track of which tab each client is currently focusing. 

If it's coming from the CLI, my plugin can look for a `pane_id` argument in the pipe message. The CLI caller can send the current pane id from `ZELLIJ_PANE_ID` env variable.

It's not perfect (the cli source is a bit cumbersome), but it's minimal, and allows for way better behavior in multiplayer mode.
