### PR TITLE
Allow Changing Search Word in Search Mode

### DIFF
--- a/zellij-utils/assets/config/default.kdl
+++ b/zellij-utils/assets/config/default.kdl
@@ -84,6 +84,7 @@ keybinds {
         // bind "Alt c" { Copy; }
     }
     search {
+        bind "s" { SwitchToMode "EnterSearch"; SearchInput 0; }
         bind "Ctrl s" { SwitchToMode "Normal"; }
         bind "Ctrl c" { ScrollToBottom; SwitchToMode "Normal"; }
         bind "j" "Down" { ScrollDown; }


### PR DESCRIPTION
Piror to this PR, it's not easy to modify my search word in search mode.

I have to:
1. ESC - quit to normal mode
2. ctrl + s - enter search mode
3. s - enter the new search word

After this PR, I can change my search word directly in search mode by pressing `s`.