### PR TITLE
reencode termwiz keycodes as current_buffer isnt reliable

### DIFF
--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -152,7 +152,7 @@ impl ClientInfo {
 
 #[derive(Debug, Clone)]
 pub(crate) enum InputInstruction {
-    KeyEvent(InputEvent, Vec<u8>),
+    KeyEvent(InputEvent),
     KeyWithModifierEvent(KeyWithModifier, Vec<u8>),
     AnsiStdinInstructions(Vec<AnsiStdinInstruction>),
     StartedParsing,

--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -125,10 +125,7 @@ pub(crate) fn stdin_loop(
                                 break;
                             }
                             send_input_instructions
-                                .send(InputInstruction::KeyEvent(
-                                    input_event.clone(),
-                                    current_buffer.clone(),
-                                ))
+                                .send(InputInstruction::KeyEvent(input_event.clone()))
                                 .unwrap();
                         }
                     }
@@ -136,11 +133,10 @@ pub(crate) fn stdin_loop(
                     holding_mouse = is_mouse_press_or_hold(&input_event);
 
                     send_input_instructions
-                        .send(InputInstruction::KeyEvent(
-                            input_event,
-                            current_buffer.drain(..).collect(),
-                        ))
+                        .send(InputInstruction::KeyEvent(input_event))
                         .unwrap();
+
+                    current_buffer.drain(..);
                 }
             },
             Err(e) => {


### PR DESCRIPTION
It's not reliable because current_buffer can sometimes contain multiple instructions at once, which are mistakenly treated as a single one. For example, if it holds [KeyCode, MouseMove], the parser might interpret it as one large KeyCode and print it directly to the terminal, leading to issues like this: https://github.com/zellij-org/zellij/issues/932