### PR TITLE
performance(render): improve rendering performance by consolidating renders and introducing repaint_delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 * refactor(terminal): track scroll_region as tuple rather than Option (https://github.com/zellij-org/zellij/pull/4082)
+* performance(terminal): reduce render count to mitigate flickering issues in apps that don't implement synchronized renders (https://github.com/zellij-org/zellij/pull/4100)
 
 ## [0.42.1] - 2025-03-21
 * fix(mouse): fix mouse handling in windows terminal (https://github.com/zellij-org/zellij/pull/4076)

--- a/zellij-server/src/background_jobs.rs
+++ b/zellij-server/src/background_jobs.rs
@@ -389,8 +389,7 @@ pub(crate) fn background_jobs_main(
                         let last_render_request = last_render_request.clone();
                         let task_start_time = current_time;
                         async move {
-                            task::sleep(std::time::Duration::from_millis(REPAINT_DELAY_MS))
-                                .await;
+                            task::sleep(std::time::Duration::from_millis(REPAINT_DELAY_MS)).await;
                             let _ = senders.send_to_screen(ScreenInstruction::Render);
                             {
                                 let mut last_render_request = last_render_request.lock().unwrap();
@@ -399,7 +398,9 @@ pub(crate) fn background_jobs_main(
                                         // another render request was received while we were
                                         // sleeping, schedule this job again so that we can also
                                         // render that request
-                                        let _ = senders.send_to_background_jobs(BackgroundJob::RenderToClients);
+                                        let _ = senders.send_to_background_jobs(
+                                            BackgroundJob::RenderToClients,
+                                        );
                                     }
                                 }
                                 // reset the last_render_request so that the task will be spawned
@@ -409,9 +410,7 @@ pub(crate) fn background_jobs_main(
                         }
                     });
                 }
-
-
-            }
+            },
             BackgroundJob::Exit => {
                 for loading_plugin in loading_plugins.values() {
                     loading_plugin.store(false, Ordering::SeqCst);

--- a/zellij-server/src/output/mod.rs
+++ b/zellij-server/src/output/mod.rs
@@ -433,9 +433,6 @@ impl Output {
                     client_serialized_render_instructions.push_str(&vte_instruction);
                 }
             }
-//             log::info!("*****");
-//             log::info!("{:?}", client_serialized_render_instructions);
-
             serialized_render_instructions.insert(client_id, client_serialized_render_instructions);
         }
         Ok(serialized_render_instructions)

--- a/zellij-server/src/output/mod.rs
+++ b/zellij-server/src/output/mod.rs
@@ -433,6 +433,8 @@ impl Output {
                     client_serialized_render_instructions.push_str(&vte_instruction);
                 }
             }
+//             log::info!("*****");
+//             log::info!("{:?}", client_serialized_render_instructions);
 
             serialized_render_instructions.insert(client_id, client_serialized_render_instructions);
         }

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -2909,7 +2909,8 @@ pub(crate) fn screen_thread_main(
                         break;
                     }
                 }
-                let _ = screen.bus
+                let _ = screen
+                    .bus
                     .senders
                     .send_to_background_jobs(BackgroundJob::RenderToClients);
             },

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -2890,15 +2890,6 @@ pub(crate) fn screen_thread_main(
         // when this cache is Dropped, for more information, see the comments in PtyWriter
         let _resize_cache = ResizeCache::new(thread_senders.clone());
 
-        if let ScreenInstruction::UpdateSessionInfos(..) = &event {
-            // no op
-        } else if let ScreenInstruction::PtyBytes(_, vte_bytes) = &event {
-            log::info!("*******");
-            log::info!("pty_bytes: {:#?}", String::from_utf8_lossy(vte_bytes));
-        } else {
-            log::info!("*******");
-            log::info!("event: {:#?}", event);
-        };
         match event {
             ScreenInstruction::PtyBytes(pid, vte_bytes) => {
                 let all_tabs = screen.get_tabs_mut();

--- a/zellij-server/src/terminal_bytes.rs
+++ b/zellij-server/src/terminal_bytes.rs
@@ -90,16 +90,23 @@ impl TerminalBytes {
                     break;
                 },
                 ReadResult::Timeout => {
-                    let time_to_send_render = self
-                        .async_send_to_screen(ScreenInstruction::Render)
-                        .await
-                        .with_context(err_context)?;
-                    self.update_render_send_time(time_to_send_render);
+//                     log::info!("ScreenInstruction::Render 0");
+//                     let time_to_send_render = self
+//                         .async_send_to_screen(ScreenInstruction::Render)
+//                         .await
+//                         .with_context(err_context)?;
+                    // self.update_render_send_time(time_to_send_render);
                     // next read does not need a deadline as we just rendered everything
                     self.render_deadline = None;
                     self.last_render = Instant::now();
                 },
                 ReadResult::Ok(n_bytes) => {
+                    // TODO:
+                    // - experiment with not sending renders through here at all, but rather in
+                    // screen, whenever we receive data, we create an atomic async task that will
+                    // send us a render after <render delay> (start with 10ms and then tune it)
+                    // - this will hopefully allow enough data to accumulate and prevent flickering
+                    // in none 2026 apps
                     let bytes = &buf[..n_bytes];
                     if self.debug {
                         let _ = debug_to_file(bytes, self.pid);
@@ -112,11 +119,12 @@ impl TerminalBytes {
                     .with_context(err_context)?;
                     if !self.backed_up {
                         // we're not backed up, let's send an immediate render instruction
-                        let time_to_send_render = self
-                            .async_send_to_screen(ScreenInstruction::Render)
-                            .await
-                            .with_context(err_context)?;
-                        self.update_render_send_time(time_to_send_render);
+//                         log::info!("ScreenInstruction::Render 1");
+//                         let time_to_send_render = self
+//                             .async_send_to_screen(ScreenInstruction::Render)
+//                             .await
+//                             .with_context(err_context)?;
+//                         self.update_render_send_time(time_to_send_render);
                         self.last_render = Instant::now();
                     }
                     // if we already have a render_deadline we keep it, otherwise we set it

--- a/zellij-server/src/terminal_bytes.rs
+++ b/zellij-server/src/terminal_bytes.rs
@@ -101,12 +101,6 @@ impl TerminalBytes {
                     self.last_render = Instant::now();
                 },
                 ReadResult::Ok(n_bytes) => {
-                    // TODO:
-                    // - experiment with not sending renders through here at all, but rather in
-                    // screen, whenever we receive data, we create an atomic async task that will
-                    // send us a render after <render delay> (start with 10ms and then tune it)
-                    // - this will hopefully allow enough data to accumulate and prevent flickering
-                    // in none 2026 apps
                     let bytes = &buf[..n_bytes];
                     if self.debug {
                         let _ = debug_to_file(bytes, self.pid);

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -511,6 +511,7 @@ pub enum BackgroundJobContext {
     RunCommand,
     WebRequest,
     ReportPluginList,
+    RenderToClients,
     Exit,
 }
 


### PR DESCRIPTION
This improves the overall rendering performance of the tool (greatly mitigating various "flickering" issues caused in applications that do not perform synchronized renders) by consolidating renders to the `Screen` thread and introducing an async repaint_delay of 10ms.