### PR TITLE
feat: set text mouse shape for text-mode panes using OSC 22 mouse shape protocol (#4173)

### DIFF
--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -281,6 +281,12 @@ impl InputHandler {
                     .send(ClientInstruction::SetSynchronizedOutput(enabled))
                     .unwrap();
             },
+            AnsiStdinInstruction::MousePointerShapesSupport(support_values) => {
+                let is_supported = !support_values.is_empty() && support_values.iter().all(|&v| v);
+                self.send_client_instructions
+                    .send(ClientInstruction::SetMousePointerShapesSupported(is_supported))
+                    .unwrap();
+            },
         }
     }
     fn handle_mouse_event(&mut self, mouse_event: &MouseEvent) {

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -28,7 +28,7 @@ pub const MAX_TITLE_STACK_SIZE: usize = 1000;
 
 use vte::{Params, Perform};
 use zellij_utils::{consts::VERSION, shared::version_number};
-
+use zellij_utils::mouse_pointer_shapes::MousePointerShape;
 use crate::output::{CharacterChunk, OutputBuffer, SixelImageChunk};
 use crate::panes::alacritty_functions::{parse_number, xparse_color};
 use crate::panes::link_handler::LinkHandler;
@@ -2384,6 +2384,12 @@ impl Grid {
                 );
                 Some(mouse_event)
             },
