### PR TITLE
Fix bash auto-start for Cosmic DE

### DIFF
--- a/zellij-utils/assets/shell/auto-start.bash
+++ b/zellij-utils/assets/shell/auto-start.bash
@@ -1,4 +1,4 @@
-if [[ -z "$ZELLIJ" ]]; then
+if [[ $- == *i* ]] && [[ -z "$ZELLIJ" ]]; then
     if [[ "$ZELLIJ_AUTO_ATTACH" == "true" ]]; then
         zellij attach -c
     else


### PR DESCRIPTION
When I installed zellij on Cosmic DE (via NixOS if it matters), and added the auto-launch feature for bash, Cosmic DE tried to run the script and launch Zellij at startup, preventing the DE to start.

Adding a check for interactivity session made every thing run smoothly.

Here's a PR if interested.