### PR TITLE
fix(ux): allow pasting and inputing wide-chars in search + tab rename + pane rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix: reap processes when using an external clipboard tool (https://github.com/zellij-org/zellij/pull/4298)
 * fix: out of bounds mouse release events (https://github.com/zellij-org/zellij/pull/4300)
 * fix: account for emoji/widechars when double/triple-clicking to mark words (https://github.com/zellij-org/zellij/pull/4302)
+* fix: allow pasting and emojis in tab/pane names and pasting in search (https://github.com/zellij-org/zellij/pull/4303)
 
 ## [0.42.2] - 2025-04-15
 * refactor(terminal): track scroll_region as tuple rather than Option (https://github.com/zellij-org/zellij/pull/4082)

--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -126,7 +126,7 @@ impl InputHandler {
         options: Options,
         send_client_instructions: SenderWithContext<ClientInstruction>,
         mode: InputMode, // TODO: we can probably get rid of this now that we're tracking it on the
-                         // server instead
+        // server instead
         receive_input_instructions: Receiver<(InputInstruction, ErrorContext)>,
     ) -> Self {
         InputHandler {

--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -125,7 +125,8 @@ impl InputHandler {
         config: Config,
         options: Options,
         send_client_instructions: SenderWithContext<ClientInstruction>,
-        mode: InputMode,
+        mode: InputMode, // TODO: we can probably get rid of this now that we're tracking it on the
+                         // server instead
         receive_input_instructions: Receiver<(InputInstruction, ErrorContext)>,
     ) -> Self {
         InputHandler {

--- a/zellij-server/src/panes/mod.rs
+++ b/zellij-server/src/panes/mod.rs
@@ -10,7 +10,7 @@ mod active_panes;
 pub mod floating_panes;
 mod plugin_pane;
 mod search;
-mod terminal_pane;
+pub mod terminal_pane;
 mod tiled_panes;
 
 pub use active_panes::*;

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -16,12 +16,12 @@ use zellij_utils::data::{
     Direction, KeyWithModifier, PaneInfo, PermissionStatus, PermissionType, PluginPermission,
     ResizeStrategy, WebSharing,
 };
-use zellij_utils::shared::clean_string_from_control_and_linebreak;
 use zellij_utils::errors::prelude::*;
 use zellij_utils::input::command::RunCommand;
 use zellij_utils::input::mouse::{MouseEvent, MouseEventType};
 use zellij_utils::position::Position;
 use zellij_utils::position::{Column, Line};
+use zellij_utils::shared::clean_string_from_control_and_linebreak;
 
 use crate::background_jobs::BackgroundJob;
 use crate::pane_groups::PaneGroups;

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -5360,6 +5360,9 @@ impl Tab {
     pub fn get_display_area(&self) -> Size {
         self.display_area.borrow().clone()
     }
+    pub fn get_client_input_mode(&self, client_id: ClientId) -> Option<InputMode> {
+        self.mode_info.borrow().get(&client_id).map(|m| m.mode)
+    }
     fn new_scrollback_editor_pane(&self, pid: u32) -> TerminalPane {
         let next_terminal_position = self.get_next_terminal_position();
         let mut new_pane = TerminalPane::new(

--- a/zellij-utils/src/shared.rs
+++ b/zellij-utils/src/shared.rs
@@ -35,6 +35,20 @@ pub fn ansi_len(s: &str) -> usize {
     from_utf8(&strip(s).unwrap()).unwrap().width()
 }
 
+pub fn clean_string_from_control_and_linebreak(input: &str) -> String {
+    input
+        .chars()
+        .filter(|c| {
+            !c.is_control() && 
+            *c != '\n' &&      // line feed
+            *c != '\r' &&      // carriage return
+            *c != '\u{2028}' && // line separator
+            *c != '\u{2029}'    // paragraph separator
+        })
+        .collect()
+}
+
+
 pub fn adjust_to_size(s: &str, rows: usize, columns: usize) -> String {
     s.lines()
         .map(|l| {

--- a/zellij-utils/src/shared.rs
+++ b/zellij-utils/src/shared.rs
@@ -39,15 +39,14 @@ pub fn clean_string_from_control_and_linebreak(input: &str) -> String {
     input
         .chars()
         .filter(|c| {
-            !c.is_control() && 
+            !c.is_control() &&
             *c != '\n' &&      // line feed
             *c != '\r' &&      // carriage return
             *c != '\u{2028}' && // line separator
-            *c != '\u{2029}'    // paragraph separator
+            *c != '\u{2029}' // paragraph separator
         })
         .collect()
 }
-
 
 pub fn adjust_to_size(s: &str, rows: usize, columns: usize) -> String {
     s.lines()


### PR DESCRIPTION
This fixes several issues:
1. It is now possible to paste strings into the search, when renaming tabs and when renaming panes
2. It is now possible to have tab names and pane names that include wide characters (eg. emojis)*

*it is unfortunately still not possible to search for emojis, because the search is not wide-char aware - something I'd be happy to fix given the chance!