### PR TITLE
feat: add focus-follows-mouse option

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -400,6 +400,7 @@ impl SessionMetaData {
                         .options
                         .advanced_mouse_actions
                         .unwrap_or(true),
+                    focus_follows_mouse: new_config.options.focus_follows_mouse.unwrap_or(false),
                 })
                 .unwrap();
             self.senders

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -271,6 +271,7 @@ fn create_new_tab(size: Size, default_mode: ModeInfo) -> Tab {
         current_group,
         currently_marking_pane_group,
         advanced_mouse_actions,
+        false, // focus_follows_mouse
         web_server_ip,
         web_server_port,
     );
@@ -352,6 +353,7 @@ fn create_new_tab_without_pane_frames(size: Size, default_mode: ModeInfo) -> Tab
         current_group,
         currently_marking_pane_group,
         advanced_mouse_actions,
+        false, // focus_follows_mouse
         web_server_ip,
         web_server_port,
     );
@@ -448,6 +450,7 @@ fn create_new_tab_with_swap_layouts(
         current_group,
         currently_marking_pane_group,
         advanced_mouse_actions,
+        false, // focus_follows_mouse
         web_server_ip,
         web_server_port,
     );
@@ -545,6 +548,7 @@ fn create_new_tab_with_os_api(
         current_group,
         currently_marking_pane_group,
         advanced_mouse_actions,
+        false, // focus_follows_mouse
         web_server_ip,
         web_server_port,
     );
@@ -628,6 +632,7 @@ fn create_new_tab_with_layout(size: Size, default_mode: ModeInfo, layout: &str) 
         current_group,
         currently_marking_pane_group,
         advanced_mouse_actions,
+        false, // focus_follows_mouse
         web_server_ip,
         web_server_port,
     );
@@ -725,6 +730,7 @@ fn create_new_tab_with_mock_pty_writer(
         current_group,
         currently_marking_pane_group,
         advanced_mouse_actions,
+        false, // focus_follows_mouse
         web_server_ip,
         web_server_port,
     );
@@ -813,6 +819,7 @@ fn create_new_tab_with_sixel_support(
         current_group,
         currently_marking_pane_group,
         advanced_mouse_actions,
+        false, // focus_follows_mouse
         web_server_ip,
         web_server_port,
     );

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -211,6 +211,7 @@ fn create_new_tab(size: Size, stacked_resize: bool) -> Tab {
         current_pane_group,
         currently_marking_pane_group,
         advanced_mouse_actions,
+        false, // focus_follows_mouse
         web_server_ip,
         web_server_port,
     );
@@ -291,6 +292,7 @@ fn create_new_tab_with_layout(size: Size, layout: TiledPaneLayout) -> Tab {
         current_pane_group,
         currently_marking_pane_group,
         advanced_mouse_actions,
+        false, // focus_follows_mouse
         web_server_ip,
         web_server_port,
     );
