### PR TITLE
fix: compose NFD Hangul Jamo to NFC syllables in terminal grid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4199,6 +4199,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "to_method"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4471,6 +4486,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a52dcaab0c48d931f7cc8ef826fa51690a08e1ea55117ef26f89864f532383f"
 dependencies = [
  "regex",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -5400,6 +5424,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "typetag",
+ "unicode-normalization",
  "unicode-width 0.1.10",
  "url",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ termwiz = { version = "0.23.2", default-features = false }
 thiserror = { version = "1.0.40", default-features = false }
 tokio = { version = "1.38.1", features = ["full"] }
 tokio-util = { version = "0.7.15" }
+unicode-normalization = { version = "0.1", default-features = false, features = ["std"] }
 unicode-width = { version = "0.1.8", default-features = false }
 url = { version = "2.2.2", default-features = false, features = ["serde"] }
 uuid = { version = "1.4.1", default-features = false, features = ["serde", "v4", "std"] }

--- a/zellij-server/Cargo.toml
+++ b/zellij-server/Cargo.toml
@@ -43,6 +43,7 @@ sixel-tokenizer = { version = "0.1.0", default-features = false }
 sysinfo = { version = "0.22.5", default-features = false }
 tempfile = { workspace = true }
 typetag = { version = "0.1.7", default-features = false }
+unicode-normalization = { workspace = true }
 unicode-width = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }


### PR DESCRIPTION
## Summary

On macOS, filenames containing Korean characters are stored in NFD (Normalization Form Decomposed), where each Hangul syllable is split into separate Jamo characters (leading consonant + vowel + optional trailing consonant). The terminal grid's `add_character()` drops zero-width characters, and since `unicode-width` reports Jungseong (vowels U+1160–U+11A7) and Jongseong (trailing consonants U+11A8–U+11FF) as width 0, these combining Jamo were silently discarded. This caused Korean folder names to display as broken sequences of leading consonants only.

**Example:** NFD `폴더` (폴더) → displayed as `ᄑᄃ` instead of `폴더`

## Root Cause

1. macOS HFS+ stores filenames in NFD, decomposing Hangul syllables into Jamo
2. `unicode-width` returns width 0 for Jungseong and Jongseong Jamo
3. `Grid::add_character()` has an early return: `if character_width == 0 { return; }` which drops these combining characters

## Fix

Added Unicode composition in `Grid::print()` using `unicode_normalization::char::compose()`. When a new character can compose with the preceding character (e.g., leading consonant + vowel → syllable, or partial syllable + trailing consonant → full syllable), the composed result replaces the preceding character in the viewport via a new `replace_preceding_character_in_viewport()` helper.

This approach:
- Handles the full NFD → NFC pipeline incrementally (char by char as VTE delivers them)
- Works for all Unicode composition, not just Korean
- Has no performance impact on non-composable character sequences (single `compose()` check returns `None`)

## Changes

- `Cargo.toml` / `zellij-server/Cargo.toml` — added `unicode-normalization` dependency
- `zellij-server/src/panes/grid.rs` — composition logic in `print()` + `replace_preceding_character_in_viewport()` helper
- `zellij-server/src/panes/unit/grid_tests.rs` — 5 new tests covering NFD Hangul composition

## Test Plan

- [x] All 737 existing tests pass (`cargo test -p zellij-server`: 737 passed, 0 failed)
- [x] 5 new tests added:
  - `nfd_hangul_jamo_composed_to_nfc_syllable` — basic NFD→NFC for "폴더명"
  - `nfd_hangul_with_ansi_color_composed_correctly` — composition preserves ANSI styles
  - `nfd_hangul_mixed_with_ascii` — mixed Korean/ASCII text
  - `nfd_hangul_two_jamo_syllable` — two-Jamo syllables (no trailing consonant)
  - `nfc_hangul_not_affected_by_composition` — pre-composed NFC input unchanged
- [x] Code formatted with `cargo xtask format`

Fixes #3148

🤖 Generated with [Claude Code](https://claude.com/claude-code)