### PR TITLE
fix(panes): scrollback page/halfpage up/down row count

### DIFF
--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -3287,8 +3287,7 @@ impl Tab {
 
     pub fn scroll_active_terminal_up_page(&mut self, client_id: ClientId) {
         if let Some(active_pane) = self.get_active_pane_or_floating_pane_mut(client_id) {
-            // prevent overflow when row == 0
-            let scroll_rows = active_pane.rows().max(1).saturating_sub(1);
+            let scroll_rows = active_pane.get_content_rows();
             active_pane.scroll_up(scroll_rows, client_id);
         }
     }
@@ -3298,8 +3297,7 @@ impl Tab {
             let fictitious_client_id = 1; // this is not checked for terminal panes and we
                                           // don't have an actual client id here
                                           // TODO: traits were a mistake
-                                          // prevent overflow when row == 0
-            let scroll_rows = terminal_pane.rows().max(1).saturating_sub(1);
+            let scroll_rows = terminal_pane.get_content_rows();
             terminal_pane.scroll_up(scroll_rows, fictitious_client_id);
         }
     }
@@ -3338,8 +3336,7 @@ impl Tab {
 
     pub fn scroll_active_terminal_up_half_page(&mut self, client_id: ClientId) {
         if let Some(active_pane) = self.get_active_pane_or_floating_pane_mut(client_id) {
-            // prevent overflow when row == 0
-            let scroll_rows = (active_pane.rows().max(1).saturating_sub(1)) / 2;
+            let scroll_rows = active_pane.get_content_rows() / 2;
             active_pane.scroll_up(scroll_rows, client_id);
         }
     }
@@ -3349,7 +3346,7 @@ impl Tab {
             || format!("failed to scroll down half a page in active pane for client {client_id}");
 
         if let Some(active_pane) = self.get_active_pane_or_floating_pane_mut(client_id) {
-            let scroll_rows = (active_pane.rows().max(1) - 1) / 2;
+            let scroll_rows = active_pane.get_content_rows() / 2;
             active_pane.scroll_down(scroll_rows, client_id);
             if !active_pane.is_scrolled() {
                 if let PaneId::Terminal(raw_fd) = active_pane.pid() {

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_page_scroll_down_action-3.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_page_scroll_down_action-3.snap
@@ -2,13 +2,13 @@
 source: zellij-server/src/./unit/screen_tests.rs
 expression: "format!(\"{}\", snapshot)"
 ---
-00 (C): ┌ Pane #1 ────────────── SCROLL:  9/13 ┐┌ Pane #2 ─────────────────────────────┐
-01 (C): │fill pane up with something 4         ││                                      │
-02 (C): │fill pane up with something 5         ││                                      │
-03 (C): │fill pane up with something 6         ││                                      │
-04 (C): │fill pane up with something 7         ││                                      │
-05 (C): │fill pane up with something 8         ││                                      │
-06 (C): │fill pane up with something 9         ││                                      │
-07 (C): │fill pane up with something 10        ││                                      │
-08 (C): │fill pane up with something 11        ││                                      │
+00 (C): ┌ Pane #1 ────────────── SCROLL:  8/13 ┐┌ Pane #2 ─────────────────────────────┐
+01 (C): │fill pane up with something 5         ││                                      │
+02 (C): │fill pane up with something 6         ││                                      │
+03 (C): │fill pane up with something 7         ││                                      │
+04 (C): │fill pane up with something 8         ││                                      │
+05 (C): │fill pane up with something 9         ││                                      │
+06 (C): │fill pane up with something 10        ││                                      │
+07 (C): │fill pane up with something 11        ││                                      │
+08 (C): │fill pane up with something 12        ││                                      │
 09 (C): └──────────────────────────────────────┘└──────────────────────────────────────┘

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_page_scroll_up_action-3.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_page_scroll_up_action-3.snap
@@ -2,13 +2,13 @@
 source: zellij-server/src/./unit/screen_tests.rs
 expression: "format!(\"{}\", snapshot)"
 ---
-00 (C): ┌ Pane #1 ────────────── SCROLL:  9/13 ┐┌ Pane #2 ─────────────────────────────┐
-01 (C): │fill pane up with something 4         ││                                      │
-02 (C): │fill pane up with something 5         ││                                      │
-03 (C): │fill pane up with something 6         ││                                      │
-04 (C): │fill pane up with something 7         ││                                      │
-05 (C): │fill pane up with something 8         ││                                      │
-06 (C): │fill pane up with something 9         ││                                      │
-07 (C): │fill pane up with something 10        ││                                      │
-08 (C): │fill pane up with something 11        ││                                      │
+00 (C): ┌ Pane #1 ────────────── SCROLL:  8/13 ┐┌ Pane #2 ─────────────────────────────┐
+01 (C): │fill pane up with something 5         ││                                      │
+02 (C): │fill pane up with something 6         ││                                      │
+03 (C): │fill pane up with something 7         ││                                      │
+04 (C): │fill pane up with something 8         ││                                      │
+05 (C): │fill pane up with something 9         ││                                      │
+06 (C): │fill pane up with something 10        ││                                      │
+07 (C): │fill pane up with something 11        ││                                      │
+08 (C): │fill pane up with something 12        ││                                      │
 09 (C): └──────────────────────────────────────┘└──────────────────────────────────────┘


### PR DESCRIPTION
Noticed that when performing `PageScrollUp` and `PageScrollDown` repeatedly my position in the buffer was shifting by one row. This was caused by using `.rows()` instead of `.get_content_rows()` when performing `PageUp`.

I believe that `.get_content_rows()` should be used for all commands related to scrolling (`PageDown` was already using that) because according to [this comment](https://github.com/DawidPietrykowski/zellij/blob/a3188a5fe530af30af0c55bfe9ddda353d826cae/zellij-server/src/panes/terminal_pane.rs#L171) it excludes the frame and the frame shouldn't be affecting the jump length. Following that I also added it in `HalfPage` commands.

I think the original code was supposed to account for the frame by subtracting one (`active_pane.rows().max(1).saturating_sub(1)`) but actually 2 rows should be subtracted so using `get_content_rows` which does that would make sense.