### PR TITLE
feat: add rename-tab --tab-index flag to rename non-active tabs

### DIFF
--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -536,6 +536,11 @@ pub(crate) fn route_action(
                 .send_to_screen(ScreenInstruction::UndoRenameTab(client_id))
                 .with_context(err_context)?;
         },
+        Action::RenameTabByIndex(tab_index, new_name) => {
+            senders
+                .send_to_screen(ScreenInstruction::RenameTabByIndex(tab_index, new_name, client_id))
+                .with_context(err_context)?;
+        },
         Action::MoveTab(direction) => {
             let screen_instr = match direction {
                 Direction::Left => ScreenInstruction::MoveTabLeft(client_id),

--- a/zellij-utils/assets/prost/api.action.rs
+++ b/zellij-utils/assets/prost/api.action.rs
@@ -3,7 +3,7 @@
 pub struct Action {
     #[prost(enumeration="ActionName", tag="1")]
     pub name: i32,
-    #[prost(oneof="action::OptionalPayload", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49")]
+    #[prost(oneof="action::OptionalPayload", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50")]
     pub optional_payload: ::core::option::Option<action::OptionalPayload>,
 }
 /// Nested message and enum types in `Action`.
@@ -101,6 +101,8 @@ pub mod action {
         MoveTabPayload(i32),
         #[prost(message, tag="49")]
         MouseEventPayload(super::MouseEventPayload),
+        #[prost(message, tag="50")]
+        RenameTabByIndexPayload(super::RenameTabByIndexPayload),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -305,6 +307,14 @@ pub struct NameAndValue {
     #[prost(string, tag="2")]
     pub value: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RenameTabByIndexPayload {
+    #[prost(uint32, tag="1")]
+    pub tab_index: u32,
+    #[prost(string, tag="2")]
+    pub new_name: ::prost::alloc::string::String,
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum SearchDirection {
@@ -453,6 +463,7 @@ pub enum ActionName {
     PreviousSwapLayout = 64,
     NextSwapLayout = 65,
     QueryTabNames = 66,
+    RenameTabByIndex = 93,
     NewTiledPluginPane = 67,
     NewFloatingPluginPane = 68,
     StartOrReloadPlugin = 69,
@@ -548,6 +559,7 @@ impl ActionName {
             ActionName::PreviousSwapLayout => "PreviousSwapLayout",
             ActionName::NextSwapLayout => "NextSwapLayout",
             ActionName::QueryTabNames => "QueryTabNames",
+            ActionName::RenameTabByIndex => "RenameTabByIndex",
             ActionName::NewTiledPluginPane => "NewTiledPluginPane",
             ActionName::NewFloatingPluginPane => "NewFloatingPluginPane",
             ActionName::StartOrReloadPlugin => "StartOrReloadPlugin",
@@ -640,6 +652,7 @@ impl ActionName {
             "PreviousSwapLayout" => Some(Self::PreviousSwapLayout),
             "NextSwapLayout" => Some(Self::NextSwapLayout),
             "QueryTabNames" => Some(Self::QueryTabNames),
+            "RenameTabByIndex" => Some(Self::RenameTabByIndex),
             "NewTiledPluginPane" => Some(Self::NewTiledPluginPane),
             "NewFloatingPluginPane" => Some(Self::NewFloatingPluginPane),
             "StartOrReloadPlugin" => Some(Self::StartOrReloadPlugin),

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -750,6 +750,8 @@ pub enum CliAction {
     /// Renames the focused pane
     RenameTab {
         name: String,
+        #[clap(long)]
+        tab_index: Option<usize>,
     },
     /// Remove a previously set tab name
     UndoRenameTab,

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -292,6 +292,7 @@ pub enum ScreenContext {
     GoToTabName,
     UpdateTabName,
     UndoRenameTab,
+    RenameTabByIndex,
     MoveTabLeft,
     MoveTabRight,
     TerminalResize,

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -214,6 +214,7 @@ pub enum Action {
     ToggleTab,
     TabNameInput(Vec<u8>),
     UndoRenameTab,
+    RenameTabByIndex(usize, String),
     MoveTab(Direction),
     /// Run specified command in new pane.
     Run(RunCommandAction),
@@ -521,10 +522,16 @@ impl Action {
             CliAction::CloseTab => Ok(vec![Action::CloseTab]),
             CliAction::GoToTab { index } => Ok(vec![Action::GoToTab(index)]),
             CliAction::GoToTabName { name, create } => Ok(vec![Action::GoToTabName(name, create)]),
-            CliAction::RenameTab { name } => Ok(vec![
-                Action::TabNameInput(vec![0]),
-                Action::TabNameInput(name.as_bytes().to_vec()),
-            ]),
+            CliAction::RenameTab { name, tab_index } => {
+                if let Some(index) = tab_index {
+                    Ok(vec![Action::RenameTabByIndex(index, name)])
+                } else {
+                    Ok(vec![
+                        Action::TabNameInput(vec![0]),
+                        Action::TabNameInput(name.as_bytes().to_vec()),
+                    ])
+                }
+            },
             CliAction::UndoRenameTab => Ok(vec![Action::UndoRenameTab]),
             CliAction::NewTab {
                 name,

--- a/zellij-utils/src/plugin_api/action.proto
+++ b/zellij-utils/src/plugin_api/action.proto
@@ -53,6 +53,7 @@ message Action {
     CliPipePayload message_payload = 47;
     MoveTabDirection move_tab_payload = 48;
     MouseEventPayload mouse_event_payload = 49;
+    RenameTabByIndexPayload rename_tab_by_index_payload = 50;
   }
 }
 
@@ -221,6 +222,7 @@ enum ActionName {
     PreviousSwapLayout = 64;
     NextSwapLayout = 65;
     QueryTabNames = 66;
+    RenameTabByIndex = 93;
     NewTiledPluginPane = 67;
     NewFloatingPluginPane = 68;
     StartOrReloadPlugin = 69;
@@ -282,4 +284,9 @@ message PluginConfiguration {
 message NameAndValue {
   string name = 1;
   string value = 2;
+}
+
+message RenameTabByIndexPayload {
+  uint32 tab_index = 1;
+  string new_name = 2;
 }

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -7,6 +7,7 @@ pub use super::generated_api::api::{
         NameAndValue as ProtobufNameAndValue, NewFloatingPanePayload, NewPanePayload,
         NewPluginPanePayload, NewTiledPanePayload, PaneIdAndShouldFloat,
         PluginConfiguration as ProtobufPluginConfiguration, Position as ProtobufPosition,
+        RenameTabByIndexPayload,
         RunCommandAction as ProtobufRunCommandAction, ScrollAtPayload,
         SearchDirection as ProtobufSearchDirection, SearchOption as ProtobufSearchOption,
         SwitchToModePayload, WriteCharsPayload, WritePayload,
@@ -360,6 +361,13 @@ impl TryFrom<ProtobufAction> for Action {
             Some(ProtobufActionName::UndoRenameTab) => match protobuf_action.optional_payload {
                 Some(_) => Err("UndoRenameTab should not have a payload"),
                 None => Ok(Action::UndoRenameTab),
+            },
+            Some(ProtobufActionName::RenameTabByIndex) => match protobuf_action.optional_payload {
+                Some(OptionalPayload::RenameTabByIndexPayload(payload)) => {
+                    Ok(Action::RenameTabByIndex(payload.tab_index as usize, payload.new_name))
+                },
+                None => Err("RenameTabByIndex requires a payload"),
+                _ => Err("RenameTabByIndex received wrong payload type"),
             },
             Some(ProtobufActionName::MoveTab) => match protobuf_action.optional_payload {
                 Some(OptionalPayload::MoveTabPayload(move_tab_payload)) => {
@@ -1035,6 +1043,15 @@ impl TryFrom<Action> for ProtobufAction {
             Action::UndoRenameTab => Ok(ProtobufAction {
                 name: ProtobufActionName::UndoRenameTab as i32,
                 optional_payload: None,
+            }),
+            Action::RenameTabByIndex(tab_index, new_name) => Ok(ProtobufAction {
+                name: ProtobufActionName::RenameTabByIndex as i32,
+                optional_payload: Some(OptionalPayload::RenameTabByIndexPayload(
+                    RenameTabByIndexPayload {
+                        tab_index: tab_index as u32,
+                        new_name,
+                    }
+                )),
             }),
             Action::MoveTab(direction) => {
                 let direction: ProtobufMoveTabDirection = direction.try_into()?;


### PR DESCRIPTION
_Disclaimer: This PR has been developed with the help of Claude, but I've tested and reviewed manually._

- Added optional --tab-index flag to rename-tab CLI action
- Created new RenameTabByIndex action variant
- Implemented full routing from CLI through to Screen handler
- Updated protobuf definitions for plugin API compatibility
- Maintains backward compatibility with existing rename-tab usage

## Usage
```bash
# Rename active tab (existing behavior)
zellij action rename-tab "New Name"

# Rename tab at specific index (new feature)
zellij action rename-tab "New Name" --tab-index 2
```