### PR TITLE
Feature: proper terminal and pane focus handling

### DIFF
--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -255,6 +255,12 @@ impl InputHandler {
                 Ok((InputInstruction::Exit, _error_context)) => {
                     self.should_exit = true;
                 },
+                Ok((InputInstruction::FocusGained, _error_context)) => {
+                    self.os_input.send_to_server(ClientToServerMsg::FocusGained);
+                },
+                Ok((InputInstruction::FocusLost, _error_context)) => {
+                    self.os_input.send_to_server(ClientToServerMsg::FocusLost);
+                },
                 Err(err) => panic!("Encountered read error: {:?}", err),
             }
         }

--- a/zellij-server/src/panes/active_panes.rs
+++ b/zellij-server/src/panes/active_panes.rs
@@ -30,11 +30,8 @@ impl ActivePanes {
         &mut self,
         client_id: ClientId,
         pane_id: PaneId,
-        panes: &mut BTreeMap<PaneId, Box<dyn Pane>>,
     ) {
-        self.unfocus_pane_for_client(client_id, panes);
         self.active_panes.insert(client_id, pane_id);
-        self.focus_pane(pane_id, panes);
     }
     pub fn clear(&mut self, panes: &mut BTreeMap<PaneId, Box<dyn Pane>>) {
         for pane_id in self.active_panes.values() {
@@ -61,32 +58,13 @@ impl ActivePanes {
         }
         self.active_panes.remove(client_id)
     }
-    pub fn unfocus_all_panes(&self, panes: &mut BTreeMap<PaneId, Box<dyn Pane>>) {
-        for (_client_id, pane_id) in &self.active_panes {
-            self.unfocus_pane(*pane_id, panes);
-        }
-    }
-    pub fn focus_all_panes(&self, panes: &mut BTreeMap<PaneId, Box<dyn Pane>>) {
-        for (_client_id, pane_id) in &self.active_panes {
-            self.focus_pane(*pane_id, panes);
-        }
-    }
     pub fn clone_active_panes(&self) -> HashMap<ClientId, PaneId> {
         self.active_panes.clone()
     }
     pub fn contains_key(&self, client_id: &ClientId) -> bool {
         self.active_panes.contains_key(client_id)
     }
-    fn unfocus_pane_for_client(
-        &self,
-        client_id: ClientId,
-        panes: &mut BTreeMap<PaneId, Box<dyn Pane>>,
-    ) {
-        if let Some(pane_id_to_unfocus) = self.active_panes.get(&client_id) {
-            self.unfocus_pane(*pane_id_to_unfocus, panes);
-        }
-    }
-    fn unfocus_pane(&self, pane_id: PaneId, panes: &mut BTreeMap<PaneId, Box<dyn Pane>>) {
+    pub fn unfocus_pane(&self, pane_id: PaneId, panes: &mut BTreeMap<PaneId, Box<dyn Pane>>) {
         if let PaneId::Terminal(terminal_id) = pane_id {
             if let Some(focus_event) = panes.get(&pane_id).and_then(|p| p.unfocus_event()) {
                 let _ = self
@@ -95,7 +73,7 @@ impl ActivePanes {
             }
         }
     }
-    fn focus_pane(&self, pane_id: PaneId, panes: &mut BTreeMap<PaneId, Box<dyn Pane>>) {
+    pub fn focus_pane(&self, pane_id: PaneId, panes: &mut BTreeMap<PaneId, Box<dyn Pane>>) {
         if let PaneId::Terminal(terminal_id) = pane_id {
             if let Some(focus_event) = panes.get(&pane_id).and_then(|p| p.focus_event()) {
                 let _ = self

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -202,6 +202,12 @@ impl FloatingPanes {
     pub fn get(&self, pane_id: &PaneId) -> Option<&Box<dyn Pane>> {
         self.panes.get(pane_id)
     }
+    pub fn send_pane_tty_focus(&mut self, pane_id: PaneId) {
+        self.active_panes.focus_pane(pane_id, &mut self.panes);
+    }
+    pub fn send_pane_tty_unfocus(&mut self, pane_id: PaneId) {
+        self.active_panes.unfocus_pane(pane_id, &mut self.panes);
+    }
     pub fn get_mut(&mut self, pane_id: &PaneId) -> Option<&mut Box<dyn Pane>> {
         self.panes.get_mut(pane_id)
     }
@@ -238,11 +244,6 @@ impl FloatingPanes {
     pub fn toggle_show_panes(&mut self, should_show_floating_panes: bool) {
         self.window_title = None; // clear so that it will be re-rendered once we toggle back
         self.show_panes = should_show_floating_panes;
-        if should_show_floating_panes {
-            self.active_panes.focus_all_panes(&mut self.panes);
-        } else {
-            self.active_panes.unfocus_all_panes(&mut self.panes);
-        }
     }
     pub fn active_panes_contain(&self, client_id: &ClientId) -> bool {
         self.active_panes.contains_key(client_id)
@@ -835,8 +836,7 @@ impl FloatingPanes {
             if active_pane_id == pane_id {
                 match next_active_pane_id {
                     Some(next_active_pane_id) => {
-                        self.active_panes
-                            .insert(client_id, next_active_pane_id, &mut self.panes);
+                        self.active_panes.insert(client_id, next_active_pane_id);
                         self.focus_pane(next_active_pane_id, client_id);
                     },
                     None => {
@@ -850,8 +850,7 @@ impl FloatingPanes {
         let connected_clients: Vec<ClientId> =
             self.connected_clients.borrow().iter().copied().collect();
         for client_id in connected_clients {
-            self.active_panes
-                .insert(client_id, pane_id, &mut self.panes);
+            self.active_panes.insert(client_id, pane_id);
         }
         self.z_indices.retain(|p_id| *p_id != pane_id);
         self.z_indices.push(pane_id);
@@ -868,8 +867,7 @@ impl FloatingPanes {
             log::error!("Cannot focus pane {:?} as it is not selectable!", pane_id);
             return;
         }
-        self.active_panes
-            .insert(client_id, pane_id, &mut self.panes);
+        self.active_panes.insert(client_id, pane_id);
         self.focus_pane_for_all_clients(pane_id);
     }
     pub fn focus_pane_if_client_not_focused(&mut self, pane_id: PaneId, client_id: ClientId) {
@@ -1091,8 +1089,7 @@ impl FloatingPanes {
             .collect();
         for client_id in clients_in_pane {
             self.active_panes.remove(&client_id, &mut self.panes);
-            self.active_panes
-                .insert(client_id, to_pane_id, &mut self.panes);
+            self.active_panes.insert(client_id, to_pane_id);
         }
     }
     pub fn reapply_pane_focus(&mut self) {

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -746,8 +746,7 @@ impl TiledPanes {
                 let _ = StackedPanes::new_from_btreemap(&mut self.panes, &self.panes_to_hide)
                     .expand_pane(&pane_id);
             }
-            self.active_panes
-                .insert(client_id, pane_id, &mut self.panes);
+            self.active_panes.insert(client_id, pane_id);
             self.set_pane_active_at(pane_id);
         }
         self.set_force_render();
@@ -788,8 +787,7 @@ impl TiledPanes {
                 .map(|p_id| pane_ids_in_stack.contains(p_id))
                 .unwrap_or(false)
             {
-                self.active_panes
-                    .insert(client_id, pane_id, &mut self.panes);
+                self.active_panes.insert(client_id, pane_id);
                 self.set_pane_active_at(pane_id);
             }
         }
@@ -810,8 +808,7 @@ impl TiledPanes {
                     {
                         stack_ids_to_pane_ids_to_expand.push((stack_id, *pane_id));
                     }
-                    self.active_panes
-                        .insert(client_id, *pane_id, &mut self.panes);
+                    self.active_panes.insert(client_id, *pane_id);
                     self.set_pane_active_at(*pane_id);
                 },
                 None => {
@@ -824,8 +821,7 @@ impl TiledPanes {
                         {
                             stack_ids_to_pane_ids_to_expand.push((stack_id, pane_id));
                         }
-                        self.active_panes
-                            .insert(client_id, pane_id, &mut self.panes);
+                        self.active_panes.insert(client_id, pane_id);
                         self.set_pane_active_at(pane_id);
                     }
                 },
@@ -850,8 +846,7 @@ impl TiledPanes {
                 for client_id in connected_clients {
                     if let Some(focused_pane_id_for_client) = self.active_panes.get(&client_id) {
                         if all_panes_in_stack.contains(focused_pane_id_for_client) {
-                            self.active_panes
-                                .insert(client_id, pane_id, &mut self.panes);
+                            self.active_panes.insert(client_id, pane_id);
                             self.set_pane_active_at(pane_id);
                         }
                     }
@@ -891,15 +886,13 @@ impl TiledPanes {
             self.focus_pane_for_all_clients_in_stack(pane_id, stack_id);
             self.reapply_pane_frames();
         }
-        self.active_panes
-            .insert(client_id, pane_id, &mut self.panes);
+        self.active_panes.insert(client_id, pane_id);
         if self.session_is_mirrored {
             // move all clients
             let connected_clients: Vec<ClientId> =
                 self.connected_clients.borrow().iter().copied().collect();
             for client_id in connected_clients {
-                self.active_panes
-                    .insert(client_id, pane_id, &mut self.panes);
+                self.active_panes.insert(client_id, pane_id);
             }
         }
         self.reset_boundaries();
@@ -966,6 +959,12 @@ impl TiledPanes {
     }
     pub fn get_pane_mut(&mut self, pane_id: PaneId) -> Option<&mut Box<dyn Pane>> {
         self.panes.get_mut(&pane_id)
+    }
+    pub fn send_pane_tty_focus(&mut self, pane_id: PaneId) {
+        self.active_panes.focus_pane(pane_id, &mut self.panes);
+    }
+    pub fn send_pane_tty_unfocus(&mut self, pane_id: PaneId) {
+        self.active_panes.unfocus_pane(pane_id, &mut self.panes);
     }
     pub fn get_active_pane_id(&self, client_id: ClientId) -> Option<PaneId> {
         self.active_panes.get(&client_id).copied()
@@ -1734,8 +1733,7 @@ impl TiledPanes {
             self.reapply_pane_frames();
         }
 
-        self.active_panes
-            .insert(client_id, next_active_pane_id, &mut self.panes);
+        self.active_panes.insert(client_id, next_active_pane_id);
         self.set_pane_active_at(next_active_pane_id);
         self.reset_boundaries();
     }
@@ -1761,8 +1759,7 @@ impl TiledPanes {
                 .expand_pane(&next_active_pane_id);
             self.reapply_pane_frames();
         }
-        self.active_panes
-            .insert(client_id, next_active_pane_id, &mut self.panes);
+        self.active_panes.insert(client_id, next_active_pane_id);
         self.set_pane_active_at(next_active_pane_id);
         self.reset_boundaries();
     }
@@ -2344,8 +2341,7 @@ impl TiledPanes {
                 }
                 for (client_id, active_pane_id) in active_panes {
                     if active_pane_id == pane_id {
-                        self.active_panes
-                            .insert(client_id, next_active_pane_id, &mut self.panes);
+                        self.active_panes.insert(client_id, next_active_pane_id);
                     }
                 }
             },
@@ -2544,12 +2540,6 @@ impl TiledPanes {
     pub fn remove_from_hidden_panels(&mut self, pid: PaneId) {
         self.panes_to_hide.remove(&pid);
     }
-    pub fn unfocus_all_panes(&mut self) {
-        self.active_panes.unfocus_all_panes(&mut self.panes);
-    }
-    pub fn focus_all_panes(&mut self) {
-        self.active_panes.focus_all_panes(&mut self.panes);
-    }
     pub fn drain(&mut self) -> BTreeMap<PaneId, Box<dyn Pane>> {
         match self.panes.iter().next().map(|(pid, _p)| *pid) {
             Some(first_pid) => self.panes.split_off(&first_pid),
@@ -2571,8 +2561,7 @@ impl TiledPanes {
             .collect();
         for client_id in clients_in_pane {
             self.active_panes.remove(&client_id, &mut self.panes);
-            self.active_panes
-                .insert(client_id, to_pane_id, &mut self.panes);
+            self.active_panes.insert(client_id, to_pane_id);
         }
     }
     fn reset_boundaries(&mut self) {

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -1779,6 +1779,24 @@ pub(crate) fn route_thread_main(
                             let _ =
                                 to_server.send(ServerInstruction::FailedToStartWebServer(error));
                         },
+                        ClientToServerMsg::FocusGained => {
+                            send_to_screen_or_retry_queue!(
+                                rlocked_sessions,
+                                ScreenInstruction::ClientGainedFocus(client_id),
+                                instruction,
+                                retry_queue
+                            )
+                            .with_context(err_context)?;
+                        },
+                        ClientToServerMsg::FocusLost => {
+                            send_to_screen_or_retry_queue!(
+                                rlocked_sessions,
+                                ScreenInstruction::ClientLostFocus(client_id),
+                                instruction,
+                                retry_queue
+                            )
+                            .with_context(err_context)?;
+                        },
                     }
                     Ok(should_break)
                 };

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -472,6 +472,8 @@ pub enum ScreenInstruction {
     RemoveWatcherClient(ClientId),
     SetFollowedClient(ClientId),
     WatcherTerminalResize(ClientId, Size),
+    ClientGainedFocus(ClientId),
+    ClientLostFocus(ClientId),
 }
 
 impl From<&ScreenInstruction> for ScreenContext {
@@ -712,6 +714,8 @@ impl From<&ScreenInstruction> for ScreenContext {
             ScreenInstruction::RemoveWatcherClient(..) => ScreenContext::RemoveWatcherClient,
             ScreenInstruction::SetFollowedClient(..) => ScreenContext::SetFollowedClient,
             ScreenInstruction::WatcherTerminalResize(..) => ScreenContext::WatcherTerminalResize, // NEW
+            ScreenInstruction::ClientGainedFocus(..) => ScreenContext::ClientGainedFocus,
+            ScreenInstruction::ClientLostFocus(..) => ScreenContext::ClientLostFocus,
         }
     }
 }
@@ -892,6 +896,8 @@ pub(crate) struct Screen {
     render_blocker: RenderBlocker,
     watcher_clients: HashMap<ClientId, WatcherState>,
     followed_client_id: Option<ClientId>,
+    tty_focused_panes: HashSet<PaneId>,
+    tty_focused_clients: HashSet<ClientId>,
 }
 
 impl Screen {
@@ -977,7 +983,44 @@ impl Screen {
             render_blocker: RenderBlocker::new(100),
             watcher_clients: HashMap::new(),
             followed_client_id: None,
+            tty_focused_panes: HashSet::new(),
+            tty_focused_clients: HashSet::new(),
         }
+    }
+
+    fn update_tty_focused_panes(&mut self) {
+        let mut new_focused_panes = HashSet::new();
+
+        for (client_id, tab_index) in &self.active_tab_indices {
+            // Only consider clients whose terminal is focused
+            if !self.tty_focused_clients.contains(client_id) {
+                continue;
+            }
+
+            if let Some(tab) = self.tabs.get(tab_index) {
+                if let Some(pane_id) = tab.get_active_pane_id(*client_id) {
+                    new_focused_panes.insert(pane_id);
+                }
+            }
+        }
+
+        let old_focused_panes = &self.tty_focused_panes;
+
+        // Panes that lost focus
+        for &pane_id in old_focused_panes.difference(&new_focused_panes) {
+            for tab in self.tabs.values_mut() {
+                tab.send_pane_tty_unfocus(pane_id);
+            }
+        }
+
+        // Panes that gained focus
+        for &pane_id in new_focused_panes.difference(old_focused_panes) {
+            for tab in self.tabs.values_mut() {
+                tab.send_pane_tty_focus(pane_id);
+            }
+        }
+
+        self.tty_focused_panes = new_focused_panes;
     }
 
     /// Returns the index where a new [`Tab`] should be created in this [`Screen`].
@@ -1873,6 +1916,7 @@ impl Screen {
             .borrow_mut()
             .insert(client_id, is_web_client);
         self.tab_history.insert(client_id, tab_history);
+        self.tty_focused_clients.insert(client_id);
         self.tabs
             .get_mut(&tab_index)
             .with_context(|| err_context(tab_index))?
@@ -1912,6 +1956,7 @@ impl Screen {
         if self.tab_history.contains_key(&client_id) {
             self.tab_history.remove(&client_id);
         }
+        self.tty_focused_clients.remove(&client_id);
         self.connected_clients.borrow_mut().remove(&client_id);
         self.log_and_report_session_state()
             .with_context(err_context)
@@ -6236,7 +6281,14 @@ pub(crate) fn screen_thread_main(
                 screen.set_watcher_size(client_id, size);
                 screen.render(None)?;
             },
+            ScreenInstruction::ClientGainedFocus(client_id) => {
+                screen.tty_focused_clients.insert(client_id);
+            },
+            ScreenInstruction::ClientLostFocus(client_id) => {
+                screen.tty_focused_clients.remove(&client_id);
+            },
         }
+        screen.update_tty_focused_panes();
     }
     Ok(())
 }

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -2932,6 +2932,14 @@ impl Tab {
     pub(crate) fn get_floating_panes(&self) -> impl Iterator<Item = (&PaneId, &Box<dyn Pane>)> {
         self.floating_panes.get_panes()
     }
+    pub(crate) fn send_pane_tty_focus(&mut self, pane_id: PaneId) {
+        self.floating_panes.send_pane_tty_focus(pane_id);
+        self.tiled_panes.send_pane_tty_focus(pane_id);
+    }
+    pub(crate) fn send_pane_tty_unfocus(&mut self, pane_id: PaneId) {
+        self.floating_panes.send_pane_tty_unfocus(pane_id);
+        self.tiled_panes.send_pane_tty_unfocus(pane_id);
+    }
     pub(crate) fn get_suppressed_panes(
         &self,
     ) -> impl Iterator<Item = (&PaneId, &(bool, Box<dyn Pane>))> {
@@ -4987,7 +4995,6 @@ impl Tab {
     pub fn show_floating_panes(&mut self) {
         // this function is to be preferred to directly invoking floating_panes.toggle_show_panes(true)
         self.floating_panes.toggle_show_panes(true);
-        self.tiled_panes.unfocus_all_panes();
         self.set_force_render();
     }
 
@@ -4995,7 +5002,6 @@ impl Tab {
         // this function is to be preferred to directly invoking
         // floating_panes.toggle_show_panes(false)
         self.floating_panes.toggle_show_panes(false);
-        self.tiled_panes.focus_all_panes();
         self.set_force_render();
     }
 

--- a/zellij-utils/assets/prost_ipc/client_server_contract.rs
+++ b/zellij-utils/assets/prost_ipc/client_server_contract.rs
@@ -2345,7 +2345,7 @@ pub struct ConfigFileUpdatedMsg {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClientToServerMsg {
-    #[prost(oneof="client_to_server_msg::Message", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16")]
+    #[prost(oneof="client_to_server_msg::Message", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18")]
     pub message: ::core::option::Option<client_to_server_msg::Message>,
 }
 /// Nested message and enum types in `ClientToServerMsg`.
@@ -2385,6 +2385,10 @@ pub mod client_to_server_msg {
         FailedToStartWebServer(super::FailedToStartWebServerMsg),
         #[prost(message, tag="16")]
         AttachWatcherClient(super::AttachWatcherClientMsg),
+        #[prost(message, tag="17")]
+        FocusGained(super::FocusGainedMsg),
+        #[prost(message, tag="18")]
+        FocusLost(super::FocusLostMsg),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -2497,4 +2501,14 @@ pub struct WebServerStartedMsg {
 pub struct FailedToStartWebServerMsg {
     #[prost(string, tag="1")]
     pub error: ::prost::alloc::string::String,
+}
+/// Empty message
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FocusGainedMsg {
+}
+/// Empty message
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FocusLostMsg {
 }

--- a/zellij-utils/src/client_server_contract/client_to_server.proto
+++ b/zellij-utils/src/client_server_contract/client_to_server.proto
@@ -21,6 +21,8 @@ message ClientToServerMsg {
     WebServerStartedMsg web_server_started = 14;
     FailedToStartWebServerMsg failed_to_start_web_server = 15;
     AttachWatcherClientMsg attach_watcher_client = 16;
+    FocusGainedMsg focus_gained = 17;
+    FocusLostMsg focus_lost = 18;
   }
 }
 
@@ -95,4 +97,12 @@ message WebServerStartedMsg {
 
 message FailedToStartWebServerMsg {
   string error = 1;
+}
+
+message FocusGainedMsg {
+  // Empty message
+}
+
+message FocusLostMsg {
+  // Empty message
 }

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -393,6 +393,8 @@ pub enum ScreenContext {
     RemoveWatcherClient,
     SetFollowedClient,
     WatcherTerminalResize, // NEW
+    ClientGainedFocus,
+    ClientLostFocus,
 }
 
 /// Stack call representations corresponding to the different types of [`PtyInstruction`]s.

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -137,6 +137,8 @@ pub enum ClientToServerMsg {
     FailedToStartWebServer {
         error: String,
     },
+    FocusGained,
+    FocusLost,
 }
 
 // Types of messages sent from the server to the client

--- a/zellij-utils/src/ipc/protobuf_conversion.rs
+++ b/zellij-utils/src/ipc/protobuf_conversion.rs
@@ -4,9 +4,9 @@ use crate::{
         AttachWatcherClientMsg, BackgroundColorMsg, CliPipeOutputMsg, ClientExitedMsg,
         ClientToServerMsg as ProtoClientToServerMsg, ColorRegistersMsg, ConfigFileUpdatedMsg,
         ConnStatusMsg, ConnectedMsg, DetachSessionMsg, ExitMsg, ExitReason as ProtoExitReason,
-        FailedToStartWebServerMsg, FirstClientConnectedMsg, ForegroundColorMsg,
-        InputMode as ProtoInputMode, KeyMsg, KillSessionMsg, LogErrorMsg, LogMsg,
-        QueryTerminalSizeMsg, RenamedSessionMsg, RenderMsg,
+        FailedToStartWebServerMsg, FirstClientConnectedMsg, FocusGainedMsg, FocusLostMsg,
+        ForegroundColorMsg, InputMode as ProtoInputMode, KeyMsg, KillSessionMsg, LogErrorMsg,
+        LogMsg, QueryTerminalSizeMsg, RenamedSessionMsg, RenderMsg,
         ServerToClientMsg as ProtoServerToClientMsg, StartWebServerMsg, SwitchSessionMsg,
         TerminalPixelDimensionsMsg, TerminalResizeMsg, UnblockCliPipeInputMsg,
         UnblockInputThreadMsg, WebServerStartedMsg,
@@ -110,6 +110,12 @@ impl From<ClientToServerMsg> for ProtoClientToServerMsg {
                 client_to_server_msg::Message::FailedToStartWebServer(FailedToStartWebServerMsg {
                     error,
                 })
+            },
+            ClientToServerMsg::FocusGained => {
+                client_to_server_msg::Message::FocusGained(FocusGainedMsg {})
+            },
+            ClientToServerMsg::FocusLost => {
+                client_to_server_msg::Message::FocusLost(FocusLostMsg {})
             },
         };
 
@@ -223,6 +229,12 @@ impl TryFrom<ProtoClientToServerMsg> for ClientToServerMsg {
                 Ok(ClientToServerMsg::FailedToStartWebServer {
                     error: failed.error,
                 })
+            },
+            Some(client_to_server_msg::Message::FocusGained(_)) => {
+                Ok(ClientToServerMsg::FocusGained)
+            },
+            Some(client_to_server_msg::Message::FocusLost(_)) => {
+                Ok(ClientToServerMsg::FocusLost)
             },
             None => Err(anyhow!("Empty ClientToServerMsg message")),
         }


### PR DESCRIPTION
Fixes #4522 and adds client-level terminal focus tracking.

This makes focus behavior consistent across tabs, panes, fullscreen, floating panes,
and multiple clients.

I have traded any urge to prematurely optimize in favor of clarity and resilience to future changes. I also doubt that the overhead introduced is in any way significant.