### PR TITLE
test: Tighten network privileges for e2e test container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     image: ghcr.io/linuxserver/openssh-server
     container_name: zellij-e2e
     hostname: zellij-e2e
-    network_mode: host
     environment:
       PUID: 1000
       PGID: 1000
@@ -21,5 +20,5 @@ services:
         source: ./src/tests/fixtures
         target: /usr/src/zellij/fixtures
     ports:
-      - 2222:2222
+      - "127.0.0.1:2222:2222/tcp"
     restart: unless-stopped


### PR DESCRIPTION
and prevent it from leaking network resources to the host. Previously, the port binding was effectively useless since the container was already sharing the hosts network (`network_mode: host`). Restrict the port binding to only listen on the local host, blocking all connections from outside the machine.

## User-facing changes

None, this is entirely related to development and CI.