### PR TITLE
fix(utils): Re-export prost

### DIFF
--- a/zellij-utils/src/lib.rs
+++ b/zellij-utils/src/lib.rs
@@ -24,3 +24,6 @@ pub mod downloader; // Requires async_std
 pub mod ipc; // Requires interprocess
 #[cfg(not(target_family = "wasm"))]
 pub mod logging; // Requires log4rs
+
+// TODO(hartan): Remove this re-export for the next minor release.
+pub use ::prost;


### PR DESCRIPTION
until shortly before the next minor release, just to make sure that subsequent patch releases don't unexpectedly break downstream consumers code.

Originally introduced via 6be8c495 (#4087).