### PR TITLE
fix(compact-bar): fix cursor length calculation for multiple users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 * feat: multiple select and bulk pane actions (https://github.com/zellij-org/zellij/pull/4169 and https://github.com/zellij-org/zellij/pull/4171 and https://github.com/zellij-org/zellij/pull/4221)
-* feat: add an optional key tooltip to show the current keybindings for the compact bar (https://github.com/zellij-org/zellij/pull/4225)
+* feat: add an optional key tooltip to show the current keybindings for the compact bar (https://github.com/zellij-org/zellij/pull/4225 and https://github.com/zellij-org/zellij/pull/4279)
 * feat: web-client, allowing users to share sessions in the browser (https://github.com/zellij-org/zellij/pull/4242, https://github.com/zellij-org/zellij/pull/4257 and https://github.com/zellij-org/zellij/pull/4278)
 * performance: consolidate renders (https://github.com/zellij-org/zellij/pull/4245)
 * feat: add plugin API to replace a pane with another existing pane (https://github.com/zellij-org/zellij/pull/4246)

--- a/default-plugins/compact-bar/src/tab.rs
+++ b/default-plugins/compact-bar/src/tab.rs
@@ -14,6 +14,7 @@ fn cursors(focused_clients: &[ClientId], colors: MultiplayerColors) -> (Vec<ANSI
             len += 1;
         }
     }
+    len += 2; // 2 for the brackets: [ and ]
     (cursors, len)
 }
 

--- a/src/tests/e2e/cases.rs
+++ b/src/tests/e2e/cases.rs
@@ -101,8 +101,10 @@ fn account_for_races_in_snapshot(snapshot: String) -> String {
     // once that happens, we should be able to remove this hack (and adjust the snapshots for the
     // trailing spaces that we had to get rid of here)
     let base_replace = Regex::new(r"Alt <\[\]>  BASE \s*\n").unwrap();
+    let base_replace_tmux_mode = Regex::new(r"Alt \[\|SPACE\|Alt \]  BASE \s*\n").unwrap();
     let eol_arrow_replace = Regex::new(r"\s*\n").unwrap();
     let snapshot = base_replace.replace_all(&snapshot, "\n").to_string();
+    let snapshot = base_replace_tmux_mode.replace_all(&snapshot, "\n").to_string();
     let snapshot = eol_arrow_replace.replace_all(&snapshot, "\n").to_string();
 
     snapshot

--- a/src/tests/e2e/cases.rs
+++ b/src/tests/e2e/cases.rs
@@ -104,7 +104,9 @@ fn account_for_races_in_snapshot(snapshot: String) -> String {
     let base_replace_tmux_mode = Regex::new(r"Alt \[\|SPACE\|Alt \]  BASE \s*\n").unwrap();
     let eol_arrow_replace = Regex::new(r"\s*\n").unwrap();
     let snapshot = base_replace.replace_all(&snapshot, "\n").to_string();
-    let snapshot = base_replace_tmux_mode.replace_all(&snapshot, "\n").to_string();
+    let snapshot = base_replace_tmux_mode
+        .replace_all(&snapshot, "\n")
+        .to_string();
     let snapshot = eol_arrow_replace.replace_all(&snapshot, "\n").to_string();
 
     snapshot


### PR DESCRIPTION
This fixes an issue with the compact bar that happened after some refactoring. When multiple users are connected, it calculated the length wrong (ignoring the square brackets), causing the bar to add extra padding that messed up the rendering.

This also attempts to fix some flakiness in our e2e tests (unrelated).