### PR TITLE
fix(web): avoid sending single meta keypresses, cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+* fix: meta key handling in web client (https://github.com/zellij-org/zellij/pull/4376)
 
 ## [0.43.1] - 2025-08-08
 * fix: pane rename backspace regression (https://github.com/zellij-org/zellij/pull/4346)

--- a/zellij-client/assets/input.js
+++ b/zellij-client/assets/input.js
@@ -26,29 +26,7 @@ export function setupInputHandlers(term, sendFunction) {
                 // pass cmd-v onwards so that paste is interpreted by xterm.js
                 return;
             }
-
-            let modifiers_count = 0;
-            let shift_keycode = 16;
-            let alt_keycode = 17;
-            let ctrl_keycode = 18;
-            if (ev.altKey) {
-                modifiers_count += 1;
-            }
-            if (ev.ctrlKey) {
-                modifiers_count += 1;
-            }
-            if (ev.shiftKey) {
-                modifiers_count += 1;
-            }
-            if (ev.metaKey) {
-                modifiers_count += 1;
-            }
-            if (
-                (modifiers_count > 1 || ev.metaKey) &&
-                ev.keyCode != shift_keycode &&
-                ev.keyCode != alt_keycode &&
-                ev.keyCode != ctrl_keycode
-            ) {
+            if (hasModifiersToHandle(ev)) {
                 ev.preventDefault();
                 encode_kitty_key(ev, sendFunction);
                 return false;
@@ -131,4 +109,26 @@ export function setupInputHandlers(term, sendFunction) {
         }
         sendFunction(buffer);
     });
+}
+
+/**
+ * Check if a key event has modifiers and is not a modifier key itself
+ * @param {KeyboardEvent} ev - The keyboard event
+ * @returns {boolean} - True if the key has modifiers that need special handling
+ */
+function hasModifiersToHandle(ev) {
+    // Use key property for simpler modifier key detection
+    const MODIFIER_KEYS = ["Shift", "Control", "Alt", "Meta"];
+
+    // Count active modifiers
+    const modifiers_count = [
+        ev.altKey,
+        ev.ctrlKey,
+        ev.shiftKey,
+        ev.metaKey,
+    ].filter(Boolean).length;
+
+    // Check if we have multiple modifiers or meta key, and it's not a modifier key itself
+    const isModifierKey = MODIFIER_KEYS.includes(ev.key);
+    return (modifiers_count > 1 || ev.metaKey) && !isModifierKey;
 }

--- a/zellij-client/src/web_client/mod.rs
+++ b/zellij-client/src/web_client/mod.rs
@@ -33,7 +33,6 @@ use nix::sys::stat::{umask, Mode};
 use interprocess::unnamed_pipe::pipe;
 use std::io::{prelude::*, BufRead, BufReader};
 use tokio::runtime::Runtime;
-use tower_http::cors::CorsLayer;
 use zellij_utils::input::{
     config::{watch_config_file_changes, Config},
     options::Options,
@@ -259,7 +258,6 @@ pub async fn serve_web_client(
         .route("/assets/{*path}", get(get_static_asset))
         .route("/command/login", post(login_handler))
         .route("/info/version", get(version_handler))
-        .layer(CorsLayer::permissive()) // TODO: configure properly
         .with_state(state);
 
     match rustls_config {


### PR DESCRIPTION
- extend the logic already used to skip single modifier key presses to meta
- refactor: extract the code into a function, make it simpler and use event.key instead of deprecated event.keyCode
- cleanup leftover axum cors config from feature development

Fix #4359 