### PR TITLE
fix(themes): frame highlight and some contrast issues

### DIFF
--- a/zellij-utils/assets/themes/ansi.kdl
+++ b/zellij-utils/assets/themes/ansi.kdl
@@ -88,7 +88,7 @@ themes {
         frame_highlight {
             base 9
             background 0
-            emphasis_0 9
+            emphasis_0 5
             emphasis_1 9
             emphasis_2 9
             emphasis_3 9

--- a/zellij-utils/assets/themes/ao.kdl
+++ b/zellij-utils/assets/themes/ao.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 229 151 40
             background 0
-            emphasis_0 229 151 40
+            emphasis_0 210 168 255
             emphasis_1 229 151 40
             emphasis_2 229 151 40
             emphasis_3 229 151 40

--- a/zellij-utils/assets/themes/atelier.kdl
+++ b/zellij-utils/assets/themes/atelier.kdl
@@ -85,7 +85,7 @@ themes {
         frame_highlight {
             base 199 107 41
             background 0
-            emphasis_0 199 107 41
+            emphasis_0 156 99 122
             emphasis_1 199 107 41
             emphasis_2 199 107 41
             emphasis_3 199 107 41

--- a/zellij-utils/assets/themes/ayu-dark.kdl
+++ b/zellij-utils/assets/themes/ayu-dark.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 255 143 64
             background 0
-            emphasis_0 255 143 64
+            emphasis_0 210 166 255
             emphasis_1 255 143 64
             emphasis_2 255 143 64
             emphasis_3 255 143 64

--- a/zellij-utils/assets/themes/ayu-light.kdl
+++ b/zellij-utils/assets/themes/ayu-light.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 250 141 62
             background 0
-            emphasis_0 250 141 62
+            emphasis_0 163 122 204
             emphasis_1 250 141 62
             emphasis_2 250 141 62
             emphasis_3 250 141 62

--- a/zellij-utils/assets/themes/ayu-mirage.kdl
+++ b/zellij-utils/assets/themes/ayu-mirage.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 255 173 102
             background 0
-            emphasis_0 255 173 102
+            emphasis_0 223 191 255
             emphasis_1 255 173 102
             emphasis_2 255 173 102
             emphasis_3 255 173 102

--- a/zellij-utils/assets/themes/blade-runner.kdl
+++ b/zellij-utils/assets/themes/blade-runner.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 255 140 13
             background 0
-            emphasis_0 255 140 13
+            emphasis_0 255 0 255
             emphasis_1 255 140 13
             emphasis_2 255 140 13
             emphasis_3 255 140 13

--- a/zellij-utils/assets/themes/catppuccin-frappe.kdl
+++ b/zellij-utils/assets/themes/catppuccin-frappe.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 239 159 118
             background 0
-            emphasis_0 239 159 118
+            emphasis_0 244 184 228
             emphasis_1 239 159 118
             emphasis_2 239 159 118
             emphasis_3 239 159 118

--- a/zellij-utils/assets/themes/catppuccin-macchiato.kdl
+++ b/zellij-utils/assets/themes/catppuccin-macchiato.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 245 169 127
             background 0
-            emphasis_0 245 169 127
+            emphasis_0 245 189 230
             emphasis_1 245 169 127
             emphasis_2 245 169 127
             emphasis_3 245 169 127

--- a/zellij-utils/assets/themes/catppuccin-mocha.kdl
+++ b/zellij-utils/assets/themes/catppuccin-mocha.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 250 179 135
             background 0
-            emphasis_0 250 179 135
+            emphasis_0 245 194 231
             emphasis_1 250 179 135
             emphasis_2 250 179 135
             emphasis_3 250 179 135

--- a/zellij-utils/assets/themes/cyber-noir.kdl
+++ b/zellij-utils/assets/themes/cyber-noir.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 255 127 80
             background 0
-            emphasis_0 255 127 80
+            emphasis_0 255 0 255
             emphasis_1 255 127 80
             emphasis_2 255 127 80
             emphasis_3 255 127 80

--- a/zellij-utils/assets/themes/dayfox.kdl
+++ b/zellij-utils/assets/themes/dayfox.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 149 95 97
             background 0
-            emphasis_0 149 95 97
+            emphasis_0 110 51 206
             emphasis_1 149 95 97
             emphasis_2 149 95 97
             emphasis_3 149 95 97

--- a/zellij-utils/assets/themes/dracula.kdl
+++ b/zellij-utils/assets/themes/dracula.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 255 184 108
             background 0
-            emphasis_0 255 184 108
+            emphasis_0 255 121 198
             emphasis_1 255 184 108
             emphasis_2 255 184 108
             emphasis_3 255 184 108

--- a/zellij-utils/assets/themes/everforest-dark.kdl
+++ b/zellij-utils/assets/themes/everforest-dark.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 255 158 100
             background 0
-            emphasis_0 255 158 100
+            emphasis_0 214 153 182
             emphasis_1 255 158 100
             emphasis_2 255 158 100
             emphasis_3 255 158 100

--- a/zellij-utils/assets/themes/everforest-light.kdl
+++ b/zellij-utils/assets/themes/everforest-light.kdl
@@ -1,8 +1,8 @@
 themes {
   everforest-light {
         text_unselected {
-            base 223 221 200
-            background 92 106 114
+            base 92 106 114
+            background 242 239 223
             emphasis_0 255 158 100
             emphasis_1 53 167 124
             emphasis_2 141 161 1
@@ -17,17 +17,17 @@ themes {
             emphasis_3 223 105 186
         }
         ribbon_selected {
-            base 92 106 114
+            base 242 239 223
             background 141 161 1
-            emphasis_0 248 85 82
+            emphasis_0 79 88 94
             emphasis_1 255 158 100
             emphasis_2 223 105 186
             emphasis_3 58 148 197
         }
         ribbon_unselected {
-            base 92 106 114
-            background 92 106 114
-            emphasis_0 248 85 82
+            base 242 239 223
+            background 130 145 129
+            emphasis_0 79 88 94
             emphasis_1 223 221 200
             emphasis_2 58 148 197
             emphasis_3 223 105 186
@@ -41,15 +41,15 @@ themes {
             emphasis_3 223 105 186
         }
         table_cell_selected {
-            base 223 221 200
-            background 255 249 232
+            base 92 106 114
+            background 229 223 197
             emphasis_0 255 158 100
             emphasis_1 53 167 124
             emphasis_2 141 161 1
             emphasis_3 223 105 186
         }
         table_cell_unselected {
-            base 223 221 200
+            base 92 106 114
             background 92 106 114
             emphasis_0 255 158 100
             emphasis_1 53 167 124
@@ -57,7 +57,7 @@ themes {
             emphasis_3 223 105 186
         }
         list_selected {
-            base 223 221 200
+            base 92 106 114
             background 255 249 232
             emphasis_0 255 158 100
             emphasis_1 53 167 124
@@ -65,7 +65,7 @@ themes {
             emphasis_3 223 105 186
         }
         list_unselected {
-            base 223 221 200
+            base 92 106 114
             background 92 106 114
             emphasis_0 255 158 100
             emphasis_1 53 167 124

--- a/zellij-utils/assets/themes/everforest-light.kdl
+++ b/zellij-utils/assets/themes/everforest-light.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 255 158 100
             background 0
-            emphasis_0 255 158 100
+            emphasis_0 223 105 186
             emphasis_1 255 158 100
             emphasis_2 255 158 100
             emphasis_3 255 158 100

--- a/zellij-utils/assets/themes/gruvbox-dark.kdl
+++ b/zellij-utils/assets/themes/gruvbox-dark.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 214 93 14
             background 0
-            emphasis_0 214 93 14
+            emphasis_0 177 98 134
             emphasis_1 214 93 14
             emphasis_2 214 93 14
             emphasis_3 214 93 14

--- a/zellij-utils/assets/themes/gruvbox-light.kdl
+++ b/zellij-utils/assets/themes/gruvbox-light.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 152 0 5
             background 0
-            emphasis_0 152 0 5
+            emphasis_0 177 98 134
             emphasis_1 152 0 5
             emphasis_2 152 0 5
             emphasis_3 152 0 5

--- a/zellij-utils/assets/themes/iceberg-dark.kdl
+++ b/zellij-utils/assets/themes/iceberg-dark.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 226 165 120
             background 0
-            emphasis_0 226 165 120
+            emphasis_0 160 147 199
             emphasis_1 226 165 120
             emphasis_2 226 165 120
             emphasis_3 226 165 120

--- a/zellij-utils/assets/themes/iceberg-light.kdl
+++ b/zellij-utils/assets/themes/iceberg-light.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 198 116 57
             background 0
-            emphasis_0 198 116 57
+            emphasis_0 119 89 180
             emphasis_1 198 116 57
             emphasis_2 198 116 57
             emphasis_3 198 116 57

--- a/zellij-utils/assets/themes/kanagawa.kdl
+++ b/zellij-utils/assets/themes/kanagawa.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 255 160 102
             background 0
-            emphasis_0 255 160 102
+            emphasis_0 149 127 184
             emphasis_1 255 160 102
             emphasis_2 255 160 102
             emphasis_3 255 160 102

--- a/zellij-utils/assets/themes/lucario.kdl
+++ b/zellij-utils/assets/themes/lucario.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 233 75 53
             background 0
-            emphasis_0 233 75 53
+            emphasis_0 202 148 255
             emphasis_1 233 75 53
             emphasis_2 233 75 53
             emphasis_3 233 75 53

--- a/zellij-utils/assets/themes/menace.kdl
+++ b/zellij-utils/assets/themes/menace.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 255 184 108
             background 0
-            emphasis_0 255 184 108
+            emphasis_0 255 121 198
             emphasis_1 255 184 108
             emphasis_2 255 184 108
             emphasis_3 255 184 108

--- a/zellij-utils/assets/themes/molokai-dark.kdl
+++ b/zellij-utils/assets/themes/molokai-dark.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 253 151 31
             background 0
-            emphasis_0 253 151 31
+            emphasis_0 174 129 255
             emphasis_1 253 151 31
             emphasis_2 253 151 31
             emphasis_3 253 151 31

--- a/zellij-utils/assets/themes/night-owl.kdl
+++ b/zellij-utils/assets/themes/night-owl.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 250 179 135
             background 0
-            emphasis_0 250 179 135
+            emphasis_0 190 148 228
             emphasis_1 250 179 135
             emphasis_2 250 179 135
             emphasis_3 250 179 135

--- a/zellij-utils/assets/themes/nightfox.kdl
+++ b/zellij-utils/assets/themes/nightfox.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 244 162 97
             background 0
-            emphasis_0 244 162 97
+            emphasis_0 157 121 214
             emphasis_1 244 162 97
             emphasis_2 244 162 97
             emphasis_3 244 162 97

--- a/zellij-utils/assets/themes/nord.kdl
+++ b/zellij-utils/assets/themes/nord.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 208 135 112
             background 0
-            emphasis_0 208 135 112
+            emphasis_0 180 142 173
             emphasis_1 208 135 112
             emphasis_2 208 135 112
             emphasis_3 208 135 112

--- a/zellij-utils/assets/themes/one-half-dark.kdl
+++ b/zellij-utils/assets/themes/one-half-dark.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 216 133 76
             background 0
-            emphasis_0 216 133 76
+            emphasis_0 198 120 221
             emphasis_1 216 133 76
             emphasis_2 216 133 76
             emphasis_3 216 133 76

--- a/zellij-utils/assets/themes/onedark.kdl
+++ b/zellij-utils/assets/themes/onedark.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 209 154 102
             background 0
-            emphasis_0 209 154 102
+            emphasis_0 198 120 221
             emphasis_1 209 154 102
             emphasis_2 209 154 102
             emphasis_3 209 154 102

--- a/zellij-utils/assets/themes/pencil-light.kdl
+++ b/zellij-utils/assets/themes/pencil-light.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 215 95 95
             background 0
-            emphasis_0 215 95 95
+            emphasis_0 182 214 253
             emphasis_1 215 95 95
             emphasis_2 215 95 95
             emphasis_3 215 95 95

--- a/zellij-utils/assets/themes/pencil-light.kdl
+++ b/zellij-utils/assets/themes/pencil-light.kdl
@@ -6,7 +6,7 @@ themes {
             emphasis_0 215 95 95
             emphasis_1 32 165 186
             emphasis_2 16 167 120
-            emphasis_3 182 214 253
+            emphasis_3 0 142 196
         }
         text_selected {
             base 66 66 66
@@ -14,7 +14,7 @@ themes {
             emphasis_0 215 95 95
             emphasis_1 32 165 186
             emphasis_2 16 167 120
-            emphasis_3 182 214 253
+            emphasis_3 0 142 196
         }
         ribbon_selected {
             base 241 241 241
@@ -34,7 +34,7 @@ themes {
         }
         table_title {
             base 16 167 120
-            background 0
+            background 241 241 241
             emphasis_0 215 95 95
             emphasis_1 32 165 186
             emphasis_2 16 167 120
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 215 95 95
             background 0
-            emphasis_0 182 214 253
+            emphasis_0 0 142 196
             emphasis_1 215 95 95
             emphasis_2 215 95 95
             emphasis_3 215 95 95

--- a/zellij-utils/assets/themes/retro-wave.kdl
+++ b/zellij-utils/assets/themes/retro-wave.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 255 102 17
             background 0
-            emphasis_0 255 102 17
+            emphasis_0 255 0 255
             emphasis_1 255 102 17
             emphasis_2 255 102 17
             emphasis_3 255 102 17

--- a/zellij-utils/assets/themes/solarized-dark.kdl
+++ b/zellij-utils/assets/themes/solarized-dark.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 203 75 22
             background 0
-            emphasis_0 203 75 22
+            emphasis_0 211 54 130
             emphasis_1 203 75 22
             emphasis_2 203 75 22
             emphasis_3 203 75 22

--- a/zellij-utils/assets/themes/solarized-light.kdl
+++ b/zellij-utils/assets/themes/solarized-light.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 203 75 22
             background 0
-            emphasis_0 203 75 22
+            emphasis_0 211 54 130
             emphasis_1 203 75 22
             emphasis_2 203 75 22
             emphasis_3 203 75 22

--- a/zellij-utils/assets/themes/terafox.kdl
+++ b/zellij-utils/assets/themes/terafox.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 255 131 73
             background 0
-            emphasis_0 255 131 73
+            emphasis_0 173 92 124
             emphasis_1 255 131 73
             emphasis_2 255 131 73
             emphasis_3 255 131 73

--- a/zellij-utils/assets/themes/tokyo-night-dark.kdl
+++ b/zellij-utils/assets/themes/tokyo-night-dark.kdl
@@ -87,7 +87,7 @@ themes {
         frame_highlight {
             base 255 158 100
             background 0
-            emphasis_0 255 158 100
+            emphasis_0 187 154 247
             emphasis_1 255 158 100
             emphasis_2 255 158 100
             emphasis_3 255 158 100

--- a/zellij-utils/assets/themes/tokyo-night-light.kdl
+++ b/zellij-utils/assets/themes/tokyo-night-light.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 150 80 39
             background 0
-            emphasis_0 150 80 39
+            emphasis_0 90 74 120
             emphasis_1 150 80 39
             emphasis_2 150 80 39
             emphasis_3 150 80 39

--- a/zellij-utils/assets/themes/tokyo-night-storm.kdl
+++ b/zellij-utils/assets/themes/tokyo-night-storm.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 255 158 100
             background 0
-            emphasis_0 255 158 100
+            emphasis_0 187 154 247
             emphasis_1 255 158 100
             emphasis_2 255 158 100
             emphasis_3 255 158 100

--- a/zellij-utils/assets/themes/tokyo-night.kdl
+++ b/zellij-utils/assets/themes/tokyo-night.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 255 158 100
             background 0
-            emphasis_0 255 158 100
+            emphasis_0 187 154 247
             emphasis_1 255 158 100
             emphasis_2 255 158 100
             emphasis_3 255 158 100

--- a/zellij-utils/assets/themes/vesper.kdl
+++ b/zellij-utils/assets/themes/vesper.kdl
@@ -83,7 +83,7 @@ themes {
         frame_highlight {
             base 255 199 153
             background 0
-            emphasis_0 255 199 153
+            emphasis_0 226 158 202
             emphasis_1 255 199 153
             emphasis_2 255 199 153
             emphasis_3 255 199 153


### PR DESCRIPTION
This adds `emphasis_0` to `highlighted_frame` in all themes to make sure the grouped pane has a distinct color. For clarification: the field existed before but was not used, so themes did not implement it.

This also fixes some color contrast issues in the everforst-light and pencil-light themes.