### PR TITLE
fix(themes): add missing frame_unselected values to all themes

### DIFF
--- a/zellij-utils/assets/themes/ansi.kdl
+++ b/zellij-utils/assets/themes/ansi.kdl
@@ -77,6 +77,14 @@ themes {
             emphasis_2 2
             emphasis_3 5
         }
+        frame_unselected {
+            base 8 8 8
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 2
             background 0

--- a/zellij-utils/assets/themes/ao.kdl
+++ b/zellij-utils/assets/themes/ao.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 60 110 180
             emphasis_3 210 168 255
         }
+        frame_unselected {
+            base 44 84 132
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 60 110 180
             background 0

--- a/zellij-utils/assets/themes/atelier.kdl
+++ b/zellij-utils/assets/themes/atelier.kdl
@@ -74,6 +74,14 @@ themes {
             emphasis_2 172 151 57
             emphasis_3 156 99 122
         }
+        frame_unselected {
+            base 41 50 86
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 172 151 57
             background 0

--- a/zellij-utils/assets/themes/ayu-dark.kdl
+++ b/zellij-utils/assets/themes/ayu-dark.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 170 217 76
             emphasis_3 210 166 255
         }
+        frame_unselected {
+            base 89 120 25
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 170 217 76
             background 0

--- a/zellij-utils/assets/themes/ayu-light.kdl
+++ b/zellij-utils/assets/themes/ayu-light.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 134 179 0
             emphasis_3 163 122 204
         }
+        frame_unselected {
+            base 194 255 13
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 134 179 0
             background 0

--- a/zellij-utils/assets/themes/ayu-mirage.kdl
+++ b/zellij-utils/assets/themes/ayu-mirage.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 213 255 128
             emphasis_3 223 191 255
         }
+        frame_unselected {
+            base 128 191 0
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 213 255 128
             background 0

--- a/zellij-utils/assets/themes/blade-runner.kdl
+++ b/zellij-utils/assets/themes/blade-runner.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 0 255 0
             emphasis_3 255 0 255
         }
+        frame_unselected {
+            base 0 127 0
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 0 255 0
             background 0

--- a/zellij-utils/assets/themes/catppuccin-frappe.kdl
+++ b/zellij-utils/assets/themes/catppuccin-frappe.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 166 209 137
             emphasis_3 244 184 228
         }
+        frame_unselected {
+            base 48 52 70
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 166 209 137
             background 0

--- a/zellij-utils/assets/themes/catppuccin-latte.kdl
+++ b/zellij-utils/assets/themes/catppuccin-latte.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 64 160 43
             emphasis_3 234 118 203
         }
+        frame_unselected {
+            base 239 241 245
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 64 160 43
             background 0

--- a/zellij-utils/assets/themes/catppuccin-macchiato.kdl
+++ b/zellij-utils/assets/themes/catppuccin-macchiato.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 166 218 149
             emphasis_3 245 189 230
         }
+        frame_unselected {
+            base 36 39 58
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 166 218 149
             background 0

--- a/zellij-utils/assets/themes/catppuccin-mocha.kdl
+++ b/zellij-utils/assets/themes/catppuccin-mocha.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 166 227 161
             emphasis_3 245 194 231
         }
+        frame_unselected {
+            base 52 149 44
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 166 227 161
             background 0

--- a/zellij-utils/assets/themes/cyber-noir.kdl
+++ b/zellij-utils/assets/themes/cyber-noir.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 0 255 0
             emphasis_3 255 0 255
         }
+        frame_unselected {
+            base 0 127 0
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 0 255 0
             background 0

--- a/zellij-utils/assets/themes/dayfox.kdl
+++ b/zellij-utils/assets/themes/dayfox.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 57 104 71
             emphasis_3 110 51 206
         }
+        frame_unselected {
+            base 28 52 35
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 57 104 71
             background 0

--- a/zellij-utils/assets/themes/dracula.kdl
+++ b/zellij-utils/assets/themes/dracula.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 80 250 123
             emphasis_3 255 121 198
         }
+        frame_unselected {
+            base 40 42 54
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 80 250 123
             background 0

--- a/zellij-utils/assets/themes/everforest-dark.kdl
+++ b/zellij-utils/assets/themes/everforest-dark.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 167 192 128
             emphasis_3 214 153 182
         }
+        frame_unselected {
+            base 43 51 57
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 167 192 128
             background 0

--- a/zellij-utils/assets/themes/everforest-light.kdl
+++ b/zellij-utils/assets/themes/everforest-light.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 141 161 1
             emphasis_3 223 105 186
         }
+        frame_unselected {
+            base 211 241 1
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 141 161 1
             background 0

--- a/zellij-utils/assets/themes/gruvbox-dark.kdl
+++ b/zellij-utils/assets/themes/gruvbox-dark.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 152 151 26
             emphasis_3 177 98 134
         }
+        frame_unselected {
+            base 76 75 12
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 152 151 26
             background 0

--- a/zellij-utils/assets/themes/gruvbox-light.kdl
+++ b/zellij-utils/assets/themes/gruvbox-light.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 121 116 14
             emphasis_3 177 98 134
         }
+        frame_unselected {
+            base 251 241 199
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 121 116 14
             background 0

--- a/zellij-utils/assets/themes/iceberg-dark.kdl
+++ b/zellij-utils/assets/themes/iceberg-dark.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 132 160 198
             emphasis_3 160 147 199
         }
+        frame_unselected {
+            base 52 77 112
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 132 160 198
             background 0

--- a/zellij-utils/assets/themes/iceberg-light.kdl
+++ b/zellij-utils/assets/themes/iceberg-light.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 45 83 158
             emphasis_3 119 89 180
         }
+        frame_unselected {
+            base 95 133 209
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 45 83 158
             background 0

--- a/zellij-utils/assets/themes/kanagawa.kdl
+++ b/zellij-utils/assets/themes/kanagawa.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 118 148 106
             emphasis_3 149 127 184
         }
+        frame_unselected {
+            base 58 73 53
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 118 148 106
             background 0

--- a/zellij-utils/assets/themes/lucario.kdl
+++ b/zellij-utils/assets/themes/lucario.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 25 156 75
             emphasis_3 202 148 255
         }
+        frame_unselected {
+            base 44 62 80
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 25 156 75
             background 0

--- a/zellij-utils/assets/themes/menace.kdl
+++ b/zellij-utils/assets/themes/menace.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 80 250 123
             emphasis_3 255 121 198
         }
+        frame_unselected {
+            base 44 62 80
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 80 250 123
             background 0

--- a/zellij-utils/assets/themes/molokai-dark.kdl
+++ b/zellij-utils/assets/themes/molokai-dark.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 0 140 0
             emphasis_3 174 129 255
         }
+        frame_unselected {
+            base 0 70 0
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 0 140 0
             background 0

--- a/zellij-utils/assets/themes/night-owl.kdl
+++ b/zellij-utils/assets/themes/night-owl.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 103 214 121
             emphasis_3 190 148 228
         }
+        frame_unselected {
+            base 33 124 48
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 103 214 121
             background 0

--- a/zellij-utils/assets/themes/nightfox.kdl
+++ b/zellij-utils/assets/themes/nightfox.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 129 178 154
             emphasis_3 157 121 214
         }
+        frame_unselected {
+            base 58 95 77
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 129 178 154
             background 0

--- a/zellij-utils/assets/themes/nord.kdl
+++ b/zellij-utils/assets/themes/nord.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 163 190 140
             emphasis_3 180 142 173
         }
+        frame_unselected {
+            base 46 52 64
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 163 190 140
             background 0

--- a/zellij-utils/assets/themes/one-half-dark.kdl
+++ b/zellij-utils/assets/themes/one-half-dark.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 152 195 121
             emphasis_3 198 120 221
         }
+        frame_unselected {
+            base 40 44 52
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 152 195 121
             background 0

--- a/zellij-utils/assets/themes/onedark.kdl
+++ b/zellij-utils/assets/themes/onedark.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 152 195 121
             emphasis_3 198 120 221
         }
+        frame_unselected {
+            base 40 44 52
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 152 195 121
             background 0

--- a/zellij-utils/assets/themes/pencil-light.kdl
+++ b/zellij-utils/assets/themes/pencil-light.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 16 167 120
             emphasis_3 182 214 253
         }
+        frame_unselected {
+            base 40 234 173
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 16 167 120
             background 0

--- a/zellij-utils/assets/themes/retro-wave.kdl
+++ b/zellij-utils/assets/themes/retro-wave.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 0 255 0
             emphasis_3 255 0 255
         }
+        frame_unselected {
+            base 0 127 0
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 0 255 0
             background 0

--- a/zellij-utils/assets/themes/solarized-dark.kdl
+++ b/zellij-utils/assets/themes/solarized-dark.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 133 153 0
             emphasis_3 211 54 130
         }
+        frame_unselected {
+            base 0 43 54
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 133 153 0
             background 0

--- a/zellij-utils/assets/themes/solarized-light.kdl
+++ b/zellij-utils/assets/themes/solarized-light.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 133 153 0
             emphasis_3 211 54 130
         }
+        frame_unselected {
+            base 253 246 227
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 133 153 0
             background 0

--- a/zellij-utils/assets/themes/terafox.kdl
+++ b/zellij-utils/assets/themes/terafox.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 122 164 161
             emphasis_3 173 92 124
         }
+        frame_unselected {
+            base 58 84 82
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 122 164 161
             background 0

--- a/zellij-utils/assets/themes/tokyo-night-dark.kdl
+++ b/zellij-utils/assets/themes/tokyo-night-dark.kdl
@@ -76,6 +76,14 @@ themes {
             emphasis_2 158 206 106
             emphasis_3 187 154 247
         }
+        frame_unselected {
+            base 79 117 38
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 158 206 106
             background 0

--- a/zellij-utils/assets/themes/tokyo-night-light.kdl
+++ b/zellij-utils/assets/themes/tokyo-night-light.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 72 94 48
             emphasis_3 90 74 120
         }
+        frame_unselected {
+            base 208 214 230
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 72 94 48
             background 0

--- a/zellij-utils/assets/themes/tokyo-night-storm.kdl
+++ b/zellij-utils/assets/themes/tokyo-night-storm.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 158 206 106
             emphasis_3 187 154 247
         }
+        frame_unselected {
+            base 36 40 59
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 158 206 106
             background 0

--- a/zellij-utils/assets/themes/tokyo-night.kdl
+++ b/zellij-utils/assets/themes/tokyo-night.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 158 206 106
             emphasis_3 187 154 247
         }
+        frame_unselected {
+            base 79 117 38
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 158 206 106
             background 0

--- a/zellij-utils/assets/themes/vesper.kdl
+++ b/zellij-utils/assets/themes/vesper.kdl
@@ -72,6 +72,14 @@ themes {
             emphasis_2 144 185 159
             emphasis_3 226 158 202
         }
+        frame_unselected {
+            base 63 100 77
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
         frame_selected {
             base 144 185 159
             background 0


### PR DESCRIPTION
Zellij v0.43 now works correctly with "frame_unselected" theme colors. Updated the built in themes to set these colors - derived from legacy theme "bg" value, and if not available, created by darkening the "frame_selected" base color for dark themes, and lightening it for light themes.