### PR TITLE
fix(grid): account for wide characters when double-triple mouse clicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix: don't show popups in the welcome screen (https://github.com/zellij-org/zellij/pull/4294)
 * fix: reap processes when using an external clipboard tool (https://github.com/zellij-org/zellij/pull/4298)
 * fix: out of bounds mouse release events (https://github.com/zellij-org/zellij/pull/4300)
+* fix: account for emoji/widechars when double/triple-clicking to mark words (https://github.com/zellij-org/zellij/pull/4302)
 
 ## [0.42.2] - 2025-04-15
 * refactor(terminal): track scroll_region as tuple rather than Option (https://github.com/zellij-org/zellij/pull/4082)

--- a/src/tests/e2e/cases.rs
+++ b/src/tests/e2e/cases.rs
@@ -101,10 +101,14 @@ fn account_for_races_in_snapshot(snapshot: String) -> String {
     // once that happens, we should be able to remove this hack (and adjust the snapshots for the
     // trailing spaces that we had to get rid of here)
     let base_replace = Regex::new(r"Alt <\[\]>  BASE \s*\n").unwrap();
-    let base_replace_tmux_mode = Regex::new(r"Alt \[\|SPACE\|Alt \]  BASE \s*\n").unwrap();
+    let base_replace_tmux_mode_1 = Regex::new(r"Alt \[\|SPACE\|Alt \]  BASE \s*\n").unwrap();
+    let base_replace_tmux_mode_2 = Regex::new(r"Alt \[\|Alt \]\|SPACE  BASE \s*\n").unwrap();
     let eol_arrow_replace = Regex::new(r"\s*\n").unwrap();
     let snapshot = base_replace.replace_all(&snapshot, "\n").to_string();
-    let snapshot = base_replace_tmux_mode
+    let snapshot = base_replace_tmux_mode_1
+        .replace_all(&snapshot, "\n")
+        .to_string();
+    let snapshot = base_replace_tmux_mode_2
         .replace_all(&snapshot, "\n")
         .to_string();
     let snapshot = eol_arrow_replace.replace_all(&snapshot, "\n").to_string();


### PR DESCRIPTION
This is a fix for https://github.com/zellij-org/zellij/issues/4162 - in which when we double-click a word which has an emoji *before* it, the marking would not account for wide characters.

When I implemented this feature, I accounted for wide characters inside the clicked word, but I forgot to account for wide characters before the word (oops!)

This remedies the situation.