### PR TITLE
feat(web): allow specifying ip/port/cert/key through the cli

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,4 +1,5 @@
 use dialoguer::Confirm;
+use std::net::IpAddr;
 use std::{fs::File, io::prelude::*, path::PathBuf, process, time::Duration};
 
 #[cfg(feature = "web_server_capability")]
@@ -159,7 +160,14 @@ pub(crate) fn start_server(path: PathBuf, debug: bool) {
 }
 
 #[cfg(feature = "web_server_capability")]
-pub(crate) fn start_web_server(opts: CliArgs, run_daemonized: bool) {
+pub(crate) fn start_web_server(
+    opts: CliArgs,
+    run_daemonized: bool,
+    ip: Option<IpAddr>,
+    port: Option<u16>,
+    cert: Option<PathBuf>,
+    key: Option<PathBuf>,
+) {
     // TODO: move this outside of this function
     let (config, _layout, config_options, _config_without_layout, _config_options_without_layout) =
         match Setup::from_cli_args(&opts) {
@@ -174,8 +182,16 @@ pub(crate) fn start_web_server(opts: CliArgs, run_daemonized: bool) {
                 process::exit(1);
             },
         };
-
-    start_web_client_impl(config, config_options, opts.config, run_daemonized);
+    start_web_client_impl(
+        config,
+        config_options,
+        opts.config,
+        run_daemonized,
+        ip,
+        port,
+        cert,
+        key,
+    );
 }
 
 #[cfg(not(feature = "web_server_capability"))]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -195,7 +195,14 @@ pub(crate) fn start_web_server(
 }
 
 #[cfg(not(feature = "web_server_capability"))]
-pub(crate) fn start_web_server(_opts: CliArgs, _run_daemonized: bool) {
+pub(crate) fn start_web_server(
+    _opts: CliArgs,
+    _run_daemonized: bool,
+    _ip: Option<IpAddr>,
+    _port: Option<u16>,
+    _cert: Option<PathBuf>,
+    _key: Option<PathBuf>,
+) {
     log::error!(
         "This version of Zellij was compiled without web server support, cannot run web server!"
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,7 +231,14 @@ fn main() {
     } else if let Some(Command::Web(web_opts)) = &opts.command {
         if web_opts.get_start() {
             let daemonize = web_opts.daemonize;
-            commands::start_web_server(opts, daemonize);
+            commands::start_web_server(
+                opts.clone(),
+                daemonize,
+                web_opts.ip,
+                web_opts.port,
+                web_opts.cert.clone(),
+                web_opts.key.clone(),
+            );
         } else if web_opts.stop {
             match commands::stop_web_server() {
                 Ok(()) => {

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use clap::{Args, Parser, Subcommand};
 use serde::{Deserialize, Serialize};
+use std::net::IpAddr;
 use std::path::PathBuf;
 use url::Url;
 
@@ -144,6 +145,38 @@ pub struct WebCli {
     /// List token names and their creation dates (cannot show actual tokens)
     #[clap(long, value_parser, exclusive(true), display_order = 8)]
     pub list_tokens: bool,
+    /// The ip address to listen on locally for connections (defaults to 127.0.0.1)
+    #[clap(
+        long,
+        value_parser,
+        conflicts_with_all(&["stop", "status", "create-token", "revoke-token", "revoke-all-tokens"]),
+        display_order = 9
+    )]
+    pub ip: Option<IpAddr>,
+    /// The port to listen on locally for connections (defaults to 8082)
+    #[clap(
+        long,
+        value_parser,
+        conflicts_with_all(&["stop", "status", "create-token", "revoke-token", "revoke-all-tokens"]),
+        display_order = 10
+    )]
+    pub port: Option<u16>,
+    /// The path to the SSL certificate (required if not listening on 127.0.0.1)
+    #[clap(
+        long,
+        value_parser,
+        conflicts_with_all(&["stop", "status", "create-token", "revoke-token", "revoke-all-tokens"]),
+        display_order = 11
+    )]
+    pub cert: Option<PathBuf>,
+    /// The path to the SSL key (required if not listening on 127.0.0.1)
+    #[clap(
+        long,
+        value_parser,
+        conflicts_with_all(&["stop", "status", "create-token", "revoke-token", "revoke-all-tokens"]),
+        display_order = 12
+    )]
+    pub key: Option<PathBuf>,
 }
 
 impl WebCli {


### PR DESCRIPTION
Previously it was only possible to specify these through the config, now it's also possible to specify them through the cli.