### PR TITLE
fix(sessions): remove popups from welcome screen

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -576,6 +576,8 @@ pub(crate) fn start_client(opts: CliArgs) {
             process::exit(1);
         },
     };
+    let layout_is_welcome_screen = opts.layout == Some(PathBuf::from("welcome"))
+        || config.options.default_layout == Some(PathBuf::from("welcome"));
 
     let mut reconnect_to_session: Option<ConnectToSession> = None;
     let os_input = get_os_input(get_client_os_input);
@@ -750,6 +752,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                 pane_id_to_focus,
                 is_a_reconnect,
                 should_create_detached,
+                layout_is_welcome_screen,
             );
         } else {
             if let Some(session_name) = opts.session.clone() {
@@ -765,6 +768,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                     None,
                     is_a_reconnect,
                     should_create_detached,
+                    layout_is_welcome_screen,
                 );
             } else {
                 if let Some(session_name) = config_options.session_name.as_ref() {
@@ -806,6 +810,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                                 None,
                                 is_a_reconnect,
                                 should_create_detached,
+                                layout_is_welcome_screen,
                             );
                         },
                         _ => {
@@ -821,6 +826,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                                 None,
                                 is_a_reconnect,
                                 should_create_detached,
+                                layout_is_welcome_screen,
                             );
                         },
                     }
@@ -845,6 +851,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                     None,
                     is_a_reconnect,
                     should_create_detached,
+                    layout_is_welcome_screen,
                 );
             }
         }

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -217,6 +217,7 @@ pub fn start_client(
     pane_id_to_focus: Option<(u32, bool)>, // (pane_id, is_plugin)
     is_a_reconnect: bool,
     start_detached_and_exit: bool,
+    layout_is_welcome_screen: bool,
 ) -> Option<ConnectToSession> {
     if start_detached_and_exit {
         start_server_detached(os_input, opts, config, config_options, info, layout);
@@ -339,6 +340,7 @@ pub fn start_client(
                     Box::new(config.plugins.clone()),
                     is_web_client,
                     should_launch_setup_wizard,
+                    layout_is_welcome_screen,
                 ),
                 ipc_pipe,
             )
@@ -741,6 +743,7 @@ pub fn start_server_detached(
                     Box::new(config.plugins.clone()),
                     is_web_client,
                     should_launch_setup_wizard,
+                    false,
                 ),
                 ipc_pipe,
             )

