### PR TITLE
fix(terminal): handle omitted flags in kitty keyboard protocol push sequence

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -3142,8 +3142,14 @@ impl Perform for Grid {
         } else if c == 'u' && intermediates == &[b'>'] {
             // Zellij only supports the first "progressive enhancement" layer of the kitty keyboard
             // protocol
+            // 0 disables, everything else enables.
+            let count = next_param_or(0);
             if !self.explicitly_disable_kitty_keyboard_protocol {
-                self.supports_kitty_keyboard_protocol = true;
+                if count > 0 {
+                    self.supports_kitty_keyboard_protocol = true;
+                } else {
+                    self.supports_kitty_keyboard_protocol = false;
+                }
             }
         } else if c == 'u' && intermediates == &[b'<'] {
             // Zellij only supports the first "progressive enhancement" layer of the kitty keyboard


### PR DESCRIPTION
The `CSI > u` sequence (push) should default omitted flags to `0` per the [Kitty keyboard protocol specification](https://sw.kovidgoyal.net/kitty/keyboard-protocol/#progressive-enhancement). Previously, omitted flags incorrectly defaulted to 1, causing progressive enhancements to be enabled when they should remain disabled.

This fix ensures push with no flags (`printf "\e[>u"`) correctly sets flags to `0`, matching the protocol specification and making push behavior consistent with the existing `CSI = u` implementation introduced in #3942.

Fixes #4333.