### PR TITLE
fix(web): use session name as initial document title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix: terminal title regression (https://github.com/zellij-org/zellij/pull/4352)
 * fix: resurrection listing regression (https://github.com/zellij-org/zellij/pull/4354)
 * fix: tooltip keybinding backgrounds (https://github.com/zellij-org/zellij/pull/4356)
+* fix: default to session name for window/tab title in Zellij Web (https://github.com/zellij-org/zellij/pull/4357)
 
 ## [0.43.0] - 2025-08-05
 * feat: multiple select and bulk pane actions (https://github.com/zellij-org/zellij/pull/4169 and https://github.com/zellij-org/zellij/pull/4171, https://github.com/zellij-org/zellij/pull/4221 and https://github.com/zellij-org/zellij/pull/4286)

--- a/zellij-client/assets/index.js
+++ b/zellij-client/assets/index.js
@@ -18,6 +18,7 @@ document.addEventListener("DOMContentLoaded", async (event) => {
     
     setupInputHandlers(term, sendAnsiKey);
 
+    document.title = sessionName;
     const websockets = initWebSockets(webClientId, sessionName, term, fitAddon, sendAnsiKey);
     
     // Update sendAnsiKey to use the actual WebSocket function returned by initWebSockets


### PR DESCRIPTION
Minor adjustment so that the tab name would be the same as the session name initially, rather than "Zellij Web Client".