### PR TITLE
fix(resurrection): do not parse resurrection layouts on startup

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -90,7 +90,7 @@ pub(crate) fn delete_all_sessions(yes: bool, force: bool) {
     } else {
         resurrectable_sessions
             .iter()
-            .filter(|(name, _, _)| !active_sessions.contains(name))
+            .filter(|(name, _)| !active_sessions.contains(name))
             .cloned()
             .collect()
     };

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -697,7 +697,15 @@ pub(crate) fn start_client(opts: CliArgs) {
                     .and_then(|s| session_exists(&s).ok())
                     .unwrap_or(false);
                 let resurrection_layout =
-                    session_name.as_ref().and_then(|s| resurrection_layout(&s));
+                    session_name
+                        .as_ref()
+                        .and_then(|s| match resurrection_layout(&s) {
+                            Ok(layout) => Some(layout),
+                            Err(e) => {
+                                eprintln!("{}", e);
+                                process::exit(2);
+                            },
+                        });
                 if (create || should_create_detached)
                     && !session_exists
                     && resurrection_layout.is_none()

--- a/zellij-client/src/web_client/session_management.rs
+++ b/zellij-client/src/web_client/session_management.rs
@@ -110,7 +110,7 @@ pub fn spawn_session_if_needed(
             });
 
         match resurrection_layout {
-            Some(resurrection_layout) => spawn_new_session(
+            Ok(resurrection_layout) => spawn_new_session(
                 &session_name,
                 os_input.clone(),
                 config.clone(),
@@ -118,7 +118,7 @@ pub fn spawn_session_if_needed(
                 Some(resurrection_layout),
                 client_attributes,
             ),
-            None => {
+            Err(_) => {
                 let new_session_layout = layout_for_new_session(&config, requested_layout);
 
                 spawn_new_session(

--- a/zellij-client/src/web_client/types.rs
+++ b/zellij-client/src/web_client/types.rs
@@ -60,7 +60,7 @@ impl SessionManager for RealSessionManager {
         &self,
         session_name: &str,
     ) -> Option<zellij_utils::input::layout::Layout> {
-        zellij_utils::sessions::resurrection_layout(session_name)
+        zellij_utils::sessions::resurrection_layout(session_name).ok()
     }
 
     fn spawn_session_if_needed(

--- a/zellij-utils/src/sessions.rs
+++ b/zellij-utils/src/sessions.rs
@@ -21,16 +21,17 @@ pub fn get_sessions() -> Result<Vec<(String, Duration)>, io::ErrorKind> {
         Ok(files) => {
             let mut sessions = Vec::new();
             files.for_each(|file| {
-                let file = file.unwrap();
-                let file_name = file.file_name().into_string().unwrap();
-                let ctime = std::fs::metadata(&file.path())
-                    .ok()
-                    .and_then(|f| f.created().ok())
-                    .and_then(|d| d.elapsed().ok())
-                    .unwrap_or_default();
-                let duration = Duration::from_secs(ctime.as_secs());
-                if file.file_type().unwrap().is_socket() && assert_socket(&file_name) {
-                    sessions.push((file_name, duration));
+                if let Ok(file) = file {
+                    let file_name = file.file_name().into_string().unwrap();
+                    let ctime = std::fs::metadata(&file.path())
+                        .ok()
+                        .and_then(|f| f.created().ok())
+                        .and_then(|d| d.elapsed().ok())
+                        .unwrap_or_default();
+                    let duration = Duration::from_secs(ctime.as_secs());
+                    if file.file_type().unwrap().is_socket() && assert_socket(&file_name) {
+                        sessions.push((file_name, duration));
+                    }
                 }
             });
             Ok(sessions)
@@ -40,7 +41,7 @@ pub fn get_sessions() -> Result<Vec<(String, Duration)>, io::ErrorKind> {
     }
 }
 
-pub fn get_resurrectable_sessions() -> Vec<(String, Duration, Layout)> {
+pub fn get_resurrectable_sessions() -> Vec<(String, Duration)> {
     match fs::read_dir(&*ZELLIJ_SESSION_INFO_CACHE_DIR) {
         Ok(files_in_session_info_folder) => {
             let files_that_are_folders = files_in_session_info_folder
@@ -50,29 +51,11 @@ pub fn get_resurrectable_sessions() -> Vec<(String, Duration, Layout)> {
                 .filter_map(|folder_name| {
                     let layout_file_name =
                         session_layout_cache_file_name(&folder_name.display().to_string());
-                    let raw_layout = match std::fs::read_to_string(&layout_file_name) {
-                        Ok(raw_layout) => raw_layout,
-                        Err(_e) => {
-                            return None;
-                        },
-                    };
                     let ctime = match std::fs::metadata(&layout_file_name)
                         .and_then(|metadata| metadata.created())
                     {
                         Ok(created) => Some(created),
                         Err(_e) => None,
-                    };
-                    let layout = match Layout::from_kdl(
-                        &raw_layout,
-                        Some(layout_file_name.display().to_string()),
-                        None,
-                        None,
-                    ) {
-                        Ok(layout) => layout,
-                        Err(e) => {
-                            log::error!("Failed to parse resurrection layout file: {}", e);
-                            return None;
-                        },
                     };
                     let elapsed_duration = ctime
                         .map(|ctime| {
@@ -82,7 +65,7 @@ pub fn get_resurrectable_sessions() -> Vec<(String, Duration, Layout)> {
                     let session_name = folder_name
                         .file_name()
                         .map(|f| std::path::PathBuf::from(f).display().to_string())?;
-                    Some((session_name, elapsed_duration, layout))
+                    Some((session_name, elapsed_duration))
                 })
                 .collect()
         },
@@ -291,7 +274,7 @@ pub fn list_sessions(no_formatting: bool, short: bool, reverse: bool) {
             let resurrectable_sessions = get_resurrectable_sessions();
             let mut all_sessions: HashMap<String, (Duration, bool)> = resurrectable_sessions
                 .iter()
-                .map(|(name, timestamp, _layout)| (name.clone(), (timestamp.clone(), true)))
+                .map(|(name, timestamp)| (name.clone(), (timestamp.clone(), true)))
                 .collect();
             for (session_name, duration) in running_sessions {
                 all_sessions.insert(session_name.clone(), (duration, false));
@@ -363,16 +346,25 @@ pub fn session_exists(name: &str) -> Result<bool, io::ErrorKind> {
 
 // if the session is resurrecable, the returned layout is the one to be used to resurrect it
 pub fn resurrection_layout(session_name_to_resurrect: &str) -> Option<Layout> {
-    let resurrectable_sessions = get_resurrectable_sessions();
-    resurrectable_sessions
-        .iter()
-        .find_map(|(name, _timestamp, layout)| {
-            if name == session_name_to_resurrect {
-                Some(layout.clone())
-            } else {
-                None
-            }
-        })
+    let layout_file_name = session_layout_cache_file_name(&session_name_to_resurrect);
+    let raw_layout = match std::fs::read_to_string(&layout_file_name) {
+        Ok(raw_layout) => raw_layout,
+        Err(_e) => {
+            return None;
+        },
+    };
+    match Layout::from_kdl(
+        &raw_layout,
+        Some(layout_file_name.display().to_string()),
+        None,
+        None,
+    ) {
+        Ok(layout) => Some(layout),
+        Err(e) => {
+            log::error!("Failed to parse resurrection layout file: {}", e);
+            return None;
+        },
+    }
 }
 
 pub fn assert_session(name: &str) {


### PR DESCRIPTION
This is a minor fix that makes sure we don't needlessly parse resurrection layouts on startup. This contributed to some occasions of a slow startup when there were lots of dead sessions in the cache.