### PR TITLE
fix(zellij-server): unblock building on 32bit targets

### DIFF
--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -161,7 +161,7 @@ pub enum RcCharacterStyles {
     Rc(Rc<CharacterStyles>),
 }
 
-// #[cfg(target_arch = "x86_64")]
+#[cfg(target_arch = "x86_64")]
 const _: [(); 8] = [(); std::mem::size_of::<RcCharacterStyles>()];
 
 impl From<CharacterStyles> for RcCharacterStyles {
@@ -931,7 +931,7 @@ pub struct TerminalCharacter {
 
 // This size has significant memory and CPU implications for long lines,
 // be careful about allowing it to grow
-// #[cfg(target_arch = "x86_64")]
+#[cfg(target_arch = "x86_64")]
 const _: [(); 16] = [(); std::mem::size_of::<TerminalCharacter>()];
 
 impl TerminalCharacter {


### PR DESCRIPTION
After the migration to `wasmi` (https://github.com/zellij-org/zellij/pull/4449), we should be able to build for 32bit targets (wasm runtimes have notoriously had issues with such targets, see https://docs.wasmtime.dev/stability-tiers.html#unsupported-features-and-platforms).

While testing with builds on Void Linux for i686, I noticed the static asserts in our code that hardcode support for 64bit platforms only. These were introduced as an optimization (https://github.com/zellij-org/zellij/pull/3043), but I'd argue that this is a bit overly pedantic, especially when it effectively limits possible target platforms for no reason.

Hence, my proposal to drop them altogether as a simple solution. I'm aware that we could instead rewrite those to take platform-specific pointer size into account, but especially in the case of `TerminalCharacter` it becomes cumbersome to cleanly express what the expected size should be.

When testing I at least made sure that the new reported size only goes **down** for the affected target.

cc @aidanhs for comments and suggestions