@@ -377,6 +379,7 @@ fn create_new_tab_with_cell_size(
         current_pane_group,
         currently_marking_pane_group,
         advanced_mouse_actions,
+        false, // focus_follows_mouse
         web_server_ip,
         web_server_port,
     );

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -302,6 +302,7 @@ fn create_new_screen(size: Size, advanced_mouse_actions: bool) -> Screen {
         false,
         web_sharing,
         advanced_mouse_actions,
+        false, // focus_follows_mouse
         web_server_ip,
         web_server_port,
     );

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -220,6 +220,12 @@ pub struct Options {
     #[serde(default)]
     pub advanced_mouse_actions: Option<bool>,
 
+    /// Whether to automatically focus panes when mouse hovers over them
+    /// default is false
+    #[clap(long, value_parser)]
+    #[serde(default)]
+    pub focus_follows_mouse: Option<bool>,
+
     // these are intentionally excluded from the CLI options as they must be specified in the
     // configuration file
     pub web_server_ip: Option<IpAddr>,
@@ -315,6 +321,7 @@ impl Options {
         let show_startup_tips = other.show_startup_tips.or(self.show_startup_tips);
         let show_release_notes = other.show_release_notes.or(self.show_release_notes);
         let advanced_mouse_actions = other.advanced_mouse_actions.or(self.advanced_mouse_actions);
+        let focus_follows_mouse = other.focus_follows_mouse.or(self.focus_follows_mouse);
         let web_server_ip = other.web_server_ip.or(self.web_server_ip);
         let web_server_port = other.web_server_port.or(self.web_server_port);
         let web_server_cert = other
@@ -362,6 +369,7 @@ impl Options {
             show_startup_tips,
             show_release_notes,
             advanced_mouse_actions,
+            focus_follows_mouse,
             web_server_ip,
             web_server_port,
             web_server_cert,
@@ -433,6 +441,7 @@ impl Options {
         let show_release_notes = other.show_release_notes.or(self.show_release_notes);
         let advanced_mouse_actions = other.advanced_mouse_actions.or(self.advanced_mouse_actions);
         let web_server_ip = other.web_server_ip.or(self.web_server_ip);
+        let focus_follows_mouse = other.focus_follows_mouse.or(self.focus_follows_mouse);
         let web_server_port = other.web_server_port.or(self.web_server_port);
         let web_server_cert = other
             .web_server_cert
@@ -479,6 +488,7 @@ impl Options {
             show_startup_tips,
             show_release_notes,
             advanced_mouse_actions,
+            focus_follows_mouse,
             web_server_ip,
             web_server_port,
             web_server_cert,
@@ -556,6 +566,7 @@ impl From<CliOptions> for Options {
             show_startup_tips: opts.show_startup_tips,
             show_release_notes: opts.show_release_notes,
             advanced_mouse_actions: opts.advanced_mouse_actions,
+            focus_follows_mouse: opts.focus_follows_mouse,
             web_server_ip: opts.web_server_ip,
             web_server_port: opts.web_server_port,
             web_server_cert: opts.web_server_cert,

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -2377,6 +2377,9 @@ impl Options {
         let advanced_mouse_actions =
             kdl_property_first_arg_as_bool_or_error!(kdl_options, "advanced_mouse_actions")
                 .map(|(v, _)| v);
+        let focus_follows_mouse =
+            kdl_property_first_arg_as_bool_or_error!(kdl_options, "focus_follows_mouse")
+                .map(|(v, _)| v);
         let web_server_ip =
             match kdl_property_first_arg_as_string_or_error!(kdl_options, "web_server_ip") {
                 Some((string, entry)) => Some(IpAddr::from_str(string).map_err(|_| {
@@ -2437,6 +2440,7 @@ impl Options {
             show_startup_tips,
             show_release_notes,
             advanced_mouse_actions,
+            focus_follows_mouse,
             web_server_ip,
             web_server_port,
             web_server_cert,
@@ -3510,6 +3514,33 @@ impl Options {
             None
         }
     }
+    fn focus_follows_mouse_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
+        let comment_text = format!(
+            "{}\n{}\n{}",
+            " ",
+            "// Whether to automatically focus panes when mouse hovers over them",
+            "// default is false",
+        );
+
+        let create_node = |node_value: bool| -> KdlNode {
+            let mut node = KdlNode::new("focus_follows_mouse");
+            node.push(KdlValue::Bool(node_value));
+            node
+        };
+        if let Some(focus_follows_mouse) = self.focus_follows_mouse {
+            let mut node = create_node(focus_follows_mouse);
+            if add_comments {
+                node.set_leading(format!("{}\n", comment_text));
+            }
+            Some(node)
+        } else if add_comments {
+            let mut node = create_node(false);
+            node.set_leading(format!("{}\n// ", comment_text));
+            Some(node)
+        } else {
+            None
+        }
+    }
     fn web_server_ip_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
         let comment_text = format!(
             "{}\n{}\n{}\n{}",
@@ -3711,6 +3742,9 @@ impl Options {
         }
         if let Some(advanced_mouse_actions) = self.advanced_mouse_actions_to_kdl(add_comments) {
             nodes.push(advanced_mouse_actions);
+        }
+        if let Some(focus_follows_mouse) = self.focus_follows_mouse_to_kdl(add_comments) {
+            nodes.push(focus_follows_mouse);
         }
         if let Some(web_server_ip) = self.web_server_ip_to_kdl(add_comments) {
             nodes.push(web_server_ip);

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__bare_config_from_default_assets_to_string_with_comments.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__bare_config_from_default_assets_to_string_with_comments.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/kdl/mod.rs
+assertion_line: 6484
 expression: fake_config_stringified
 ---
 keybinds clear-defaults=true {
@@ -518,6 +519,10 @@ web_client {
 // default is true
 // advanced_mouse_actions false
  
+// Whether to automatically focus panes when mouse hovers over them
+// default is false
+// focus_follows_mouse false
+ 
 // The ip address the web server should listen on when it starts
 // Default: "127.0.0.1"
 // (Requires restart)
@@ -534,3 +539,4 @@ web_client {
 // can be useful for removing wrappers around commands
 // Note: be sure to escape backslashes and similar characters properly
 // post_command_discovery_hook "echo $RESURRECT_COMMAND | sed <your_regex_here>"
+

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__config_options_to_string_with_comments.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__config_options_to_string_with_comments.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/kdl/mod.rs
+assertion_line: 6423
 expression: fake_document.to_string()
 ---
  
@@ -245,6 +246,10 @@ web_sharing "disabled"
 // default is true
 // advanced_mouse_actions false
  
+// Whether to automatically focus panes when mouse hovers over them
+// default is false
+// focus_follows_mouse false
+ 
 // The ip address the web server should listen on when it starts
 // Default: "127.0.0.1"
 // (Requires restart)
@@ -261,3 +266,4 @@ web_sharing "disabled"
 // can be useful for removing wrappers around commands
 // Note: be sure to escape backslashes and similar characters properly
 // post_command_discovery_hook "echo $RESURRECT_COMMAND | sed <your_regex_here>"
+

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 770
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -38,6 +39,7 @@ Options {
     show_startup_tips: None,
     show_release_notes: None,
     advanced_mouse_actions: None,
+    focus_follows_mouse: None,
     web_server_ip: None,
     web_server_port: None,
     web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 798
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -38,6 +39,7 @@ Options {
     show_startup_tips: None,
     show_release_notes: None,
     advanced_mouse_actions: None,
+    focus_follows_mouse: None,
     web_server_ip: None,
     web_server_port: None,
     web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 757
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -36,6 +37,7 @@ Options {
     show_startup_tips: None,
     show_release_notes: None,
     advanced_mouse_actions: None,
+    focus_follows_mouse: None,
     web_server_ip: None,
     web_server_port: None,
     web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 755
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -5964,6 +5965,7 @@ Config {
         show_startup_tips: None,
         show_release_notes: None,
         advanced_mouse_actions: None,
+        focus_follows_mouse: None,
         web_server_ip: None,
         web_server_port: None,
         web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 813
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -5964,6 +5965,7 @@ Config {
         show_startup_tips: None,
         show_release_notes: None,
         advanced_mouse_actions: None,
+        focus_follows_mouse: None,
         web_server_ip: None,
         web_server_port: None,
         web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 855
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -123,6 +124,7 @@ Config {
         show_startup_tips: None,
         show_release_notes: None,
         advanced_mouse_actions: None,
+        focus_follows_mouse: None,
         web_server_ip: None,
         web_server_port: None,
         web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 780
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -38,6 +39,7 @@ Options {
     show_startup_tips: None,
     show_release_notes: None,
     advanced_mouse_actions: None,
+    focus_follows_mouse: None,
     web_server_ip: None,
     web_server_port: None,
     web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 841
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -5964,6 +5965,7 @@ Config {
         show_startup_tips: None,
         show_release_notes: None,
         advanced_mouse_actions: None,
+        focus_follows_mouse: None,
         web_server_ip: None,
         web_server_port: None,
         web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 827
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -5964,6 +5965,7 @@ Config {
         show_startup_tips: None,
         show_release_notes: None,
         advanced_mouse_actions: None,
+        focus_follows_mouse: None,
         web_server_ip: None,
         web_server_port: None,
         web_server_cert: None,


### PR DESCRIPTION
## Summary
- Add new `focus_follows_mouse` configuration option that automatically focuses panes when the mouse hovers over them
- Integrates seamlessly with existing mouse hover detection system
- Requires `advanced_mouse_actions` to be enabled

## Configuration
Works via both config file and CLI:

**Config file:**
```kdl
options {
    advanced_mouse_actions true
    focus_follows_mouse true
}
```

**CLI:**
```bash
zellij options --focus-follows-mouse true
```

## Implementation Details
- Defaults to `false` for backwards compatibility
- Leverages existing hover detection in `tab/mod.rs`
- Uses existing `focus_pane_with_id()` method for consistency
- Extends `MouseEffect` struct with `focus_changed` field
- Minimal implementation (~100 lines of code)

## Test plan
- [x] All existing tests pass
- [x] New configuration option appears in generated config files
- [x] CLI flag works correctly with `options` subcommand
- [x] Feature integrates properly with existing mouse system
- [x] Backwards compatible (defaults to disabled)

🤖 Generated with [opencode](https://opencode.ai)