### PR TITLE
build: Fix build on FreeBSD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3463,6 +3463,7 @@ dependencies = [
  "libc",
  "ntapi",
  "once_cell",
+ "rayon",
  "winapi",
 ]
 

--- a/zellij-server/Cargo.toml
+++ b/zellij-server/Cargo.toml
@@ -38,7 +38,7 @@ serde_json = { workspace = true }
 signal-hook = { workspace = true }
 sixel-image = { version = "0.1.0", default-features = false }
 sixel-tokenizer = { version = "0.1.0", default-features = false }
-sysinfo = { version = "0.22.5", default-features = false }
+sysinfo = "0.22.5"
 tempfile = { workspace = true }
 typetag = { version = "0.1.7", default-features = false }
 unicode-width = { workspace = true }


### PR DESCRIPTION
Changing the sysinfo crate to `default-features = false` in commit a2ae822 breaks the build on FreeBSD. This change resolves the issue and results in successful builds on FreeBSD again.

Fixes: #4146