### PR TITLE
feat(zellij-server): restore tab position when re-attaching

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -672,6 +672,7 @@ pub(crate) struct Screen {
     connected_clients: Rc<RefCell<HashSet<ClientId>>>,
     /// The indices of this [`Screen`]'s active [`Tab`]s.
     active_tab_indices: BTreeMap<ClientId, usize>,
+    global_last_active_tab_index: usize,
     tab_history: BTreeMap<ClientId, Vec<usize>>,
     mode_info: BTreeMap<ClientId, ModeInfo>,
     default_mode_info: ModeInfo, // TODO: restructure ModeInfo to prevent this duplication
@@ -740,6 +741,7 @@ impl Screen {
             style: client_attributes.style,
             connected_clients: Rc::new(RefCell::new(HashSet::new())),
             active_tab_indices: BTreeMap::new(),
+            global_last_active_tab_index: 0,
             tabs: BTreeMap::new(),
             overlay: OverlayWindow::default(),
             terminal_emulator_colors: Rc::new(RefCell::new(Palette::default())),
@@ -1489,6 +1491,8 @@ impl Screen {
             self.active_tab_indices.iter().next()
         {
             *first_active_tab_index
+        } else if self.tabs.contains_key(&self.global_last_active_tab_index) {
+            self.global_last_active_tab_index
         } else if self.tabs.contains_key(&0) {
             0
         } else if let Some(tab_index) = self.tabs.keys().next() {
@@ -1517,6 +1521,7 @@ impl Screen {
             }
         }
         if self.active_tab_indices.contains_key(&client_id) {
+            self.global_last_active_tab_index = *self.active_tab_indices.get(&client_id).unwrap();
             self.active_tab_indices.remove(&client_id);
         }
         if self.tab_history.contains_key(&client_id) {


### PR DESCRIPTION
Fix #3416 #3337 .

This PR focuses on improving user experience: when users detach all clients, the next time users attach to the session, they expect to see the last tab they were at from the last connection, instead of always being the first tab. The changes in this PR allow a session to remember the last tab position on exit globally, and restore to it. When there is more than zero active client, no behavior will be changed.