### PR TITLE
fix(zellij-utils): Fix duplication of `PaneId` in protobuf

### DIFF
--- a/zellij-utils/assets/prost/api.event.rs
+++ b/zellij-utils/assets/prost/api.event.rs
@@ -102,7 +102,7 @@ pub struct ClientInfo {
     #[prost(uint32, tag = "1")]
     pub client_id: u32,
     #[prost(message, optional, tag = "2")]
-    pub pane_id: ::core::option::Option<PaneId>,
+    pub pane_id: ::core::option::Option<super::pane_id::PaneId>,
     #[prost(string, tag = "3")]
     pub running_command: ::prost::alloc::string::String,
     #[prost(bool, tag = "4")]
@@ -126,16 +126,7 @@ pub struct CommandPaneReRunPayload {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PaneClosedPayload {
     #[prost(message, optional, tag = "1")]
-    pub pane_id: ::core::option::Option<PaneId>,
-}
-/// duplicate of plugin_command.PaneId because protobuffs don't like recursive imports
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PaneId {
-    #[prost(enumeration = "PaneType", tag = "1")]
-    pub pane_type: i32,
-    #[prost(uint32, tag = "2")]
-    pub id: u32,
+    pub pane_id: ::core::option::Option<super::pane_id::PaneId>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -597,33 +588,6 @@ impl EventType {
             "FailedToChangeHostFolder" => Some(Self::FailedToChangeHostFolder),
             "PastedText" => Some(Self::PastedText),
             "ConfigWasWrittenToDisk" => Some(Self::ConfigWasWrittenToDisk),
-            _ => None,
-        }
-    }
-}
-/// duplicate of plugin_command.PaneType because protobuffs don't like recursive imports
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
-#[repr(i32)]
-pub enum PaneType {
-    Terminal = 0,
-    Plugin = 1,
-}
-impl PaneType {
-    /// String value of the enum field names used in the ProtoBuf definition.
-    ///
-    /// The values are not transformed in any way and thus are considered stable
-    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-    pub fn as_str_name(&self) -> &'static str {
-        match self {
-            PaneType::Terminal => "Terminal",
-            PaneType::Plugin => "Plugin",
-        }
-    }
-    /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-        match value {
-            "Terminal" => Some(Self::Terminal),
-            "Plugin" => Some(Self::Plugin),
             _ => None,
         }
     }

--- a/zellij-utils/assets/prost/api.pane_id.rs
+++ b/zellij-utils/assets/prost/api.pane_id.rs
@@ -1,0 +1,34 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PaneId {
+    #[prost(enumeration = "PaneType", tag = "1")]
+    pub pane_type: i32,
+    #[prost(uint32, tag = "2")]
+    pub id: u32,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum PaneType {
+    Terminal = 0,
+    Plugin = 1,
+}
+impl PaneType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            PaneType::Terminal => "Terminal",
+            PaneType::Plugin => "Plugin",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "Terminal" => Some(Self::Terminal),
+            "Plugin" => Some(Self::Plugin),
+            _ => None,
+        }
+    }
+}

