### PR TITLE
feat(web): add WebSocket heartbeat to prevent false disconnections

### DIFF
--- a/zellij-client/src/web_client/websocket_handlers.rs
+++ b/zellij-client/src/web_client/websocket_handlers.rs
@@ -18,12 +18,17 @@ use axum::{
 };
 use futures::StreamExt;
 use std::sync::{atomic::AtomicBool, Arc};
+use tokio::sync::Mutex;
+use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use zellij_utils::{
     input::mouse::MouseEvent,
     ipc::{ClientToServerMsg, PixelDimensions, ResizeCause},
     pane_size::SizeInPixels,
 };
+
+const PING_INTERVAL_SECS: u64 = 30;
+const PONG_TIMEOUT_SECS: u64 = 45;
 
 pub async fn ws_handler_control(
     ws: WebSocketUpgrade,
@@ -62,6 +67,41 @@ async fn handle_ws_control(
     let _ = control_channel_tx.send(Message::Text(
         serde_json::to_string(&set_config_msg).unwrap().into(),
     ));
+
+    // Track the time of the last received Pong (shared with the ping task).
+    // Browsers automatically reply to WebSocket protocol-level Pings with Pongs,
+    // even when the page's JS event loop is blocked or the tab is throttled,
+    // so this is a reliable end-to-end liveness signal.
+    let last_pong = Arc::new(Mutex::new(Instant::now()));
+    let ping_cancellation = CancellationToken::new();
+
+    // Spawn the ping task: send a Ping every PING_INTERVAL_SECS, and tear down
+    // the connection if no Pong has been observed within PONG_TIMEOUT_SECS.
+    let ping_tx = control_channel_tx.clone();
+    let ping_last_pong = last_pong.clone();
+    let ping_cancel = ping_cancellation.clone();
+    tokio::spawn(async move {
+        let mut interval =
+            tokio::time::interval(tokio::time::Duration::from_secs(PING_INTERVAL_SECS));
+        loop {
+            tokio::select! {
+                _ = ping_cancel.cancelled() => {
+                    break;
+                }
+                _ = interval.tick() => {
+                    let elapsed = ping_last_pong.lock().await.elapsed();
+                    if elapsed.as_secs() > PONG_TIMEOUT_SECS {
+                        log::warn!("WebSocket control connection timed out (no Pong received)");
+                        break;
+                    }
+
+                    if ping_tx.send(Message::Ping(Vec::new().into())).is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    });
 
     let send_message_to_server = |deserialized_msg: WebClientToWebServerControlMessage| {
         let Some(client_connection) = state
@@ -149,7 +189,11 @@ async fn handle_ws_control(
                     },
                 }
             },
+            Message::Pong(_) => {
+                *last_pong.lock().await = Instant::now();
+            },
             Message::Close(_) => {
+                ping_cancellation.cancel();
                 return;
             },
             _ => {
@@ -157,6 +201,8 @@ async fn handle_ws_control(
             },
         }
     }
+
+    ping_cancellation.cancel();
 }
 
 async fn handle_ws_terminal(


### PR DESCRIPTION
Idle WebSocket connections are often silently closed by network intermediaries (proxies, load balancers, firewalls) after their timeout expires. This causes false "connection lost" messages in the web client even though the underlying session is still alive.

Add application-level heartbeat messages on the control WebSocket:
- Server sends Heartbeat every 30 seconds (before typical 60s proxy timeout)
- Client responds with HeartbeatResponse
- Server closes connection if no response within 45 seconds

Application-level heartbeats are used instead of WebSocket protocol ping/pong because some proxies intercept protocol-level pings without forwarding them, whereas application messages verify the entire path.