### PR TITLE
fix(screen): tab actions work on sessions with no attached clients

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1310,6 +1310,10 @@ impl Screen {
 
                     self.log_and_report_session_state()
                         .with_context(err_context)?;
+                    // Update global_last_active_tab_index to track the current tab
+                    // This ensures subsequent actions target the correct tab even after
+                    // ephemeral clients (like CLI action clients) disconnect
+                    self.global_last_active_tab_index = new_tab_index;
                     return self.render(None).with_context(err_context);
                 },
                 Err(err) => Err::<(), _>(err).with_context(err_context).non_fatal(),

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -154,13 +154,15 @@ macro_rules! active_tab_and_connected_client_id_with_first_tab_fallback {
                         Err(err) => Err::<(), _>(err).non_fatal(),
                     }
                 } else {
-                    match $screen.get_indexed_tab_mut(0) {
-                        Some(first_tab) => {
-                            $closure(first_tab, None);
-                        },
-                        None => {
-                            log::error!("Not tabs found!");
-                        },
+                    // No clients connected - use fallback to find the appropriate tab
+                    if let Some(fallback_tab_index) = $screen.get_active_tab_index_with_fallback($client_id) {
+                        if let Some(fallback_tab) = $screen.get_indexed_tab_mut(fallback_tab_index) {
+                            $closure(fallback_tab, None);
+                        } else {
+                            log::error!("Failed to get tab at fallback index: {}", fallback_tab_index);
+                        }
+                    } else {
+                        log::error!("No tabs found!");
                     }
                 };
             },
