### PR TITLE
Use tab pos instead of tab idx for `ScreenInstruction::RenameTab`

### DIFF
--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -1805,9 +1805,9 @@ fn rename_plugin_pane(env: &PluginEnv, plugin_pane_id: u32, new_name: &str) {
     apply_action!(rename_pane_action, error_msg, env);
 }
 
-fn rename_tab(env: &PluginEnv, tab_index: u32, new_name: &str) {
+fn rename_tab(env: &PluginEnv, tab_position: u32, new_name: &str) {
     let error_msg = || format!("Failed to rename tab");
-    let rename_tab_action = Action::RenameTab(tab_index, new_name.as_bytes().to_vec());
+    let rename_tab_action = Action::RenameTab(tab_position, new_name.as_bytes().to_vec());
     apply_action!(rename_tab_action, error_msg, env);
 }
 

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -4727,13 +4727,17 @@ pub(crate) fn screen_thread_main(
                 }
                 screen.log_and_report_session_state()?;
             },
-            ScreenInstruction::RenameTab(tab_index, new_name) => {
-                match screen.tabs.get_mut(&tab_index.saturating_sub(1)) {
+            ScreenInstruction::RenameTab(tab_position, new_name) => {
+                match screen
+                    .tabs
+                    .values_mut()
+                    .find(|t| t.position == tab_position)
+                {
                     Some(tab) => {
                         tab.name = String::from_utf8_lossy(&new_name).to_string();
                     },
                     None => {
-                        log::error!("Failed to find tab with index: {:?}", tab_index);
+                        log::error!("Failed to find tab with position: {:?}", tab_position);
                     },
                 }
                 screen.log_and_report_session_state()?;

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -664,9 +664,9 @@ impl TryFrom<ProtobufAction> for Action {
             },
             Some(ProtobufActionName::RenameTab) => match protobuf_action.optional_payload {
                 Some(OptionalPayload::RenameTabPayload(payload)) => {
-                    let tab_index = payload.id;
+                    let tab_position = payload.id;
                     let new_tab_name = payload.name;
-                    Ok(Action::RenameTab(tab_index, new_tab_name))
+                    Ok(Action::RenameTab(tab_position, new_tab_name))
                 },
                 _ => Err("Wrong payload for Action::RenameTab"),
             },
@@ -1215,11 +1215,11 @@ impl TryFrom<Action> for ProtobufAction {
                     id: plugin_pane_id,
                 })),
             }),
-            Action::RenameTab(tab_index, new_name) => Ok(ProtobufAction {
+            Action::RenameTab(tab_position, new_name) => Ok(ProtobufAction {
                 name: ProtobufActionName::RenameTab as i32,
                 optional_payload: Some(OptionalPayload::RenameTabPayload(IdAndName {
                     name: new_name,
-                    id: tab_index,
+                    id: tab_position,
                 })),
             }),
             Action::BreakPane => Ok(ProtobufAction {


### PR DESCRIPTION
Fixes #3535

Currently, `ScreenInstruction::RenameTab` is used for plugin API only and from the plugin's side, there is no way to find a tab's index rather than poisition and `zellij-tile`'s [`rename_tab` api](https://docs.rs/zellij-tile/0.42.2/zellij_tile/shim/fn.rename_tab.html) is quite unusable in current state.
I think that using tab position instead of index would be better for this.