### PR TITLE
fix(web): set secure cookie flag only for https

### DIFF
--- a/zellij-client/src/web_client/mod.rs
+++ b/zellij-client/src/web_client/mod.rs
@@ -229,6 +229,7 @@ pub async fn serve_web_client(
         }
     });
 
+    let is_https = rustls_config.is_some();
     let state = AppState {
         connection_table: connection_table.clone(),
         config: Arc::new(Mutex::new(config)),
@@ -236,6 +237,7 @@ pub async fn serve_web_client(
         config_file_path,
         session_manager,
         client_os_api_factory,
+        is_https,
     };
 
     tokio::spawn({

--- a/zellij-client/src/web_client/types.rs
+++ b/zellij-client/src/web_client/types.rs
@@ -174,6 +174,7 @@ pub struct AppState {
     pub config_file_path: PathBuf,
     pub session_manager: Arc<dyn SessionManager>,
     pub client_os_api_factory: Arc<dyn ClientOsApiFactory>,
+    pub is_https: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Previously, we would set the `secure` cookie flag (meaning the cookie should only be sent on https connections) to our session_token cookie whether we were on http or https. Most browsers have a "localhost exception" for this, meaning they send secure cookies on non-https connections so long as they are to localhost. Safari does not have this exception, so users were unable to log-in before they set an https certificate.

This fixes the issue by conditionally setting the `secure` flag depending on whether the connection is https or not. Since the web client does not perform any http (or indeed, any remote) requests other than to the server, this is not considered risky.