### PR TITLE
fix(resurrection): occasional status-bar pop-out after resurrection

### DIFF
--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -1656,6 +1656,21 @@ impl Layout {
                     .map(|f| f.populate_run_plugin_if_needed(&plugin_aliases));
             }
         }
+        for swap_tiled_layout in &mut self.swap_tiled_layouts {
+            for (_constraint, tiled_pane_layout) in &mut swap_tiled_layout.0 {
+                tiled_pane_layout.populate_plugin_aliases_in_layout(plugin_aliases);
+            }
+        }
+        for swap_floating_layout in &mut self.swap_floating_layouts {
+            for (_constraint, floating_pane_layouts) in &mut swap_floating_layout.0 {
+                for floating_pane_layout in floating_pane_layouts {
+                    floating_pane_layout
+                        .run
+                        .as_mut()
+                        .map(|f| f.populate_run_plugin_if_needed(plugin_aliases));
+                }
+            }
+        }
     }
     pub fn add_cwd_to_layout(&mut self, cwd: &PathBuf) {
         for (_, tiled_pane_layout, floating_panes) in self.tabs.iter_mut() {


### PR DESCRIPTION
This is a fix for https://github.com/zellij-org/zellij/issues/4338

The issue was that when serializing layouts for resurrection, we would not properly serialize the swap layouts (those in charge of snapping panes in a tab into their location when closing panes or adding new ones). Instead of serializing the fully qualified path for plugins that were invoked from aliases (as are all default UI plugins) we would instead just serialize the alias. Since we *do* properly serialize the full path for base layout, when applying the swap there would be a mismatch when comparing pane contents which caused a race condition that would occasionally reorder the panes.

This fixes the issue by properly serializing the full path of the plugins in the swap layouts as well.