### PR TITLE
Implement regex search as SearchToggleOption

### DIFF
--- a/default-plugins/status-bar/src/one_line_ui.rs
+++ b/default-plugins/status-bar/src/one_line_ui.rs
@@ -1363,6 +1363,8 @@ fn get_keys_and_hints(mi: &ModeInfo) -> Vec<(String, String, Vec<KeyWithModifier
             action_key(&km, &[A::SearchToggleOption(SOpt::Wrap)])),
         (s("Whole words"), s("Whole"),
             action_key(&km, &[A::SearchToggleOption(SOpt::WholeWord)])),
+        (s("Regex"), s("Regex"),
+            action_key(&km, &[A::SearchToggleOption(SOpt::Regex)])),
     ]} else if mi.mode == IM::Session { vec![
         (s("Detach"), s("Detach"), action_key(&km, &[Action::Detach])),
         (s("Session Manager"), s("Manager"), session_manager_key(&km)),

--- a/default-plugins/status-bar/src/second_line.rs
+++ b/default-plugins/status-bar/src/second_line.rs
@@ -242,6 +242,8 @@ fn get_keys_and_hints(mi: &ModeInfo) -> Vec<(String, String, Vec<KeyWithModifier
             action_key(&km, &[A::SearchToggleOption(SOpt::Wrap)])),
         (s("Whole words"), s("Whole"),
             action_key(&km, &[A::SearchToggleOption(SOpt::WholeWord)])),
+        (s("Regex"), s("Regex"),
+            action_key(&km, &[A::SearchToggleOption(SOpt::Regex)])),
     ]} else if mi.mode == IM::Session { vec![
         (s("Detach"), s("Detach"), action_key(&km, &[Action::Detach])),
         (s("Session Manager"), s("Manager"), action_key(&km, &[A::LaunchOrFocusPlugin(Default::default(), true, true, false, false), TO_NORMAL])), // not entirely accurate

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -367,6 +367,9 @@ impl Pane for TerminalPane {
                 if self.grid.search_results.wrap_search {
                     modifiers.push("w")
                 }
+                if self.grid.search_results.regex_search {
+                    modifiers.push("r")
+                }
                 modifier_text.push_str(&modifiers.join(", "));
                 modifier_text.push(']');
             }
@@ -723,6 +726,10 @@ impl Pane for TerminalPane {
     }
     fn toggle_search_wrap(&mut self) {
         self.grid.toggle_search_wrap();
+    }
+    fn toggle_search_regex(&mut self) {
+        self.grid.toggle_search_regex();
+        self.set_should_render(true);
     }
     fn clear_search(&mut self) {
         self.grid.clear_search();

--- a/zellij-server/src/panes/unit/search_in_pane_tests.rs
+++ b/zellij-server/src/panes/unit/search_in_pane_tests.rs
@@ -421,3 +421,131 @@ pub fn searching_whole_word_case_insensitive() {
         format!("{:?}", terminal_pane.grid)
     );
 }
+
+#[test]
+pub fn searching_regex_simple() {
+    let mut terminal_pane = create_pane();
+    terminal_pane.update_search_term(r"t[o]r[t]or");
+    assert_snapshot!("grid_copy", format!("{:?}", terminal_pane.grid));
+
+    terminal_pane.toggle_search_regex();
+    assert_snapshot!(
+        "grid_copy_tortor_highlighted",
+        format!("{:?}", terminal_pane.grid)
+    );
+
+    terminal_pane.toggle_search_regex();
+    assert_snapshot!("grid_copy", format!("{:?}", terminal_pane.grid));
+}
+
+#[test]
+pub fn searching_regex_case_insensitive() {
+    let mut terminal_pane = create_pane();
+    terminal_pane.update_search_term(r"(?i)quam");
+    assert_snapshot!(
+        "grid_copy_quam_highlighted",
+        format!("{:?}", terminal_pane.grid)
+    );
+
+    terminal_pane.toggle_search_regex();
+    assert_snapshot!(
+        "grid_copy_quam_regex_highlighted",
+        format!("{:?}", terminal_pane.grid)
+    );
+
+    terminal_pane.toggle_search_case_sensitivity();
+    assert_snapshot!(
+        "grid_copy_quam_regex_case_sensitive",
+        format!("{:?}", terminal_pane.grid)
+    );
+
+    terminal_pane.toggle_search_regex();
+    assert_snapshot!(
+        "grid_copy_quam_highlighted",
+        format!("{:?}", terminal_pane.grid)
+    );
+}
+
+#[test]
+pub fn searching_regex_whole_word() {
+    let mut terminal_pane = create_pane();
+    terminal_pane.update_search_term(r"\bquam\b");
+    assert_snapshot!(
+        "grid_copy_quam_highlighted",
+        format!("{:?}", terminal_pane.grid)
+    );
+
+    terminal_pane.toggle_search_regex();
+    assert_snapshot!(
+        "grid_copy_quam_regex_highlighted",
+        format!("{:?}", terminal_pane.grid)
+    );
+
+    terminal_pane.toggle_search_whole_words();
+    assert_snapshot!(
+        "grid_copy_quam_regex_whole_word",
+        format!("{:?}", terminal_pane.grid)
+    );
+
+    terminal_pane.toggle_search_regex();
+    assert_snapshot!(
+        "grid_copy_quam_highlighted",
+        format!("{:?}", terminal_pane.grid)
+    );
+}
+
+#[test]
+pub fn searching_regex_across_line_wrap() {
+    let mut terminal_pane = create_pane();
+    terminal_pane.update_search_term(r"aliquam.*fringilla");
+    // Spread across two lines
+    terminal_pane.grid.change_size(30, 60);
+    assert_snapshot!(
+        "grid_copy_multiline_highlighted",
+        format!("{:?}", terminal_pane.grid)
+    );
+
+    terminal_pane.toggle_search_regex();
+    assert_snapshot!(
+        "grid_copy_multiline_regex_highlighted",
+        format!("{:?}", terminal_pane.grid)
+    );
+
+    // Spread across 4 lines
+    terminal_pane.grid.change_size(40, 4);
+    assert_snapshot!(
+        "grid_copy_multiline_regex_highlighted_narrow",
+        format!("{:?}", terminal_pane.grid)
+    );
+
+    terminal_pane.search_up();
+    assert_snapshot!(
+        "grid_copy_multiline_regex_selected_narrow",
+        format!("{:?}", terminal_pane.grid)
+    );
+
+    // Wrap on
+    terminal_pane.toggle_search_wrap();
+    terminal_pane.search_down();
+    assert_snapshot!(
+        "grid_copy_multiline_regex_selected_wrap_narrow",
+        format!("{:?}", terminal_pane.grid)
+    );
+
+    // Wrap off
+    terminal_pane.toggle_search_wrap();
+    // Don't forget the current selection
+    terminal_pane.search_up();
+    assert_snapshot!(
+        "grid_copy_multiline_regex_selected_wrap_narrow",
+        format!("{:?}", terminal_pane.grid)
+    );
+
+    // Wrap on
+    terminal_pane.toggle_search_wrap();
+    terminal_pane.search_up();
+    assert_snapshot!(
+        "grid_copy_multiline_regex_selected_narrow",
+        format!("{:?}", terminal_pane.grid)
+    );
+}

--- a/zellij-server/src/panes/unit/snapshots/zellij_server__panes__terminal_pane__search_tests__grid_copy.snap
+++ b/zellij-server/src/panes/unit/snapshots/zellij_server__panes__terminal_pane__search_tests__grid_copy.snap
@@ -1,0 +1,25 @@
+---
+source: zellij-server/src/panes/./unit/search_in_pane_tests.rs
+expression: "format!(\"{:?}\", terminal_pane.grid)"
+---
+00 (C): 
+01 (C): Quisque id diam vel quam. Id porta nibh venenatis cras sed felis eget velit aliquet. Sagittis aliquam malesuada bibendum 
+02 (W): arcu. Libero id faucibus nisl tincidunt eget nullam non. Sed elementum tempus egestas sed sed risus pretium quam vulputat
+03 (W): e. Turpis egestas maecenas pharetra convallis. Arcu cursus vitae congue mauris rhoncus aenean vel. Augue ut lectus arcu b
+04 (W): ibendum. Scelerisque varius morbi enim nunc faucibus a pellentesque. Mattis pellentesque id nibh tortor id aliquet lectus
+05 (W):  proin nibh. In aliquam sem fringilla ut. Urna et pharetra pharetra massa massa ultricies mi. Enim nulla aliquet porttito
+06 (W): r lacus luctus accumsan tortor posuere. Malesuada fames ac turpis egestas integer. Venenatis tellus in metus vulputate eu
+07 (W):  scelerisque felis. Suspendisse faucibus interdum posuere lorem ipsum dolor sit amet.
+08 (C): 
+09 (C): Quam elementum pulvinar etiam non quam lacus suspendisse faucibus. Egestas sed sed risus pretium quam vulputate dignissim
+10 (W):  suspendisse. Risus nec feugiat in fermentum posuere urna. Vestibulum lorem sed risus ultricies. Egestas maecenas pharetr
+11 (W): a convallis posuere morbi. Egestas tellus rutrum tellus pellentesque. Pulvinar etiam non quam lacus suspendisse faucibus.
+12 (W):  Lectus proin nibh nisl condimentum id venenatis a condimentum. Adipiscing elit pellentesque habitant morbi tristique sen
+13 (W): ectus et netus. Nunc id cursus metus aliquam eleifend. Urna nec tincidunt praesent semper feugiat nibh sed pulvinar. Done
+14 (W): c ultrices tincidunt arcu non sodales neque sodales ut etiam. Suspendisse sed nisi lacus sed viverra tellus in hac habita
+15 (W): sse. Nunc scelerisque viverra mauris in aliquam sem fringilla.
+16 (C): ⏎                                                                                                                        
+17 (W):                                                                                                                          
+18 (C): zellij on  mouse-support [?] is 📦 v0.14.0 via 🦀 v1.53.0-beta.3                                                        
+19 (C): ❯                                                                                                                        
+

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -644,6 +644,7 @@ pub(crate) fn route_action(
                 },
                 SearchOption::WholeWord => ScreenInstruction::SearchToggleWholeWord(client_id),
                 SearchOption::Wrap => ScreenInstruction::SearchToggleWrap(client_id),
+                SearchOption::Regex => ScreenInstruction::SearchToggleRegex(client_id),
             };
             senders
                 .send_to_screen(instruction)

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -269,6 +269,7 @@ pub enum ScreenInstruction {
     SearchToggleCaseSensitivity(ClientId),
     SearchToggleWholeWord(ClientId),
     SearchToggleWrap(ClientId),
+    SearchToggleRegex(ClientId),
     AddRedPaneFrameColorOverride(Vec<PaneId>, Option<String>), // Option<String> => optional error text
     ClearPaneFrameColorOverride(Vec<PaneId>),
     PreviousSwapLayout(ClientId),
@@ -537,6 +538,7 @@ impl From<&ScreenInstruction> for ScreenContext {
             },
             ScreenInstruction::SearchToggleWholeWord(..) => ScreenContext::SearchToggleWholeWord,
             ScreenInstruction::SearchToggleWrap(..) => ScreenContext::SearchToggleWrap,
+            ScreenInstruction::SearchToggleRegex(..) => ScreenContext::SearchToggleRegex,
             ScreenInstruction::AddRedPaneFrameColorOverride(..) => {
                 ScreenContext::AddRedPaneFrameColorOverride
             },
@@ -3999,6 +4001,15 @@ pub(crate) fn screen_thread_main(
                     screen,
                     client_id,
                     |tab: &mut Tab, client_id: ClientId| tab.toggle_search_whole_words(client_id)
+                );
+                screen.render(None)?;
+                screen.unblock_input()?;
+            },
+            ScreenInstruction::SearchToggleRegex(client_id) => {
+                active_tab_and_connected_client_id!(
+                    screen,
+                    client_id,
+                    |tab: &mut Tab, client_id: ClientId| tab.toggle_search_regex(client_id)
                 );
                 screen.render(None)?;
                 screen.unblock_input()?;

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -514,6 +514,9 @@ pub trait Pane {
     fn toggle_search_wrap(&mut self) {
         // No-op by default (only terminal-panes currently have search capability)
     }
+    fn toggle_search_regex(&mut self) {
+        // No-op by default (only terminal-panes currently have search capability)
+    }
     fn clear_search(&mut self) {
         // No-op by default (only terminal-panes currently have search capability)
     }
@@ -4168,6 +4171,12 @@ impl Tab {
     pub fn toggle_search_whole_words(&mut self, client_id: ClientId) {
         if let Some(active_pane) = self.get_active_pane_or_floating_pane_mut(client_id) {
             active_pane.toggle_search_whole_words();
+        }
+    }
+
+    pub fn toggle_search_regex(&mut self, client_id: ClientId) {
+        if let Some(active_pane) = self.get_active_pane_or_floating_pane_mut(client_id) {
+            active_pane.toggle_search_regex();
         }
     }
 

--- a/zellij-utils/assets/prost/api.action.rs
+++ b/zellij-utils/assets/prost/api.action.rs
@@ -340,6 +340,7 @@ pub enum SearchOption {
     CaseSensitivity = 0,
     WholeWord = 1,
     Wrap = 2,
+    Regex = 3,
 }
 impl SearchOption {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -351,6 +352,7 @@ impl SearchOption {
             SearchOption::CaseSensitivity => "CaseSensitivity",
             SearchOption::WholeWord => "WholeWord",
             SearchOption::Wrap => "Wrap",
+            SearchOption::Regex => "Regex",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -359,6 +361,7 @@ impl SearchOption {
             "CaseSensitivity" => Some(Self::CaseSensitivity),
             "WholeWord" => Some(Self::WholeWord),
             "Wrap" => Some(Self::Wrap),
+            "Regex" => Some(Self::Regex),
             _ => None,
         }
     }

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -321,6 +321,7 @@ pub enum ScreenContext {
     SearchToggleCaseSensitivity,
     SearchToggleWholeWord,
     SearchToggleWrap,
+    SearchToggleRegex,
     AddRedPaneFrameColorOverride,
     ClearPaneFrameColorOverride,
     PreviousSwapLayout,

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -74,6 +74,7 @@ pub enum SearchOption {
     CaseSensitivity,
     WholeWord,
     Wrap,
+    Regex,
 }
 
 impl FromStr for SearchOption {
@@ -85,6 +86,7 @@ impl FromStr for SearchOption {
             },
             "WholeWord" | "wholeword" | "Wholeword" => Ok(SearchOption::WholeWord),
             "Wrap" | "wrap" => Ok(SearchOption::Wrap),
+            "Regex" | "regex" => Ok(SearchOption::Regex),
             _ => Err(format!(
                 "Failed to parse SearchOption. Unknown SearchOption: {}",
                 s

--- a/zellij-utils/src/plugin_api/action.proto
+++ b/zellij-utils/src/plugin_api/action.proto
@@ -88,6 +88,7 @@ enum SearchOption {
   CaseSensitivity = 0;
   WholeWord = 1;
   Wrap = 2;
+  Regex = 3;
 }
 
 enum MoveTabDirection {

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -1259,6 +1259,7 @@ impl TryFrom<ProtobufSearchOption> for SearchOption {
             ProtobufSearchOption::CaseSensitivity => Ok(SearchOption::CaseSensitivity),
             ProtobufSearchOption::WholeWord => Ok(SearchOption::WholeWord),
             ProtobufSearchOption::Wrap => Ok(SearchOption::Wrap),
+            ProtobufSearchOption::Regex => Ok(SearchOption::Regex),
         }
     }
 }
@@ -1270,6 +1271,7 @@ impl TryFrom<SearchOption> for ProtobufSearchOption {
             SearchOption::CaseSensitivity => Ok(ProtobufSearchOption::CaseSensitivity),
             SearchOption::WholeWord => Ok(ProtobufSearchOption::WholeWord),
             SearchOption::Wrap => Ok(ProtobufSearchOption::Wrap),
+            SearchOption::Regex => Ok(ProtobufSearchOption::Regex),
         }
     }
 }


### PR DESCRIPTION
Implement regex search functionality as a new SearchToggleOption.

* Add a new field `regex_search` to the `SearchResult` struct in `zellij-server/src/panes/search.rs`.
* Implement regex search functionality in the `search_row` method of `SearchResult` in `zellij-server/src/panes/search.rs`.
* Update the `check_if_haystack_char_matches_needle` method to handle regex search in `zellij-server/src/panes/search.rs`.
* Add a new method `toggle_search_regex` to the `Grid` struct in `zellij-server/src/panes/terminal_pane.rs` to toggle regex search.
* Update the `set_search_string` method in `Grid` to handle regex search if `regex_search` is enabled in `zellij-server/src/panes/terminal_pane.rs`.
* Add unit tests for regex search functionality in `search_row` method of `SearchResult` in `zellij-server/src/panes/unit/search_in_pane_tests.rs`.
* Add unit tests for `toggle_search_regex` method in `Grid` struct in `zellij-server/src/panes/unit/search_in_pane_tests.rs`.

