### PR TITLE
Switch from the unmaintained daemonize crate to a maintained fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix: clear existing pane name when entering rename input (https://github.com/zellij-org/zellij/pull/5369)
 * fix: occasional input spam when pressing ESC and holding the mouse over slow SSH connections (https://github.com/zellij-org/zellij/pull/5323)
 * chore: switch cassowary deps to maintained fork kasuari (https://github.com/zellij-org/zellij/pull/5416)
+* chore: switch unmaintained daemonize with maintained fork daemonix (https://github.com/zellij-org/zellij/pull/4512)
 
 ## [0.44.3] - 2026-05-13
 * fix(windows): bump windows-sys to 0.59 to align manifest with code, fixing source builds via `cargo install`/`cargo binstall` (https://github.com/zellij-org/zellij/pull/5139)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,10 +785,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "daemonize"
-version = "0.5.0"
+name = "daemonix"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
+checksum = "f0b747381562a10fd2104e9333ad72fe5158d79de81b64426fc9e229c6d3fb38"
 dependencies = [
  "libc",
 ]
@@ -4998,7 +4998,7 @@ dependencies = [
  "axum-extra",
  "axum-server",
  "crossterm",
- "daemonize",
+ "daemonix",
  "dialoguer",
  "futures",
  "futures-util",
@@ -5068,7 +5068,7 @@ dependencies = [
  "chrono",
  "close_fds",
  "crossbeam",
- "daemonize",
+ "daemonix",
  "highway",
  "insta",
  "interprocess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ anyhow = { version = "1.0.70", default-features = false, features = ["backtrace"
 async-trait = { version = "0.1", default-features = false }
 clap = { version = "3.2.2", default-features = false, features = ["env", "derive", "color", "std", "suggestions"] }
 crossterm = { version = "0.28", default-features = false, features = ["windows"] }
-daemonize = { version = "0.5", default-features = false }
+daemonize = { package = "daemonix", version = "0.1", default-features = false }
 dialoguer = { version = "0.10.4", default-features = false, features = ["password", "completion"] }
 humantime = { version = "2.1.0", default-features = false }
 interprocess = { version = "2.2", default-features = false, features = ["tokio"] }


### PR DESCRIPTION
The daemonize crate was marked as unmaintained. It also has a UB issue, and zellij-client uses the affected API (`Daemonize::privileged_action` - see <https://github.com/knsd/daemonize/pull/57> for the original PR / report against `daemonize`).

This PR switches the dependency to a maintained fork (maintained by me) where that UB issue was resolved in a published version. `daemonix` v0.1 is guaranteed to be a drop-in replacement for `daemonize` v0.5.0, except that it doesn't have the aforementioned UB issue in `Daemonize::privileged_action`.

In the spirit of making this soundness fix as trivial a change and as easy to review as possible (yes, I have read the contribution guidelines), I have simply switched the crate dependency but kept the imported name the same - this way, the changes are limited to a one-line change in Cargo.toml and the corresponding changes in Cargo.lock.

c.f. https://rustsec.org/advisories/RUSTSEC-2025-0069.html
