### PR TITLE
fix(web_server): Handle extracting session_token from multiple cookies

### DIFF
--- a/zellij-client/src/web_client/utils.rs
+++ b/zellij-client/src/web_client/utils.rs
@@ -46,7 +46,7 @@ pub fn should_use_https(
 pub fn parse_cookies<T>(request: &Request<T>) -> HashMap<String, String> {
     let mut cookies = HashMap::new();
 
-    if let Some(cookie_header) = request.headers().get("cookie") {
+    for cookie_header in request.headers().get_all("cookie") {
         if let Ok(cookie_str) = cookie_header.to_str() {
             for cookie_part in cookie_str.split(';') {
                 if let Ok(cookie) = Cookie::parse(cookie_part.trim()) {


### PR DESCRIPTION
Thanks for the feature, I was testing it locally and on a server and I started having problems.

I was experiencing an issue with authorization when accessing my server, but not my local instance. The `/login` request was passing with `200` but the `/session` request was returning `401`. This was caused by the fact that for a request with a cookie header containing multiple cookies like:
```
Cookie: a=x; b=x; c=x; session_token=xxxx
```
the call to `request.headers().get("cookie")` only returned `a=x`. That's why changing it to `get_all` solves the problem.

Now the reason is still unknown to my as to why is Axum doing this. I tried removing the `cookie` feature but it was still happening. I tried sending the exact same request locally with curl and the exact same headers and it was not happening.

I verified the received data by running zellij first, but then replacing its server with:
```
openssl s_server -key "/xxx" -cert "/xxx -accept 9080 -msg -debug -state
```
and I could see that the header sent by Firefox is not split.

I'm not sure what other variables could be affecting this splitting logic. Perhaps it's that the browser is using the same connection for 2 requests. HTTPS makes it more difficult to test but I can only reproduce it on a server due to having multiple cookies for that IP. I could spend more time on it but it's already been a few hours and the change already solves the problem and I believe it makes sense.

I also noticed that the `http` library itself also uses `get_all("cookie")` in one of their examples: https://github.com/hyperium/http/blob/master/src/header/map.rs#L2087C1-L2087C39