### PR TITLE
fix(filepicker): Make <ESC> close the file picker if not standalone

### DIFF
--- a/default-plugins/strider/src/main.rs
+++ b/default-plugins/strider/src/main.rs
@@ -73,6 +73,8 @@ impl ZellijPlugin for State {
                 BareKey::Esc if key.has_no_modifiers() => {
                     if self.is_searching {
                         self.clear_search_term();
+                    } else if self.handling_filepick_request_from.is_some() {
+                        close_self();
                     } else {
                         self.file_list_view.clear_selected();
                     }


### PR DESCRIPTION
This allows the filepicker to be closed with <ESC> if the search field is empty and the filepicker was opened from a different plugin / context.

For example, if the filepicker is launched from the "New" tab of the session manager, it can be closed by pressing <ESC>, either once if the search field is empty, or twice otherwise (first <ESC> clears the field).

This makes the filepicker behave like other modals that can be closed with <ESC>.

- Fixes https://github.com/zellij-org/zellij/issues/4665