### PR TITLE
fix: preserve pane_name when creating new terminal panes

### DIFF
--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1509,7 +1509,7 @@ impl Tab {
                     PaneGeom::default(), // this will be filled out later
                     self.style,
                     next_terminal_position,
-                    String::new(),
+                    initial_pane_title.clone().unwrap_or_default(),
                     self.link_handler.clone(),
                     self.character_cell_size.clone(),
                     self.sixel_image_store.clone(),
@@ -1622,7 +1622,7 @@ impl Tab {
                     PaneGeom::default(), // this will be filled out later
                     self.style,
                     next_terminal_position,
-                    String::new(),
+                    initial_pane_title.clone().unwrap_or_default(),
                     self.link_handler.clone(),
                     self.character_cell_size.clone(),
                     self.sixel_image_store.clone(),
@@ -1724,7 +1724,7 @@ impl Tab {
                     PaneGeom::default(), // this will be filled out later
                     self.style,
                     next_terminal_position,
-                    String::new(),
+                    initial_pane_title.clone().unwrap_or_default(),
                     self.link_handler.clone(),
                     self.character_cell_size.clone(),
                     self.sixel_image_store.clone(),
@@ -1870,7 +1870,7 @@ impl Tab {
                     PaneGeom::default(), // this will be filled out later
                     self.style,
                     next_terminal_position,
-                    String::new(),
+                    initial_pane_title.clone().unwrap_or_default(),
                     self.link_handler.clone(),
                     self.character_cell_size.clone(),
                     self.sixel_image_store.clone(),
@@ -2284,7 +2284,7 @@ impl Tab {
                     PaneGeom::default(), // the initial size will be set later
                     self.style,
                     next_terminal_position,
-                    String::new(),
+                    initial_pane_title.clone().unwrap_or_default(),
                     self.link_handler.clone(),
                     self.character_cell_size.clone(),
                     self.sixel_image_store.clone(),
@@ -2351,7 +2351,7 @@ impl Tab {
                     PaneGeom::default(), // the initial size will be set later
                     self.style,
                     next_terminal_position,
-                    String::new(),
+                    initial_pane_title.clone().unwrap_or_default(),
                     self.link_handler.clone(),
                     self.character_cell_size.clone(),
                     self.sixel_image_store.clone(),


### PR DESCRIPTION
## Summary

When creating a new tiled/floating/stacked pane with an explicit name (via `initial_pane_title`), the `pane_name` parameter was always passed as `String::new()`, causing the name to be discarded. The name was only stored in `initial_pane_title`, which gets overridden by the shell's OSC title escape sequences.

This fix passes `initial_pane_title` to the `pane_name` parameter as well, so that explicitly named panes preserve their names even when the shell sends OSC title sequences.

## Changes

- `new_no_preference_pane`: pass `initial_pane_title` instead of `String::new()`
- `new_tiled_pane`: same
- `new_floating_pane`: same
- `new_stacked_pane`: same
- `horizontal_split`: same
- `vertical_split`: same

## Use Case

This enables plugins to create named panes that maintain their identity. For example, a multi-agent orchestration plugin can spawn panes like "worker-1", "worker-2" and reliably send messages to them by name, without the shell's dynamic title (showing current directory or command) overwriting the pane name.

## Testing

- Built and tested locally with a custom plugin that creates named panes
- Verified pane names persist after shell initialization and command execution