### PR TITLE
fix: use the new geometry's pinnedness

### DIFF
--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -178,9 +178,7 @@ impl Pane for TerminalPane {
         self.reflow_lines();
     }
     fn set_geom(&mut self, position_and_size: PaneGeom) {
-        let is_pinned = self.geom.is_pinned;
         self.geom = position_and_size;
-        self.geom.is_pinned = is_pinned;
         self.reflow_lines();
         self.render_full_viewport();
     }


### PR DESCRIPTION
With this, it seems that scrollback editors maintain the terminal pane's pinnedness. https://github.com/zellij-org/zellij/issues/4244