### PR TITLE
fix(plugins): use the terminal title when spawning terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * feat: add plugin API to replace a pane with another existing pane (https://github.com/zellij-org/zellij/pull/4246)
 * feat: add "stack" keybinding and CLI action to add a stacked pane to the current pane (https://github.com/zellij-org/zellij/pull/4255)
 * fix: support multiline hyperlinks (https://github.com/zellij-org/zellij/pull/4264)
+* fix: use terminal title when spawning terminal panes from plugin (https://github.com/zellij-org/zellij/pull/4272)
 
 ## [0.42.2] - 2025-04-15
 * refactor(terminal): track scroll_region as tuple rather than Option (https://github.com/zellij-org/zellij/pull/4082)

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -369,6 +369,7 @@ impl SessionMetaData {
                 TerminalAction::RunCommand(RunCommand {
                     command: shell.clone(),
                     cwd: new_config.options.default_cwd.clone(),
+                    use_terminal_title: true,
                     ..Default::default()
                 })
             });
@@ -705,6 +706,7 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                     TerminalAction::RunCommand(RunCommand {
                         command: shell,
                         cwd: config.options.default_cwd.clone(),
+                        use_terminal_title: true,
                         ..Default::default()
                     })
                 });
@@ -1481,6 +1483,7 @@ fn init_session(
     let default_shell = config_options.default_shell.clone().map(|command| {
         TerminalAction::RunCommand(RunCommand {
             command,
+            use_terminal_title: true,
             ..Default::default()
         })
     });

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__break_panes_to_new_tab_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__break_panes_to_new_tab_plugin_command.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-server/src/plugins/./unit/plugin_tests.rs
-assertion_line: 8246
 expression: "format!(\"{:#?}\", screen_instruction)"
 ---
 Some(
@@ -22,6 +21,7 @@ Some(
                     hold_on_close: false,
                     hold_on_start: false,
                     originating_plugin: None,
+                    use_terminal_title: true,
                 },
             ),
         ),

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_command_pane_background_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_command_pane_background_plugin_command.snap
@@ -24,6 +24,7 @@ Some(
                             context: {},
                         },
                     ),
+                    use_terminal_title: false,
                 },
             ),
         ),

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_command_pane_floating_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_command_pane_floating_plugin_command.snap
@@ -22,6 +22,7 @@ Some(
                             context: {},
                         },
                     ),
+                    use_terminal_title: false,
                 },
             ),
         ),

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_command_pane_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_command_pane_plugin_command.snap
@@ -22,6 +22,7 @@ Some(
                             context: {},
                         },
                     ),
+                    use_terminal_title: false,
                 },
             ),
         ),

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_terminal_floating_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_terminal_floating_plugin_command.snap
@@ -15,6 +15,7 @@ Some(
                     hold_on_close: false,
                     hold_on_start: false,
                     originating_plugin: None,
+                    use_terminal_title: true,
                 },
             ),
         ),

