### PR TITLE
fix(tabs): do not send release event to inactive tab

### DIFF
--- a/default-plugins/multiple-select/src/main.rs
+++ b/default-plugins/multiple-select/src/main.rs
@@ -133,10 +133,10 @@ impl App {
     }
 
     fn shortcuts_line2_text() -> (&'static str, Text) {
-        let text = "<r> - break right, <l> - break left";
+        let text = "<l> - break left, <r> - break right";
         let component = Text::new(text)
-            .color_substring(3, "<r>")
-            .color_substring(3, "<l>");
+            .color_substring(3, "<l>")
+            .color_substring(3, "<r>");
         (text, component)
     }
 

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -4276,7 +4276,17 @@ impl Tab {
             self.floating_panes
                 .stop_moving_pane_with_mouse(event.position);
         } else {
-            self.write_mouse_event_to_active_pane(event, client_id)?;
+            let active_pane_id = self
+                .get_active_pane_id(client_id)
+                .ok_or(anyhow!("Failed to find pane at position"))?;
+            let pane_id_at_position = self
+                .get_pane_at(&event.position, false)
+                .with_context(err_context)?
+                .ok_or_else(|| anyhow!("Failed to find pane at position"))?
+                .pid();
+            if active_pane_id == pane_id_at_position {
+                self.write_mouse_event_to_active_pane(event, client_id)?;
+            }
         }
         if leave_clipboard_message {
             Ok(MouseEffect::leave_clipboard_message())


### PR DESCRIPTION
This fixes a minor issue where we would send a release mouse event to the active pane if it happened on an inactive pane.

This also contains a minor UI fix for the new multiple-select plugin.