### PR TITLE
fix(list): do not list sessions as resurrectable unless they are

### DIFF
--- a/zellij-utils/src/sessions.rs
+++ b/zellij-utils/src/sessions.rs
@@ -65,7 +65,11 @@ pub fn get_resurrectable_sessions() -> Vec<(String, Duration)> {
                     let session_name = folder_name
                         .file_name()
                         .map(|f| std::path::PathBuf::from(f).display().to_string())?;
-                    Some((session_name, elapsed_duration))
+                    if std::path::Path::new(&layout_file_name).exists() {
+                        Some((session_name, elapsed_duration))
+                    } else {
+                        None
+                    }
                 })
                 .collect()
         },


### PR DESCRIPTION
Fixes a regression where `zellij ls` would list dead sessions as resurrectable even if they were not.