### PR TITLE
fix(web-server): thread leak due to excess file watching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
-* feat: multiple select and bulk pane actions (https://github.com/zellij-org/zellij/pull/4169 and https://github.com/zellij-org/zellij/pull/4171 and https://github.com/zellij-org/zellij/pull/4221)
+* feat: multiple select and bulk pane actions (https://github.com/zellij-org/zellij/pull/4169 and https://github.com/zellij-org/zellij/pull/4171, https://github.com/zellij-org/zellij/pull/4221 and https://github.com/zellij-org/zellij/pull/4286)
 * feat: add an optional key tooltip to show the current keybindings for the compact bar (https://github.com/zellij-org/zellij/pull/4225 and https://github.com/zellij-org/zellij/pull/4279)
 * feat: web-client, allowing users to share sessions in the browser (https://github.com/zellij-org/zellij/pull/4242, https://github.com/zellij-org/zellij/pull/4257 and https://github.com/zellij-org/zellij/pull/4278)
 * performance: consolidate renders (https://github.com/zellij-org/zellij/pull/4245)

--- a/zellij-client/src/web_client/ipc_listener.rs
+++ b/zellij-client/src/web_client/ipc_listener.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 use tokio::io::AsyncReadExt;
 use tokio::net::{UnixListener, UnixStream};
 use zellij_utils::consts::WEBSERVER_SOCKET_PATH;
+use zellij_utils::ipc::ClientToServerMsg;
 use zellij_utils::web_server_commands::InstructionForWebServer;
 
 pub async fn create_webserver_receiver(
@@ -86,6 +87,16 @@ pub async fn listen_to_web_server_instructions(
                                             );
                                         },
                                     }
+                                }
+                                if let Some(os_input) = connection_table
+                                    .lock()
+                                    .unwrap()
+                                    .get_client_os_api(&client_id)
+                                {
+                                    // notify the zellij server of the config change
+                                    os_input.send_to_server(
+                                        ClientToServerMsg::ConfigWrittenToDisk(new_config.clone()),
+                                    );
                                 }
                             }
                             // Continue loop to recreate receiver for next message

--- a/zellij-client/src/web_client/mod.rs
+++ b/zellij-client/src/web_client/mod.rs
@@ -44,6 +44,7 @@ use http_handlers::{
     create_new_client, get_static_asset, login_handler, serve_html, version_handler,
 };
 use ipc_listener::listen_to_web_server_instructions;
+
 use types::{
     AppState, ClientOsApiFactory, ConnectionTable, RealClientOsApiFactory, RealSessionManager,
     SessionManager,
@@ -53,7 +54,9 @@ use uuid::Uuid;
 use websocket_handlers::{ws_handler_control, ws_handler_terminal};
 
 use zellij_utils::{
+    cli::CliArgs,
     consts::WEBSERVER_SOCKET_PATH,
+    ipc::{ClientAttributes, ClientToServerMsg, ExitReason, ServerToClientMsg},
     web_server_commands::{
         create_webserver_sender, send_webserver_instruction, InstructionForWebServer,
     },

--- a/zellij-client/src/web_client/server_listener.rs
+++ b/zellij-client/src/web_client/server_listener.rs
@@ -1,5 +1,4 @@
 use crate::os_input_output::ClientOsApi;
-use crate::report_changes_in_config_file;
 use crate::web_client::control_message::WebServerToWebClientControlMessage;
 use crate::web_client::session_management::build_initial_connection;
 use crate::web_client::types::{ClientConnectionBus, ConnectionTable, SessionManager};
@@ -96,10 +95,6 @@ pub fn zellij_server_listener(
 
                     os_input.connect_to_server(&zellij_ipc_pipe);
                     os_input.send_to_server(first_message);
-
-                    let mut args_for_report = CliArgs::default();
-                    args_for_report.config = config_file_path.clone();
-                    report_changes_in_config_file(&args_for_report, &os_input);
 
                     client_connection_bus.send_control(
                         WebServerToWebClientControlMessage::SwitchedSession {


### PR DESCRIPTION
This fixes an issue in the yet-to-be-released web server where we would watch the config again for each connection (and not clean up the watcher on disconnect!) - causing a thread leak. While this did not really affect CPU/memory since all the threads were waiting, it's still not an ideal situation.

To fix, I removed the extra watcher and merged the client/server config change notifications.