### PR TITLE
fix(compact-bar): tooltip duplication

### DIFF
--- a/default-plugins/compact-bar/src/action_types.rs
+++ b/default-plugins/compact-bar/src/action_types.rs
@@ -34,6 +34,7 @@ pub enum ActionType {
     NewTab,
     Detach,
     Quit,
+    NewStackedPane,
     Other(String), // Fallback for unhandled actions
 }
 
@@ -75,6 +76,7 @@ impl ActionType {
             },
             ActionType::SwitchToMode(input_mode) => format!("{:?}", input_mode),
             ActionType::TogglePaneEmbedOrFloating => "Float or embed".to_string(),
+            ActionType::NewStackedPane => "New stacked pane".to_string(),
             ActionType::ToggleFocusFullscreen => "Toggle fullscreen".to_string(),
             ActionType::ToggleFloatingPanes => "Show/hide floating panes".to_string(),
             ActionType::CloseFocus => "Close pane".to_string(),
@@ -101,6 +103,7 @@ impl ActionType {
             Action::Search(_) => ActionType::Search,
             Action::NewPane(Some(_), _, _) => ActionType::NewPaneWithDirection,
             Action::NewPane(None, _, _) => ActionType::NewPaneWithoutDirection,
+            Action::NewStackedPane(_, _) => ActionType::NewStackedPane,
             Action::BreakPaneLeft | Action::BreakPaneRight => ActionType::BreakPaneLeftOrRight,
             Action::GoToPreviousTab | Action::GoToNextTab => ActionType::GoToAdjacentTab,
             Action::ScrollUp | Action::ScrollDown => ActionType::Scroll,

--- a/default-plugins/compact-bar/src/keybind_utils.rs
+++ b/default-plugins/compact-bar/src/keybind_utils.rs
@@ -50,7 +50,6 @@ impl KeybindProcessor {
                             let should_add_brackets_to_keys = mode != InputMode::Normal;
 
                             // Check if this is switching to normal mode
-                            // let is_switching_to_locked = matches!(first_action, Action::SwitchToMode(InputMode::Normal));
                             let is_switching_to_locked =
                                 matches!(first_action, Action::SwitchToMode(InputMode::Locked));
 
@@ -334,6 +333,7 @@ impl KeybindProcessor {
                     |action: &Action| matches!(action, Action::ToggleFocusFullscreen),
                     |action: &Action| matches!(action, Action::ToggleFloatingPanes),
                     |action: &Action| matches!(action, Action::TogglePaneEmbedOrFloating),
+                    |action: &Action| matches!(action, Action::NewStackedPane(None, None)),
                     |action: &Action| {
                         matches!(action, Action::NewPane(Some(Direction::Right), None, false))
                     },


### PR DESCRIPTION
This fixes a few issues with the new tooltip functionality of the compact-bar:
1. We now use the proper configuration when for the keybind toggle (so as not to launch the compact-bar a second time)
2. We now only send the tooltip toggle once (based on the focused tab) to prevent double opening of the tooltip in multiple tabs (we move the tooltip to the active tab anyway)
3. The new "new stacked pane" action has been added to pane mode