### PR TITLE
feat(attach): add layout support to attach command

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -631,6 +631,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                     force_run_commands: false,
                     index: None,
                     options: None,
+                    layout: None,
                 }));
             } else {
                 opts.command = None;
@@ -658,6 +659,7 @@ pub(crate) fn start_client(opts: CliArgs) {
             force_run_commands,
             index,
             options,
+            layout,
         })) = opts.command.clone()
         {
             let config_options = match options.as_deref() {
@@ -667,6 +669,14 @@ pub(crate) fn start_client(opts: CliArgs) {
                 None => config_options,
             };
             should_create_detached = create_background;
+
+            if let Some(layout) = layout {
+                if create || should_create_detached {
+                    layout_info = Some(zellij_utils::data::LayoutInfo::File(
+                        layout.display().to_string(),
+                    ));
+                }
+            }
 
             let mut client = if let Some(idx) = index {
                 attach_with_session_index(

--- a/src/tests/e2e/cases.rs
+++ b/src/tests/e2e/cases.rs
@@ -2536,3 +2536,57 @@ pub fn pin_floating_panes() {
     let last_snapshot = account_for_races_in_snapshot(last_snapshot);
     assert_snapshot!(last_snapshot);
 }
+
+#[test]
+#[ignore]
+pub fn attach_with_layout_creates_session() {
+    let fake_win_size = Size {
+        cols: 120,
+        rows: 24,
+    };
+    let mut test_attempts = 10;
+    let last_snapshot = loop {
+        RemoteRunner::kill_running_sessions(fake_win_size);
+        let mut runner = RemoteRunner::new_attach_session_with_layout(
+            fake_win_size,
+            "test_attach_layout_session",
+            "splitted_test_layout.kdl",
+        )
+        .add_step(Step {
+            name: "Wait for session to be created with layout",
+            instruction: |remote_terminal: RemoteTerminal| -> bool {
+                let mut step_is_complete = false;
+                if remote_terminal.status_bar_appears()
+                    && remote_terminal.snapshot_contains("Test Tab")
+                {
+                    // Layout has been applied and tab name from layout is visible
+                    step_is_complete = true;
+                }
+                step_is_complete
+            },
+        });
+
+        runner.run_all_steps();
+        let last_snapshot = runner.take_snapshot_after(Step {
+            name: "Wait for layout to be fully loaded",
+            instruction: |remote_terminal: RemoteTerminal| -> bool {
+                let mut step_is_complete = false;
+                if remote_terminal.cursor_position_is(0, 2)
+                    && remote_terminal.snapshot_contains("Test Tab")
+                {
+                    // Session is fully loaded with the layout applied
+                    step_is_complete = true;
+                }
+                step_is_complete
+            },
+        });
+        if runner.test_timed_out && test_attempts > 0 {
+            test_attempts -= 1;
+            continue;
+        } else {
+            break last_snapshot;
+        }
+    };
+    let last_snapshot = account_for_races_in_snapshot(last_snapshot);
+    assert_snapshot!(last_snapshot);
+}

--- a/src/tests/e2e/remote_runner.rs
+++ b/src/tests/e2e/remote_runner.rs
@@ -180,6 +180,28 @@ fn attach_to_existing_session(channel: &mut ssh2::Channel, session_name: &str) {
     std::thread::sleep(std::time::Duration::from_secs(3)); // wait until Zellij stops parsing startup ANSI codes from the terminal STDIN
 }
 
+fn attach_session_with_layout(
+    channel: &mut ssh2::Channel,
+    session_name: &str,
+    layout_file_name: &str,
+) {
+    stop_zellij(channel);
+    channel
+        .write_all(
+            format!(
+                "{} {} attach {} --create --layout {}\n",
+                SET_ENV_VARIABLES,
+                ZELLIJ_EXECUTABLE_LOCATION,
+                session_name,
+                format!("{}/{}", ZELLIJ_FIXTURE_PATH, layout_file_name)
+            )
+            .as_bytes(),
+        )
+        .unwrap();
+    channel.flush().unwrap();
+    std::thread::sleep(std::time::Duration::from_secs(3)); // wait until Zellij stops parsing startup ANSI codes from the terminal STDIN
+}
+
 fn start_zellij_without_frames(channel: &mut ssh2::Channel) {
     stop_zellij(channel);
     channel
@@ -668,6 +690,48 @@ impl RemoteRunner {
         };
         setup_remote_environment(&mut channel, win_size);
         attach_to_existing_session(&mut channel, session_name);
+        let channel = Arc::new(Mutex::new(channel));
+        let last_snapshot = Arc::new(Mutex::new(String::new()));
+        let cursor_coordinates = Arc::new(Mutex::new((0, 0)));
+        sess.set_blocking(false);
+        let reader_thread =
+            read_from_channel(&channel, &last_snapshot, &cursor_coordinates, &pane_geom);
+        RemoteRunner {
+            steps: vec![],
+            channel,
+            currently_running_step: None,
+            current_step_index: 0,
+            retries_left: RETRIES,
+            retry_pause_ms: 100,
+            test_timed_out: false,
+            panic_on_no_retries_left: true,
+            last_snapshot,
+            cursor_coordinates,
+            reader_thread,
+        }
+    }
+    pub fn new_attach_session_with_layout(
+        win_size: Size,
+        session_name: &str,
+        layout_file_name: &str,
+    ) -> Self {
+        let sess = ssh_connect();
+        let mut channel = sess.channel_session().unwrap();
+        let mut rows = Dimension::fixed(win_size.rows);
+        let mut cols = Dimension::fixed(win_size.cols);
+        rows.set_inner(win_size.rows);
+        cols.set_inner(win_size.cols);
+        let pane_geom = PaneGeom {
+            x: 0,
+            y: 0,
+            rows,
+            cols,
+            stacked: None,
+            is_pinned: false,
+            logical_position: None,
+        };
+        setup_remote_environment(&mut channel, win_size);
+        attach_session_with_layout(&mut channel, session_name, layout_file_name);
         let channel = Arc::new(Mutex::new(channel));
         let last_snapshot = Arc::new(Mutex::new(String::new()));
         let cursor_coordinates = Arc::new(Mutex::new((0, 0)));

--- a/src/tests/e2e/snapshots/zellij__tests__e2e__cases__attach_with_layout_creates_session.snap
+++ b/src/tests/e2e/snapshots/zellij__tests__e2e__cases__attach_with_layout_creates_session.snap
@@ -1,9 +1,8 @@
 ---
 source: src/tests/e2e/cases.rs
-assertion_line: 482
 expression: last_snapshot
 ---
- Zellij (e2e-test)  Tab #1 
+ Zellij (test_attach_layout_session)  Test Tab 
 ┌ Pane #1 ─────────────────────────────────────────────────┐┌ Pane #2 ─────────────────────────────────────────────────┐
 │$ █                                                       ││$                                                         │
 │                                                          ││                                                          │
@@ -25,5 +24,5 @@ expression: last_snapshot
 │                                                          ││                                                          │
 │                                                          ││                                                          │
 └──────────────────────────────────────────────────────────┘└──────────────────────────────────────────────────────────┘
- Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT 
- <←→> Move focus / <n> New / <x> Close / <r> Rename / <s> Sync / <TAB> Toggle / <ENTER> Select pane
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT  BASE 
+ Tip: Alt + <n> => new pane. Alt + <←↓↑→> or Alt + <hjkl> => navigate. Alt + <+|-> => resize pane.

--- a/src/tests/fixtures/splitted_test_layout.kdl
+++ b/src/tests/fixtures/splitted_test_layout.kdl
@@ -1,0 +1,14 @@
+layout {
+    tab name="Test Tab" {
+        pane size=1 borderless=true {
+            plugin location="zellij:tab-bar"
+        }
+        pane split_direction="vertical" {
+            pane cwd="/tmp" focus=true
+            pane cwd="/home"
+        }
+        pane size=2 borderless=true {
+            plugin location="zellij:status-bar"
+        }
+    }
+}

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -257,6 +257,11 @@ pub enum Sessions {
         /// If resurrecting a dead session, immediately run all its commands on startup
         #[clap(short, long, value_parser, takes_value(false), default_value("false"))]
         force_run_commands: bool,
+
+        /// Name of a predefined layout inside the layout directory or the path to a layout file
+        /// Only effective when creating a session (with --create/-c or --create-background/-b)
+        #[clap(short, long, value_parser)]
+        layout: Option<PathBuf>,
     },
 
     /// Kill a specific session


### PR DESCRIPTION
Allow users to specify a predefined layout when creating a session through the attach command using the --layout/-l flag. The layout option is only effective when creating a new session (with --create/-c or --create-background/-b).

Changes:
- Add layout field to Sessions::Attach CLI structure
- Update attach command processing to handle layout parameter
- Add layout_info assignment when creating sessions with layout
- Add e2e test for attach with layout functionality
- Add splitted_test_layout.kdl fixture for testing

Usage:
  zellij attach session-name --create --layout my-layout