--- a/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_terminal_plugin_command.snap
+++ b/zellij-server/src/plugins/unit/snapshots/zellij_server__plugins__plugin_tests__open_terminal_plugin_command.snap
@@ -15,6 +15,7 @@ Some(
                     hold_on_close: false,
                     hold_on_start: false,
                     originating_plugin: None,
+                    use_terminal_title: true,
                 },
             ),
         ),

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -816,6 +816,7 @@ fn open_terminal(env: &PluginEnv, cwd: PathBuf) {
     let mut default_shell = env.default_shell.clone().unwrap_or_else(|| {
         TerminalAction::RunCommand(RunCommand {
             command: env.path_to_default_shell.clone(),
+            use_terminal_title: true,
             ..Default::default()
         })
     });
@@ -833,6 +834,7 @@ fn open_terminal_near_plugin(env: &PluginEnv, cwd: PathBuf) {
     let mut default_shell = env.default_shell.clone().unwrap_or_else(|| {
         TerminalAction::RunCommand(RunCommand {
             command: env.path_to_default_shell.clone(),
+            use_terminal_title: true,
             ..Default::default()
         })
     });
@@ -857,6 +859,7 @@ fn open_terminal_floating(
     let mut default_shell = env.default_shell.clone().unwrap_or_else(|| {
         TerminalAction::RunCommand(RunCommand {
             command: env.path_to_default_shell.clone(),
+            use_terminal_title: true,
             ..Default::default()
         })
     });
@@ -878,6 +881,7 @@ fn open_terminal_floating_near_plugin(
     let mut default_shell = env.default_shell.clone().unwrap_or_else(|| {
         TerminalAction::RunCommand(RunCommand {
             command: env.path_to_default_shell.clone(),
+            use_terminal_title: true,
             ..Default::default()
         })
     });
@@ -898,6 +902,7 @@ fn open_terminal_in_place(env: &PluginEnv, cwd: PathBuf) {
     let mut default_shell = env.default_shell.clone().unwrap_or_else(|| {
         TerminalAction::RunCommand(RunCommand {
             command: env.path_to_default_shell.clone(),
+            use_terminal_title: true,
             ..Default::default()
         })
     });
@@ -919,6 +924,7 @@ fn open_terminal_in_place_of_plugin(
     let mut default_shell = env.default_shell.clone().unwrap_or_else(|| {
         TerminalAction::RunCommand(RunCommand {
             command: env.path_to_default_shell.clone(),
+            use_terminal_title: true,
             ..Default::default()
         })
     });
@@ -947,6 +953,7 @@ fn open_command_pane_in_place_of_plugin(
     let hold_on_close = true;
     let hold_on_start = false;
     let name = None;
+    let use_terminal_title = false; // TODO: support this
     let run_command_action = RunCommandAction {
         command,
         args,
@@ -959,6 +966,7 @@ fn open_command_pane_in_place_of_plugin(
             env.client_id,
             context,
         )),
+        use_terminal_title,
     };
     let run_cmd = TerminalAction::RunCommand(run_command_action.into());
     let _ = env
@@ -984,6 +992,7 @@ fn open_command_pane(
     let hold_on_close = true;
     let hold_on_start = false;
     let name = None;
+    let use_terminal_title = false; // TODO: support this
     let run_command_action = RunCommandAction {
         command,
         args,
@@ -996,6 +1005,7 @@ fn open_command_pane(
             env.client_id,
             context,
         )),
+        use_terminal_title,
     };
     let action = Action::NewTiledPane(direction, Some(run_command_action), name);
     apply_action!(action, error_msg, env);
@@ -1013,6 +1023,7 @@ fn open_command_pane_near_plugin(
     let hold_on_close = true;
     let hold_on_start = false;
     let name = None;
+    let use_terminal_title = false; // TODO: support this
     let run_command_action = RunCommandAction {
         command,
         args,
@@ -1025,6 +1036,7 @@ fn open_command_pane_near_plugin(
             env.client_id,
             context,
         )),
+        use_terminal_title,
     };
     let run_cmd = TerminalAction::RunCommand(run_command_action.into());
     let _ = env.senders.send_to_pty(PtyInstruction::SpawnTerminal(
@@ -1050,6 +1062,7 @@ fn open_command_pane_floating(
     let hold_on_close = true;
     let hold_on_start = false;
     let name = None;
+    let use_terminal_title = false; // TODO: support this
     let run_command_action = RunCommandAction {
         command,
         args,
@@ -1062,6 +1075,7 @@ fn open_command_pane_floating(
             env.client_id,
             context,
         )),
+        use_terminal_title,
     };
     let action = Action::NewFloatingPane(Some(run_command_action), name, floating_pane_coordinates);
     apply_action!(action, error_msg, env);
@@ -1080,6 +1094,7 @@ fn open_command_pane_floating_near_plugin(
     let hold_on_close = true;
     let hold_on_start = false;
     let name = None;
+    let use_terminal_title = false; // TODO: support this
     let run_command_action = RunCommandAction {
         command,
         args,
@@ -1092,6 +1107,7 @@ fn open_command_pane_floating_near_plugin(
             env.client_id,
             context,
         )),
+        use_terminal_title,
     };
     let run_cmd = TerminalAction::RunCommand(run_command_action.into());
     let _ = env.senders.send_to_pty(PtyInstruction::SpawnTerminal(
@@ -1116,6 +1132,7 @@ fn open_command_pane_in_place(
     let hold_on_close = true;
     let hold_on_start = false;
     let name = None;
+    let use_terminal_title = false; // TODO: support this
     let run_command_action = RunCommandAction {
         command,
         args,
@@ -1128,6 +1145,7 @@ fn open_command_pane_in_place(
             env.client_id,
             context,
         )),
+        use_terminal_title,
     };
     let action = Action::NewInPlacePane(Some(run_command_action), name);
     apply_action!(action, error_msg, env);
@@ -1149,6 +1167,7 @@ fn open_command_pane_background(
     let hold_on_start = false;
     let start_suppressed = true;
     let name = None;
+    let use_terminal_title = false; // TODO: support this
     let run_command_action = RunCommandAction {
         command,
         args,
@@ -1161,6 +1180,7 @@ fn open_command_pane_background(
             env.client_id,
             context,
         )),
+        use_terminal_title,
     };
     let run_cmd = TerminalAction::RunCommand(run_command_action.into());
     let _ = env.senders.send_to_pty(PtyInstruction::SpawnTerminal(
@@ -2113,6 +2133,7 @@ fn break_panes_to_new_tab(
     let default_shell = env.default_shell.clone().or_else(|| {
         Some(TerminalAction::RunCommand(RunCommand {
             command: env.path_to_default_shell.clone(),
+            use_terminal_title: true,
             ..Default::default()
         }))
     });

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -233,7 +233,11 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                         Some(TerminalAction::RunCommand(run_command)) => (
                             run_command.hold_on_close,
                             Some(run_command.clone()),
-                            Some(name.unwrap_or_else(|| run_command.to_string())),
+                            if run_command.use_terminal_title {
+                                None
+                            } else {
+                                Some(name.unwrap_or_else(|| run_command.to_string()))
+                            },
                             None,
                         ),
                         Some(TerminalAction::OpenFile(open_file_payload)) => {
@@ -359,7 +363,11 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                     Some(TerminalAction::RunCommand(run_command)) => (
                         run_command.hold_on_close,
                         Some(run_command.clone()),
-                        Some(name.unwrap_or_else(|| run_command.to_string())),
+                        if run_command.use_terminal_title {
+                            None
+                        } else {
+                            Some(name.unwrap_or_else(|| run_command.to_string()))
+                        },
                     ),
                     _ => (false, None, name),
                 };

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_pane_action_with_command_and_cwd.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_pane_action_with_command_and_cwd.snap
@@ -2,4 +2,4 @@
 source: zellij-server/src/./unit/screen_tests.rs
 expression: "format!(\"{:?}\", new_pane_instruction)"
 ---
-Some(SpawnTerminal(Some(RunCommand(RunCommand { command: "htop", args: [], cwd: Some("/some/folder"), hold_on_close: true, hold_on_start: false, originating_plugin: None })), None, Tiled(Some(Right)), false, ClientId(10)))
+Some(SpawnTerminal(Some(RunCommand(RunCommand { command: "htop", args: [], cwd: Some("/some/folder"), hold_on_close: true, hold_on_start: false, originating_plugin: None, use_terminal_title: false })), None, Tiled(Some(Right)), false, ClientId(10)))

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_pane_action_with_floating_pane_and_coordinates.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_pane_action_with_floating_pane_and_coordinates.snap
@@ -2,4 +2,4 @@
 source: zellij-server/src/./unit/screen_tests.rs
 expression: "format!(\"{:?}\", *received_pty_instructions.lock().unwrap())"
 ---
-[UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), SpawnTerminal(Some(RunCommand(RunCommand { command: "htop", args: [], cwd: Some("/some/folder"), hold_on_close: true, hold_on_start: false, originating_plugin: None })), None, Floating(Some(FloatingPaneCoordinates { x: Some(Fixed(10)), y: None, width: Some(Percent(20)), height: None, pinned: None })), false, ClientId(10)), Exit]
+[UpdateActivePane(Some(Terminal(0)), 1), UpdateActivePane(Some(Terminal(0)), 1), SpawnTerminal(Some(RunCommand(RunCommand { command: "htop", args: [], cwd: Some("/some/folder"), hold_on_close: true, hold_on_start: false, originating_plugin: None, use_terminal_title: false })), None, Floating(Some(FloatingPaneCoordinates { x: Some(Fixed(10)), y: None, width: Some(Percent(20)), height: None, pinned: None })), false, ClientId(10)), Exit]

--- a/zellij-utils/src/input/command.rs
+++ b/zellij-utils/src/input/command.rs
@@ -59,6 +59,8 @@ pub struct RunCommand {
     pub hold_on_start: bool,
     #[serde(default)]
     pub originating_plugin: Option<OriginatingPlugin>,
+    #[serde(default)]
+    pub use_terminal_title: bool,
 }
 
 impl std::fmt::Display for RunCommand {
@@ -94,6 +96,8 @@ pub struct RunCommandAction {
     pub hold_on_start: bool,
     #[serde(default)]
     pub originating_plugin: Option<OriginatingPlugin>,
+    #[serde(default)]
+    pub use_terminal_title: bool,
 }
 
 impl From<RunCommandAction> for RunCommand {
@@ -105,6 +109,7 @@ impl From<RunCommandAction> for RunCommand {
             hold_on_close: action.hold_on_close,
             hold_on_start: action.hold_on_start,
             originating_plugin: action.originating_plugin,
+            use_terminal_title: action.use_terminal_title,
         }
     }
 }
@@ -119,6 +124,7 @@ impl From<RunCommand> for RunCommandAction {
             hold_on_close: run_command.hold_on_close,
             hold_on_start: run_command.hold_on_start,
             originating_plugin: run_command.originating_plugin,
+            use_terminal_title: run_command.use_terminal_title,
         }
     }
 }

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__args_added_to_args_in_template.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__args_added_to_args_in_template.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1410
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -26,6 +25,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),
@@ -56,6 +56,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__args_override_args_in_template.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__args_override_args_in_template.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1375
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -29,6 +28,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),
@@ -59,6 +59,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__close_on_exit_added_to_close_on_exit_in_template.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__close_on_exit_added_to_close_on_exit_in_template.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1427
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -26,6 +25,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),
@@ -53,6 +53,7 @@ Layout {
                                     hold_on_close: false,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__close_on_exit_overrides_close_on_exit_in_template.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__close_on_exit_overrides_close_on_exit_in_template.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1393
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -26,6 +25,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),
@@ -53,6 +53,7 @@ Layout {
                                     hold_on_close: false,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__cwd_added_to_cwd_in_template.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__cwd_added_to_cwd_in_template.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1462
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -26,6 +25,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),
@@ -55,6 +55,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__cwd_override_cwd_in_template.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__cwd_override_cwd_in_template.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1445
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -28,6 +27,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),
@@ -57,6 +57,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__env_var_expansion.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__env_var_expansion.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 2230
 expression: "format!(\"{layout:#?}\")"
 ---
 Layout {
@@ -108,6 +107,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),
@@ -185,6 +185,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1847
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -47,6 +46,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd_in_pane_templates.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd_in_pane_templates.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1868
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -51,6 +50,7 @@ Layout {
                                             hold_on_close: true,
                                             hold_on_start: false,
                                             originating_plugin: None,
+                                            use_terminal_title: false,
                                         },
                                     ),
                                 ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd_in_tab_templates.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_and_tab_cwd_prepended_to_panes_with_and_without_cwd_in_tab_templates.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1887
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -47,6 +46,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_given_to_panes_without_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_given_to_panes_without_cwd.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1732
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -48,6 +47,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_passed_from_layout_constructor.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_passed_from_layout_constructor.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1765
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -48,6 +47,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_passed_from_layout_constructor_overrides_global_cwd_in_layout_file.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_passed_from_layout_constructor_overrides_global_cwd_in_layout_file.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1786
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -48,6 +47,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_prepended_to_panes_with_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_prepended_to_panes_with_cwd.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1745
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -48,6 +47,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_with_tab_cwd_given_to_panes_without_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__global_cwd_with_tab_cwd_given_to_panes_without_cwd.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1802
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -47,6 +46,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__layout_with_command_panes_and_close_on_exit.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__layout_with_command_panes_and_close_on_exit.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 511
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -26,6 +25,7 @@ Layout {
                                     hold_on_close: false,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__layout_with_command_panes_and_start_suspended.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__layout_with_command_panes_and_start_suspended.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 524
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -26,6 +25,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: true,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__layout_with_tab_and_pane_templates.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__layout_with_tab_and_pane_templates.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 892
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -49,6 +48,7 @@ Layout {
                                                     hold_on_close: true,
                                                     hold_on_start: false,
                                                     originating_plugin: None,
+                                                    use_terminal_title: false,
                                                 },
                                             ),
                                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_with_cwd_is_overriden_by_its_consumers_bare_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_with_cwd_is_overriden_by_its_consumers_bare_cwd.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1616
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -28,6 +27,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_with_cwd_overriden_by_its_consumers_command_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_with_cwd_overriden_by_its_consumers_command_cwd.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1562
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -28,6 +27,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_with_cwd_remains_when_its_consumer_command_does_not_have_a_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_with_cwd_remains_when_its_consumer_command_does_not_have_a_cwd.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1579
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -28,6 +27,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_without_cwd_is_overriden_by_its_consumers_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_without_cwd_is_overriden_by_its_consumers_cwd.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1597
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -28,6 +27,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_without_cwd_receives_its_consumers_bare_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_command_without_cwd_receives_its_consumers_bare_cwd.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1634
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -28,6 +27,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_bare_propagated_to_its_consumer_command_with_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_bare_propagated_to_its_consumer_command_with_cwd.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1686
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -28,6 +27,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_bare_propagated_to_its_consumer_command_without_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__pane_template_with_bare_propagated_to_its_consumer_command_without_cwd.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1668
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -28,6 +27,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__tab_cwd_given_to_panes_without_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__tab_cwd_given_to_panes_without_cwd.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1817
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -47,6 +46,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__tab_cwd_prepended_to_panes_with_cwd.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__layout__layout_test__tab_cwd_prepended_to_panes_with_cwd.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-utils/src/input/./unit/layout_test.rs
-assertion_line: 1832
 expression: "format!(\"{:#?}\", layout)"
 ---
 Layout {
@@ -47,6 +46,7 @@ Layout {
                                     hold_on_close: true,
                                     hold_on_start: false,
                                     originating_plugin: None,
+                                    use_terminal_title: false,
                                 },
                             ),
                         ),


### PR DESCRIPTION
This is a small fix to the various plugin API commands that spawn a terminal with the user's default shell. Previously these commands would make the terminal title start out as the name of the default shell rather than whatever the default shell wants to set the title to (as we do when opening terminal panes normally, eg. through a keybinding).

This fixes it.