--- a/zellij-client/src/web_client/server_listener.rs
+++ b/zellij-client/src/web_client/server_listener.rs
@@ -33,14 +33,14 @@ pub fn zellij_server_listener(
             move || {
                 let mut client_connection_bus =
                     ClientConnectionBus::new(&web_client_id, &connection_table);
-                let mut reconnect_to_session = match build_initial_connection(session_name, &config)
-                {
-                    Ok(initial_session_connection) => initial_session_connection,
-                    Err(e) => {
-                        log::error!("{}", e);
-                        return;
-                    },
-                };
+                let (mut reconnect_to_session, is_welcome_screen) =
+                    match build_initial_connection(session_name, &config) {
+                        Ok(initial_session_connection) => initial_session_connection,
+                        Err(e) => {
+                            log::error!("{}", e);
+                            return;
+                        },
+                    };
                 'reconnect_loop: loop {
                     let reconnect_info = reconnect_to_session.take();
                     let path = {
@@ -91,6 +91,7 @@ pub fn zellij_server_listener(
                         is_web_client,
                         os_input.clone(),
                         reconnect_info.as_ref().and_then(|r| r.layout.clone()),
+                        is_welcome_screen,
                     );
 
                     os_input.connect_to_server(&zellij_ipc_pipe);

--- a/zellij-client/src/web_client/session_management.rs
+++ b/zellij-client/src/web_client/session_management.rs
@@ -19,7 +19,8 @@ use zellij_utils::{
 pub fn build_initial_connection(
     session_name: Option<String>,
     config: &Config,
-) -> Result<Option<ConnectToSession>, &'static str> {
+) -> Result<(Option<ConnectToSession>, bool), &'static str> {
+    // bool -> is_welcome_screen
     let should_start_with_welcome_screen = session_name.is_none();
     let default_layout_from_config =
         LayoutInfo::from_config(&config.options.layout_dir, &config.options.default_layout);
@@ -28,24 +29,33 @@ pub fn build_initial_connection(
         else {
             return Err("Failed to generate unique session name, bailing.");
         };
-        Ok(Some(ConnectToSession {
-            name: Some(initial_session_name.clone()),
-            layout: Some(LayoutInfo::BuiltIn("welcome".to_owned())),
-            ..Default::default()
-        }))
+        Ok((
+            Some(ConnectToSession {
+                name: Some(initial_session_name.clone()),
+                layout: Some(LayoutInfo::BuiltIn("welcome".to_owned())),
+                ..Default::default()
+            }),
+            should_start_with_welcome_screen,
+        ))
     } else if let Some(session_name) = session_name {
-        Ok(Some(ConnectToSession {
-            name: Some(session_name.clone()),
-            layout: default_layout_from_config,
-            ..Default::default()
-        }))
+        Ok((
+            Some(ConnectToSession {
+                name: Some(session_name.clone()),
+                layout: default_layout_from_config,
+                ..Default::default()
+            }),
+            should_start_with_welcome_screen,
+        ))
     } else if default_layout_from_config.is_some() {
-        Ok(Some(ConnectToSession {
-            layout: default_layout_from_config,
-            ..Default::default()
-        }))
+        Ok((
+            Some(ConnectToSession {
+                layout: default_layout_from_config,
+                ..Default::default()
+            }),
+            should_start_with_welcome_screen,
+        ))
     } else {
-        Ok(None)
+        Ok((None, should_start_with_welcome_screen))
     }
 }
 
@@ -90,6 +100,7 @@ pub fn spawn_session_if_needed(
     is_web_client: bool,
     os_input: Box<dyn ClientOsApi>,
     requested_layout: Option<LayoutInfo>,
+    is_welcome_screen: bool,
 ) -> (ClientToServerMsg, PathBuf) {
     if session_exists(&session_name).unwrap_or(false) {
         ipc_pipe_and_first_message_for_existing_session(
@@ -117,6 +128,7 @@ pub fn spawn_session_if_needed(
                 config_options.clone(),
                 Some(resurrection_layout),
                 client_attributes,
+                is_welcome_screen,
             ),
             None => {
                 let new_session_layout = layout_for_new_session(&config, requested_layout);
@@ -128,6 +140,7 @@ pub fn spawn_session_if_needed(
                     config_options.clone(),
                     new_session_layout.ok().map(|(l, _c)| l),
                     client_attributes,
+                    is_welcome_screen,
                 )
             },
         }
@@ -141,6 +154,7 @@ fn spawn_new_session(
     config_opts: Options,
     layout: Option<Layout>,
     client_attributes: ClientAttributes,
+    is_welcome_screen: bool,
 ) -> (ClientToServerMsg, PathBuf) {
     let debug = false;
     envs::set_session_name(name.to_owned());
@@ -176,6 +190,7 @@ fn spawn_new_session(
             Box::new(config.plugins.clone()),
             should_launch_setup_wizard,
             is_web_client,
+            is_welcome_screen,
         ),
         zellij_ipc_pipe,
     )

--- a/zellij-client/src/web_client/types.rs
+++ b/zellij-client/src/web_client/types.rs
@@ -44,6 +44,7 @@ pub trait SessionManager: Send + Sync + std::fmt::Debug {
         is_web_client: bool,
         os_input: Box<dyn ClientOsApi>,
         requested_layout: Option<LayoutInfo>,
+        is_welcome_screen: bool,
     ) -> (ClientToServerMsg, PathBuf);
 }
 
@@ -73,6 +74,7 @@ impl SessionManager for RealSessionManager {
         is_web_client: bool,
         os_input: Box<dyn ClientOsApi>,
         requested_layout: Option<LayoutInfo>,
+        is_welcome_screen: bool,
     ) -> (ClientToServerMsg, PathBuf) {
         crate::web_client::session_management::spawn_session_if_needed(
             session_name,
@@ -83,6 +85,7 @@ impl SessionManager for RealSessionManager {
             is_web_client,
             os_input,
             requested_layout,
+            is_welcome_screen,
         )
     }
 }

--- a/zellij-client/src/web_client/unit/web_client_tests.rs
+++ b/zellij-client/src/web_client/unit/web_client_tests.rs
@@ -1297,6 +1297,7 @@ impl SessionManager for MockSessionManager {
         is_web_client: bool,
         _os_input: Box<dyn ClientOsApi>,
         _requested_layout: Option<LayoutInfo>,
+        _is_welcome_screen: bool,
     ) -> (ClientToServerMsg, PathBuf) {
         let mock_ipc_path = PathBuf::from(format!("/tmp/mock_zellij_{}", session_name));
 

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -79,6 +79,7 @@ pub enum ServerInstruction {
         Box<PluginAliases>,
         bool, // should launch setup wizard
         bool, // is_web_client
+        bool, // layout_is_welcome_screen
         ClientId,
     ),
     Render(Option<HashMap<ClientId, String>>),
@@ -668,6 +669,7 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                 plugin_aliases,
                 should_launch_setup_wizard,
                 is_web_client,
+                layout_is_welcome_screen,
                 client_id,
             ) => {
                 let mut session = init_session(
@@ -762,10 +764,16 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                         // intrusive
                         let setup_wizard = setup_wizard_floating_pane();
                         floating_panes.push(setup_wizard);
-                    } else if should_show_release_notes(runtime_config_options.show_release_notes) {
+                    } else if should_show_release_notes(
+                        runtime_config_options.show_release_notes,
+                        layout_is_welcome_screen,
+                    ) {
                         let about = about_floating_pane();
                         floating_panes.push(about);
-                    } else if should_show_startup_tip(runtime_config_options.show_startup_tips) {
+                    } else if should_show_startup_tip(
+                        runtime_config_options.show_startup_tips,
+                        layout_is_welcome_screen,
+                    ) {
                         let tip = tip_floating_pane();
                         floating_panes.push(tip);
                     }
@@ -1708,7 +1716,13 @@ fn tip_floating_pane() -> FloatingPaneLayout {
     about_pane
 }
 
-fn should_show_release_notes(should_show_release_notes_config: Option<bool>) -> bool {
+fn should_show_release_notes(
+    should_show_release_notes_config: Option<bool>,
+    layout_is_welcome_screen: bool,
+) -> bool {
+    if layout_is_welcome_screen {
+        return false;
+    }
     if let Some(should_show_release_notes_config) = should_show_release_notes_config {
         if !should_show_release_notes_config {
             // if we were explicitly told not to show release notes, we don't show them,
@@ -1731,8 +1745,15 @@ fn should_show_release_notes(should_show_release_notes_config: Option<bool>) -> 
     }
 }
 
-fn should_show_startup_tip(should_show_startup_tip_config: Option<bool>) -> bool {
-    should_show_startup_tip_config.unwrap_or(true)
+fn should_show_startup_tip(
+    should_show_startup_tip_config: Option<bool>,
+    layout_is_welcome_screen: bool,
+) -> bool {
+    if layout_is_welcome_screen {
+        false
+    } else {
+        should_show_startup_tip_config.unwrap_or(true)
+    }
 }
 
 #[cfg(not(feature = "singlepass"))]

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -1109,6 +1109,7 @@ pub(crate) fn route_thread_main(
                             plugin_aliases,
                             should_launch_setup_wizard,
                             is_web_client,
+                            layout_is_welcome_screen,
                         ) => {
                             let new_client_instruction = ServerInstruction::NewClient(
                                 client_attributes,
@@ -1119,6 +1120,7 @@ pub(crate) fn route_thread_main(
                                 plugin_aliases,
                                 should_launch_setup_wizard,
                                 is_web_client,
+                                layout_is_welcome_screen,
                                 client_id,
                             );
                             to_server

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -80,6 +80,7 @@ pub enum ClientToServerMsg {
         Box<PluginAliases>,
         bool, // should launch setup wizard
         bool, // is_web_client
+        bool, // layout_is_welcome_screen
     ),
     AttachClient(
         ClientAttributes,


### PR DESCRIPTION
This prevents the "release-notes" and "startup tips" popups to be shown when Zellij starts with a welcome screen. (Thanks @Zykino for pointing this out!)