@@ -181,13 +183,15 @@ macro_rules! active_tab_and_connected_client_id_with_first_tab_fallback {
                         Err(err) => Err::<(), _>(err).non_fatal(),
                     }
                 } else {
-                    match $screen.get_indexed_tab_mut(0) {
-                        Some(first_tab) => {
-                            $closure(first_tab, None)?;
-                        },
-                        None => {
-                            log::error!("Not tabs found!");
-                        },
+                    // No clients connected - use fallback to find the appropriate tab
+                    if let Some(fallback_tab_index) = $screen.get_active_tab_index_with_fallback($client_id) {
+                        if let Some(fallback_tab) = $screen.get_indexed_tab_mut(fallback_tab_index) {
+                            $closure(fallback_tab, None)?;
+                        } else {
+                            log::error!("Failed to get tab at fallback index: {}", fallback_tab_index);
+                        }
+                    } else {
+                        log::error!("No tabs found!");
                     }
                 };
             },

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1327,11 +1327,7 @@ impl Screen {
     ) -> Result<()> {
         let err_context = || format!("failed to switch to next tab for client {client_id}");
 
-        let effective_client_id = if self.get_active_tab(client_id).is_ok() {
-            Some(client_id)
-        } else {
-            self.get_first_client_id()
-        };
+        let effective_client_id = self.client_id(client_id);
 
         if let Some(client_id) = effective_client_id {
             match self.get_active_tab(client_id) {
@@ -1369,11 +1365,7 @@ impl Screen {
     ) -> Result<()> {
         let err_context = || format!("failed to switch to previous tab for client {client_id}");
 
-        let effective_client_id = if self.get_active_tab(client_id).is_ok() {
-            Some(client_id)
-        } else {
-            self.get_first_client_id()
-        };
+        let effective_client_id = self.client_id(client_id);
 
         if let Some(client_id) = effective_client_id {
             match self.get_active_tab(client_id) {
@@ -1481,11 +1473,7 @@ impl Screen {
     pub fn close_tab(&mut self, client_id: ClientId) -> Result<()> {
         let err_context = || format!("failed to close tab for client {client_id:?}");
 
-        let effective_client_id = if self.get_active_tab(client_id).is_ok() {
-            Some(client_id)
-        } else {
-            self.get_first_client_id()
-        };
+        let effective_client_id = self.client_id(client_id);
 
         match effective_client_id {
             Some(client_id) => {
@@ -2311,11 +2299,7 @@ impl Screen {
         let err_context =
             || format!("failed to update active tabs name for client id: {client_id:?}");
 
-        let effective_client_id = if self.get_active_tab(client_id).is_ok() {
-            Some(client_id)
-        } else {
-            self.get_first_client_id()
-        };
+        let effective_client_id = self.client_id(client_id);
 
         let s = str::from_utf8(&buf)
             .with_context(|| format!("failed to construct tab name from buf: {buf:?}"))
@@ -2368,11 +2352,7 @@ impl Screen {
     pub fn undo_active_rename_tab(&mut self, client_id: ClientId) -> Result<()> {
         let err_context = || format!("failed to undo active tab rename for client {}", client_id);
 
-        let effective_client_id = if self.get_active_tab(client_id).is_ok() {
-            Some(client_id)
-        } else {
-            self.get_first_client_id()
-        };
+        let effective_client_id = self.client_id(client_id);
 
         // Helper closure to undo rename on a tab
         let undo_rename = |tab: &mut Tab| -> bool {
@@ -2641,11 +2621,7 @@ impl Screen {
             )
         };
 
-        let effective_client_id = if self.get_active_tab(client_id).is_ok() {
-            Some(client_id)
-        } else {
-            self.get_first_client_id()
-        };
+        let effective_client_id = self.client_id(client_id);
 
         if let Some(client_id) = effective_client_id {
             match self.get_active_tab_mut(client_id) {
@@ -2681,11 +2657,7 @@ impl Screen {
             )
         };
 
-        let effective_client_id = if self.get_active_tab(client_id).is_ok() {
-            Some(client_id)
-        } else {
-            self.get_first_client_id()
-        };
+        let effective_client_id = self.client_id(client_id);
 
         if let Some(client_id) = effective_client_id {
             match self.get_active_tab_mut(client_id) {

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1445,6 +1445,18 @@ impl Tab {
                             borderless,
                         )?;
                     }
+                } else {
+                    // No client connected - fall back to directionless tiled pane
+                    self.new_tiled_pane(
+                        pid,
+                        initial_pane_title,
+                        invoked_with,
+                        start_suppressed,
+                        should_focus_pane,
+                        client_id,
+                        blocking_notification,
+                        borderless,
+                    )?;
                 }
                 Ok(())
             },


### PR DESCRIPTION
## Summary

Extends the fix from #4626 (which addressed #4535) to all other tab-related CLI actions that had the same silent failure pattern when targeting a session with no attached clients.

### The Problem

After #4626, `zellij run --session` and `zellij action new-pane` correctly work on detached sessions. However, other tab actions still silently returned success without doing anything:

- `zellij --session X action close-tab`
- `zellij --session X action rename-tab "name"`
- `zellij --session X action go-to-next-tab`
- etc.

### The Fix

Added a helper method `get_active_tab_index_with_fallback()` that mirrors the fallback logic in `add_client()`:
1. Specified client's active tab
2. First connected client's active tab
3. `global_last_active_tab_index` if that tab exists
4. First tab by index

Applied this fallback to 9 methods:
- `switch_tab_next` / `switch_tab_prev`
- `close_tab`
- `update_active_tab_name` / `undo_active_rename_tab`
- `move_active_tab_to_left` / `move_active_tab_to_right`
- `move_focus_left_or_previous_tab` / `move_focus_right_or_next_tab`

Also modified `switch_tabs()` to accept `Option<ClientId>` and update `global_last_active_tab_index` when no client is connected, so tab move operations work correctly in detached sessions.

### Additional Cleanup

Refactored all affected methods to use the existing `client_id()` helper for consistent client ID resolution, reducing code duplication.

## Test Plan

- [x] All 90 existing screen tests pass
- [ ] Manual testing with detached session:
  ```bash
  zellij --session test
  # Create multiple tabs, detach
  
  zellij --session test action go-to-next-tab
  zellij --session test action rename-tab "NewName"
  zellij --session test action close-tab
  
  # Reattach and verify actions took effect
  zellij attach test
  ```