### PR TITLE
fix: remove layout config when switching sessions

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -613,7 +613,7 @@ pub(crate) fn start_client(opts: CliArgs) {
     let os_input = get_os_input(get_client_os_input);
     loop {
         let os_input = os_input.clone();
-        let config = config.clone();
+        let mut config = config.clone();
         let mut config_options = config_options.clone();
         let mut opts = opts.clone();
         let mut is_a_reconnect = false;
@@ -655,6 +655,8 @@ pub(crate) fn start_client(opts: CliArgs) {
             if let Some(cwd) = &reconnect_to_session.cwd {
                 new_session_cwd = Some(cwd.clone());
             }
+            config = config_without_layout.clone();
+            config_options = config_options_without_layout.clone();
             is_a_reconnect = true;
         }
 


### PR DESCRIPTION
The primary reason for fixing this was to address https://github.com/zellij-org/zellij/issues/4582. This was happening because the built-in `welcome` layout has `session_serialization false` as part of its layout file (so that the welcome screen layouts will not be resurrectable).

The fix involves erasing the configuration values we get from the layout file in the reconnect loop - which should be the right behavior for any case (i.e. we don't want the configuration files we got from a layout used to create our current session to be passed on to a session we're reconnecting to).