### PR TITLE
fix(session-manager): Make <ESC> exit from "New" tab if form is empty

### DIFF
--- a/default-plugins/session-manager/src/main.rs
+++ b/default-plugins/session-manager/src/main.rs
@@ -288,7 +288,15 @@ impl State {
                 should_render = true;
             },
             BareKey::Esc if key.has_no_modifiers() => {
-                self.new_session_info.handle_key(key);
+                if self.new_session_info.entering_new_session_name()
+                    && self.new_session_info.name().is_empty()
+                {
+                    if !self.is_welcome_screen {
+                        hide_self();
+                    }
+                } else {
+                    self.new_session_info.handle_key(key);
+                }
                 should_render = true;
             },
             _ => {},


### PR DESCRIPTION
Currently Esc is unconditionally bound to clear the form, making it impossible to close the session manager from the "New" tab. This change makes it so that Esc closes the session manager if the form on the "New" tab is already empty.

I manually verified by running zellij at head with this change.

- Fixes https://github.com/zellij-org/zellij/issues/4441
- Fixes https://github.com/zellij-org/zellij/issues/3408