### PR TITLE
fix(status-bar): proper truncation of secondary info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix: stack pane ordering when stacking multiple panes (https://github.com/zellij-org/zellij/pull/4308)
 * fix: normalize focusing of plugins launched through pipes (https://github.com/zellij-org/zellij/pull/4309)
 * performance: improve dumping screen for when editing scrollback with $EDITOR (https://github.com/zellij-org/zellij/pull/2548)
+* fix: properly truncate status bar secondary info (https://github.com/zellij-org/zellij/pull/4313)
 
 ## [0.42.2] - 2025-04-15
 * refactor(terminal): track scroll_region as tuple rather than Option (https://github.com/zellij-org/zellij/pull/4082)

--- a/default-plugins/status-bar/src/one_line_ui.rs
+++ b/default-plugins/status-bar/src/one_line_ui.rs
@@ -982,15 +982,11 @@ fn secondary_keybinds(help: &ModeInfo, tab_info: Option<&TabInfo>, max_len: usiz
             short_line
         } else if max_len >= 3 {
             let part = serialize_text(
-                &Text::new(format!(
-                    "{:>width$}",
-                    "...",
-                    width = max_len.saturating_sub(3)
-                ))
-                .color_range(0, ..)
-                .opaque(),
+                &Text::new(format!("{:>width$}", "...", width = max_len))
+                    .color_range(0, ..)
+                    .opaque(),
             );
-            let len = std::cmp::max(max_len.saturating_sub(3), 3);
+            let len = max_len;
             LinePart { part, len }
         } else {
             LinePart {

--- a/default-plugins/status-bar/src/one_line_ui.rs
+++ b/default-plugins/status-bar/src/one_line_ui.rs
@@ -993,7 +993,10 @@ fn secondary_keybinds(help: &ModeInfo, tab_info: Option<&TabInfo>, max_len: usiz
             let len = std::cmp::max(max_len.saturating_sub(3), 3);
             LinePart { part, len }
         } else {
-            LinePart { part: "".to_owned(), len: 0 }
+            LinePart {
+                part: "".to_owned(),
+                len: 0,
+            }
         }
     }
 }

--- a/default-plugins/status-bar/src/one_line_ui.rs
+++ b/default-plugins/status-bar/src/one_line_ui.rs
@@ -980,7 +980,7 @@ fn secondary_keybinds(help: &ModeInfo, tab_info: Option<&TabInfo>, max_len: usiz
         }
         if short_line.len <= max_len {
             short_line
-        } else {
+        } else if max_len >= 3 {
             let part = serialize_text(
                 &Text::new(format!(
                     "{:>width$}",
@@ -990,8 +990,10 @@ fn secondary_keybinds(help: &ModeInfo, tab_info: Option<&TabInfo>, max_len: usiz
                 .color_range(0, ..)
                 .opaque(),
             );
-            let len = max_len.saturating_sub(3);
+            let len = std::cmp::max(max_len.saturating_sub(3), 3);
             LinePart { part, len }
+        } else {
+            LinePart { part: "".to_owned(), len: 0 }
         }
     }
 }

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__bracketed_paste.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__bracketed_paste.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 2000
 expression: last_snapshot
 ---
  Zellij (e2e-test)  Tab #1 
@@ -26,4 +25,4 @@ expression: last_snapshot
 │                                                                                                                      │
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__cannot_split_terminals_vertically_when_active_terminal_is_too_small.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__cannot_split_terminals_vertically_when_active_terminal_is_too_small.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 239
 expression: last_snapshot
 ---
  Zellij 
@@ -22,4 +21,4 @@ expression: last_snapshot
 │      │
 │      │
 └──────┘
-...     
+ Ctrl +

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__close_pane.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__close_pane.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 714
 expression: last_snapshot
 ---
  Zellij (e2e-test)  Tab #1 
@@ -26,4 +25,4 @@ expression: last_snapshot
 │                                                                                                                      │
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__focus_pane_with_mouse.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__focus_pane_with_mouse.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 1373
 expression: last_snapshot
 ---
  Zellij (e2e-test)  Tab #1 
@@ -26,4 +25,4 @@ expression: last_snapshot
 │                                                          ││                                                          │
 │                                                          ││                                                          │
 └──────────────────────────────────────────────────────────┘└──────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__mirrored_sessions.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__mirrored_sessions.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 1650
 expression: first_runner_snapshot
 ---
  Zellij (mirrored_sessions)  Tab #1  Tab #2 
@@ -26,4 +25,4 @@ expression: first_runner_snapshot
 │                                                          ││                                                          │
 │                                                          ││                                                          │
 └──────────────────────────────────────────────────────────┘└──────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__move_tab_to_left.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__move_tab_to_left.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 562
 expression: account_for_races_in_snapshot(last_snapshot)
 ---
  Zellij (e2e-test)  Tab #1  Tab #3  Tab #2 
@@ -26,4 +25,4 @@ expression: account_for_races_in_snapshot(last_snapshot)
 │                                                                                                                      │
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__move_tab_to_left_until_it_wraps_around.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__move_tab_to_left_until_it_wraps_around.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 624
 expression: account_for_races_in_snapshot(last_snapshot)
 ---
  Zellij (e2e-test)  Tab #2  Tab #1  Tab #3 
@@ -26,4 +25,4 @@ expression: account_for_races_in_snapshot(last_snapshot)
 │                                                                                                                      │
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__move_tab_to_right.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__move_tab_to_right.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 596
 expression: account_for_races_in_snapshot(last_snapshot)
 ---
  Zellij (e2e-test)  Tab #1  Tab #3  Tab #2 
@@ -26,4 +25,4 @@ expression: account_for_races_in_snapshot(last_snapshot)
 │                                                                                                                      │
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__move_tab_to_right_until_it_wraps_around.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__move_tab_to_right_until_it_wraps_around.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 648
 expression: account_for_races_in_snapshot(last_snapshot)
 ---
  Zellij (e2e-test)  Tab #3  Tab #2  Tab #1 
@@ -26,4 +25,4 @@ expression: account_for_races_in_snapshot(last_snapshot)
 │                                                                                                                      │
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_different_panes_and_same_tab-2.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_different_panes_and_same_tab-2.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 1836
 expression: second_runner_snapshot
 ---
  Zellij (multiple_users_in_same_pane_and_tab)  Tab #1 [ ]
@@ -26,4 +25,4 @@ expression: second_runner_snapshot
 │                                                          ││                                                          │
 │                                                          ││                                                          │
 └──────────────────────────────────────────────────────────┘└──────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_different_panes_and_same_tab.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_different_panes_and_same_tab.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 1835
 expression: first_runner_snapshot
 ---
  Zellij (multiple_users_in_same_pane_and_tab)  Tab #1 [ ]
@@ -26,4 +25,4 @@ expression: first_runner_snapshot
 │                                                          ││                                                          │
 │                                                          ││                                                          │
 └──────────────────────────────────────────────────────────┘└──────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_different_tabs-2.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_different_tabs-2.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 1936
 expression: second_runner_snapshot
 ---
  Zellij (multiple_users_in_different_tabs)  Tab #1 [ ] Tab #2 
@@ -26,4 +25,4 @@ expression: second_runner_snapshot
 │                                                                                                                      │
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_different_tabs.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_different_tabs.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 1935
 expression: first_runner_snapshot
 ---
  Zellij (multiple_users_in_different_tabs)  Tab #1  Tab #2 [ ]
@@ -26,4 +25,4 @@ expression: first_runner_snapshot
 │                                                                                                                      │
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_same_pane_and_tab-2.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_same_pane_and_tab-2.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 1741
 expression: second_runner_snapshot
 ---
  Zellij (multiple_users_in_same_pane_and_tab)  Tab #1 [ ]
@@ -26,4 +25,4 @@ expression: second_runner_snapshot
 │                                                                                                                      │
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_same_pane_and_tab.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__multiple_users_in_same_pane_and_tab.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 1740
 expression: first_runner_snapshot
 ---
  Zellij (multiple_users_in_same_pane_and_tab)  Tab #1 [ ]
@@ -26,4 +25,4 @@ expression: first_runner_snapshot
 │                                                                                                                      │
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__open_new_tab.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__open_new_tab.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 454
 expression: last_snapshot
 ---
  Zellij (e2e-test)  Tab #1  Tab #2 
@@ -26,4 +25,4 @@ expression: last_snapshot
 │                                                                                                                      │
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__pin_floating_panes.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__pin_floating_panes.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 2521
 expression: last_snapshot
 ---
  Zellij (e2e-test)  Tab #1 
@@ -26,4 +25,4 @@ expression: last_snapshot
 │                                                                                                                      │
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__resize_pane.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__resize_pane.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 935
 expression: last_snapshot
 ---
  Zellij (e2e-test)  Tab #1 
@@ -26,4 +25,4 @@ expression: last_snapshot
 │                                                    ││                                                                │
 │                                                    ││                                                                │
 └────────────────────────────────────────────────────┘└────────────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__resize_terminal_window.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__resize_terminal_window.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 1064
 expression: last_snapshot
 ---
  Zellij (e2e-test)  Tab #1 
@@ -26,4 +25,4 @@ expression: last_snapshot
 │                                                ││                                                │                    
 │                                                ││                                                │                    
 └────────────────────────────────────────────────┘└────────────────────────────────────────────────┘                    
- Ctrl + g  p  t  n  h  s  o  q                                                 ...                     
+ Ctrl + g  p  t  n  h  s  o  q                                                  ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__scrolling_inside_a_pane_with_mouse.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__scrolling_inside_a_pane_with_mouse.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 1451
 expression: last_snapshot
 ---
  Zellij (e2e-test)  Tab #1 
@@ -26,4 +25,4 @@ expression: last_snapshot
 │                                                          ││line18                                                    │
 │                                                          ││li█e19                                                    │
 └──────────────────────────────────────────────────────────┘└──────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__send_command_through_the_cli.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__send_command_through_the_cli.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 2372
 expression: last_snapshot
 ---
  Zellij (e2e-test)  Tab #1                                                                                                    Alt <[]>  VERTICAL 
@@ -26,4 +25,4 @@ expression: last_snapshot
 │                                                                         ││                                                                         │
 │                                                                         ││                                                                         │
 └─────────────────────────────────────────────────────────────────────────┘└ [ EXIT CODE: 0 ] <ENTER> re-run, <ESC> drop to shell, <Ctrl-c> exit ────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT                                     ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT                                      ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__split_terminals_vertically.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__split_terminals_vertically.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 195
 expression: last_snapshot
 ---
  Zellij (e2e-test)  Tab #1 
@@ -26,4 +25,4 @@ expression: last_snapshot
 │                                                          ││                                                          │
 │                                                          ││                                                          │
 └──────────────────────────────────────────────────────────┘└──────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__start_without_pane_frames.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__start_without_pane_frames.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 1500
 expression: last_snapshot
 ---
  Zellij (e2e-test)  Tab #1 
@@ -26,4 +25,4 @@ $                                                          │
                                                            │                                                            
                                                            │                                                            
                                                            │                                                            
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__starts_with_one_terminal.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__starts_with_one_terminal.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 145
 expression: last_snapshot
 ---
  Zellij (e2e-test)  Tab #1 
@@ -26,4 +25,4 @@ expression: last_snapshot
 │                                                                                                                      │
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__tmux_mode.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__tmux_mode.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 2099
 expression: last_snapshot
 ---
  Zellij (e2e-test)  Tab #1 
@@ -26,4 +25,4 @@ expression: last_snapshot
 │                                                          ││                                                          │
 │                                                          ││                                                          │
 └──────────────────────────────────────────────────────────┘└──────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__toggle_floating_panes.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__toggle_floating_panes.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 2049
 expression: last_snapshot
 ---
  Zellij (e2e-test)  Tab #1                                                                     Alt <[]>  STAGGERED 
@@ -26,4 +25,4 @@ expression: last_snapshot
 │                                                                                                                      │
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__toggle_pane_fullscreen.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__toggle_pane_fullscreen.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 386
 expression: last_snapshot
 ---
  Zellij (e2e-test)  Tab #1 (FULLSCREEN) 
@@ -26,4 +25,4 @@ expression: last_snapshot
 │                                                                                                                      │
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__typing_exit_closes_pane.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__typing_exit_closes_pane.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 867
 expression: last_snapshot
 ---
  Zellij (e2e-test)  Tab #1 
@@ -26,4 +25,4 @@ expression: last_snapshot
 │                                                                                                                      │
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__undo_rename_pane.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__undo_rename_pane.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 2263
 expression: last_snapshot
 ---
  Zellij (e2e-test)  Tab #1 
@@ -26,4 +25,4 @@ expression: last_snapshot
 │                                                                                                                      │
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__undo_rename_tab.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__undo_rename_tab.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 2206
 expression: last_snapshot
 ---
  Zellij (e2e-test)  Tab #1 
@@ -26,4 +25,4 @@ expression: last_snapshot
 │                                                                                                                      │
 │                                                                                                                      │
 └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT       ... 
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...


### PR DESCRIPTION
This fixes a small issue where when there isn't enough space on the bottom bar to render the secondary info and the remaining space is less than 4 characters, the status bar would overflow and thus only 1 or two dots would be printed.

This should fix https://github.com/zellij-org/zellij/issues/4119