### PR TITLE
fix(zellij-server): send mouse events to non selectable panes in fullscreen

### DIFF
--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -3952,12 +3952,14 @@ impl Tab {
                 .with_context(err_context)?
         {
             // non-selectable panes are visible in fullscreen
-            if let Some(id) = self
-                .get_non_selectable_tiled_panes()
-                .find(|(_, p)| pane_contains_point(p, point, &stacked_pane_ids_under_flexible_pane))
-                .map(|(&id, _)| id)
-            {
-                if !search_selectable {
+            if !search_selectable {
+                if let Some(id) = self
+                    .get_non_selectable_tiled_panes()
+                    .find(|(_, p)| {
+                        pane_contains_point(p, point, &stacked_pane_ids_under_flexible_pane)
+                    })
+                    .map(|(&id, _)| id)
+                {
                     return Ok(Some(id));
                 }
             }


### PR DESCRIPTION
Resolves #4268

This resolves my issue but even though tests are passing, I'm not sure it has no other side effect. I don't know if non-selectable panes are always meant to be visible in fullscreen mode.

Let me know if you need a rework!