### PR TITLE
fix: create per version cache dir

### DIFF
--- a/zellij-client/src/stdin_ansi_parser.rs
+++ b/zellij-client/src/stdin_ansi_parser.rs
@@ -129,6 +129,12 @@ impl StdinAnsiParser {
     }
     pub fn write_cache(&self, events: Vec<AnsiStdinInstruction>) {
         if let Ok(serialized_events) = serde_json::to_string(&events) {
+            if let Some(parent) = ZELLIJ_STDIN_CACHE_FILE.parent() {
+                if let Err(e) = std::fs::create_dir_all(parent) {
+                    log::error!("Failed to create stdin cache directory: {:?}", e);
+                    return;
+                }
+            }
             if let Ok(mut file) = File::create(ZELLIJ_STDIN_CACHE_FILE.as_path()) {
                 let _ = file.write_all(serialized_events.as_bytes());
             }

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -1917,6 +1917,12 @@ fn should_show_release_notes(
     if ZELLIJ_SEEN_RELEASE_NOTES_CACHE_FILE.exists() {
         return false;
     } else {
+        if let Some(parent) = ZELLIJ_SEEN_RELEASE_NOTES_CACHE_FILE.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                log::error!("Failed to create release notes cache directory: {}", e);
+                return false;
+            }
+        }
         if let Err(e) = std::fs::write(&*ZELLIJ_SEEN_RELEASE_NOTES_CACHE_FILE, &[]) {
             log::error!(
                 "Failed to write seen release notes indication to disk: {}",


### PR DESCRIPTION
## Summary

Fixes a bug where cache file writes fail silently if the parent directory (`~/.cache/zellij/{VERSION}/`) doesn't exist. This was introduced in commit fb1af39a when the cache location was refactored from a flat structure to a version-specific subdirectory.

## Problem

Two cache file writes don't create their parent directory:
1. `stdin_ansi_parser.rs:132` - Terminal query cache
2. `lib.rs:2044` - Release notes seen indicator

Currently, these files only work because `dump_builtin_plugins()` creates the `{VERSION}/` directory as a side effect during plugin installation. If plugin installation is skipped or fails, cache writes fail silently.

## Root Cause

**Commit fb1af39a** refactored cache paths:
- **Before**: `~/.cache/zellij/zellij-stdin-cache-v{VERSION}` (parent exists via `create_config_and_cache_folders()`)
- **After**: `~/.cache/zellij/{VERSION}/stdin_cache` (parent not explicitly created)

The refactor moved cache into a VERSION subdirectory but didn't add parent directory creation.

## Changes

### 1. `zellij-client/src/stdin_ansi_parser.rs`
Added `create_dir_all()` for parent directory before writing stdin cache:
```rust
pub fn write_cache(&self, events: Vec<AnsiStdinInstruction>) {
    if let Ok(serialized_events) = serde_json::to_string(&events) {
        if let Some(parent) = ZELLIJ_STDIN_CACHE_FILE.parent() {
            if let Err(e) = std::fs::create_dir_all(parent) {
                log::error!("Failed to create stdin cache directory: {:?}", e);
                return;
            }
        }
        if let Ok(mut file) = File::create(ZELLIJ_STDIN_CACHE_FILE.as_path()) {
            let _ = file.write_all(serialized_events.as_bytes());
        }
    };
}
```

### 2. `zellij-server/src/lib.rs`
Added `create_dir_all()` for parent directory before writing release notes cache:
```rust
if ZELLIJ_SEEN_RELEASE_NOTES_CACHE_FILE.exists() {
    return false;
} else {
    if let Some(parent) = ZELLIJ_SEEN_RELEASE_NOTES_CACHE_FILE.parent() {
        if let Err(e) = std::fs::create_dir_all(parent) {
            log::error!("Failed to create release notes cache directory: {}", e);
            return false;
        }
    }
    if let Err(e) = std::fs::write(&*ZELLIJ_SEEN_RELEASE_NOTES_CACHE_FILE, &[]) {
        log::error!(
            "Failed to write seen release notes indication to disk: {}",
            e
        );
        return false;
    }
    return true;
}
```

## Testing

The fix ensures cache writes work independently of plugin installation:
1. Delete `~/.cache/zellij/{VERSION}/` directory
2. Launch Zellij
3. Verify `~/.cache/zellij/{VERSION}/stdin_cache` is created successfully

## Impact

- **No breaking changes**
- Makes cache code self-sufficient and robust
- Eliminates silent failures when VERSION directory doesn't exist
- Follows the same pattern used in `dump_builtin_plugins()` (setup.rs:293-294)
