### PR TITLE
feat(kitty): support REPORT_ALTERNATE_KEYS for shifted key combinations

### DIFF
--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -476,7 +476,7 @@ pub fn start_remote_client(
     let clear_client_terminal_attributes = "\u{1b}[?1l\u{1b}=\u{1b}[r\u{1b}[?1000l\u{1b}[?1002l\u{1b}[?1003l\u{1b}[?1005l\u{1b}[?1006l\u{1b}[?12l";
     let take_snapshot = "\u{1b}[?1049h";
     let bracketed_paste = "\u{1b}[?2004h";
-    let enter_kitty_keyboard_mode = "\u{1b}[>1u";
+    let enter_kitty_keyboard_mode = "\u{1b}[>5u"; // flags 1 (DISAMBIGUATE) + 4 (REPORT_ALTERNATE_KEYS)
     os_input.unset_raw_mode(0).unwrap();
 
     let _ = os_input
@@ -588,7 +588,7 @@ pub fn start_client(
     let clear_client_terminal_attributes = "\u{1b}[?1l\u{1b}=\u{1b}[r\u{1b}[?1000l\u{1b}[?1002l\u{1b}[?1003l\u{1b}[?1005l\u{1b}[?1006l\u{1b}[?12l";
     let take_snapshot = "\u{1b}[?1049h";
     let bracketed_paste = "\u{1b}[?2004h";
-    let enter_kitty_keyboard_mode = "\u{1b}[>1u";
+    let enter_kitty_keyboard_mode = "\u{1b}[>5u"; // flags 1 (DISAMBIGUATE) + 4 (REPORT_ALTERNATE_KEYS)
     os_input.unset_raw_mode(0).unwrap();
 
     if !is_a_reconnect {

--- a/zellij-client/src/web_client/utils.rs
+++ b/zellij-client/src/web_client/utils.rs
@@ -63,7 +63,7 @@ pub fn terminal_init_messages() -> Vec<&'static str> {
     let clear_client_terminal_attributes = "\u{1b}[?1l\u{1b}=\u{1b}[r\u{1b}[?1000l\u{1b}[?1002l\u{1b}[?1003l\u{1b}[?1005l\u{1b}[?1006l\u{1b}[?12l";
     let enter_alternate_screen = "\u{1b}[?1049h";
     let bracketed_paste = "\u{1b}[?2004h";
-    let enter_kitty_keyboard_mode = "\u{1b}[>1u";
+    let enter_kitty_keyboard_mode = "\u{1b}[>5u"; // flags 1 (DISAMBIGUATE) + 4 (REPORT_ALTERNATE_KEYS)
     let enable_mouse_mode = "\u{1b}[?1000h\u{1b}[?1002h\u{1b}[?1015h\u{1b}[?1006h";
     vec![
         clear_client_terminal_attributes,

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -3177,9 +3177,8 @@ impl Perform for Grid {
         } else if c == 's' {
             self.save_cursor_position();
         } else if c == 'u' && intermediates == &[b'>'] {
-            // Zellij only supports the first "progressive enhancement" layer of the kitty keyboard
-            // protocol
-            // 0 disables, everything else enables.
+            // Zellij supports DISAMBIGUATE_ESCAPE_CODES (1) and REPORT_ALTERNATE_KEYS (4)
+            // 0 disables, any positive value enables these enhancements.
             let count = next_param_or(0);
             if !self.explicitly_disable_kitty_keyboard_protocol {
                 if count > 0 {
@@ -3189,16 +3188,15 @@ impl Perform for Grid {
                 }
             }
         } else if c == 'u' && intermediates == &[b'<'] {
-            // Zellij only supports the first "progressive enhancement" layer of the kitty keyboard
-            // protocol
+            // Pop kitty keyboard protocol state (disable)
             if !self.explicitly_disable_kitty_keyboard_protocol {
                 self.supports_kitty_keyboard_protocol = false;
             }
         } else if c == 'u' && intermediates == &[b'?'] {
-            // Zellij only supports the first "progressive enhancement" layer of the kitty keyboard
-            // protocol
+            // Zellij supports DISAMBIGUATE_ESCAPE_CODES (1) and REPORT_ALTERNATE_KEYS (4)
+            // Combined value: 1 + 4 = 5
             let reply = if self.supports_kitty_keyboard_protocol {
-                "\u{1b}[?1u"
+                "\u{1b}[?5u"
             } else {
                 "\u{1b}[?0u"
             };

--- a/zellij-utils/assets/prost_ipc/client_server_contract.rs
+++ b/zellij-utils/assets/prost_ipc/client_server_contract.rs
@@ -48,6 +48,12 @@ pub struct KeyWithModifier {
     /// Only set when bare_key is CHAR
     #[prost(string, optional, tag="3")]
     pub character: ::core::option::Option<::prost::alloc::string::String>,
+    /// From REPORT_ALTERNATE_KEYS
+    #[prost(enumeration="BareKey", optional, tag="4")]
+    pub shifted_key: ::core::option::Option<i32>,
+    /// Only set when shifted_key is CHAR
+    #[prost(string, optional, tag="5")]
+    pub shifted_character: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2421,122 +2427,6 @@ impl WebSharing {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ServerToClientMsg {
-    #[prost(oneof="server_to_client_msg::Message", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13")]
-    pub message: ::core::option::Option<server_to_client_msg::Message>,
-}
-/// Nested message and enum types in `ServerToClientMsg`.
-pub mod server_to_client_msg {
-    #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Message {
-        #[prost(message, tag="1")]
-        Render(super::RenderMsg),
-        #[prost(message, tag="2")]
-        UnblockInputThread(super::UnblockInputThreadMsg),
-        #[prost(message, tag="3")]
-        Exit(super::ExitMsg),
-        #[prost(message, tag="4")]
-        Connected(super::ConnectedMsg),
-        #[prost(message, tag="5")]
-        Log(super::LogMsg),
-        #[prost(message, tag="6")]
-        LogError(super::LogErrorMsg),
-        #[prost(message, tag="7")]
-        SwitchSession(super::SwitchSessionMsg),
-        #[prost(message, tag="8")]
-        UnblockCliPipeInput(super::UnblockCliPipeInputMsg),
-        #[prost(message, tag="9")]
-        CliPipeOutput(super::CliPipeOutputMsg),
-        #[prost(message, tag="10")]
-        QueryTerminalSize(super::QueryTerminalSizeMsg),
-        #[prost(message, tag="11")]
-        StartWebServer(super::StartWebServerMsg),
-        #[prost(message, tag="12")]
-        RenamedSession(super::RenamedSessionMsg),
-        #[prost(message, tag="13")]
-        ConfigFileUpdated(super::ConfigFileUpdatedMsg),
-    }
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RenderMsg {
-    #[prost(string, tag="1")]
-    pub content: ::prost::alloc::string::String,
-}
-/// Empty message
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct UnblockInputThreadMsg {
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ExitMsg {
-    #[prost(enumeration="ExitReason", tag="1")]
-    pub exit_reason: i32,
-    #[prost(string, optional, tag="2")]
-    pub payload: ::core::option::Option<::prost::alloc::string::String>,
-}
-/// Empty message
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ConnectedMsg {
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct LogMsg {
-    #[prost(string, repeated, tag="1")]
-    pub lines: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct LogErrorMsg {
-    #[prost(string, repeated, tag="1")]
-    pub lines: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SwitchSessionMsg {
-    #[prost(message, optional, tag="1")]
-    pub connect_to_session: ::core::option::Option<ConnectToSession>,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct UnblockCliPipeInputMsg {
-    #[prost(string, tag="1")]
-    pub pipe_name: ::prost::alloc::string::String,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CliPipeOutputMsg {
-    #[prost(string, tag="1")]
-    pub pipe_name: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
-    pub output: ::prost::alloc::string::String,
-}
-/// Empty message
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct QueryTerminalSizeMsg {
-}
-/// Empty message
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct StartWebServerMsg {
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RenamedSessionMsg {
-    #[prost(string, tag="1")]
-    pub name: ::prost::alloc::string::String,
-}
-/// Empty message
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ConfigFileUpdatedMsg {
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClientToServerMsg {
     #[prost(oneof="client_to_server_msg::Message", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16")]
     pub message: ::core::option::Option<client_to_server_msg::Message>,
@@ -2692,4 +2582,120 @@ pub struct WebServerStartedMsg {
 pub struct FailedToStartWebServerMsg {
     #[prost(string, tag="1")]
     pub error: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ServerToClientMsg {
+    #[prost(oneof="server_to_client_msg::Message", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13")]
+    pub message: ::core::option::Option<server_to_client_msg::Message>,
+}
+/// Nested message and enum types in `ServerToClientMsg`.
+pub mod server_to_client_msg {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Message {
+        #[prost(message, tag="1")]
+        Render(super::RenderMsg),
+        #[prost(message, tag="2")]
+        UnblockInputThread(super::UnblockInputThreadMsg),
+        #[prost(message, tag="3")]
+        Exit(super::ExitMsg),
+        #[prost(message, tag="4")]
+        Connected(super::ConnectedMsg),
+        #[prost(message, tag="5")]
+        Log(super::LogMsg),
+        #[prost(message, tag="6")]
+        LogError(super::LogErrorMsg),
+        #[prost(message, tag="7")]
+        SwitchSession(super::SwitchSessionMsg),
+        #[prost(message, tag="8")]
+        UnblockCliPipeInput(super::UnblockCliPipeInputMsg),
+        #[prost(message, tag="9")]
+        CliPipeOutput(super::CliPipeOutputMsg),
+        #[prost(message, tag="10")]
+        QueryTerminalSize(super::QueryTerminalSizeMsg),
+        #[prost(message, tag="11")]
+        StartWebServer(super::StartWebServerMsg),
+        #[prost(message, tag="12")]
+        RenamedSession(super::RenamedSessionMsg),
+        #[prost(message, tag="13")]
+        ConfigFileUpdated(super::ConfigFileUpdatedMsg),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RenderMsg {
+    #[prost(string, tag="1")]
+    pub content: ::prost::alloc::string::String,
+}
+/// Empty message
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UnblockInputThreadMsg {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ExitMsg {
+    #[prost(enumeration="ExitReason", tag="1")]
+    pub exit_reason: i32,
+    #[prost(string, optional, tag="2")]
+    pub payload: ::core::option::Option<::prost::alloc::string::String>,
+}
+/// Empty message
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ConnectedMsg {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LogMsg {
+    #[prost(string, repeated, tag="1")]
+    pub lines: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LogErrorMsg {
+    #[prost(string, repeated, tag="1")]
+    pub lines: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SwitchSessionMsg {
+    #[prost(message, optional, tag="1")]
+    pub connect_to_session: ::core::option::Option<ConnectToSession>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UnblockCliPipeInputMsg {
+    #[prost(string, tag="1")]
+    pub pipe_name: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CliPipeOutputMsg {
+    #[prost(string, tag="1")]
+    pub pipe_name: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub output: ::prost::alloc::string::String,
+}
+/// Empty message
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryTerminalSizeMsg {
+}
+/// Empty message
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StartWebServerMsg {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RenamedSessionMsg {
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+}
+/// Empty message
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ConfigFileUpdatedMsg {
 }

--- a/zellij-utils/src/client_server_contract/common_types.proto
+++ b/zellij-utils/src/client_server_contract/common_types.proto
@@ -30,6 +30,8 @@ message KeyWithModifier {
   BareKey bare_key = 1;
   repeated KeyModifier key_modifiers = 2;
   optional string character = 3; // Only set when bare_key is CHAR
+  optional BareKey shifted_key = 4; // From REPORT_ALTERNATE_KEYS
+  optional string shifted_character = 5; // Only set when shifted_key is CHAR
 }
 
 enum BareKey {

--- a/zellij-utils/src/ipc/tests/roundtrip_tests.rs
+++ b/zellij-utils/src/ipc/tests/roundtrip_tests.rs
@@ -2709,6 +2709,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::PageDown,
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2717,6 +2718,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::PageDown,
             key_modifiers: demo_modifiers_1,
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2725,6 +2727,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::PageDown,
             key_modifiers: demo_modifiers_2,
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2733,6 +2736,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::PageDown,
             key_modifiers: demo_modifiers_3,
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2741,6 +2745,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::PageDown,
             key_modifiers: demo_modifiers_4,
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2749,6 +2754,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::PageUp,
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2757,6 +2763,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::Down,
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2765,6 +2772,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::Up,
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2773,6 +2781,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::Right,
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2781,6 +2790,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::Home,
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2789,6 +2799,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::End,
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2797,6 +2808,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::Backspace,
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2805,6 +2817,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::Delete,
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2813,6 +2826,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::Insert,
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2821,6 +2835,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::Tab,
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2829,6 +2844,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::Esc,
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2837,6 +2853,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::Enter,
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2845,6 +2862,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::CapsLock,
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2853,6 +2871,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::ScrollLock,
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2861,6 +2880,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::NumLock,
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2869,6 +2889,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::PrintScreen,
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2877,6 +2898,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::Pause,
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2885,6 +2907,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::Menu,
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2893,6 +2916,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::F(1),
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2901,6 +2925,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::F(2),
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2909,6 +2934,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::F(3),
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2917,6 +2943,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::F(4),
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2925,6 +2952,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::F(5),
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2933,6 +2961,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::F(6),
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2941,6 +2970,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::F(7),
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2949,6 +2979,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::F(8),
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2957,6 +2988,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::F(9),
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2965,6 +2997,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::F(10),
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2973,6 +3006,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::F(11),
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2981,6 +3015,7 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::F(12),
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
@@ -2989,9 +3024,23 @@ fn test_client_messages() {
         key: KeyWithModifier {
             bare_key: BareKey::Char('a'),
             key_modifiers: BTreeSet::new(),
+            shifted_key: None,
         },
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
+    });
+    // Test with shifted_key (for REPORT_ALTERNATE_KEYS)
+    let mut shift_alt_modifiers = BTreeSet::new();
+    shift_alt_modifiers.insert(KeyModifier::Shift);
+    shift_alt_modifiers.insert(KeyModifier::Alt);
+    test_client_roundtrip!(ClientToServerMsg::Key {
+        key: KeyWithModifier {
+            bare_key: BareKey::Char(','),
+            key_modifiers: shift_alt_modifiers,
+            shifted_key: Some(BareKey::Char('<')),
+        },
+        raw_bytes: "\x1b[44:60;4u".as_bytes().to_vec(),
+        is_kitty_keyboard_protocol: true,
     });
     test_client_roundtrip!(ClientToServerMsg::ClientExited);
     test_client_roundtrip!(ClientToServerMsg::KillSession);

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -2068,6 +2068,7 @@ impl TryFrom<ProtobufKeyWithModifier> for KeyWithModifier {
 
         Ok(KeyWithModifier {
             bare_key,
+            shifted_key: None,
             key_modifiers,
         })
     }

--- a/zellij-utils/src/plugin_api/key.rs
+++ b/zellij-utils/src/plugin_api/key.rs
@@ -101,6 +101,7 @@ impl TryFrom<ProtobufKey> for KeyWithModifier {
         }
         Ok(KeyWithModifier {
             bare_key,
+            shifted_key: None,
             key_modifiers,
         })
     }


### PR DESCRIPTION
## Summary

- Adds support for Kitty keyboard protocol flag 4 (REPORT_ALTERNATE_KEYS) in addition to flag 1 (DISAMBIGUATE_ESCAPE_CODES)
- Fixes Shift+Alt key combinations not being correctly forwarded to non-Kitty applications (like Emacs)
- When terminal sends `CSI base:shifted;modifiers u`, we now parse and use the shifted key

## Problem

When pressing M-< (Alt+Shift+comma) in Emacs inside Zellij, Emacs received M-, instead. The shift modifier was being lost because Zellij only supported DISAMBIGUATE_ESCAPE_CODES (flag 1), which sends the base key with modifier flags. Non-Kitty applications expect the actual shifted character.

Related: #4509 (user there is also running into this issue)

## Solution

Enable REPORT_ALTERNATE_KEYS (flag 4) which causes the terminal to send both base and shifted keys in format `ESC[44:60;4u` (base=comma, shifted=<). When serializing to non-Kitty apps, we now use the shifted key directly.

## Test plan

- [x] Unit tests for keyboard parser with shifted key format
- [x] Roundtrip tests for protobuf serialization with shifted_key
- [x] Manual testing: M-< in Emacs now correctly triggers `beginning-of-buffer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)