### PR TITLE
feat(session-manager): add bidirectional tab navigation with Shift+Tab

### DIFF
--- a/default-plugins/session-manager/src/main.rs
+++ b/default-plugins/session-manager/src/main.rs
@@ -228,7 +228,11 @@ impl State {
                 should_render = true;
             },
             BareKey::Tab if key.has_no_modifiers() => {
-                self.toggle_active_screen();
+                self.toggle_active_screen_forward();
+                should_render = true;
+            },
+            BareKey::Tab if key.has_modifiers(&[KeyModifier::Shift]) => {
+                self.toggle_active_screen_backward();
                 should_render = true;
             },
             BareKey::Char('f') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
@@ -383,7 +387,11 @@ impl State {
                     should_render = true;
                 },
                 BareKey::Tab if key.has_no_modifiers() => {
-                    self.toggle_active_screen();
+                    self.toggle_active_screen_forward();
+                    should_render = true;
+                },
+                BareKey::Tab if key.has_modifiers(&[KeyModifier::Shift]) => {
+                    self.toggle_active_screen_backward();
                     should_render = true;
                 },
                 BareKey::Esc if key.has_no_modifiers() => {
@@ -431,7 +439,11 @@ impl State {
                 should_render = true;
             },
             BareKey::Tab if key.has_no_modifiers() => {
-                self.toggle_active_screen();
+                self.toggle_active_screen_forward();
+                should_render = true;
+            },
+            BareKey::Tab if key.has_modifiers(&[KeyModifier::Shift]) => {
+                self.toggle_active_screen_backward();
                 should_render = true;
             },
             BareKey::Delete if key.has_no_modifiers() => {
@@ -546,11 +558,18 @@ impl State {
             },
         }
     }
-    fn toggle_active_screen(&mut self) {
+    fn toggle_active_screen_forward(&mut self) {
         self.active_screen = match self.active_screen {
             ActiveScreen::NewSession => ActiveScreen::AttachToSession,
             ActiveScreen::AttachToSession => ActiveScreen::ResurrectSession,
             ActiveScreen::ResurrectSession => ActiveScreen::NewSession,
+        };
+    }
+    fn toggle_active_screen_backward(&mut self) {
+        self.active_screen = match self.active_screen {
+            ActiveScreen::NewSession => ActiveScreen::ResurrectSession,
+            ActiveScreen::AttachToSession => ActiveScreen::NewSession,
+            ActiveScreen::ResurrectSession => ActiveScreen::AttachToSession,
         };
     }
     fn show_error(&mut self, error_text: &str) {


### PR DESCRIPTION
Enables backward navigation through session manager screens using `Shift+Tab`, complementing the existing Tab key for forward navigation. I found myself using this feature subconsciously every time, so I decided to add it.