### PR TITLE
fix(themes): improve solarized-dark contrast and color consistency

### DIFF
--- a/zellij-utils/assets/themes/solarized-dark.kdl
+++ b/zellij-utils/assets/themes/solarized-dark.kdl
@@ -1,7 +1,7 @@
 themes {
     solarized-dark {
         text_unselected {
-            base 238 232 213
+            base 147 161 161
             background 7 54 66
             emphasis_0 203 75 22
             emphasis_1 42 161 152
@@ -9,7 +9,7 @@ themes {
             emphasis_3 211 54 130
         }
         text_selected {
-            base 238 232 213
+            base 147 161 161
             background 7 54 66
             emphasis_0 203 75 22
             emphasis_1 42 161 152
@@ -26,7 +26,7 @@ themes {
         }
         ribbon_unselected {
             base 7 54 66
-            background 253 246 227
+            background 147 161 161
             emphasis_0 220 50 47
             emphasis_1 238 232 213
             emphasis_2 38 139 210
@@ -41,15 +41,15 @@ themes {
             emphasis_3 211 54 130
         }
         table_cell_selected {
-            base 238 232 213
-            background 0 43 54
+            base 147 161 161
+            background 7 54 66
             emphasis_0 203 75 22
             emphasis_1 42 161 152
             emphasis_2 133 153 0
             emphasis_3 211 54 130
         }
         table_cell_unselected {
-            base 238 232 213
+            base 147 161 161
             background 7 54 66
             emphasis_0 203 75 22
             emphasis_1 42 161 152
@@ -57,15 +57,15 @@ themes {
             emphasis_3 211 54 130
         }
         list_selected {
-            base 238 232 213
-            background 0 43 54
+            base 147 161 161
+            background 7 54 66
             emphasis_0 203 75 22
             emphasis_1 42 161 152
             emphasis_2 133 153 0
             emphasis_3 211 54 130
         }
         list_unselected {
-            base 238 232 213
+            base 147 161 161
             background 7 54 66
             emphasis_0 203 75 22
             emphasis_1 42 161 152


### PR DESCRIPTION
The solarized-dark theme has several issues:

- The selection for tables and lists is not visible
- It is using base values that should not be present in the dark version of the theme
- The normal relationship for background and body text is base03:base0 and base02:base1 for highlighted content
- Contrast is totally wrong for some elements

This is making the appearance of the solarized-dark theme very inconsistent and wrong.

To fix:

- Standardize text color to base1 (147 161 161) for better readability
- Fix ribbon_unselected background from base3 to base1 for dark theme consistency
- Improve selection backgrounds using base02 for better contrast

Before:

<img width="1709" alt="Screenshot 2025-05-24 at 09 53 52" src="https://github.com/user-attachments/assets/6c5cd2f3-c90a-407d-be7b-69a00c2d3a4c" />

After:

<img width="1709" alt="Screenshot 2025-05-24 at 09 54 25" src="https://github.com/user-attachments/assets/616bd846-aadf-42d3-b172-938346ee44d9" />
