### PR TITLE
Expose tab name to panes via environment variable (e.g., ZELLIJ_TAB_N…

### DIFF
--- a/zellij-server/src/tab/unit/layout_applier_tests.rs
+++ b/zellij-server/src/tab/unit/layout_applier_tests.rs
@@ -49,6 +49,7 @@ impl ServerOsApi for FakeInputOutput {
         _file_to_open: TerminalAction,
         _quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>,
         _default_editor: Option<PathBuf>,
+        _tab_name: Option<String>,
     ) -> Result<(u32, RawFd, RawFd)> {
         unimplemented!()
     }
@@ -114,6 +115,7 @@ impl ServerOsApi for FakeInputOutput {
         _terminal_id: u32,
         _run_command: RunCommand,
         _quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>,
+        _tab_name: Option<String>,
     ) -> Result<(RawFd, RawFd)> {
         unimplemented!()
     }

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -70,6 +70,7 @@ impl ServerOsApi for FakeInputOutput {
         _file_to_open: TerminalAction,
         _quit_db: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>,
         _default_editor: Option<PathBuf>,
+        _tab_name: Option<String>,
     ) -> Result<(u32, RawFd, RawFd)> {
         unimplemented!()
     }
@@ -132,6 +133,7 @@ impl ServerOsApi for FakeInputOutput {
         _terminal_id: u32,
         _run_command: RunCommand,
         _quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>, // u32 is the exit status
+        _tab_name: Option<String>,
     ) -> Result<(RawFd, RawFd)> {
         unimplemented!()
     }

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -48,6 +48,7 @@ impl ServerOsApi for FakeInputOutput {
         _file_to_open: TerminalAction,
         _quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>,
         _default_editor: Option<PathBuf>,
+        _tab_name: Option<String>,
     ) -> Result<(u32, RawFd, RawFd)> {
         unimplemented!()
     }
@@ -100,6 +101,7 @@ impl ServerOsApi for FakeInputOutput {
         _terminal_id: u32,
         _run_command: RunCommand,
         _quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>, // u32 is the exit status
+        _tab_name: Option<String>,
     ) -> Result<(RawFd, RawFd)> {
         unimplemented!()
     }

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -182,6 +182,7 @@ impl ServerOsApi for FakeInputOutput {
         _file_to_open: TerminalAction,
         _quit_db: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>,
         _default_editor: Option<PathBuf>,
+        _tab_name: Option<String>,
     ) -> Result<(u32, RawFd, RawFd)> {
         unimplemented!()
     }
@@ -245,6 +246,7 @@ impl ServerOsApi for FakeInputOutput {
         _terminal_id: u32,
         _run_command: RunCommand,
         _quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>, // u32 is the exit status
+        _tab_name: Option<String>,
     ) -> Result<(RawFd, RawFd)> {
         unimplemented!()
     }

--- a/zellij-utils/src/envs.rs
+++ b/zellij-utils/src/envs.rs
@@ -18,6 +18,8 @@ pub fn set_zellij(v: String) {
 
 pub const SESSION_NAME_ENV_KEY: &str = "ZELLIJ_SESSION_NAME";
 
+pub const TAB_NAME_ENV_KEY: &str = "ZELLIJ_TAB_NAME";
+
 pub fn get_session_name() -> Result<String> {
     Ok(var(SESSION_NAME_ENV_KEY)?)
 }

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -430,6 +430,7 @@ pub enum PtyContext {
     SendSigkillToPaneId,
     GetPanePid,
     UpdateAndReportCwds,
+    UpdateClientTabName,
     Exit,
 }
 


### PR DESCRIPTION
## Fix: #4651 
## Problem
Panes have no way to know which tab they belong to or what that tab is called. That limits:

- Showing the tab name in shell prompts 
- Scripts that depend on the current tab
- Logging or tagging output by tab

ZELLIJ_SESSION_NAME and ZELLIJ_PANE_ID already exist; there was no equivalent for the tab.
## Solution
Introduce a ZELLIJ_TAB_NAME environment variable that is set for every terminal pane and reflects the name of the tab it belongs to.
When set: On spawn (new pane, layout, re-run). Value is the current name of the tab containing the pane.
When it changes: Tab name is updated in pty state when the user switches tabs or renames a tab. New panes (and re-run) get the updated name; already-running processes keep their original env (env cannot be changed for existing processes).