### PR TITLE
New Feature: remote attach to a Zellij session from the terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix: make sessions compatible across versions (https://github.com/zellij-org/zellij/pull/4439)
 * fix: occasional status-bar pop-out after resurrecting a session (https://github.com/zellij-org/zellij/pull/4440)
 * fix: properly serialize/resurrect layouts with one-line split panes (https://github.com/zellij-org/zellij/pull/4442)
+* feat: allow attaching to remote Zellij sessions over https (eg. `zellij attach https://example.com/my-cool-session`) (https://github.com/zellij-org/zellij/pull/4460)
 
 ## [0.43.1] - 2025-08-08
 * fix: pane rename backspace regression (https://github.com/zellij-org/zellij/pull/4346)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,6 +891,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,6 +1227,7 @@ checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
 dependencies = [
  "console",
  "shell-words",
+ "zeroize",
 ]
 
 [[package]]
@@ -1492,6 +1503,21 @@ name = "foldhash"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2681,6 +2707,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nix"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2819,6 +2862,32 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "openssl"
+version = "0.10.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -3612,6 +3681,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
+name = "security-framework"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4383,6 +4475,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4400,7 +4502,9 @@ checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "tokio",
+ "tokio-native-tls",
  "tungstenite 0.20.1",
 ]
 
@@ -4579,6 +4683,7 @@ dependencies = [
  "http 0.2.9",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.8.5",
  "sha1",
  "thiserror 1.0.61",
@@ -5760,10 +5865,12 @@ name = "zellij-client"
 version = "0.44.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "axum-extra",
  "axum-server",
  "daemonize",
+ "dialoguer",
  "futures",
  "futures-util",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ zellij-server = { path = "zellij-server/", version = "0.44.0" }
 zellij-utils = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
-dialoguer = { version = "0.10.4", default-features = false }
+dialoguer = { workspace = true }
 humantime = { workspace = true }
 interprocess = { workspace = true }
 log = { workspace = true }
@@ -63,8 +63,10 @@ members = [
 ansi_term = { version = "0.12.1", default-features = false }
 anyhow = { version = "1.0.70", default-features = false, features = ["backtrace", "std"] }
 async-std = { version = "1.3.0", default-features = false, features = ["attributes", "default", "std", "unstable"] }
+async-trait = { version = "0.1", default-features = false }
 clap = { version = "3.2.2", default-features = false, features = ["env", "derive", "color", "std", "suggestions"] }
 daemonize = { version = "0.5", default-features = false }
+dialoguer = { version = "0.10.4", default-features = false, features = ["password", "completion"] }
 humantime = { version = "2.1.0", default-features = false }
 interprocess = { version = "1.2.1", default-features = false }
 isahc = { version = "1.7.2", default-features = false, features = ["http2", "text-decoding"] }

--- a/zellij-client/Cargo.toml
+++ b/zellij-client/Cargo.toml
@@ -20,7 +20,9 @@ time = { version = "0.3", optional = true }
 tower-http = { version = "0.6.4", features = ["cors"], optional = true }
 
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 daemonize = { workspace = true }
+dialoguer = { workspace = true }
 interprocess = { workspace = true }
 lazy_static = { workspace = true }
 libc = { workspace = true }
@@ -40,13 +42,13 @@ include_dir = { workspace = true }
 zellij-utils = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
+isahc = { workspace = true }
+tokio-tungstenite = { version = "0.20", features = ["native-tls"] } #TODO: see about this native-tls...
+futures-util = "0.3"
+urlencoding = "2.1"
 
 [dev-dependencies]
 insta = "1.6.0"
-isahc = { workspace = true }
-tokio-tungstenite = "0.20"
-futures-util = "0.3"
-urlencoding = "2.1"
 serde_json = "1.0"
 serial_test = "3.0"
 

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -5,6 +5,8 @@ mod command_is_executing;
 mod input_handler;
 mod keyboard_parser;
 pub mod old_config_converter;
+#[cfg(feature = "web_server_capability")]
+pub mod remote_attach;
 mod stdin_ansi_parser;
 mod stdin_handler;
 #[cfg(feature = "web_server_capability")]
@@ -20,6 +22,58 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use zellij_utils::errors::FatalError;
 use zellij_utils::shared::web_server_base_url;
+
+#[cfg(feature = "web_server_capability")]
+use futures_util::{SinkExt, StreamExt};
+#[cfg(feature = "web_server_capability")]
+use tokio::runtime::Runtime;
+#[cfg(feature = "web_server_capability")]
+use tokio_tungstenite::tungstenite::Message;
+
+#[cfg(feature = "web_server_capability")]
+use crate::web_client::control_message::{
+    WebClientToWebServerControlMessage, WebClientToWebServerControlMessagePayload,
+    WebServerToWebClientControlMessage,
+};
+
+#[derive(Debug)]
+pub enum RemoteClientError {
+    InvalidAuthToken,
+    SessionTokenExpired,
+    Unauthorized,
+    ConnectionFailed(String),
+    UrlParseError(url::ParseError),
+    IoError(std::io::Error),
+    Other(Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl std::fmt::Display for RemoteClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RemoteClientError::InvalidAuthToken => write!(f, "Invalid authentication token"),
+            RemoteClientError::SessionTokenExpired => write!(f, "Session token expired"),
+            RemoteClientError::Unauthorized => write!(f, "Unauthorized"),
+            RemoteClientError::ConnectionFailed(msg) => write!(f, "Connection failed: {}", msg),
+            RemoteClientError::UrlParseError(e) => write!(f, "Invalid URL: {}", e),
+            RemoteClientError::IoError(e) => write!(f, "IO error: {}", e),
+            RemoteClientError::Other(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl std::error::Error for RemoteClientError {}
+
+impl From<url::ParseError> for RemoteClientError {
+    fn from(error: url::ParseError) -> Self {
+        RemoteClientError::UrlParseError(error)
+    }
+}
+
+impl From<std::io::Error> for RemoteClientError {
+    fn from(error: std::io::Error) -> Self {
+        RemoteClientError::IoError(error)
+    }
+}
 
 use crate::stdin_ansi_parser::{AnsiStdinInstruction, StdinAnsiParser, SyncOutput};
 use crate::{
@@ -214,6 +268,296 @@ pub(crate) enum InputInstruction {
     StartedParsing,
     DoneParsing,
     Exit,
+}
+
+#[cfg(feature = "web_server_capability")]
+pub async fn run_remote_client_terminal_loop(
+    os_input: Box<dyn ClientOsApi>,
+    mut connections: remote_attach::WebSocketConnections,
+) -> Result<Option<ConnectToSession>, RemoteClientError> {
+    use crate::os_input_output::{AsyncSignals, AsyncStdin};
+
+    let synchronised_output = match os_input.env_variable("TERM").as_deref() {
+        Some("alacritty") => Some(SyncOutput::DCS),
+        _ => None,
+    };
+
+    let mut async_stdin: Box<dyn AsyncStdin> = os_input.get_async_stdin_reader();
+    let mut async_signals: Box<dyn AsyncSignals> = os_input
+        .get_async_signal_listener()
+        .map_err(|e| RemoteClientError::IoError(e))?;
+
+    let create_resize_message = |size: Size| {
+        Message::Text(
+            serde_json::to_string(&WebClientToWebServerControlMessage {
+                web_client_id: connections.web_client_id.clone(),
+                payload: WebClientToWebServerControlMessagePayload::TerminalResize(size),
+            })
+            .unwrap(),
+        )
+    };
+
+    // send size on startup
+    let new_size = os_input.get_terminal_size_using_fd(0);
+    if let Err(e) = connections
+        .control_ws
+        .send(create_resize_message(new_size))
+        .await
+    {
+        log::error!("Failed to send resize message: {}", e);
+    }
+
+    loop {
+        tokio::select! {
+            // Handle stdin input
+            result = async_stdin.read() => {
+                match result {
+                    Ok(buf) if !buf.is_empty() => {
+                        if let Err(e) = connections.terminal_ws.send(Message::Binary(buf)).await {
+                            log::error!("Failed to send stdin to terminal WebSocket: {}", e);
+                            break;
+                        }
+                    }
+                    Ok(_) => {
+                        // Empty buffer means EOF
+                        break;
+                    }
+                    Err(e) => {
+                        log::error!("Error reading from stdin: {}", e);
+                        break;
+                    }
+                }
+            }
+
+            // Handle signals
+            Some(signal) = async_signals.recv() => {
+                match signal {
+                    crate::os_input_output::SignalEvent::Resize => {
+                        let new_size = os_input.get_terminal_size_using_fd(0);
+                        if let Err(e) = connections.control_ws.send(create_resize_message(new_size)).await {
+                            log::error!("Failed to send resize message: {}", e);
+                            break;
+                        }
+                    }
+                    crate::os_input_output::SignalEvent::Quit => {
+                        break;
+                    }
+                }
+            }
+
+            // Handle terminal messages
+            terminal_msg = connections.terminal_ws.next() => {
+                match terminal_msg {
+                    Some(Ok(Message::Text(text))) => {
+                        let mut stdout = os_input.get_stdout_writer();
+                        if let Some(sync) = synchronised_output {
+                            stdout
+                                .write_all(sync.start_seq())
+                                .expect("cannot write to stdout");
+                        }
+                        stdout
+                            .write_all(text.as_bytes())
+                            .expect("cannot write to stdout");
+                        if let Some(sync) = synchronised_output {
+                            stdout
+                                .write_all(sync.end_seq())
+                                .expect("cannot write to stdout");
+                        }
+                        stdout.flush().expect("could not flush");
+                    }
+                    Some(Ok(Message::Binary(data))) => {
+                        let mut stdout = os_input.get_stdout_writer();
+                        if let Some(sync) = synchronised_output {
+                            stdout
+                                .write_all(sync.start_seq())
+                                .expect("cannot write to stdout");
+                        }
+                        stdout
+                            .write_all(&data)
+                            .expect("cannot write to stdout");
+                        if let Some(sync) = synchronised_output {
+                            stdout
+                                .write_all(sync.end_seq())
+                                .expect("cannot write to stdout");
+                        }
+                        stdout.flush().expect("could not flush");
+                    }
+                    Some(Ok(Message::Close(_))) => {
+                        break;
+                    }
+                    Some(Err(e)) => {
+                        log::error!("Error: {}", e);
+                        break;
+                    }
+                    None => {
+                        log::error!("Received empty message from web server");
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+
+            control_msg = connections.control_ws.next() => {
+                match control_msg {
+                    Some(Ok(Message::Text(msg))) => {
+                        let deserialized_msg: Result<WebServerToWebClientControlMessage, _> =
+                            serde_json::from_str(&msg);
+                        match deserialized_msg {
+                            Ok(WebServerToWebClientControlMessage::SetConfig(..)) => {
+                                // no-op
+                            }
+                            Ok(WebServerToWebClientControlMessage::QueryTerminalSize) => {
+                                let new_size = os_input.get_terminal_size_using_fd(0);
+                                if let Err(e) = connections.control_ws.send(create_resize_message(new_size)).await {
+                                    log::error!("Failed to send resize message: {}", e);
+                                }
+                            }
+                            Ok(WebServerToWebClientControlMessage::Log { lines }) => {
+                                for line in lines {
+                                    log::info!("{}", line);
+                                }
+                            }
+                            Ok(WebServerToWebClientControlMessage::LogError { lines }) => {
+                                for line in lines {
+                                    log::error!("{}", line);
+                                }
+                            }
+                            Ok(WebServerToWebClientControlMessage::SwitchedSession{ .. }) => {
+                                // no-op
+                            }
+                            Err(e) => {
+                                log::error!("Failed to deserialize control message: {}", e);
+                            }
+                        }
+
+                    }
+                    Some(Ok(Message::Close(_))) => {
+                        break;
+                    }
+                    Some(Err(e)) => {
+                        log::error!("{}", e);
+                        break;
+                    }
+                    None => break,
+                    _ => {}
+                }
+            }
+
+        }
+    }
+
+    Ok(None)
+}
+
+#[cfg(feature = "web_server_capability")]
+pub fn start_remote_client(
+    mut os_input: Box<dyn ClientOsApi>,
+    remote_session_url: &str,
+    token: Option<String>,
+    remember: bool,
+    forget: bool,
+) -> Result<Option<ConnectToSession>, RemoteClientError> {
+    info!("Starting Zellij client!");
+
+    let runtime = Runtime::new().map_err(|e| RemoteClientError::IoError(e))?;
+
+    let connections = remote_attach::attach_to_remote_session(
+        &runtime,
+        os_input.clone(),
+        remote_session_url,
+        token,
+        remember,
+        forget,
+    )?;
+
+    let reconnect_to_session = None;
+    let clear_client_terminal_attributes = "\u{1b}[?1l\u{1b}=\u{1b}[r\u{1b}[?1000l\u{1b}[?1002l\u{1b}[?1003l\u{1b}[?1005l\u{1b}[?1006l\u{1b}[?12l";
+    let take_snapshot = "\u{1b}[?1049h";
+    let bracketed_paste = "\u{1b}[?2004h";
+    let enter_kitty_keyboard_mode = "\u{1b}[>1u";
+    os_input.unset_raw_mode(0).unwrap();
+
+    let _ = os_input
+        .get_stdout_writer()
+        .write(take_snapshot.as_bytes())
+        .unwrap();
+    let _ = os_input
+        .get_stdout_writer()
+        .write(clear_client_terminal_attributes.as_bytes())
+        .unwrap();
+    let _ = os_input
+        .get_stdout_writer()
+        .write(enter_kitty_keyboard_mode.as_bytes())
+        .unwrap();
+
+    envs::set_zellij("0".to_string());
+
+    let full_screen_ws = os_input.get_terminal_size_using_fd(0);
+
+    os_input.set_raw_mode(0);
+    let _ = os_input
+        .get_stdout_writer()
+        .write(bracketed_paste.as_bytes())
+        .unwrap();
+
+    std::panic::set_hook({
+        use zellij_utils::errors::handle_panic;
+        let os_input = os_input.clone();
+        Box::new(move |info| {
+            if let Ok(()) = os_input.unset_raw_mode(0) {
+                handle_panic::<ClientInstruction>(info, None);
+            }
+        })
+    });
+
+    let reset_controlling_terminal_state = |e: String, exit_status: i32| {
+        os_input.unset_raw_mode(0).unwrap();
+        let goto_start_of_last_line = format!("\u{1b}[{};{}H", full_screen_ws.rows, 1);
+        let restore_alternate_screen = "\u{1b}[?1049l";
+        let exit_kitty_keyboard_mode = "\u{1b}[<1u";
+        let reset_style = "\u{1b}[m";
+        let show_cursor = "\u{1b}[?25h";
+        os_input.disable_mouse().non_fatal();
+        let error = format!(
+            "{}{}{}{}\n{}{}\n",
+            reset_style,
+            show_cursor,
+            restore_alternate_screen,
+            exit_kitty_keyboard_mode,
+            goto_start_of_last_line,
+            e
+        );
+        let _ = os_input
+            .get_stdout_writer()
+            .write(error.as_bytes())
+            .unwrap();
+        let _ = os_input.get_stdout_writer().flush().unwrap();
+        if exit_status == 0 {
+            log::info!("{}", e);
+        } else {
+            log::error!("{}", e);
+        };
+        std::process::exit(exit_status);
+    };
+
+    runtime.block_on(run_remote_client_terminal_loop(
+        os_input.clone(),
+        connections,
+    ))?;
+
+    let exit_msg = String::from("Bye from Zellij!");
+
+    if reconnect_to_session.is_none() {
+        reset_controlling_terminal_state(exit_msg, 0);
+        std::process::exit(0);
+    } else {
+        let clear_screen = "\u{1b}[2J";
+        let mut stdout = os_input.get_stdout_writer();
+        let _ = stdout.write(clear_screen.as_bytes()).unwrap();
+        stdout.flush().unwrap();
+    }
+
+    Ok(reconnect_to_session)
 }
 
 pub fn start_client(
@@ -444,7 +788,7 @@ pub fn start_client(
         let os_input = os_input.clone();
         Box::new(move |info| {
             if let Ok(()) = os_input.unset_raw_mode(0) {
-                handle_panic(info, &send_client_instructions);
+                handle_panic(info, Some(&send_client_instructions));
             }
         })
     });
@@ -856,3 +1200,6 @@ pub fn start_server_detached(
     os_input.connect_to_server(&*ipc_pipe);
     os_input.send_to_server(first_msg);
 }
+
+#[cfg(test)]
+mod unit;

--- a/zellij-client/src/remote_attach/auth.rs
+++ b/zellij-client/src/remote_attach/auth.rs
@@ -1,0 +1,145 @@
+use super::config::{LOGIN_ENDPOINT, SESSION_ENDPOINT};
+use super::http_client::HttpClientWithCookies;
+use crate::RemoteClientError;
+use isahc::{AsyncReadResponseExt, Request};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize)]
+struct LoginRequest {
+    auth_token: String,
+    remember_me: bool,
+}
+
+#[derive(Deserialize)]
+pub struct SessionResponse {
+    pub web_client_id: String,
+}
+
+pub async fn authenticate(
+    server_base_url: &str,
+    auth_token: &str,
+    remember_me: bool,
+) -> Result<(String, HttpClientWithCookies, Option<String>), RemoteClientError> {
+    let http_client =
+        HttpClientWithCookies::new().map_err(|e| RemoteClientError::Other(Box::new(e)))?;
+
+    // Step 1: Login with auth token
+    let login_url = format!("{}{}", server_base_url, LOGIN_ENDPOINT);
+
+    let login_request = LoginRequest {
+        auth_token: auth_token.to_string(),
+        remember_me,
+    };
+
+    let response = http_client
+        .send_with_cookies(
+            Request::post(login_url)
+                .header("Content-Type", "application/json")
+                .header("User-Agent", "http-terminal-client/1.0")
+                .header("Accept", "application/json")
+                .body(
+                    serde_json::to_vec(&login_request)
+                        .map_err(|e| RemoteClientError::Other(Box::new(e)))?,
+                )
+                .map_err(|e| RemoteClientError::Other(Box::new(e)))?,
+        )
+        .await
+        .map_err(|e| RemoteClientError::ConnectionFailed(e.to_string()))?;
+
+    // Handle HTTP status codes
+    match response.status().as_u16() {
+        401 => return Err(RemoteClientError::InvalidAuthToken),
+        status if !response.status().is_success() => {
+            return Err(RemoteClientError::ConnectionFailed(format!(
+                "Server returned status {}",
+                status
+            )));
+        },
+        _ => {},
+    }
+
+    // Step 2: Get session/client ID
+    let session_url = format!("{}{}", server_base_url, SESSION_ENDPOINT);
+
+    let mut session_response = http_client
+        .send_with_cookies(
+            Request::post(session_url)
+                .header("Content-Type", "application/json")
+                .header("User-Agent", "http-terminal-client/1.0")
+                .header("Accept", "application/json")
+                .body("{}".as_bytes().to_vec())
+                .map_err(|e| RemoteClientError::Other(Box::new(e)))?,
+        )
+        .await
+        .map_err(|e| RemoteClientError::ConnectionFailed(e.to_string()))?;
+
+    // Handle session response
+    match session_response.status().as_u16() {
+        401 => return Err(RemoteClientError::Unauthorized),
+        status if !session_response.status().is_success() => {
+            return Err(RemoteClientError::ConnectionFailed(format!(
+                "Server returned status {}",
+                status
+            )));
+        },
+        _ => {},
+    }
+
+    let response_body = session_response
+        .text()
+        .await
+        .map_err(|e| RemoteClientError::Other(Box::new(e)))?;
+    let session_data: SessionResponse =
+        serde_json::from_str(&response_body).map_err(|e| RemoteClientError::Other(Box::new(e)))?;
+
+    // Extract session_token if remember_me was true
+    let session_token = if remember_me {
+        http_client.get_cookie("session_token")
+    } else {
+        None
+    };
+
+    Ok((session_data.web_client_id, http_client, session_token))
+}
+
+pub async fn validate_session_token(
+    server_base_url: &str,
+    session_token: &str,
+) -> Result<(String, HttpClientWithCookies), RemoteClientError> {
+    let http_client =
+        HttpClientWithCookies::new().map_err(|e| RemoteClientError::Other(Box::new(e)))?;
+
+    // Pre-populate the session_token cookie
+    http_client.set_cookie("session_token".to_string(), session_token.to_string());
+
+    // Skip /login, go directly to /session endpoint
+    let session_url = format!("{}{}", server_base_url, SESSION_ENDPOINT);
+
+    let mut session_response = http_client
+        .send_with_cookies(
+            Request::post(session_url)
+                .header("Content-Type", "application/json")
+                .header("User-Agent", "http-terminal-client/1.0")
+                .header("Accept", "application/json")
+                .body("{}".as_bytes().to_vec())
+                .map_err(|e| RemoteClientError::Other(Box::new(e)))?,
+        )
+        .await
+        .map_err(|e| RemoteClientError::ConnectionFailed(e.to_string()))?;
+
+    match session_response.status().as_u16() {
+        401 => Err(RemoteClientError::SessionTokenExpired),
+        status if !session_response.status().is_success() => Err(
+            RemoteClientError::ConnectionFailed(format!("Server returned status {}", status)),
+        ),
+        _ => {
+            let response_body = session_response
+                .text()
+                .await
+                .map_err(|e| RemoteClientError::Other(Box::new(e)))?;
+            let session_data: SessionResponse = serde_json::from_str(&response_body)
+                .map_err(|e| RemoteClientError::Other(Box::new(e)))?;
+            Ok((session_data.web_client_id, http_client))
+        },
+    }
+}

--- a/zellij-client/src/remote_attach/config.rs
+++ b/zellij-client/src/remote_attach/config.rs
@@ -1,0 +1,14 @@
+use std::time::Duration;
+
+// API endpoints
+pub const LOGIN_ENDPOINT: &str = "/command/login";
+pub const SESSION_ENDPOINT: &str = "/session";
+pub const WS_TERMINAL_ENDPOINT: &str = "/ws/terminal";
+pub const WS_CONTROL_ENDPOINT: &str = "/ws/control";
+
+// Connection settings
+pub const CONNECTION_TIMEOUT_SECS: u64 = 30;
+
+pub fn connection_timeout() -> Duration {
+    Duration::from_secs(CONNECTION_TIMEOUT_SECS)
+}

--- a/zellij-client/src/remote_attach/http_client.rs
+++ b/zellij-client/src/remote_attach/http_client.rs
@@ -1,0 +1,106 @@
+use super::config::connection_timeout;
+use isahc::prelude::*;
+use isahc::{config::RedirectPolicy, AsyncBody, HttpClient, Request, Response};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+pub fn create_http_client() -> Result<HttpClient, isahc::Error> {
+    HttpClient::builder()
+        .redirect_policy(RedirectPolicy::Follow)
+        .ssl_options(isahc::config::SslOption::DANGER_ACCEPT_INVALID_CERTS)
+        .timeout(connection_timeout())
+        .build()
+}
+
+pub struct HttpClientWithCookies {
+    client: HttpClient,
+    cookies: Arc<Mutex<HashMap<String, String>>>,
+}
+
+impl HttpClientWithCookies {
+    pub fn new() -> Result<Self, isahc::Error> {
+        Ok(Self {
+            client: create_http_client()?,
+            cookies: Arc::new(Mutex::new(HashMap::new())),
+        })
+    }
+
+    pub async fn send_with_cookies<T: Into<Request<Vec<u8>>>>(
+        &self,
+        request: T,
+    ) -> Result<Response<AsyncBody>, isahc::Error> {
+        let mut req = request.into();
+
+        // Add cookies to request
+        if let Ok(cookies) = self.cookies.lock() {
+            if !cookies.is_empty() {
+                let cookie_header = cookies
+                    .iter()
+                    .map(|(k, v)| format!("{}={}", k, v))
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                req.headers_mut()
+                    .insert("cookie", cookie_header.parse().unwrap());
+            }
+        }
+
+        let response = self.client.send_async(req).await?;
+
+        // Extract and store cookies from response
+        if let Some(set_cookie_headers) = response.headers().get_all("set-cookie").iter().next() {
+            if let Ok(cookie_str) = set_cookie_headers.to_str() {
+                self.parse_and_store_cookies(cookie_str);
+            }
+        }
+
+        Ok(response)
+    }
+
+    fn parse_and_store_cookies(&self, cookie_header: &str) {
+        if let Ok(mut cookies) = self.cookies.lock() {
+            // Simple cookie parsing - just extract name=value pairs
+            for cookie_part in cookie_header.split(';') {
+                let cookie_part = cookie_part.trim();
+                if let Some((name, value)) = cookie_part.split_once('=') {
+                    // Skip cookie attributes like Path, Domain, HttpOnly, etc.
+                    if ![
+                        "path", "domain", "httponly", "secure", "samesite", "expires", "max-age",
+                    ]
+                    .contains(&name.to_lowercase().as_str())
+                    {
+                        cookies.insert(name.trim().to_string(), value.trim().to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn get_cookie_header(&self) -> Option<String> {
+        if let Ok(cookies) = self.cookies.lock() {
+            if !cookies.is_empty() {
+                let cookie_header = cookies
+                    .iter()
+                    .map(|(k, v)| format!("{}={}", k, v))
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                return Some(cookie_header);
+            }
+        }
+        None
+    }
+
+    /// Extract a specific cookie value
+    pub fn get_cookie(&self, name: &str) -> Option<String> {
+        if let Ok(cookies) = self.cookies.lock() {
+            return cookies.get(name).cloned();
+        }
+        None
+    }
+
+    /// Pre-populate a cookie (for saved session tokens)
+    pub fn set_cookie(&self, name: String, value: String) {
+        if let Ok(mut cookies) = self.cookies.lock() {
+            cookies.insert(name, value);
+        }
+    }
+}

--- a/zellij-client/src/remote_attach/mod.rs
+++ b/zellij-client/src/remote_attach/mod.rs
@@ -1,0 +1,221 @@
+mod auth;
+mod config;
+mod http_client;
+mod websockets;
+
+#[cfg(test)]
+mod unit;
+
+pub use websockets::WebSocketConnections;
+
+use crate::os_input_output::ClientOsApi;
+use crate::RemoteClientError;
+use tokio::runtime::Runtime;
+use zellij_utils::remote_session_tokens;
+
+// In tests, only attempt once (no retries) to avoid interactive prompts
+// In production, allow up to 3 attempts (initial + 2 retries)
+#[cfg(test)]
+const MAX_AUTH_ATTEMPTS: u32 = 1;
+
+#[cfg(not(test))]
+const MAX_AUTH_ATTEMPTS: u32 = 3;
+
+/// Attach to a remote Zellij session via HTTP(S)
+///
+/// This function handles the complete authentication flow including:
+/// - URL validation
+/// - Session token management (--forget, --token flags)
+/// - Trying saved session tokens
+/// - Interactive authentication with retry logic
+/// - Saving session tokens when --remember is used
+///
+/// Returns WebSocketConnections on success
+pub fn attach_to_remote_session(
+    runtime: &Runtime,
+    _os_input: Box<dyn ClientOsApi>,
+    remote_session_url: &str,
+    token: Option<String>,
+    remember: bool,
+    forget: bool,
+) -> Result<WebSocketConnections, RemoteClientError> {
+    // Extract server URL for token management
+    let server_url = extract_server_url(remote_session_url)?;
+
+    // Handle --forget flag
+    if forget {
+        let _ = remote_session_tokens::delete_session_token(&server_url);
+    }
+
+    // If --token provided, delete saved session token
+    if token.is_some() {
+        let _ = remote_session_tokens::delete_session_token(&server_url);
+    }
+
+    if token.is_none() {
+        if let Some(connections) =
+            try_to_connect_with_saved_session_token(runtime, remote_session_url, &server_url)?
+        {
+            return Ok(connections);
+        }
+    }
+
+    // Normal auth flow with retry logic
+    authenticate_with_retry(runtime, remote_session_url, token, remember)
+}
+
+/// Try to connect using a saved session token
+/// Returns Ok(Some(connections)) on success, Ok(None) if should retry with auth
+fn try_to_connect_with_saved_session_token(
+    runtime: &Runtime,
+    remote_session_url: &str,
+    server_url: &str,
+) -> Result<Option<WebSocketConnections>, RemoteClientError> {
+    if let Ok(Some(saved_session_token)) = remote_session_tokens::get_session_token(server_url) {
+        // we have a saved session token, let's try to authenticate with it
+        match runtime.block_on(async move {
+            remote_attach_with_session_token(remote_session_url, &saved_session_token).await
+        }) {
+            Ok(connections) => {
+                return Ok(Some(connections));
+            },
+            Err(RemoteClientError::SessionTokenExpired) => {
+                // Session expired - delete and return to retry
+                let _ = remote_session_tokens::delete_session_token(server_url);
+                eprintln!("Session expired, please re-authenticate");
+                return Ok(None);
+            },
+            Err(e) => {
+                return Err(e);
+            },
+        }
+    }
+    Ok(None)
+}
+
+fn authenticate_with_retry(
+    runtime: &Runtime,
+    remote_session_url: &str,
+    initial_token: Option<String>,
+    remember: bool,
+) -> Result<WebSocketConnections, RemoteClientError> {
+    use dialoguer::{Confirm, Password};
+
+    let mut attempt = 0;
+    let mut current_token = initial_token;
+
+    loop {
+        attempt += 1;
+
+        let auth_token = match &current_token {
+            Some(t) => t.clone(),
+            None => Password::new()
+                .with_prompt("Enter authentication token")
+                .interact()
+                .map_err(|e| RemoteClientError::IoError(e))?,
+        };
+
+        match runtime
+            .block_on(async move { remote_attach(remote_session_url, &auth_token, remember).await })
+        {
+            Ok((connections, session_token_opt)) => {
+                // Save session token if we got one
+                if let Some(session_token) = session_token_opt {
+                    let server_url = extract_server_url(remote_session_url)?;
+                    let _ = remote_session_tokens::save_session_token(&server_url, &session_token);
+                }
+                return Ok(connections);
+            },
+            Err(RemoteClientError::InvalidAuthToken) => {
+                eprintln!("Invalid authentication token");
+
+                if attempt >= MAX_AUTH_ATTEMPTS {
+                    eprintln!(
+                        "Maximum authentication attempts ({}) exceeded.",
+                        MAX_AUTH_ATTEMPTS
+                    );
+                    return Err(RemoteClientError::InvalidAuthToken);
+                }
+
+                match Confirm::new()
+                    .with_prompt("Try again?")
+                    .default(true)
+                    .interact()
+                {
+                    Ok(true) => {
+                        current_token = None;
+                        continue;
+                    },
+                    Ok(false) => {
+                        return Err(RemoteClientError::InvalidAuthToken);
+                    },
+                    Err(e) => {
+                        return Err(RemoteClientError::IoError(e));
+                    },
+                }
+            },
+            Err(e) => {
+                return Err(e);
+            },
+        }
+    }
+}
+
+async fn remote_attach(
+    server_url: &str,
+    auth_token: &str,
+    remember_me: bool,
+) -> Result<(websockets::WebSocketConnections, Option<String>), RemoteClientError> {
+    let server_base_url = extract_server_url(server_url)?;
+    let session_name = extract_session_name(server_url)?;
+    let (web_client_id, http_client, session_token) =
+        auth::authenticate(&server_base_url, auth_token, remember_me).await?;
+    let connections = websockets::establish_websocket_connections(
+        &web_client_id,
+        &http_client,
+        &server_base_url,
+        &session_name,
+    )
+    .await
+    .map_err(|e| RemoteClientError::ConnectionFailed(e.to_string()))?;
+    Ok((connections, session_token))
+}
+
+async fn remote_attach_with_session_token(
+    server_url: &str,
+    session_token: &str,
+) -> Result<websockets::WebSocketConnections, RemoteClientError> {
+    let server_base_url = extract_server_url(server_url)?;
+    let session_name = extract_session_name(server_url)?;
+    let (web_client_id, http_client) =
+        auth::validate_session_token(&server_base_url, session_token).await?;
+    let connections = websockets::establish_websocket_connections(
+        &web_client_id,
+        &http_client,
+        &server_base_url,
+        &session_name,
+    )
+    .await
+    .map_err(|e| RemoteClientError::ConnectionFailed(e.to_string()))?;
+    Ok(connections)
+}
+
+pub fn extract_server_url(full_url: &str) -> Result<String, RemoteClientError> {
+    let parsed = url::Url::parse(full_url)?;
+    let mut base_url = parsed.clone();
+    base_url.set_path("");
+    base_url.set_query(None);
+    base_url.set_fragment(None);
+    Ok(base_url.to_string().trim_end_matches('/').to_string())
+}
+
+fn extract_session_name(server_url: &str) -> Result<String, RemoteClientError> {
+    let parsed_url = url::Url::parse(server_url)?;
+    let path = parsed_url.path();
+    // Extract session name from path (everything after the first /)
+    if path.len() > 1 && path.starts_with('/') {
+        Ok(path[1..].trim_end_matches('/').to_string())
+    } else {
+        Ok(String::new())
+    }
+}

--- a/zellij-client/src/remote_attach/unit/mod.rs
+++ b/zellij-client/src/remote_attach/unit/mod.rs
@@ -1,0 +1,1 @@
+mod remote_attach_tests;

--- a/zellij-client/src/remote_attach/unit/remote_attach_tests.rs
+++ b/zellij-client/src/remote_attach/unit/remote_attach_tests.rs
@@ -1,0 +1,675 @@
+use super::super::*;
+use crate::RemoteClientError;
+use serial_test::serial;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use zellij_utils::remote_session_tokens;
+
+// Mock server infrastructure
+#[cfg(feature = "web_server_capability")]
+mod mock_server {
+    use super::*;
+    use axum::{
+        extract::State,
+        http::StatusCode,
+        response::Response,
+        routing::{get, post},
+        Json, Router,
+    };
+    use axum_extra::extract::cookie::{Cookie, CookieJar};
+    use serde::Deserialize;
+    use serde_json::json;
+    use tokio::net::TcpListener;
+    use uuid::Uuid;
+
+    #[derive(Clone)]
+    pub struct MockRemoteServerState {
+        pub valid_auth_tokens: Arc<Mutex<HashMap<String, ()>>>,
+        pub session_tokens: Arc<Mutex<HashMap<String, String>>>, // token -> web_client_id
+        pub endpoints_called: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl MockRemoteServerState {
+        pub fn new() -> Self {
+            Self {
+                valid_auth_tokens: Arc::new(Mutex::new(HashMap::new())),
+                session_tokens: Arc::new(Mutex::new(HashMap::new())),
+                endpoints_called: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        pub fn add_valid_token(&self, token: &str) {
+            self.valid_auth_tokens
+                .lock()
+                .unwrap()
+                .insert(token.to_string(), ());
+        }
+
+        fn record_endpoint(&self, endpoint: &str) {
+            self.endpoints_called
+                .lock()
+                .unwrap()
+                .push(endpoint.to_string());
+        }
+
+        pub fn get_endpoints_called(&self) -> Vec<String> {
+            self.endpoints_called.lock().unwrap().clone()
+        }
+    }
+
+    #[derive(Deserialize)]
+    struct LoginRequest {
+        auth_token: String,
+    }
+
+    async fn handle_login(
+        State(state): State<MockRemoteServerState>,
+        jar: CookieJar,
+        Json(payload): Json<LoginRequest>,
+    ) -> Result<(CookieJar, Json<serde_json::Value>), StatusCode> {
+        state.record_endpoint("/command/login");
+
+        let valid_tokens = state.valid_auth_tokens.lock().unwrap();
+        if !valid_tokens.contains_key(&payload.auth_token) {
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+        drop(valid_tokens);
+
+        // Always create a session token (cookie is always set)
+        let session_token = Uuid::new_v4().to_string();
+        let web_client_id = Uuid::new_v4().to_string();
+
+        state
+            .session_tokens
+            .lock()
+            .unwrap()
+            .insert(session_token.clone(), web_client_id);
+
+        let cookie = Cookie::build(("session_token", session_token))
+            .path("/")
+            .http_only(true)
+            .build();
+        let jar = jar.add(cookie);
+
+        Ok((
+            jar,
+            Json(json!({
+                "success": true,
+                "message": "Login successful"
+            })),
+        ))
+    }
+
+    async fn handle_session(
+        State(state): State<MockRemoteServerState>,
+        jar: CookieJar,
+    ) -> Result<Json<serde_json::Value>, StatusCode> {
+        state.record_endpoint("/session");
+
+        let session_token = jar
+            .get("session_token")
+            .map(|c| c.value().to_string())
+            .ok_or(StatusCode::UNAUTHORIZED)?;
+
+        let session_tokens = state.session_tokens.lock().unwrap();
+        let web_client_id = session_tokens
+            .get(&session_token)
+            .ok_or(StatusCode::UNAUTHORIZED)?
+            .clone();
+        drop(session_tokens);
+
+        Ok(Json(json!({
+            "web_client_id": web_client_id
+        })))
+    }
+
+    async fn handle_ws_terminal(
+        ws: axum::extract::ws::WebSocketUpgrade,
+        State(state): State<MockRemoteServerState>,
+        jar: CookieJar,
+    ) -> Result<Response, StatusCode> {
+        state.record_endpoint("/ws/terminal");
+
+        // Validate session token
+        let session_token = jar
+            .get("session_token")
+            .map(|c| c.value().to_string())
+            .ok_or(StatusCode::UNAUTHORIZED)?;
+
+        let session_tokens = state.session_tokens.lock().unwrap();
+        if !session_tokens.contains_key(&session_token) {
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+        drop(session_tokens);
+
+        Ok(ws.on_upgrade(|socket| async move {
+            // Basic echo WebSocket handler
+            use axum::extract::ws::Message;
+            use futures_util::{SinkExt, StreamExt};
+            let (mut sender, mut receiver) = socket.split();
+
+            while let Some(Ok(msg)) = receiver.next().await {
+                if let Message::Text(text) = msg {
+                    let _ = sender.send(Message::Text(text)).await;
+                }
+            }
+        }))
+    }
+
+    async fn handle_ws_control(
+        ws: axum::extract::ws::WebSocketUpgrade,
+        State(state): State<MockRemoteServerState>,
+        jar: CookieJar,
+    ) -> Result<Response, StatusCode> {
+        state.record_endpoint("/ws/control");
+
+        // Validate session token
+        let session_token = jar
+            .get("session_token")
+            .map(|c| c.value().to_string())
+            .ok_or(StatusCode::UNAUTHORIZED)?;
+
+        let session_tokens = state.session_tokens.lock().unwrap();
+        if !session_tokens.contains_key(&session_token) {
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+        drop(session_tokens);
+
+        Ok(ws.on_upgrade(|socket| async move {
+            // Basic echo WebSocket handler
+            use axum::extract::ws::Message;
+            use futures_util::{SinkExt, StreamExt};
+            let (mut sender, mut receiver) = socket.split();
+
+            while let Some(Ok(msg)) = receiver.next().await {
+                if let Message::Text(text) = msg {
+                    let _ = sender.send(Message::Text(text)).await;
+                }
+            }
+        }))
+    }
+
+    pub async fn start_mock_server(
+        state: MockRemoteServerState,
+    ) -> (u16, tokio::task::JoinHandle<()>) {
+        let app = Router::new()
+            .route("/command/login", post(handle_login))
+            .route("/session", post(handle_session))
+            .route("/ws/terminal", get(handle_ws_terminal))
+            .route("/ws/terminal/{session_name}", get(handle_ws_terminal))
+            .route("/ws/control", get(handle_ws_control))
+            .with_state(state);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let server_handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        // Wait for server to be ready
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        (port, server_handle)
+    }
+}
+
+// Database test helpers
+fn setup_test_db(server_url: &str) {
+    let _ = remote_session_tokens::delete_session_token(server_url);
+}
+
+fn cleanup_test_db(server_url: &str) {
+    let _ = remote_session_tokens::delete_session_token(server_url);
+}
+
+// Mock ClientOsApi for testing
+#[derive(Debug, Clone)]
+struct MockClientOsApi;
+
+impl crate::os_input_output::ClientOsApi for MockClientOsApi {
+    fn get_terminal_size_using_fd(&self, _fd: i32) -> zellij_utils::pane_size::Size {
+        zellij_utils::pane_size::Size { rows: 24, cols: 80 }
+    }
+
+    fn set_raw_mode(&mut self, _fd: i32) {}
+
+    fn unset_raw_mode(&self, _fd: i32) -> Result<(), nix::Error> {
+        Ok(())
+    }
+
+    fn box_clone(&self) -> Box<dyn crate::os_input_output::ClientOsApi> {
+        Box::new(MockClientOsApi)
+    }
+
+    fn read_from_stdin(&mut self) -> Result<Vec<u8>, &'static str> {
+        Ok(Vec::new())
+    }
+
+    fn get_stdin_reader(&self) -> Box<dyn std::io::BufRead> {
+        Box::new(std::io::BufReader::new(std::io::empty()))
+    }
+
+    fn get_stdout_writer(&self) -> Box<dyn std::io::Write> {
+        Box::new(std::io::sink())
+    }
+
+    fn update_session_name(&mut self, _new_session_name: String) {}
+
+    fn send_to_server(&self, _msg: zellij_utils::ipc::ClientToServerMsg) {}
+
+    fn recv_from_server(
+        &self,
+    ) -> Option<(
+        zellij_utils::ipc::ServerToClientMsg,
+        zellij_utils::errors::ErrorContext,
+    )> {
+        None
+    }
+
+    fn handle_signals(&self, _sigwinch_cb: Box<dyn Fn()>, _quit_cb: Box<dyn Fn()>) {}
+
+    fn connect_to_server(&self, _path: &std::path::Path) {}
+
+    fn load_palette(&self) -> zellij_utils::data::Palette {
+        zellij_utils::shared::default_palette()
+    }
+
+    fn enable_mouse(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn disable_mouse(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn stdin_poller(&self) -> crate::os_input_output::StdinPoller {
+        crate::os_input_output::StdinPoller::default()
+    }
+}
+
+// Tests
+#[cfg(feature = "web_server_capability")]
+mod tests {
+    use super::mock_server::*;
+    use super::*;
+
+    // Helper function to call attach_to_remote_session from async context
+    async fn call_attach_to_remote_session(
+        remote_session_url: String,
+        token: Option<String>,
+        remember: bool,
+        forget: bool,
+    ) -> Result<WebSocketConnections, RemoteClientError> {
+        tokio::task::spawn_blocking(move || {
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            let os_input: Box<dyn crate::os_input_output::ClientOsApi> = Box::new(MockClientOsApi);
+            attach_to_remote_session(
+                &runtime,
+                os_input,
+                &remote_session_url,
+                token,
+                remember,
+                forget,
+            )
+        })
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_successful_authentication_with_valid_token() {
+        let server_state = MockRemoteServerState::new();
+        let auth_token = "test-auth-token-123";
+        server_state.add_valid_token(auth_token);
+
+        let (port, server_handle) = start_mock_server(server_state.clone()).await;
+        let server_url = format!("http://127.0.0.1:{}/session-name", port);
+
+        setup_test_db(&format!("http://127.0.0.1:{}", port));
+
+        let result =
+            call_attach_to_remote_session(server_url, Some(auth_token.to_string()), false, false)
+                .await;
+
+        assert!(
+            result.is_ok(),
+            "Should successfully authenticate: {:?}",
+            result.err()
+        );
+
+        let endpoints = server_state.get_endpoints_called();
+        assert!(
+            endpoints.contains(&"/command/login".to_string()),
+            "Should call login endpoint"
+        );
+        assert!(
+            endpoints.contains(&"/session".to_string()),
+            "Should call session endpoint"
+        );
+        assert!(
+            endpoints.contains(&"/ws/terminal".to_string()),
+            "Should establish terminal WebSocket"
+        );
+        assert!(
+            endpoints.contains(&"/ws/control".to_string()),
+            "Should establish control WebSocket"
+        );
+
+        server_handle.abort();
+        cleanup_test_db(&format!("http://127.0.0.1:{}", port));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_failed_authentication_with_invalid_token() {
+        let server_state = MockRemoteServerState::new();
+        // Don't add the token to valid tokens - server will reject it
+
+        let (port, server_handle) = start_mock_server(server_state.clone()).await;
+        let server_url = format!("http://127.0.0.1:{}/session-name", port);
+
+        setup_test_db(&format!("http://127.0.0.1:{}", port));
+
+        let result = call_attach_to_remote_session(
+            server_url,
+            Some("invalid-token".to_string()),
+            false,
+            false,
+        )
+        .await;
+
+        assert!(result.is_err(), "Should fail with invalid token");
+        assert!(
+            matches!(result.unwrap_err(), RemoteClientError::InvalidAuthToken),
+            "Should return InvalidAuthToken error"
+        );
+
+        server_handle.abort();
+        cleanup_test_db(&format!("http://127.0.0.1:{}", port));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_save_session_token_with_remember_true() {
+        let server_state = MockRemoteServerState::new();
+        let auth_token = "test-token-remember";
+        server_state.add_valid_token(auth_token);
+
+        let (port, server_handle) = start_mock_server(server_state.clone()).await;
+        let server_url = format!("http://127.0.0.1:{}/session-name", port);
+        let base_url = format!("http://127.0.0.1:{}", port);
+
+        setup_test_db(&base_url);
+
+        let result = call_attach_to_remote_session(
+            server_url,
+            Some(auth_token.to_string()),
+            true, // remember = true
+            false,
+        )
+        .await;
+
+        assert!(result.is_ok(), "Connection should succeed");
+
+        // Verify token was saved
+        let saved_token = remote_session_tokens::get_session_token(&base_url);
+        assert!(saved_token.is_ok());
+        assert!(
+            saved_token.unwrap().is_some(),
+            "Session token should be saved"
+        );
+
+        server_handle.abort();
+        cleanup_test_db(&base_url);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_dont_save_token_with_remember_false() {
+        let server_state = MockRemoteServerState::new();
+        let auth_token = "test-token-no-remember";
+        server_state.add_valid_token(auth_token);
+
+        let (port, server_handle) = start_mock_server(server_state.clone()).await;
+        let server_url = format!("http://127.0.0.1:{}/session-name", port);
+        let base_url = format!("http://127.0.0.1:{}", port);
+
+        setup_test_db(&base_url);
+
+        let result = call_attach_to_remote_session(
+            server_url,
+            Some(auth_token.to_string()),
+            false, // remember = false
+            false,
+        )
+        .await;
+
+        assert!(result.is_ok(), "Connection should succeed");
+
+        // Verify token was NOT saved
+        let saved_token = remote_session_tokens::get_session_token(&base_url);
+        assert!(saved_token.is_ok());
+        assert!(
+            saved_token.unwrap().is_none(),
+            "Session token should NOT be saved"
+        );
+
+        server_handle.abort();
+        cleanup_test_db(&base_url);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_load_and_use_saved_session_token() {
+        let server_state = MockRemoteServerState::new();
+
+        // Pre-create a session token
+        let session_token = uuid::Uuid::new_v4().to_string();
+        let web_client_id = uuid::Uuid::new_v4().to_string();
+        server_state
+            .session_tokens
+            .lock()
+            .unwrap()
+            .insert(session_token.clone(), web_client_id);
+
+        let (port, server_handle) = start_mock_server(server_state.clone()).await;
+        let server_url = format!("http://127.0.0.1:{}/session-name", port);
+        let base_url = format!("http://127.0.0.1:{}", port);
+
+        setup_test_db(&base_url);
+
+        // Save the session token
+        remote_session_tokens::save_session_token(&base_url, &session_token).unwrap();
+
+        let result = call_attach_to_remote_session(
+            server_url, None, // No auth token provided
+            false, false,
+        )
+        .await;
+
+        assert!(result.is_ok(), "Should successfully use saved token");
+
+        // Verify we did NOT call login endpoint (used saved token directly)
+        let endpoints = server_state.get_endpoints_called();
+        assert!(
+            !endpoints.contains(&"/command/login".to_string()),
+            "Should NOT call login endpoint"
+        );
+        assert!(
+            endpoints.contains(&"/session".to_string()),
+            "Should call session endpoint"
+        );
+
+        server_handle.abort();
+        cleanup_test_db(&base_url);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_token_flag_deletes_saved_token() {
+        let server_state = MockRemoteServerState::new();
+        let auth_token = "new-auth-token";
+        server_state.add_valid_token(auth_token);
+
+        let (port, server_handle) = start_mock_server(server_state.clone()).await;
+        let server_url = format!("http://127.0.0.1:{}/session-name", port);
+        let base_url = format!("http://127.0.0.1:{}", port);
+
+        setup_test_db(&base_url);
+
+        // Pre-save an old token
+        remote_session_tokens::save_session_token(&base_url, "old-token").unwrap();
+
+        let result = call_attach_to_remote_session(
+            server_url,
+            Some(auth_token.to_string()), // Providing new token
+            false,
+            false,
+        )
+        .await;
+
+        assert!(result.is_ok(), "Should succeed with new token");
+
+        // The old token should have been deleted before using new one
+        // (New token won't be saved because remember=false)
+        // Verify by checking that session endpoint was called (not using saved token)
+        let endpoints = server_state.get_endpoints_called();
+        assert!(
+            endpoints.contains(&"/command/login".to_string()),
+            "Should use new auth token, not saved token"
+        );
+
+        server_handle.abort();
+        cleanup_test_db(&base_url);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_successful_websocket_establishment() {
+        let server_state = MockRemoteServerState::new();
+        let auth_token = "test-ws-token";
+        server_state.add_valid_token(auth_token);
+
+        let (port, server_handle) = start_mock_server(server_state.clone()).await;
+        let server_url = format!("http://127.0.0.1:{}/test-session", port);
+        let base_url = format!("http://127.0.0.1:{}", port);
+
+        setup_test_db(&base_url);
+
+        let result =
+            call_attach_to_remote_session(server_url, Some(auth_token.to_string()), false, false)
+                .await;
+
+        assert!(
+            result.is_ok(),
+            "WebSocket connections should be established"
+        );
+
+        let connections = result.unwrap();
+        assert!(
+            !connections.web_client_id.is_empty(),
+            "Should have web_client_id"
+        );
+
+        // Verify both WebSocket endpoints were called
+        let endpoints = server_state.get_endpoints_called();
+        assert!(
+            endpoints.contains(&"/ws/terminal".to_string()),
+            "Terminal WebSocket should be established"
+        );
+        assert!(
+            endpoints.contains(&"/ws/control".to_string()),
+            "Control WebSocket should be established"
+        );
+
+        server_handle.abort();
+        cleanup_test_db(&base_url);
+    }
+
+    #[tokio::test]
+    async fn test_url_parsing_for_session_name() {
+        // Test various URL formats
+        let test_cases = vec![
+            ("https://example.com/my-session", "my-session"),
+            ("https://example.com/", ""),
+            ("https://example.com/path/to/session", "path/to/session"),
+            ("http://localhost:8080/test", "test"),
+        ];
+
+        for (url, expected_name) in test_cases {
+            let result = extract_session_name(url);
+            assert!(result.is_ok(), "Failed to parse URL: {}", url);
+            assert_eq!(
+                result.unwrap(),
+                expected_name,
+                "Wrong session name for URL: {}",
+                url
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_server_url_extraction() {
+        // Test various URL formats
+        let test_cases = vec![
+            (
+                "https://example.com:8080/session?foo=bar",
+                "https://example.com:8080",
+            ),
+            ("http://localhost/test", "http://localhost"),
+            (
+                "https://example.com/path/to/session#anchor",
+                "https://example.com",
+            ),
+        ];
+
+        for (url, expected_base) in test_cases {
+            let result = extract_server_url(url);
+            assert!(result.is_ok(), "Failed to extract server URL: {}", url);
+            assert_eq!(
+                result.unwrap(),
+                expected_base,
+                "Wrong base URL for: {}",
+                url
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_invalid_url_format() {
+        let result = call_attach_to_remote_session(
+            "not-a-valid-url".to_string(),
+            Some("token".to_string()),
+            false,
+            false,
+        )
+        .await;
+
+        assert!(result.is_err(), "Should fail with malformed URL");
+        assert!(matches!(
+            result.unwrap_err(),
+            RemoteClientError::UrlParseError(_)
+        ));
+    }
+}
+
+// Tests that don't require the web_server_capability feature
+#[cfg(not(feature = "web_server_capability"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_url_parsing_without_server() {
+        // Basic URL parsing tests that don't require a server
+        let result = extract_session_name("https://example.com/my-session");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "my-session");
+
+        let result = extract_server_url("https://example.com:8080/session?foo=bar");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "https://example.com:8080");
+    }
+}

--- a/zellij-client/src/remote_attach/websockets.rs
+++ b/zellij-client/src/remote_attach/websockets.rs
@@ -1,0 +1,99 @@
+use super::config::{WS_CONTROL_ENDPOINT, WS_TERMINAL_ENDPOINT};
+use super::http_client::HttpClientWithCookies;
+use tokio::net::TcpStream;
+use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+
+pub struct WebSocketConnections {
+    pub terminal_ws: WebSocketStream<MaybeTlsStream<TcpStream>>,
+    pub control_ws: WebSocketStream<MaybeTlsStream<TcpStream>>,
+    pub web_client_id: String,
+}
+
+impl std::fmt::Debug for WebSocketConnections {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WebSocketConnections")
+            .field("web_client_id", &self.web_client_id)
+            .finish()
+    }
+}
+
+pub async fn establish_websocket_connections(
+    web_client_id: &str,
+    http_client: &HttpClientWithCookies,
+    server_base_url: &str,
+    session_name: &str,
+) -> Result<WebSocketConnections, Box<dyn std::error::Error>> {
+    let ws_protocol = if server_base_url.starts_with("https") {
+        "wss"
+    } else {
+        "ws"
+    };
+    let base_host = server_base_url
+        .replace("https://", "")
+        .replace("http://", "");
+
+    let terminal_url = if session_name.is_empty() {
+        format!(
+            "{}://{}{WS_TERMINAL_ENDPOINT}?web_client_id={}",
+            ws_protocol,
+            base_host,
+            urlencoding::encode(web_client_id)
+        )
+    } else {
+        format!(
+            "{}://{}{WS_TERMINAL_ENDPOINT}/{}?web_client_id={}",
+            ws_protocol,
+            base_host,
+            urlencoding::encode(session_name),
+            urlencoding::encode(web_client_id)
+        )
+    };
+
+    let control_url = format!("{}://{}{WS_CONTROL_ENDPOINT}", ws_protocol, base_host);
+
+    log::info!("Connecting to terminal WebSocket: {}", terminal_url);
+    log::info!("Connecting to control WebSocket: {}", control_url);
+
+    // Create WebSocket request with cookies
+    let mut terminal_request = tokio_tungstenite::tungstenite::http::Request::builder()
+        .uri(&terminal_url)
+        .header("Host", &base_host)
+        .header("Upgrade", "websocket")
+        .header("Connection", "Upgrade")
+        .header(
+            "Sec-WebSocket-Key",
+            tokio_tungstenite::tungstenite::handshake::client::generate_key(),
+        )
+        .header("Sec-WebSocket-Version", "13");
+
+    let mut control_request = tokio_tungstenite::tungstenite::http::Request::builder()
+        .uri(&control_url)
+        .header("Host", &base_host)
+        .header("Upgrade", "websocket")
+        .header("Connection", "Upgrade")
+        .header(
+            "Sec-WebSocket-Key",
+            tokio_tungstenite::tungstenite::handshake::client::generate_key(),
+        )
+        .header("Sec-WebSocket-Version", "13");
+
+    // Add cookies if available
+    if let Some(cookie_header) = http_client.get_cookie_header() {
+        terminal_request = terminal_request.header("Cookie", &cookie_header);
+        control_request = control_request.header("Cookie", &cookie_header);
+    }
+
+    let terminal_request = terminal_request.body(())?;
+    let control_request = control_request.body(())?;
+
+    // Connect to both WebSockets concurrently
+    // tokio-tungstenite handles TLS automatically for wss:// URLs
+    let (terminal_ws, _) = connect_async(terminal_request).await?;
+    let (control_ws, _) = connect_async(control_request).await?;
+
+    Ok(WebSocketConnections {
+        terminal_ws,
+        control_ws,
+        web_client_id: web_client_id.to_owned(),
+    })
+}

--- a/zellij-client/src/unit/mod.rs
+++ b/zellij-client/src/unit/mod.rs
@@ -1,0 +1,3 @@
+#[cfg(test)]
+#[cfg(feature = "web_server_capability")]
+mod terminal_loop_tests;

--- a/zellij-client/src/unit/terminal_loop_tests.rs
+++ b/zellij-client/src/unit/terminal_loop_tests.rs
@@ -1,0 +1,665 @@
+use crate::os_input_output::{AsyncSignals, AsyncStdin, ClientOsApi, SignalEvent};
+use crate::remote_attach::WebSocketConnections;
+use crate::run_remote_client_terminal_loop;
+use crate::web_client::control_message::{
+    WebClientToWebServerControlMessage, WebClientToWebServerControlMessagePayload,
+    WebServerToWebClientControlMessage,
+};
+use async_trait::async_trait;
+use futures_util::{SinkExt, StreamExt};
+use serial_test::serial;
+use std::io::{self, Write};
+use std::os::unix::io::RawFd;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+use zellij_utils::data::Palette;
+use zellij_utils::errors::ErrorContext;
+use zellij_utils::ipc::{ClientToServerMsg, ServerToClientMsg};
+use zellij_utils::pane_size::Size;
+
+/// Mock stdin that allows tests to inject input data
+struct MockAsyncStdin {
+    rx: Arc<tokio::sync::Mutex<mpsc::UnboundedReceiver<Vec<u8>>>>,
+}
+
+#[async_trait]
+impl AsyncStdin for MockAsyncStdin {
+    async fn read(&mut self) -> io::Result<Vec<u8>> {
+        match self.rx.lock().await.recv().await {
+            Some(data) => Ok(data),
+            None => Ok(Vec::new()), // EOF
+        }
+    }
+}
+
+/// Mock signal listener that allows tests to inject signals
+struct MockAsyncSignals {
+    rx: Arc<tokio::sync::Mutex<mpsc::UnboundedReceiver<SignalEvent>>>,
+}
+
+#[async_trait]
+impl AsyncSignals for MockAsyncSignals {
+    async fn recv(&mut self) -> Option<SignalEvent> {
+        self.rx.lock().await.recv().await
+    }
+}
+
+/// Mock ClientOsApi for testing
+#[derive(Clone)]
+struct TestClientOsApi {
+    stdout_buffer: Arc<Mutex<Vec<u8>>>,
+    stdin_rx: Arc<tokio::sync::Mutex<mpsc::UnboundedReceiver<Vec<u8>>>>,
+    signal_rx: Arc<tokio::sync::Mutex<mpsc::UnboundedReceiver<SignalEvent>>>,
+    terminal_size: Size,
+}
+
+impl TestClientOsApi {
+    fn new(
+        stdin_rx: mpsc::UnboundedReceiver<Vec<u8>>,
+        signal_rx: mpsc::UnboundedReceiver<SignalEvent>,
+    ) -> Self {
+        Self {
+            stdout_buffer: Arc::new(Mutex::new(Vec::new())),
+            stdin_rx: Arc::new(tokio::sync::Mutex::new(stdin_rx)),
+            signal_rx: Arc::new(tokio::sync::Mutex::new(signal_rx)),
+            terminal_size: Size { rows: 24, cols: 80 },
+        }
+    }
+}
+
+impl std::fmt::Debug for TestClientOsApi {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TestClientOsApi").finish()
+    }
+}
+
+impl ClientOsApi for TestClientOsApi {
+    fn get_terminal_size_using_fd(&self, _fd: RawFd) -> Size {
+        self.terminal_size
+    }
+
+    fn set_raw_mode(&mut self, _fd: RawFd) {}
+
+    fn unset_raw_mode(&self, _fd: RawFd) -> Result<(), nix::Error> {
+        Ok(())
+    }
+
+    fn get_stdout_writer(&self) -> Box<dyn Write> {
+        Box::new(TestWriter {
+            buffer: self.stdout_buffer.clone(),
+        })
+    }
+
+    fn get_stdin_reader(&self) -> Box<dyn io::BufRead> {
+        Box::new(io::Cursor::new(Vec::new()))
+    }
+
+    fn update_session_name(&mut self, _new_session_name: String) {}
+
+    fn read_from_stdin(&mut self) -> Result<Vec<u8>, &'static str> {
+        Ok(Vec::new())
+    }
+
+    fn box_clone(&self) -> Box<dyn ClientOsApi> {
+        Box::new(self.clone())
+    }
+
+    fn send_to_server(&self, _msg: ClientToServerMsg) {}
+
+    fn recv_from_server(&self) -> Option<(ServerToClientMsg, ErrorContext)> {
+        None
+    }
+
+    fn handle_signals(&self, _sigwinch_cb: Box<dyn Fn()>, _quit_cb: Box<dyn Fn()>) {}
+
+    fn connect_to_server(&self, _path: &std::path::Path) {}
+
+    fn load_palette(&self) -> Palette {
+        Palette::default()
+    }
+
+    fn enable_mouse(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn disable_mouse(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn stdin_poller(&self) -> crate::os_input_output::StdinPoller {
+        crate::os_input_output::StdinPoller::default()
+    }
+
+    fn get_async_stdin_reader(&self) -> Box<dyn AsyncStdin> {
+        Box::new(MockAsyncStdin {
+            rx: self.stdin_rx.clone(),
+        })
+    }
+
+    fn get_async_signal_listener(&self) -> io::Result<Box<dyn AsyncSignals>> {
+        Ok(Box::new(MockAsyncSignals {
+            rx: self.signal_rx.clone(),
+        }))
+    }
+}
+
+struct TestWriter {
+    buffer: Arc<Mutex<Vec<u8>>>,
+}
+
+impl Write for TestWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buffer.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+mod mock_ws_server {
+    use super::*;
+    use axum::{
+        extract::{
+            ws::{WebSocket, WebSocketUpgrade},
+            State,
+        },
+        routing::get,
+        Router,
+    };
+    use tokio::net::TcpListener;
+    use tokio::task::JoinHandle;
+
+    #[derive(Clone)]
+    struct WsState {
+        client_tx: Arc<Mutex<mpsc::UnboundedSender<Message>>>,
+        server_rx: Arc<Mutex<mpsc::UnboundedReceiver<Message>>>,
+    }
+
+    pub struct MockWsServer {
+        pub terminal_to_client_tx: mpsc::UnboundedSender<Message>,
+        pub control_to_client_tx: mpsc::UnboundedSender<Message>,
+        pub client_to_terminal_rx: Arc<Mutex<mpsc::UnboundedReceiver<Message>>>,
+        pub client_to_control_rx: Arc<Mutex<mpsc::UnboundedReceiver<Message>>>,
+    }
+
+    impl MockWsServer {
+        pub async fn start() -> (u16, Self, JoinHandle<()>) {
+            let (terminal_to_client_tx, terminal_to_client_rx) = mpsc::unbounded_channel();
+            let (client_to_terminal_tx, client_to_terminal_rx) = mpsc::unbounded_channel();
+            let (control_to_client_tx, control_to_client_rx) = mpsc::unbounded_channel();
+            let (client_to_control_tx, client_to_control_rx) = mpsc::unbounded_channel();
+
+            let terminal_state = WsState {
+                client_tx: Arc::new(Mutex::new(client_to_terminal_tx)),
+                server_rx: Arc::new(Mutex::new(terminal_to_client_rx)),
+            };
+
+            let control_state = WsState {
+                client_tx: Arc::new(Mutex::new(client_to_control_tx)),
+                server_rx: Arc::new(Mutex::new(control_to_client_rx)),
+            };
+
+            let app = Router::new()
+                .route(
+                    "/ws/terminal",
+                    get(terminal_handler).with_state(terminal_state.clone()),
+                )
+                .route(
+                    "/ws/control",
+                    get(control_handler).with_state(control_state.clone()),
+                );
+
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let port = listener.local_addr().unwrap().port();
+
+            let server_handle = tokio::spawn(async move {
+                axum::serve(listener, app).await.unwrap();
+            });
+
+            // Wait for server to start
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            let server = MockWsServer {
+                terminal_to_client_tx,
+                control_to_client_tx,
+                client_to_terminal_rx: Arc::new(Mutex::new(client_to_terminal_rx)),
+                client_to_control_rx: Arc::new(Mutex::new(client_to_control_rx)),
+            };
+
+            (port, server, server_handle)
+        }
+    }
+
+    async fn terminal_handler(
+        ws: WebSocketUpgrade,
+        State(state): State<WsState>,
+    ) -> impl axum::response::IntoResponse {
+        ws.on_upgrade(move |socket| handle_websocket(socket, state))
+    }
+
+    async fn control_handler(
+        ws: WebSocketUpgrade,
+        State(state): State<WsState>,
+    ) -> impl axum::response::IntoResponse {
+        ws.on_upgrade(move |socket| handle_websocket(socket, state))
+    }
+
+    async fn handle_websocket(socket: WebSocket, state: WsState) {
+        let (mut ws_tx, mut ws_rx) = socket.split();
+        let client_tx = state.client_tx.clone();
+
+        let recv_task = tokio::spawn(async move {
+            while let Some(Ok(axum_msg)) = ws_rx.next().await {
+                // Convert axum::extract::ws::Message to tokio_tungstenite::tungstenite::Message
+                let tungstenite_msg = match axum_msg {
+                    axum::extract::ws::Message::Text(text) => Message::Text(text.to_string()),
+                    axum::extract::ws::Message::Binary(data) => Message::Binary(data.to_vec()),
+                    axum::extract::ws::Message::Ping(data) => Message::Ping(data.to_vec()),
+                    axum::extract::ws::Message::Pong(data) => Message::Pong(data.to_vec()),
+                    axum::extract::ws::Message::Close(frame) => {
+                        if let Some(f) = frame {
+                            Message::Close(Some(tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                                code: tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::from(f.code),
+                                reason: std::borrow::Cow::Owned(f.reason.to_string()),
+                            }))
+                        } else {
+                            Message::Close(None)
+                        }
+                    },
+                };
+                let _ = client_tx.lock().unwrap().send(tungstenite_msg);
+            }
+        });
+
+        loop {
+            let msg = state.server_rx.lock().unwrap().try_recv();
+            match msg {
+                Ok(tungstenite_msg) => {
+                    // Convert tokio_tungstenite::tungstenite::Message to axum::extract::ws::Message
+                    let axum_msg = match tungstenite_msg {
+                        Message::Text(text) => axum::extract::ws::Message::Text(text.into()),
+                        Message::Binary(data) => axum::extract::ws::Message::Binary(data.into()),
+                        Message::Ping(data) => axum::extract::ws::Message::Ping(data.into()),
+                        Message::Pong(data) => axum::extract::ws::Message::Pong(data.into()),
+                        Message::Close(frame) => {
+                            if let Some(f) = frame {
+                                axum::extract::ws::Message::Close(Some(
+                                    axum::extract::ws::CloseFrame {
+                                        code: f.code.into(),
+                                        reason: f.reason.to_string().into(),
+                                    },
+                                ))
+                            } else {
+                                axum::extract::ws::Message::Close(None)
+                            }
+                        },
+                        Message::Frame(_) => continue, // Skip raw frames
+                    };
+                    if ws_tx.send(axum_msg).await.is_err() {
+                        break;
+                    }
+                },
+                Err(_) => {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                },
+            }
+        }
+
+        recv_task.abort();
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_stdin_forwarded_to_terminal_websocket() {
+    // Setup mock WebSocket server
+    let (port, server, _server_handle) = mock_ws_server::MockWsServer::start().await;
+
+    // Create WebSocket connections
+    let terminal_url = format!("ws://127.0.0.1:{}/ws/terminal", port);
+    let control_url = format!("ws://127.0.0.1:{}/ws/control", port);
+
+    let (terminal_ws, _) = connect_async(&terminal_url).await.unwrap();
+    let (control_ws, _) = connect_async(&control_url).await.unwrap();
+
+    let connections = WebSocketConnections {
+        terminal_ws,
+        control_ws,
+        web_client_id: "test-stdin".to_string(),
+    };
+
+    // Create mock OS API with controllable stdin
+    let (stdin_tx, stdin_rx) = mpsc::unbounded_channel();
+    let (_signal_tx, signal_rx) = mpsc::unbounded_channel();
+
+    let os_input = Box::new(TestClientOsApi::new(stdin_rx, signal_rx));
+
+    // Spawn the async loop
+    let loop_handle =
+        tokio::spawn(async move { run_remote_client_terminal_loop(os_input, connections).await });
+
+    // Send stdin data
+    let test_data = b"hello from stdin\n".to_vec();
+    stdin_tx.send(test_data.clone()).unwrap();
+
+    // Verify terminal WebSocket received the data
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let received = tokio::time::timeout(
+        Duration::from_secs(1),
+        server.client_to_terminal_rx.lock().unwrap().recv(),
+    )
+    .await
+    .expect("Timeout")
+    .expect("No message");
+
+    match received {
+        Message::Binary(data) => assert_eq!(data, test_data),
+        _ => panic!("Expected Binary message, got: {:?}", received),
+    }
+
+    // Cleanup: send EOF via stdin
+    drop(stdin_tx);
+    let _ = tokio::time::timeout(Duration::from_secs(2), loop_handle)
+        .await
+        .expect("Loop didn't exit")
+        .unwrap();
+}
+
+#[tokio::test]
+#[serial]
+async fn test_terminal_output_written_to_stdout() {
+    let (port, server, _server_handle) = mock_ws_server::MockWsServer::start().await;
+
+    let terminal_url = format!("ws://127.0.0.1:{}/ws/terminal", port);
+    let control_url = format!("ws://127.0.0.1:{}/ws/control", port);
+
+    let (terminal_ws, _) = connect_async(&terminal_url).await.unwrap();
+    let (control_ws, _) = connect_async(&control_url).await.unwrap();
+
+    let connections = WebSocketConnections {
+        terminal_ws,
+        control_ws,
+        web_client_id: "test-stdout".to_string(),
+    };
+
+    let (_stdin_tx, stdin_rx) = mpsc::unbounded_channel();
+    let (_signal_tx, signal_rx) = mpsc::unbounded_channel();
+
+    let os_input = TestClientOsApi::new(stdin_rx, signal_rx);
+    let stdout_buffer = os_input.stdout_buffer.clone();
+    let os_input = Box::new(os_input);
+
+    let loop_handle =
+        tokio::spawn(async move { run_remote_client_terminal_loop(os_input, connections).await });
+
+    // Send terminal output from server
+    let test_output = "Hello from terminal";
+    server
+        .terminal_to_client_tx
+        .send(Message::Text(test_output.to_string()))
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Verify stdout received the output
+    let stdout = stdout_buffer.lock().unwrap().clone();
+    let stdout_str = String::from_utf8_lossy(&stdout);
+    assert!(
+        stdout_str.contains(test_output),
+        "Expected stdout to contain '{}', got: '{}'",
+        test_output,
+        stdout_str
+    );
+
+    // Cleanup
+    server
+        .terminal_to_client_tx
+        .send(Message::Close(None))
+        .unwrap();
+    let _ = tokio::time::timeout(Duration::from_secs(2), loop_handle)
+        .await
+        .expect("Loop didn't exit")
+        .unwrap();
+}
+
+#[tokio::test]
+#[serial]
+async fn test_resize_signal_sends_control_message() {
+    let (port, server, _server_handle) = mock_ws_server::MockWsServer::start().await;
+
+    let terminal_url = format!("ws://127.0.0.1:{}/ws/terminal", port);
+    let control_url = format!("ws://127.0.0.1:{}/ws/control", port);
+
+    let (terminal_ws, _) = connect_async(&terminal_url).await.unwrap();
+    let (control_ws, _) = connect_async(&control_url).await.unwrap();
+
+    let connections = WebSocketConnections {
+        terminal_ws,
+        control_ws,
+        web_client_id: "test-resize".to_string(),
+    };
+
+    let (_stdin_tx, stdin_rx) = mpsc::unbounded_channel();
+    let (signal_tx, signal_rx) = mpsc::unbounded_channel();
+
+    let os_input = Box::new(TestClientOsApi::new(stdin_rx, signal_rx));
+
+    let loop_handle =
+        tokio::spawn(async move { run_remote_client_terminal_loop(os_input, connections).await });
+
+    // Wait for initial resize message to be sent on startup
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Consume the initial resize message
+    let _ = tokio::time::timeout(
+        Duration::from_millis(500),
+        server.client_to_control_rx.lock().unwrap().recv(),
+    )
+    .await;
+
+    // Send resize signal
+    signal_tx.send(SignalEvent::Resize).unwrap();
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Verify control WebSocket received resize message
+    let received = tokio::time::timeout(
+        Duration::from_secs(1),
+        server.client_to_control_rx.lock().unwrap().recv(),
+    )
+    .await
+    .expect("Timeout")
+    .expect("No message");
+
+    match received {
+        Message::Text(text) => {
+            let parsed: WebClientToWebServerControlMessage =
+                serde_json::from_str(&text).expect("Failed to parse");
+            assert!(
+                matches!(
+                    parsed.payload,
+                    WebClientToWebServerControlMessagePayload::TerminalResize(_)
+                ),
+                "Expected TerminalResize, got: {:?}",
+                parsed.payload
+            );
+        },
+        _ => panic!("Expected Text message, got: {:?}", received),
+    }
+
+    // Cleanup
+    signal_tx.send(SignalEvent::Quit).unwrap();
+    let _ = tokio::time::timeout(Duration::from_secs(2), loop_handle)
+        .await
+        .expect("Loop didn't exit")
+        .unwrap();
+}
+
+#[tokio::test]
+#[serial]
+async fn test_quit_signal_exits_loop() {
+    let (port, _server, _server_handle) = mock_ws_server::MockWsServer::start().await;
+
+    let terminal_url = format!("ws://127.0.0.1:{}/ws/terminal", port);
+    let control_url = format!("ws://127.0.0.1:{}/ws/control", port);
+
+    let (terminal_ws, _) = connect_async(&terminal_url).await.unwrap();
+    let (control_ws, _) = connect_async(&control_url).await.unwrap();
+
+    let connections = WebSocketConnections {
+        terminal_ws,
+        control_ws,
+        web_client_id: "test-quit".to_string(),
+    };
+
+    let (_stdin_tx, stdin_rx) = mpsc::unbounded_channel();
+    let (signal_tx, signal_rx) = mpsc::unbounded_channel();
+
+    let os_input = Box::new(TestClientOsApi::new(stdin_rx, signal_rx));
+
+    let loop_handle =
+        tokio::spawn(async move { run_remote_client_terminal_loop(os_input, connections).await });
+
+    // Send quit signal
+    signal_tx.send(SignalEvent::Quit).unwrap();
+
+    // Verify loop exits cleanly
+    let result = tokio::time::timeout(Duration::from_secs(2), loop_handle)
+        .await
+        .expect("Loop didn't exit within timeout")
+        .expect("Loop panicked");
+
+    assert!(result.is_ok(), "Expected Ok result, got: {:?}", result);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_websocket_close_exits_loop() {
+    let (port, server, _server_handle) = mock_ws_server::MockWsServer::start().await;
+
+    let terminal_url = format!("ws://127.0.0.1:{}/ws/terminal", port);
+    let control_url = format!("ws://127.0.0.1:{}/ws/control", port);
+
+    let (terminal_ws, _) = connect_async(&terminal_url).await.unwrap();
+    let (control_ws, _) = connect_async(&control_url).await.unwrap();
+
+    let connections = WebSocketConnections {
+        terminal_ws,
+        control_ws,
+        web_client_id: "test-close".to_string(),
+    };
+
+    let (_stdin_tx, stdin_rx) = mpsc::unbounded_channel();
+    let (_signal_tx, signal_rx) = mpsc::unbounded_channel();
+
+    let os_input = Box::new(TestClientOsApi::new(stdin_rx, signal_rx));
+
+    let loop_handle =
+        tokio::spawn(async move { run_remote_client_terminal_loop(os_input, connections).await });
+
+    // Send close message
+    server
+        .terminal_to_client_tx
+        .send(Message::Close(None))
+        .unwrap();
+
+    // Verify loop exits cleanly
+    let result = tokio::time::timeout(Duration::from_secs(2), loop_handle)
+        .await
+        .expect("Loop didn't exit within timeout")
+        .expect("Loop panicked");
+
+    assert!(result.is_ok(), "Expected Ok result, got: {:?}", result);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_control_message_handling() {
+    let (port, server, _server_handle) = mock_ws_server::MockWsServer::start().await;
+
+    let terminal_url = format!("ws://127.0.0.1:{}/ws/terminal", port);
+    let control_url = format!("ws://127.0.0.1:{}/ws/control", port);
+
+    let (terminal_ws, _) = connect_async(&terminal_url).await.unwrap();
+    let (control_ws, _) = connect_async(&control_url).await.unwrap();
+
+    let connections = WebSocketConnections {
+        terminal_ws,
+        control_ws,
+        web_client_id: "test-control".to_string(),
+    };
+
+    let (_stdin_tx, stdin_rx) = mpsc::unbounded_channel();
+    let (_signal_tx, signal_rx) = mpsc::unbounded_channel();
+
+    let os_input = TestClientOsApi::new(stdin_rx, signal_rx);
+    let terminal_size = os_input.terminal_size;
+    let os_input = Box::new(os_input);
+
+    let loop_handle =
+        tokio::spawn(async move { run_remote_client_terminal_loop(os_input, connections).await });
+
+    // Wait for initial resize message to be sent on startup
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Consume the initial resize message
+    let _ = tokio::time::timeout(
+        Duration::from_millis(500),
+        server.client_to_control_rx.lock().unwrap().recv(),
+    )
+    .await;
+
+    // Send QueryTerminalSize control message
+    let query_msg = WebServerToWebClientControlMessage::QueryTerminalSize;
+    server
+        .control_to_client_tx
+        .send(Message::Text(serde_json::to_string(&query_msg).unwrap()))
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Verify we receive a resize response
+    let received = tokio::time::timeout(
+        Duration::from_secs(1),
+        server.client_to_control_rx.lock().unwrap().recv(),
+    )
+    .await
+    .expect("Timeout")
+    .expect("No message");
+
+    match received {
+        Message::Text(text) => {
+            let parsed: WebClientToWebServerControlMessage =
+                serde_json::from_str(&text).expect("Failed to parse");
+            let WebClientToWebServerControlMessagePayload::TerminalResize(size) = parsed.payload;
+            assert_eq!(size, terminal_size);
+        },
+        _ => panic!("Expected Text message, got: {:?}", received),
+    }
+
+    // Test Log message (should not crash)
+    let log_msg = WebServerToWebClientControlMessage::Log {
+        lines: vec!["Test log".to_string()],
+    };
+    server
+        .control_to_client_tx
+        .send(Message::Text(serde_json::to_string(&log_msg).unwrap()))
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Cleanup
+    server
+        .terminal_to_client_tx
+        .send(Message::Close(None))
+        .unwrap();
+    let _ = tokio::time::timeout(Duration::from_secs(2), loop_handle)
+        .await
+        .expect("Loop didn't exit")
+        .unwrap();
+}

--- a/zellij-client/src/web_client/control_message.rs
+++ b/zellij-client/src/web_client/control_message.rs
@@ -3,20 +3,20 @@ use zellij_utils::{input::config::Config, pane_size::Size};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 
-pub(super) struct WebClientToWebServerControlMessage {
+pub struct WebClientToWebServerControlMessage {
     pub web_client_id: String,
     pub payload: WebClientToWebServerControlMessagePayload,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "type")]
-pub(super) enum WebClientToWebServerControlMessagePayload {
+pub enum WebClientToWebServerControlMessagePayload {
     TerminalResize(Size),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "type")]
-pub(super) enum WebServerToWebClientControlMessage {
+pub enum WebServerToWebClientControlMessage {
     SetConfig(SetConfigPayload),
     QueryTerminalSize,
     Log { lines: Vec<String> },
@@ -25,7 +25,7 @@ pub(super) enum WebServerToWebClientControlMessage {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub(super) struct SetConfigPayload {
+pub struct SetConfigPayload {
     pub font: String,
     pub theme: SetConfigPayloadTheme,
     pub cursor_blink: bool,
@@ -38,7 +38,7 @@ pub(super) struct SetConfigPayload {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct SetConfigPayloadTheme {
+pub struct SetConfigPayloadTheme {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub background: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/zellij-client/src/web_client/mod.rs
+++ b/zellij-client/src/web_client/mod.rs
@@ -1,4 +1,4 @@
-mod control_message;
+pub mod control_message;
 
 mod authentication;
 mod connection_manager;

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -590,7 +590,7 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
         use zellij_utils::errors::handle_panic;
         let to_server = to_server.clone();
         Box::new(move |info| {
-            handle_panic(info, &to_server);
+            handle_panic(info, Some(&to_server));
         })
     });
 

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -257,6 +257,18 @@ pub enum Sessions {
         /// If resurrecting a dead session, immediately run all its commands on startup
         #[clap(short, long, value_parser, takes_value(false), default_value("false"))]
         force_run_commands: bool,
+
+        /// Authentication token for remote sessions
+        #[clap(short('t'), long, value_parser)]
+        token: Option<String>,
+
+        /// Save session for automatic re-authentication (4 weeks)
+        #[clap(short('r'), long, value_parser)]
+        remember: bool,
+
+        /// Delete saved session before connecting
+        #[clap(long, value_parser)]
+        forget: bool,
     },
 
     /// Kill a specific session

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -679,7 +679,7 @@ mod not_wasm {
     }
 
     /// Custom panic handler/hook. Prints the [`ErrorContext`].
-    pub fn handle_panic<T>(info: &PanicHookInfo<'_>, sender: &SenderWithContext<T>)
+    pub fn handle_panic<T>(info: &PanicHookInfo<'_>, sender: Option<&SenderWithContext<T>>)
     where
         T: ErrorInstruction + Clone,
     {
@@ -728,14 +728,14 @@ mod not_wasm {
             )
         );
 
-        if thread == "main" {
+        if thread == "main" || sender.is_none() {
             // here we only show the first line because the backtrace is not readable otherwise
             // a better solution would be to escape raw mode before we do this, but it's not trivial
             // to get os_input here
             println!("\u{1b}[2J{}", fmt_report(report));
             process::exit(1);
         } else {
-            let _ = sender.send(T::error(fmt_report(report)));
+            let _ = sender.unwrap().send(T::error(fmt_report(report)));
         }
     }
 

--- a/zellij-utils/src/lib.rs
+++ b/zellij-utils/src/lib.rs
@@ -25,6 +25,8 @@ pub mod downloader; // Requires async_std
 pub mod ipc; // Requires interprocess
 #[cfg(not(target_family = "wasm"))]
 pub mod logging; // Requires log4rs
+#[cfg(all(not(target_family = "wasm"), feature = "web_server_capability"))]
+pub mod remote_session_tokens;
 #[cfg(not(target_family = "wasm"))]
 pub mod sessions;
 #[cfg(all(not(target_family = "wasm"), feature = "web_server_capability"))]

--- a/zellij-utils/src/remote_session_tokens.rs
+++ b/zellij-utils/src/remote_session_tokens.rs
@@ -1,0 +1,133 @@
+use crate::consts::ZELLIJ_PROJ_DIR;
+use crate::shared::set_permissions;
+use rusqlite::Connection;
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub enum TokenError {
+    Database(rusqlite::Error),
+    Io(std::io::Error),
+    InvalidPath,
+}
+
+impl std::fmt::Display for TokenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TokenError::Database(e) => write!(f, "Database error: {}", e),
+            TokenError::Io(e) => write!(f, "IO error: {}", e),
+            TokenError::InvalidPath => write!(f, "Invalid path"),
+        }
+    }
+}
+
+impl std::error::Error for TokenError {}
+
+impl From<rusqlite::Error> for TokenError {
+    fn from(error: rusqlite::Error) -> Self {
+        TokenError::Database(error)
+    }
+}
+
+impl From<std::io::Error> for TokenError {
+    fn from(error: std::io::Error) -> Self {
+        TokenError::Io(error)
+    }
+}
+
+type Result<T> = std::result::Result<T, TokenError>;
+
+fn get_db_path() -> Result<PathBuf> {
+    let data_dir = ZELLIJ_PROJ_DIR.data_dir();
+    std::fs::create_dir_all(data_dir)?;
+    let db_path = data_dir.join("remote_sessions.db");
+    Ok(db_path)
+}
+
+fn init_db(conn: &Connection) -> Result<()> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS remote_sessions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            server_url TEXT UNIQUE NOT NULL,
+            session_token TEXT NOT NULL,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            last_used_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )",
+        [],
+    )?;
+
+    Ok(())
+}
+
+/// Save session token for a server (upsert)
+pub fn save_session_token(server_url: &str, session_token: &str) -> Result<()> {
+    let db_path = get_db_path()?;
+
+    // Set file permissions to 0600 if creating new file
+    let is_new = !db_path.exists();
+
+    let conn = Connection::open(&db_path)?;
+    init_db(&conn)?;
+
+    if is_new {
+        set_permissions(&db_path, 0o600)?;
+    }
+
+    conn.execute(
+        "INSERT OR REPLACE INTO remote_sessions (server_url, session_token, last_used_at)
+         VALUES (?1, ?2, CURRENT_TIMESTAMP)",
+        [server_url, session_token],
+    )?;
+
+    Ok(())
+}
+
+/// Get session token for a server, update last_used_at
+pub fn get_session_token(server_url: &str) -> Result<Option<String>> {
+    let db_path = get_db_path()?;
+
+    if !db_path.exists() {
+        return Ok(None);
+    }
+
+    let conn = Connection::open(db_path)?;
+    init_db(&conn)?;
+
+    let token = match conn.query_row(
+        "SELECT session_token FROM remote_sessions WHERE server_url = ?1",
+        [server_url],
+        |row| row.get::<_, String>(0),
+    ) {
+        Ok(token) => Some(token),
+        Err(rusqlite::Error::QueryReturnedNoRows) => None,
+        Err(e) => return Err(TokenError::Database(e)),
+    };
+
+    if token.is_some() {
+        // Update last_used_at
+        conn.execute(
+            "UPDATE remote_sessions SET last_used_at = CURRENT_TIMESTAMP WHERE server_url = ?1",
+            [server_url],
+        )?;
+    }
+
+    Ok(token)
+}
+
+/// Delete session token for a server
+pub fn delete_session_token(server_url: &str) -> Result<bool> {
+    let db_path = get_db_path()?;
+
+    if !db_path.exists() {
+        return Ok(false);
+    }
+
+    let conn = Connection::open(db_path)?;
+    init_db(&conn)?;
+
+    let rows_affected = conn.execute(
+        "DELETE FROM remote_sessions WHERE server_url = ?1",
+        [server_url],
+    )?;
+
+    Ok(rows_affected > 0)
+}


### PR DESCRIPTION
This adds built-in remote attach capabilities to Zellij*, allowing users to attach to a remote Zellij session that has a running web-server over https, for example:

```
$ zellij attach https://example.com/my-cool-session
Enter authentication token: <hidden>
```

Once attached, this works exactly like the web-client. Users see the same terminal as those active in the session (if there are any), receive their own unique cursor, etc. The only difference is that this works through the terminal rather than the browser. For more info: https://zellij.dev/tutorials/web-client/

The connection is established over https, using the same token authentication as the browser. It's possible to save the session-token (received from the server in exchange for the real token) in an SQLite database accessible only to the user (similar to how the web server itself stores its hashed tokens). This is to replace the browser's capability to store said session tokens in cookies.

Once the connection is established, terminal/control data is exchanged between the terminal and the web-server over 2 websocket channels just like the browser.

*This feature is compiled out along with the web server for versions of Zellij compiled without `web-server-capability`