+        }
+    }
+    pub fn get_mouse_pointer_shape(&self) -> MousePointerShape {
+        match &self.mouse_tracking {
+            MouseTracking::Off => MousePointerShape::Text,
+            _ => MousePointerShape::Default
         }
     }
     pub fn is_alternate_mode_active(&self) -> bool {

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -29,7 +29,7 @@ use zellij_utils::{
     position::Position,
     shared::make_terminal_title,
 };
-
+use zellij_utils::mouse_pointer_shapes::MousePointerShape;
 use crate::ui::pane_boundaries_frame::{FrameParams, PaneFrame};
 
 pub const SELECTION_SCROLL_INTERVAL_MS: u64 = 10;
@@ -640,6 +640,10 @@ impl Pane for TerminalPane {
 
     fn exclude_from_sync(&self) -> bool {
         self.exclude_from_sync
+    }
+
+    fn get_mouse_pointer_shape(&self, _relative_position: Position) -> MousePointerShape {
+        self.grid.get_mouse_pointer_shape()
     }
 
     fn mouse_event(&self, event: &MouseEvent, _client_id: ClientId) -> Option<String> {

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -63,6 +63,8 @@ use zellij_utils::{
     },
     pane_size::{Offset, PaneGeom, Size, SizeInPixels, Viewport},
 };
+use zellij_utils::ipc::ServerToClientMsg;
+use zellij_utils::mouse_pointer_shapes::MousePointerShape;
 
 #[macro_export]
 macro_rules! resize_pty {
@@ -265,6 +267,7 @@ pub(crate) struct Tab {
     current_pane_group: Rc<RefCell<HashMap<ClientId, Vec<PaneId>>>>,
     advanced_mouse_actions: bool,
     currently_marking_pane_group: Rc<RefCell<HashMap<ClientId, bool>>>,
+    mouse_cursor_shape: HashMap<ClientId, MousePointerShape>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -500,6 +503,10 @@ pub trait Pane {
     fn borderless(&self) -> bool;
     fn set_exclude_from_sync(&mut self, exclude_from_sync: bool);
     fn exclude_from_sync(&self) -> bool;
+
+    fn get_mouse_pointer_shape(&self, relative_position: Position) -> MousePointerShape {
+        MousePointerShape::Text
+    }
 
     // TODO: this should probably be merged with the mouse_right_click
     fn handle_right_click(&mut self, _to: &Position, _client_id: ClientId) {}
@@ -776,6 +783,7 @@ impl Tab {
             current_pane_group,
             currently_marking_pane_group,
             advanced_mouse_actions,
+            mouse_cursor_shape: HashMap::new(),
         }
     }
 
@@ -3901,6 +3909,28 @@ impl Tab {
         let active_pane_id = self
             .get_active_pane_id(client_id)
             .ok_or_else(|| anyhow!("Failed to find pane at position"))?;
+
+        let new_pointer_shape = if let Some(pane) = self
+            .get_pane_at(&absolute_position, true)
+            .with_context(err_context)?
+        {
+            if pane.position_is_on_frame(&absolute_position) {
+                Some(MousePointerShape::Default)
+            } else {
+                let relative_position = pane.relative_position(&absolute_position);
+                Some(pane.get_mouse_pointer_shape(relative_position))
+            }
+        } else {
+            None
+        };
+
+        if let Some(new_shape) = new_pointer_shape {
+            let last_shape = self.mouse_cursor_shape.get(&client_id).copied().unwrap_or(MousePointerShape::Default);
+            if last_shape != new_shape {
+                self.mouse_cursor_shape.insert(client_id, new_shape);
+                let _ = self.os_api.send_to_client(client_id, ServerToClientMsg::SetMousePointerShape(new_shape));
+            }
+        }
 
         if let Some(pane) = self
             .get_pane_at(&absolute_position, false)

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -468,6 +468,8 @@ pub enum ClientContext {
     CliPipeOutput,
     QueryTerminalSize,
     WriteConfigToDisk,
+    SetMousePointerShapesSupported,
+    SetMousePointerShape,
 }
 
 /// Stack call representations corresponding to the different types of [`ServerInstruction`]s.

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -18,6 +18,7 @@ use std::{
     os::unix::io::{AsRawFd, FromRawFd},
     path::PathBuf,
 };
+use crate::mouse_pointer_shapes::MousePointerShape;
 
 type SessionId = u64;
 
@@ -110,6 +111,7 @@ pub enum ServerToClientMsg {
     CliPipeOutput(String, String), // String -> pipe name, String -> Output
     QueryTerminalSize,
     WriteConfigToDisk { config: String },
+    SetMousePointerShape(MousePointerShape),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/zellij-utils/src/lib.rs
+++ b/zellij-utils/src/lib.rs
@@ -12,6 +12,7 @@ pub mod position;
 pub mod session_serialization;
 pub mod setup;
 pub mod shared;
+pub mod mouse_pointer_shapes;
 
 // The following modules can't be used when targeting wasm
 #[cfg(not(target_family = "wasm"))]

--- a/zellij-utils/src/mouse_pointer_shapes.rs
+++ b/zellij-utils/src/mouse_pointer_shapes.rs
@@ -1,0 +1,43 @@
+use serde::{Deserialize, Serialize};
+
+/// Mouse pointer shapes as defined in the OSC 22 protocol.
+/// See https://sw.kovidgoyal.net/kitty/pointer-shapes/
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MousePointerShape {
+    /// Default cursor (arrow)
+    Default,
+    /// Text cursor (I-beam)
+    Text,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MousePointerShapeProtocolMode {
+    XTerm,
+    Kitty,
+}
+
+impl MousePointerShape {
+    /// See https://sw.kovidgoyal.net/kitty/pointer-shapes/
+    fn kitty_name(&self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::Text => "text",
+        }
+    }
+
+    /// See https://github.com/xterm-x11/xterm-snapshots/blob/5b7a08a3482b425c97/xterm.man#L4674
+    fn xterm_name(&self) -> &'static str {
+        match self {
+            Self::Default => "left_ptr",
+            Self::Text => "xterm",
+        }
+    }
+
+    pub fn generate_set_mouse_pointer_escape_sequence(&self, mode: MousePointerShapeProtocolMode) -> String {
+        let name = match mode {
+            MousePointerShapeProtocolMode::XTerm => self.xterm_name(),
+            MousePointerShapeProtocolMode::Kitty => self.kitty_name(),
+        };
+        format!("\x1b]22;{}\x1b\\", name)
+    }
+}


### PR DESCRIPTION
Fixes #4173

A picture is worth a thousand words:

https://github.com/user-attachments/assets/584c0e66-d5c0-4603-8fe6-d0fccb9e4429

## Support in terminals

It works at least in Kitty and xterm. I've also checked iTerm2, but it does not work there despite [there is](https://github.com/gnachman/iTerm2/commit/e6a5f3cbc7022e6124e9dbf169720096e85a1043) OSC 22 supporting code. I can even see "invalidateCursorRectsForView" in debug logs, which means that the OSC 22 sequence was successfully parsed, but the mouse pointer shape does not change. Probably a bug in iTerm2. In Alacritty there is a [draft PR](https://github.com/alacritty/alacritty/pull/7244) adding OSC 22 support, and I'm going to continue it. 