### PR TITLE
feat: layout-independent keybindings for non-English keyboards

### DIFF
--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -476,7 +476,7 @@ pub fn start_remote_client(
     let clear_client_terminal_attributes = "\u{1b}[?1l\u{1b}=\u{1b}[r\u{1b}[?1000l\u{1b}[?1002l\u{1b}[?1003l\u{1b}[?1005l\u{1b}[?1006l\u{1b}[?12l";
     let take_snapshot = "\u{1b}[?1049h";
     let bracketed_paste = "\u{1b}[?2004h";
-    let enter_kitty_keyboard_mode = "\u{1b}[>1u";
+    let enter_kitty_keyboard_mode = "\u{1b}[>5u";
     os_input.unset_raw_mode(0).unwrap();
 
     let _ = os_input
@@ -588,7 +588,7 @@ pub fn start_client(
     let clear_client_terminal_attributes = "\u{1b}[?1l\u{1b}=\u{1b}[r\u{1b}[?1000l\u{1b}[?1002l\u{1b}[?1003l\u{1b}[?1005l\u{1b}[?1006l\u{1b}[?12l";
     let take_snapshot = "\u{1b}[?1049h";
     let bracketed_paste = "\u{1b}[?2004h";
-    let enter_kitty_keyboard_mode = "\u{1b}[>1u";
+    let enter_kitty_keyboard_mode = "\u{1b}[>5u";
     os_input.unset_raw_mode(0).unwrap();
 
     if !is_a_reconnect {

--- a/zellij-client/src/web_client/utils.rs
+++ b/zellij-client/src/web_client/utils.rs
@@ -63,7 +63,7 @@ pub fn terminal_init_messages() -> Vec<&'static str> {
     let clear_client_terminal_attributes = "\u{1b}[?1l\u{1b}=\u{1b}[r\u{1b}[?1000l\u{1b}[?1002l\u{1b}[?1003l\u{1b}[?1005l\u{1b}[?1006l\u{1b}[?12l";
     let enter_alternate_screen = "\u{1b}[?1049h";
     let bracketed_paste = "\u{1b}[?2004h";
-    let enter_kitty_keyboard_mode = "\u{1b}[>1u";
+    let enter_kitty_keyboard_mode = "\u{1b}[>5u";
     let enable_mouse_mode = "\u{1b}[?1000h\u{1b}[?1002h\u{1b}[?1015h\u{1b}[?1006h";
     vec![
         clear_client_terminal_attributes,


### PR DESCRIPTION
Fixes #1355

Keybindings now work on non-English keyboard layouts (Ukrainian, Russian, Greek, etc.).

**Problem:** When using a non-English keyboard layout, keybindings don't work:
- `Alt+а` is sent instead of `Alt+a`
- `Ctrl+П` is sent instead of `Ctrl+g`

**Solution:** Leverage Kitty keyboard protocol's extended features:

1. **Unicode support for Alt+keys**: Changed `u8` to `u32` parsing to handle Unicode codepoints > 255

2. **Base layout key for Ctrl+keys**: Enabled "Report alternate keys" flag (`>5u` instead of `>1u`) and parse the base-layout-key field: `CSI unicode:shifted:base-layout ; modifiers u`

**Test:** Switch to non-English layout, test `Alt+n`, `Ctrl+g` - should work.