--- a/zellij-utils/assets/prost/api.plugin_command.rs
+++ b/zellij-utils/assets/prost/api.plugin_command.rs
@@ -312,13 +312,13 @@ pub struct ChangeFloatingPanesCoordinatesPayload {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StackPanesPayload {
     #[prost(message, repeated, tag = "1")]
-    pub pane_ids: ::prost::alloc::vec::Vec<PaneId>,
+    pub pane_ids: ::prost::alloc::vec::Vec<super::pane_id::PaneId>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SetFloatingPanePinnedPayload {
     #[prost(message, optional, tag = "1")]
-    pub pane_id: ::core::option::Option<PaneId>,
+    pub pane_id: ::core::option::Option<super::pane_id::PaneId>,
     #[prost(bool, tag = "2")]
     pub should_be_pinned: bool,
 }
@@ -378,7 +378,7 @@ pub struct ReloadPluginPayload {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BreakPanesToTabWithIndexPayload {
     #[prost(message, repeated, tag = "1")]
-    pub pane_ids: ::prost::alloc::vec::Vec<PaneId>,
+    pub pane_ids: ::prost::alloc::vec::Vec<super::pane_id::PaneId>,
     #[prost(uint32, tag = "2")]
     pub tab_index: u32,
     #[prost(bool, tag = "3")]
@@ -388,7 +388,7 @@ pub struct BreakPanesToTabWithIndexPayload {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BreakPanesToNewTabPayload {
     #[prost(message, repeated, tag = "1")]
-    pub pane_ids: ::prost::alloc::vec::Vec<PaneId>,
+    pub pane_ids: ::prost::alloc::vec::Vec<super::pane_id::PaneId>,
     #[prost(bool, tag = "2")]
     pub should_change_focus_to_new_tab: bool,
     #[prost(string, optional, tag = "3")]
@@ -398,13 +398,13 @@ pub struct BreakPanesToNewTabPayload {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MovePaneWithPaneIdPayload {
     #[prost(message, optional, tag = "1")]
-    pub pane_id: ::core::option::Option<PaneId>,
+    pub pane_id: ::core::option::Option<super::pane_id::PaneId>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MovePaneWithPaneIdInDirectionPayload {
     #[prost(message, optional, tag = "1")]
-    pub pane_id: ::core::option::Option<PaneId>,
+    pub pane_id: ::core::option::Option<super::pane_id::PaneId>,
     #[prost(message, optional, tag = "2")]
     pub direction: ::core::option::Option<super::resize::MoveDirection>,
 }
@@ -412,55 +412,55 @@ pub struct MovePaneWithPaneIdInDirectionPayload {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClearScreenForPaneIdPayload {
     #[prost(message, optional, tag = "1")]
-    pub pane_id: ::core::option::Option<PaneId>,
+    pub pane_id: ::core::option::Option<super::pane_id::PaneId>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScrollUpInPaneIdPayload {
     #[prost(message, optional, tag = "1")]
-    pub pane_id: ::core::option::Option<PaneId>,
+    pub pane_id: ::core::option::Option<super::pane_id::PaneId>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScrollDownInPaneIdPayload {
     #[prost(message, optional, tag = "1")]
-    pub pane_id: ::core::option::Option<PaneId>,
+    pub pane_id: ::core::option::Option<super::pane_id::PaneId>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScrollToTopInPaneIdPayload {
     #[prost(message, optional, tag = "1")]
-    pub pane_id: ::core::option::Option<PaneId>,
+    pub pane_id: ::core::option::Option<super::pane_id::PaneId>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ScrollToBottomInPaneIdPayload {
     #[prost(message, optional, tag = "1")]
-    pub pane_id: ::core::option::Option<PaneId>,
+    pub pane_id: ::core::option::Option<super::pane_id::PaneId>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PageScrollUpInPaneIdPayload {
     #[prost(message, optional, tag = "1")]
-    pub pane_id: ::core::option::Option<PaneId>,
+    pub pane_id: ::core::option::Option<super::pane_id::PaneId>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PageScrollDownInPaneIdPayload {
     #[prost(message, optional, tag = "1")]
-    pub pane_id: ::core::option::Option<PaneId>,
+    pub pane_id: ::core::option::Option<super::pane_id::PaneId>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TogglePaneIdFullscreenPayload {
     #[prost(message, optional, tag = "1")]
-    pub pane_id: ::core::option::Option<PaneId>,
+    pub pane_id: ::core::option::Option<super::pane_id::PaneId>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TogglePaneEmbedOrEjectForPaneIdPayload {
     #[prost(message, optional, tag = "1")]
-    pub pane_id: ::core::option::Option<PaneId>,
+    pub pane_id: ::core::option::Option<super::pane_id::PaneId>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -474,7 +474,7 @@ pub struct WriteCharsToPaneIdPayload {
     #[prost(string, tag = "1")]
     pub chars_to_write: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "2")]
-    pub pane_id: ::core::option::Option<PaneId>,
+    pub pane_id: ::core::option::Option<super::pane_id::PaneId>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -482,13 +482,13 @@ pub struct WriteToPaneIdPayload {
     #[prost(bytes = "vec", tag = "1")]
     pub bytes_to_write: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "2")]
-    pub pane_id: ::core::option::Option<PaneId>,
+    pub pane_id: ::core::option::Option<super::pane_id::PaneId>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EditScrollbackForPaneWithIdPayload {
     #[prost(message, optional, tag = "1")]
-    pub pane_id: ::core::option::Option<PaneId>,
+    pub pane_id: ::core::option::Option<super::pane_id::PaneId>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -496,7 +496,7 @@ pub struct ResizePaneIdWithDirectionPayload {
     #[prost(message, optional, tag = "1")]
     pub resize: ::core::option::Option<super::resize::Resize>,
     #[prost(message, optional, tag = "2")]
-    pub pane_id: ::core::option::Option<PaneId>,
+    pub pane_id: ::core::option::Option<super::pane_id::PaneId>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -516,13 +516,13 @@ pub struct RerunCommandPanePayload {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HidePaneWithIdPayload {
     #[prost(message, optional, tag = "1")]
-    pub pane_id: ::core::option::Option<PaneId>,
+    pub pane_id: ::core::option::Option<super::pane_id::PaneId>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ShowPaneWithIdPayload {
     #[prost(message, optional, tag = "1")]
-    pub pane_id: ::core::option::Option<PaneId>,
+    pub pane_id: ::core::option::Option<super::pane_id::PaneId>,
     #[prost(bool, tag = "2")]
     pub should_float_if_hidden: bool,
 }
@@ -570,21 +570,13 @@ pub struct NewPluginArgs {
     #[prost(bool, optional, tag = "1")]
     pub should_float: ::core::option::Option<bool>,
     #[prost(message, optional, tag = "2")]
-    pub pane_id_to_replace: ::core::option::Option<PaneId>,
+    pub pane_id_to_replace: ::core::option::Option<super::pane_id::PaneId>,
     #[prost(string, optional, tag = "3")]
     pub pane_title: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(string, optional, tag = "4")]
     pub cwd: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(bool, tag = "5")]
     pub skip_cache: bool,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct PaneId {
-    #[prost(enumeration = "PaneType", tag = "1")]
-    pub pane_type: i32,
-    #[prost(uint32, tag = "2")]
-    pub id: u32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -726,7 +718,7 @@ pub struct MovePayload {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PaneIdAndFloatingPaneCoordinates {
     #[prost(message, optional, tag = "1")]
-    pub pane_id: ::core::option::Option<PaneId>,
+    pub pane_id: ::core::option::Option<super::pane_id::PaneId>,
     #[prost(message, optional, tag = "2")]
     pub floating_pane_coordinates: ::core::option::Option<FloatingPaneCoordinates>,
 }
@@ -1178,32 +1170,6 @@ impl CommandName {
             "OpenFileNearPlugin" => Some(Self::OpenFileNearPlugin),
             "OpenFileFloatingNearPlugin" => Some(Self::OpenFileFloatingNearPlugin),
             "OpenFileInPlaceOfPlugin" => Some(Self::OpenFileInPlaceOfPlugin),
-            _ => None,
-        }
-    }
-}
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
-#[repr(i32)]
-pub enum PaneType {
-    Terminal = 0,
-    Plugin = 1,
-}
-impl PaneType {
-    /// String value of the enum field names used in the ProtoBuf definition.
-    ///
-    /// The values are not transformed in any way and thus are considered stable
-    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-    pub fn as_str_name(&self) -> &'static str {
-        match self {
-            PaneType::Terminal => "Terminal",
-            PaneType::Plugin => "Plugin",
-        }
-    }
-    /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-        match value {
-            "Terminal" => Some(Self::Terminal),
-            "Plugin" => Some(Self::Plugin),
             _ => None,
         }
     }

--- a/zellij-utils/assets/prost/generated_plugin_api.rs
+++ b/zellij-utils/assets/prost/generated_plugin_api.rs
@@ -20,6 +20,9 @@ pub mod api {
     pub mod message {
         include!("api.message.rs");
     }
+    pub mod pane_id {
+        include!("api.pane_id.rs");
+    }
     pub mod pipe_message {
         include!("api.pipe_message.rs");
     }

--- a/zellij-utils/src/plugin_api/event.proto
+++ b/zellij-utils/src/plugin_api/event.proto
@@ -4,6 +4,7 @@ import "input_mode.proto";
 import "key.proto";
 import "style.proto";
 import "action.proto";
+import "pane_id.proto";
 
 package api.event;
 
@@ -109,7 +110,7 @@ message ListClientsPayload {
 
 message ClientInfo {
   uint32 client_id = 1;
-  PaneId pane_id = 2;
+  api.pane_id.PaneId pane_id = 2;
   string running_command = 3;
   bool is_current_client = 4;
 }
@@ -124,19 +125,7 @@ message CommandPaneReRunPayload {
 }
 
 message PaneClosedPayload {
-  PaneId pane_id = 1;
-}
-
-// duplicate of plugin_command.PaneId because protobuffs don't like recursive imports
-message PaneId {
-  PaneType pane_type = 1;
-  uint32 id = 2;
-}
-
-// duplicate of plugin_command.PaneType because protobuffs don't like recursive imports
-enum PaneType {
-  Terminal = 0;
-  Plugin = 1;
+  api.pane_id.PaneId pane_id = 1;
 }
 
 message CommandPaneOpenedPayload {

--- a/zellij-utils/src/plugin_api/event.rs
+++ b/zellij-utils/src/plugin_api/event.rs
@@ -7,8 +7,7 @@ pub use super::generated_api::api::{
         EventType as ProtobufEventType, FileMetadata as ProtobufFileMetadata,
         InputModeKeybinds as ProtobufInputModeKeybinds, KeyBind as ProtobufKeyBind,
         LayoutInfo as ProtobufLayoutInfo, ModeUpdatePayload as ProtobufModeUpdatePayload,
-        PaneId as ProtobufPaneId, PaneInfo as ProtobufPaneInfo,
-        PaneManifest as ProtobufPaneManifest, PaneType as ProtobufPaneType,
+        PaneInfo as ProtobufPaneInfo, PaneManifest as ProtobufPaneManifest,
         PluginInfo as ProtobufPluginInfo, ResurrectableSession as ProtobufResurrectableSession,
         SessionManifest as ProtobufSessionManifest, TabInfo as ProtobufTabInfo, *,
     },
@@ -1991,37 +1990,4 @@ fn serialize_session_update_event_with_non_default_values() {
         session_update_event, deserialized_event,
         "Event properly serialized/deserialized without change"
     );
-}
-
-// note: ProtobufPaneId and ProtobufPaneType are not the same as the ones defined in plugin_command.rs
-// this is a duplicate type - we are forced to do this because protobuffs do not support recursive
-// imports
-impl TryFrom<ProtobufPaneId> for PaneId {
-    type Error = &'static str;
-    fn try_from(protobuf_pane_id: ProtobufPaneId) -> Result<Self, &'static str> {
-        match ProtobufPaneType::from_i32(protobuf_pane_id.pane_type) {
-            Some(ProtobufPaneType::Terminal) => Ok(PaneId::Terminal(protobuf_pane_id.id)),
-            Some(ProtobufPaneType::Plugin) => Ok(PaneId::Plugin(protobuf_pane_id.id)),
-            None => Err("Failed to convert PaneId"),
-        }
-    }
-}
-
-// note: ProtobufPaneId and ProtobufPaneType are not the same as the ones defined in plugin_command.rs
-// this is a duplicate type - we are forced to do this because protobuffs do not support recursive
-// imports
-impl TryFrom<PaneId> for ProtobufPaneId {
-    type Error = &'static str;
-    fn try_from(pane_id: PaneId) -> Result<Self, &'static str> {
-        match pane_id {
-            PaneId::Terminal(id) => Ok(ProtobufPaneId {
-                pane_type: ProtobufPaneType::Terminal as i32,
-                id,
-            }),
-            PaneId::Plugin(id) => Ok(ProtobufPaneId {
-                pane_type: ProtobufPaneType::Plugin as i32,
-                id,
-            }),
-        }
-    }
 }

--- a/zellij-utils/src/plugin_api/mod.rs
+++ b/zellij-utils/src/plugin_api/mod.rs
@@ -5,6 +5,7 @@ pub mod file;
 pub mod input_mode;
 pub mod key;
 pub mod message;
+pub mod pane_id;
 pub mod pipe_message;
 pub mod plugin_command;
 pub mod plugin_ids;

--- a/zellij-utils/src/plugin_api/pane_id.proto
+++ b/zellij-utils/src/plugin_api/pane_id.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package api.pane_id;
+
+message PaneId {
+  PaneType pane_type = 1;
+  uint32 id = 2;
+}
+
+enum PaneType {
+  Terminal = 0;
+  Plugin = 1;
+}

--- a/zellij-utils/src/plugin_api/pane_id.rs
+++ b/zellij-utils/src/plugin_api/pane_id.rs
@@ -1,0 +1,33 @@
+pub use super::generated_api::api::pane_id::{
+    PaneId as ProtobufPaneId, PaneType as ProtobufPaneType,
+};
+use crate::data::PaneId;
+
+use std::convert::TryFrom;
+
+impl TryFrom<ProtobufPaneId> for PaneId {
+    type Error = &'static str;
+    fn try_from(protobuf_pane_id: ProtobufPaneId) -> Result<Self, &'static str> {
+        match ProtobufPaneType::from_i32(protobuf_pane_id.pane_type) {
+            Some(ProtobufPaneType::Terminal) => Ok(PaneId::Terminal(protobuf_pane_id.id)),
+            Some(ProtobufPaneType::Plugin) => Ok(PaneId::Plugin(protobuf_pane_id.id)),
+            None => Err("Failed to convert PaneId"),
+        }
+    }
+}
+
+impl TryFrom<PaneId> for ProtobufPaneId {
+    type Error = &'static str;
+    fn try_from(pane_id: PaneId) -> Result<Self, Self::Error> {
+        Ok(match pane_id {
+            PaneId::Terminal(id) => ProtobufPaneId {
+                pane_type: ProtobufPaneType::Terminal as i32,
+                id,
+            },
+            PaneId::Plugin(id) => ProtobufPaneId {
+                pane_type: ProtobufPaneType::Plugin as i32,
+                id,
+            },
+        })
+    }
+}

--- a/zellij-utils/src/plugin_api/plugin_command.proto
+++ b/zellij-utils/src/plugin_api/plugin_command.proto
@@ -9,6 +9,7 @@ import "resize.proto";
 import "plugin_permission.proto";
 import "input_mode.proto";
 import "key.proto";
+import "pane_id.proto";
 
 package api.plugin_command;
 
@@ -298,11 +299,11 @@ message ChangeFloatingPanesCoordinatesPayload {
 }
 
 message StackPanesPayload {
-  repeated PaneId pane_ids = 1;
+  repeated api.pane_id.PaneId pane_ids = 1;
 }
 
 message SetFloatingPanePinnedPayload {
-  PaneId pane_id = 1;
+  api.pane_id.PaneId pane_id = 1;
   bool should_be_pinned = 2;
 }
 
@@ -339,60 +340,60 @@ message ReloadPluginPayload {
 }
 
 message BreakPanesToTabWithIndexPayload {
-  repeated PaneId pane_ids = 1;
+  repeated api.pane_id.PaneId pane_ids = 1;
   uint32 tab_index = 2;
   bool should_change_focus_to_target_tab = 3;
 }
 
 message BreakPanesToNewTabPayload {
-  repeated PaneId pane_ids = 1;
+  repeated api.pane_id.PaneId pane_ids = 1;
   bool should_change_focus_to_new_tab = 2;
   optional string new_tab_name = 3;
 }
 
 message MovePaneWithPaneIdPayload {
-  PaneId pane_id = 1;
+  api.pane_id.PaneId pane_id = 1;
 }
 
 message MovePaneWithPaneIdInDirectionPayload {
-  PaneId pane_id = 1;
+  api.pane_id.PaneId pane_id = 1;
   resize.MoveDirection direction = 2;
 }
 
 message ClearScreenForPaneIdPayload {
-  PaneId pane_id = 1;
+  api.pane_id.PaneId pane_id = 1;
 }
 
 message ScrollUpInPaneIdPayload {
-  PaneId pane_id = 1;
+  api.pane_id.PaneId pane_id = 1;
 }
 
 message ScrollDownInPaneIdPayload {
-  PaneId pane_id = 1;
+  api.pane_id.PaneId pane_id = 1;
 }
 
 message ScrollToTopInPaneIdPayload {
-  PaneId pane_id = 1;
+  api.pane_id.PaneId pane_id = 1;
 }
 
 message ScrollToBottomInPaneIdPayload {
-  PaneId pane_id = 1;
+  api.pane_id.PaneId pane_id = 1;
 }
 
 message PageScrollUpInPaneIdPayload {
-  PaneId pane_id = 1;
+  api.pane_id.PaneId pane_id = 1;
 }
 
 message PageScrollDownInPaneIdPayload {
-  PaneId pane_id = 1;
+  api.pane_id.PaneId pane_id = 1;
 }
 
 message TogglePaneIdFullscreenPayload {
-  PaneId pane_id = 1;
+  api.pane_id.PaneId pane_id = 1;
 }
 
 message TogglePaneEmbedOrEjectForPaneIdPayload {
-  PaneId pane_id = 1;
+  api.pane_id.PaneId pane_id = 1;
 }
 
 message CloseTabWithIndexPayload {
@@ -401,21 +402,21 @@ message CloseTabWithIndexPayload {
 
 message WriteCharsToPaneIdPayload {
   string chars_to_write = 1;
-  PaneId pane_id = 2;
+  api.pane_id.PaneId pane_id = 2;
 }
 
 message WriteToPaneIdPayload {
   bytes bytes_to_write = 1;
-  PaneId pane_id = 2;
+  api.pane_id.PaneId pane_id = 2;
 }
 
 message EditScrollbackForPaneWithIdPayload {
-  PaneId pane_id = 1;
+  api.pane_id.PaneId pane_id = 1;
 }
 
 message ResizePaneIdWithDirectionPayload {
   resize.Resize resize = 1;
-  PaneId pane_id = 2;
+  api.pane_id.PaneId pane_id = 2;
 }
 
 message ReconfigurePayload {
@@ -428,11 +429,11 @@ message RerunCommandPanePayload {
 }
 
 message HidePaneWithIdPayload {
-  PaneId pane_id = 1;
+  api.pane_id.PaneId pane_id = 1;
 }
 
 message ShowPaneWithIdPayload {
-  PaneId pane_id = 1;
+  api.pane_id.PaneId pane_id = 1;
   bool should_float_if_hidden = 2;
 }
 
@@ -461,20 +462,10 @@ message MessageToPluginPayload {
 
 message NewPluginArgs {
     optional bool should_float = 1;
-    optional PaneId pane_id_to_replace = 2;
+    optional api.pane_id.PaneId pane_id_to_replace = 2;
     optional string pane_title = 3;
     optional string cwd = 4;
     bool skip_cache = 5;
-}
-
-message PaneId {
-  PaneType pane_type = 1;
-  uint32 id = 2;
-}
-
-enum PaneType {
-  Terminal = 0;
-  Plugin = 1;
 }
 
 message SwitchSessionPayload {
@@ -567,7 +558,7 @@ message MovePayload {
 }
 
 message PaneIdAndFloatingPaneCoordinates {
-  PaneId pane_id = 1;
+  api.pane_id.PaneId pane_id = 1;
   FloatingPaneCoordinates floating_pane_coordinates = 2;
 }
 

--- a/zellij-utils/src/plugin_api/plugin_command.rs
+++ b/zellij-utils/src/plugin_api/plugin_command.rs
@@ -2,6 +2,7 @@ pub use super::generated_api::api::{
     action::{PaneIdAndShouldFloat, SwitchToModePayload},
     event::{EventNameList as ProtobufEventNameList, Header},
     input_mode::InputMode as ProtobufInputMode,
+    pane_id::{PaneId as ProtobufPaneId, PaneType as ProtobufPaneType},
     plugin_command::{
         plugin_command::Payload, BreakPanesToNewTabPayload, BreakPanesToTabWithIndexPayload,
         ChangeFloatingPanesCoordinatesPayload, ChangeHostFolderPayload,
@@ -18,12 +19,11 @@ pub use super::generated_api::api::{
         OpenCommandPanePayload, OpenFileFloatingNearPluginPayload, OpenFileInPlaceOfPluginPayload,
         OpenFileNearPluginPayload, OpenFilePayload, OpenTerminalFloatingNearPluginPayload,
         OpenTerminalInPlaceOfPluginPayload, OpenTerminalNearPluginPayload,
-        PageScrollDownInPaneIdPayload, PageScrollUpInPaneIdPayload, PaneId as ProtobufPaneId,
-        PaneIdAndFloatingPaneCoordinates, PaneType as ProtobufPaneType,
-        PluginCommand as ProtobufPluginCommand, PluginMessagePayload, RebindKeysPayload,
-        ReconfigurePayload, ReloadPluginPayload, RequestPluginPermissionPayload,
-        RerunCommandPanePayload, ResizePaneIdWithDirectionPayload, ResizePayload,
-        RunCommandPayload, ScrollDownInPaneIdPayload, ScrollToBottomInPaneIdPayload,
+        PageScrollDownInPaneIdPayload, PageScrollUpInPaneIdPayload,
+        PaneIdAndFloatingPaneCoordinates, PluginCommand as ProtobufPluginCommand,
+        PluginMessagePayload, RebindKeysPayload, ReconfigurePayload, ReloadPluginPayload,
+        RequestPluginPermissionPayload, RerunCommandPanePayload, ResizePaneIdWithDirectionPayload,
+        ResizePayload, RunCommandPayload, ScrollDownInPaneIdPayload, ScrollToBottomInPaneIdPayload,
         ScrollToTopInPaneIdPayload, ScrollUpInPaneIdPayload, SetFloatingPanePinnedPayload,
         SetTimeoutPayload, ShowPaneWithIdPayload, StackPanesPayload, SubscribePayload,
         SwitchSessionPayload, SwitchTabToPayload, TogglePaneEmbedOrEjectForPaneIdPayload,
@@ -163,33 +163,6 @@ impl Into<ProtobufHttpVerb> for HttpVerb {
             HttpVerb::Post => ProtobufHttpVerb::Post,
             HttpVerb::Put => ProtobufHttpVerb::Put,
             HttpVerb::Delete => ProtobufHttpVerb::Delete,
-        }
-    }
-}
-
-impl TryFrom<ProtobufPaneId> for PaneId {
-    type Error = &'static str;
-    fn try_from(protobuf_pane_id: ProtobufPaneId) -> Result<Self, &'static str> {
-        match ProtobufPaneType::from_i32(protobuf_pane_id.pane_type) {
-            Some(ProtobufPaneType::Terminal) => Ok(PaneId::Terminal(protobuf_pane_id.id)),
-            Some(ProtobufPaneType::Plugin) => Ok(PaneId::Plugin(protobuf_pane_id.id)),
-            None => Err("Failed to convert PaneId"),
-        }
-    }
-}
-
-impl TryFrom<PaneId> for ProtobufPaneId {
-    type Error = &'static str;
-    fn try_from(pane_id: PaneId) -> Result<Self, &'static str> {
-        match pane_id {
-            PaneId::Terminal(id) => Ok(ProtobufPaneId {
-                pane_type: ProtobufPaneType::Terminal as i32,
-                id,
-            }),
-            PaneId::Plugin(id) => Ok(ProtobufPaneId {
-                pane_type: ProtobufPaneType::Plugin as i32,
-                id,
-            }),
         }
     }
 }


### PR DESCRIPTION
# Problem

The `PaneId` message in the proto file has been duplicated to avoid import cycles.

While this works, it's not ideal to have duplicated code like that.

And you actually have to make a new copy of it each time you want to use a `PaneId` in a proto file.

# Solution

Since the `PaneId` and `PaneType` only have native types, they don't have to import any other proto file, the import cycle can actually be resolved by moving those message definition in there own file.

This is simpler, and also allows to use the `PaneId` type anywhere it is needed without duplicating it again.