### PR TITLE
fix(web): focus terminal on init

### DIFF
--- a/zellij-client/assets/input.js
+++ b/zellij-client/assets/input.js
@@ -91,7 +91,6 @@ export function setupInputHandlers(term, sendFunction) {
     // Mouse movement handler
     let terminal_element = document.getElementById("terminal");
     terminal_element.addEventListener("mousemove", function (event) {
-        window.term.focus();
         // this is a hack around: https://github.com/xtermjs/xterm.js/issues/1062
         // in short, xterm.js doesn't listen to mousemove at all and so even though
         // we send it a request for AnyEvent mouse handling, we don't get motion events in return

--- a/zellij-client/assets/terminal.js
+++ b/zellij-client/assets/terminal.js
@@ -2,7 +2,7 @@
  * Terminal initialization and management
  */
 
-import { build_link_handler } from './links.js';
+import { build_link_handler } from "./links.js";
 
 /**
  * Initialize the terminal with all required addons and configuration
@@ -20,7 +20,10 @@ export function initTerminal() {
     const clipboardAddon = new ClipboardAddon.ClipboardAddon();
 
     const { linkHandler, activateLink } = build_link_handler();
-    const webLinksAddon = new WebLinksAddon.WebLinksAddon(activateLink, linkHandler);
+    const webLinksAddon = new WebLinksAddon.WebLinksAddon(
+        activateLink,
+        linkHandler
+    );
     term.options.linkHandler = linkHandler;
 
     const webglAddon = new WebglAddon.WebglAddon();
@@ -34,5 +37,6 @@ export function initTerminal() {
     term.loadAddon(webglAddon);
     term.open(document.getElementById("terminal"));
     fitAddon.fit();
+    term.focus();
     return { term, fitAddon };
 }


### PR DESCRIPTION
Always focus the terminal during init instead of on a mouse event.