### PR TITLE
fix(theme): fix tokyo-night-storm selection bg

### DIFF
--- a/zellij-utils/assets/themes/tokyo-night-storm.kdl
+++ b/zellij-utils/assets/themes/tokyo-night-storm.kdl
@@ -10,7 +10,7 @@ themes {
         }
         text_selected {
             base 192 202 245
-            background 36 40 59
+            background 54 74 130
             emphasis_0 255 158 100
             emphasis_1 42 195 222
             emphasis_2 158 206 106


### PR DESCRIPTION
Taken from https://github.com/mbadolato/iTerm2-Color-Schemes/blob/f3d53cc/alacritty/tokyonight-storm.toml.