### PR TITLE
feat(session-manager): Make shift + tab move to previous tab

### DIFF
--- a/default-plugins/session-manager/src/main.rs
+++ b/default-plugins/session-manager/src/main.rs
@@ -260,6 +260,10 @@ impl State {
                 self.toggle_active_screen();
                 should_render = true;
             },
+            BareKey::Tab if key.has_modifiers(&[KeyModifier::Shift]) => {
+                self.toggle_active_screen_backwards();
+                should_render = true;
+            },
             BareKey::Char('f') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
                 let request_id = Uuid::new_v4();
                 let mut config = BTreeMap::new();
@@ -415,6 +419,10 @@ impl State {
                     self.toggle_active_screen();
                     should_render = true;
                 },
+                BareKey::Tab if key.has_modifiers(&[KeyModifier::Shift]) => {
+                    self.toggle_active_screen_backwards();
+                    should_render = true;
+                },
                 BareKey::Esc if key.has_no_modifiers() => {
                     if self.renaming_session_name.is_some() {
                         self.renaming_session_name = None;
@@ -469,6 +477,10 @@ impl State {
             },
             BareKey::Tab if key.has_no_modifiers() => {
                 self.toggle_active_screen();
+                should_render = true;
+            },
+            BareKey::Tab if key.has_modifiers(&[KeyModifier::Shift]) => {
+                self.toggle_active_screen_backwards();
                 should_render = true;
             },
             BareKey::Delete if key.has_no_modifiers() => {
@@ -595,6 +607,13 @@ impl State {
             ActiveScreen::NewSession => ActiveScreen::AttachToSession,
             ActiveScreen::AttachToSession => ActiveScreen::ResurrectSession,
             ActiveScreen::ResurrectSession => ActiveScreen::NewSession,
+        };
+    }
+    fn toggle_active_screen_backwards(&mut self) {
+        self.active_screen = match self.active_screen {
+            ActiveScreen::NewSession => ActiveScreen::ResurrectSession,
+            ActiveScreen::AttachToSession => ActiveScreen::NewSession,
+            ActiveScreen::ResurrectSession => ActiveScreen::AttachToSession,
         };
     }
     fn show_error(&mut self, error_text: &str) {


### PR DESCRIPTION
This holding shift to change the direction of an action is a pretty well established UX pattern. There's no reason not to implement it in the session-manager, and users have noticed that it's missing.

- Fixes https://github.com/zellij-org/zellij/issues/4416