### PR TITLE
feat(plugin): add open_external API to open URLs in default app

### DIFF
--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -246,6 +246,7 @@ fn host_run_plugin_command(mut caller: Caller<'_, PluginEnv>) {
                     PluginCommand::WebRequest(url, verb, headers, body, context) => {
                         web_request(env, url, verb, headers, body, context)
                     },
+                    PluginCommand::OpenExternal { url } => open_external(env, url),
                     PluginCommand::PostMessageTo(plugin_message) => {
                         post_message_to(env, plugin_message)?
                     },
@@ -2454,6 +2455,36 @@ fn web_request(
             body,
             context,
         ));
+}
+
+fn open_external(_env: &PluginEnv, url: String) {
+    if url.is_empty() {
+        log::error!("URL cannot be empty");
+        return;
+    }
+    std::thread::spawn(move || {
+        #[cfg(target_os = "macos")]
+        let cmd = "open";
+        #[cfg(not(target_os = "macos"))]
+        let cmd = if url.starts_with("mailto:") {
+            "xdg-email"
+        } else {
+            "xdg-open"
+        };
+
+        match std::process::Command::new(cmd)
+            .arg(&url)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+        {
+            Ok(mut child) => {
+                let _ = child.wait();
+            },
+            Err(e) => log::error!("Failed to open external URL: {}", e),
+        }
+    });
 }
 
 fn post_message_to(env: &PluginEnv, plugin_message: PluginMessage) -> Result<()> {
@@ -4885,7 +4916,8 @@ fn check_command_permission(
         | PluginCommand::OpenCommandPaneBackground(..)
         | PluginCommand::OpenCommandPaneInPlaceOfPaneId(..)
         | PluginCommand::RunCommand(..)
-        | PluginCommand::ExecCmd(..) => PermissionType::RunCommands,
+        | PluginCommand::ExecCmd(..)
+        | PluginCommand::OpenExternal { .. } => PermissionType::RunCommands,
         PluginCommand::WebRequest(..) => PermissionType::WebAccess,
         PluginCommand::Write(..)
         | PluginCommand::WriteChars(..)

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -2457,34 +2457,14 @@ fn web_request(
         ));
 }
 
-fn open_external(_env: &PluginEnv, url: String) {
+fn open_external(env: &PluginEnv, url: String) {
     if url.is_empty() {
         log::error!("URL cannot be empty");
         return;
     }
-    std::thread::spawn(move || {
-        #[cfg(target_os = "macos")]
-        let cmd = "open";
-        #[cfg(not(target_os = "macos"))]
-        let cmd = if url.starts_with("mailto:") {
-            "xdg-email"
-        } else {
-            "xdg-open"
-        };
-
-        match std::process::Command::new(cmd)
-            .arg(&url)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-        {
-            Ok(mut child) => {
-                let _ = child.wait();
-            },
-            Err(e) => log::error!("Failed to open external URL: {}", e),
-        }
-    });
+    let _ = env
+        .senders
+        .send_to_background_jobs(BackgroundJob::OpenExternal(url));
 }
 
 fn post_message_to(env: &PluginEnv, plugin_message: PluginMessage) -> Result<()> {

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -868,6 +868,19 @@ pub fn web_request<S: AsRef<str>>(
     unsafe { host_run_plugin_command() };
 }
 
+/// Open a URL or file path in the user's default external application.
+/// On macOS, this uses the `open` command.
+/// On Linux, this uses `xdg-open` (or `xdg-email` for `mailto:` URLs).
+/// This is a fire-and-forget operation — no result is returned to the plugin.
+pub fn open_external(url: &str) {
+    let plugin_command = PluginCommand::OpenExternal {
+        url: url.to_owned(),
+    };
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
 /// Hide the plugin pane (suppress it) from the UI
 pub fn hide_self() {
     let plugin_command = PluginCommand::HideSelf;

--- a/zellij-utils/assets/prost/api.plugin_command.rs
+++ b/zellij-utils/assets/prost/api.plugin_command.rs
@@ -291,9 +291,15 @@ pub mod plugin_command {
         OpenTerminalPaneInPlaceOfPaneIdPayload(super::OpenTerminalPaneInPlaceOfPaneIdPayload),
         #[prost(message, tag="154")]
         OpenEditPaneInPlaceOfPaneIdPayload(super::OpenEditPaneInPlaceOfPaneIdPayload),
-        #[prost(message, tag = "155")]
+        #[prost(message, tag="155")]
         OpenExternalPayload(super::OpenExternalPayload),
     }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OpenExternalPayload {
+    #[prost(string, tag="1")]
+    pub url: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -302,12 +308,6 @@ pub struct NewTabPayload {
     pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(string, optional, tag="2")]
     pub cwd: ::core::option::Option<::prost::alloc::string::String>,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct OpenExternalPayload {
-    #[prost(string, tag="1")]
-    pub url: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/zellij-utils/assets/prost/api.plugin_command.rs
+++ b/zellij-utils/assets/prost/api.plugin_command.rs
@@ -3,7 +3,7 @@
 pub struct PluginCommand {
     #[prost(enumeration="CommandName", tag="1")]
     pub name: i32,
-    #[prost(oneof="plugin_command::Payload", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154")]
+    #[prost(oneof="plugin_command::Payload", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155")]
     pub payload: ::core::option::Option<plugin_command::Payload>,
 }
 /// Nested message and enum types in `PluginCommand`.
@@ -291,6 +291,8 @@ pub mod plugin_command {
         OpenTerminalPaneInPlaceOfPaneIdPayload(super::OpenTerminalPaneInPlaceOfPaneIdPayload),
         #[prost(message, tag="154")]
         OpenEditPaneInPlaceOfPaneIdPayload(super::OpenEditPaneInPlaceOfPaneIdPayload),
+        #[prost(message, tag = "155")]
+        OpenExternalPayload(super::OpenExternalPayload),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -300,6 +302,12 @@ pub struct NewTabPayload {
     pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(string, optional, tag="2")]
     pub cwd: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OpenExternalPayload {
+    #[prost(string, tag="1")]
+    pub url: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1904,6 +1912,7 @@ pub enum CommandName {
     OpenCommandPaneInPlaceOfPaneId = 201,
     OpenTerminalPaneInPlaceOfPaneId = 202,
     OpenEditPaneInPlaceOfPaneId = 203,
+    OpenExternal = 204,
 }
 impl CommandName {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -2095,6 +2104,7 @@ impl CommandName {
             CommandName::OpenCommandPaneInPlaceOfPaneId => "OpenCommandPaneInPlaceOfPaneId",
             CommandName::OpenTerminalPaneInPlaceOfPaneId => "OpenTerminalPaneInPlaceOfPaneId",
             CommandName::OpenEditPaneInPlaceOfPaneId => "OpenEditPaneInPlaceOfPaneId",
+            CommandName::OpenExternal => "OpenExternal",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -2283,6 +2293,7 @@ impl CommandName {
             "OpenCommandPaneInPlaceOfPaneId" => Some(Self::OpenCommandPaneInPlaceOfPaneId),
             "OpenTerminalPaneInPlaceOfPaneId" => Some(Self::OpenTerminalPaneInPlaceOfPaneId),
             "OpenEditPaneInPlaceOfPaneId" => Some(Self::OpenEditPaneInPlaceOfPaneId),
+            "OpenExternal" => Some(Self::OpenExternal),
             _ => None,
         }
     }

--- a/zellij-utils/assets/prost_ipc/client_server_contract.rs
+++ b/zellij-utils/assets/prost_ipc/client_server_contract.rs
@@ -2536,122 +2536,6 @@ impl WebSharing {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ServerToClientMsg {
-    #[prost(oneof="server_to_client_msg::Message", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13")]
-    pub message: ::core::option::Option<server_to_client_msg::Message>,
-}
-/// Nested message and enum types in `ServerToClientMsg`.
-pub mod server_to_client_msg {
-    #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Message {
-        #[prost(message, tag="1")]
-        Render(super::RenderMsg),
-        #[prost(message, tag="2")]
-        UnblockInputThread(super::UnblockInputThreadMsg),
-        #[prost(message, tag="3")]
-        Exit(super::ExitMsg),
-        #[prost(message, tag="4")]
-        Connected(super::ConnectedMsg),
-        #[prost(message, tag="5")]
-        Log(super::LogMsg),
-        #[prost(message, tag="6")]
-        LogError(super::LogErrorMsg),
-        #[prost(message, tag="7")]
-        SwitchSession(super::SwitchSessionMsg),
-        #[prost(message, tag="8")]
-        UnblockCliPipeInput(super::UnblockCliPipeInputMsg),
-        #[prost(message, tag="9")]
-        CliPipeOutput(super::CliPipeOutputMsg),
-        #[prost(message, tag="10")]
-        QueryTerminalSize(super::QueryTerminalSizeMsg),
-        #[prost(message, tag="11")]
-        StartWebServer(super::StartWebServerMsg),
-        #[prost(message, tag="12")]
-        RenamedSession(super::RenamedSessionMsg),
-        #[prost(message, tag="13")]
-        ConfigFileUpdated(super::ConfigFileUpdatedMsg),
-    }
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RenderMsg {
-    #[prost(string, tag="1")]
-    pub content: ::prost::alloc::string::String,
-}
-/// Empty message
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct UnblockInputThreadMsg {
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ExitMsg {
-    #[prost(enumeration="ExitReason", tag="1")]
-    pub exit_reason: i32,
-    #[prost(string, optional, tag="2")]
-    pub payload: ::core::option::Option<::prost::alloc::string::String>,
-}
-/// Empty message
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ConnectedMsg {
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct LogMsg {
-    #[prost(string, repeated, tag="1")]
-    pub lines: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct LogErrorMsg {
-    #[prost(string, repeated, tag="1")]
-    pub lines: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SwitchSessionMsg {
-    #[prost(message, optional, tag="1")]
-    pub connect_to_session: ::core::option::Option<ConnectToSession>,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct UnblockCliPipeInputMsg {
-    #[prost(string, tag="1")]
-    pub pipe_name: ::prost::alloc::string::String,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct CliPipeOutputMsg {
-    #[prost(string, tag="1")]
-    pub pipe_name: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
-    pub output: ::prost::alloc::string::String,
-}
-/// Empty message
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct QueryTerminalSizeMsg {
-}
-/// Empty message
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct StartWebServerMsg {
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RenamedSessionMsg {
-    #[prost(string, tag="1")]
-    pub name: ::prost::alloc::string::String,
-}
-/// Empty message
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct ConfigFileUpdatedMsg {
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClientToServerMsg {
     #[prost(oneof="client_to_server_msg::Message", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16")]
     pub message: ::core::option::Option<client_to_server_msg::Message>,
@@ -2807,4 +2691,120 @@ pub struct WebServerStartedMsg {
 pub struct FailedToStartWebServerMsg {
     #[prost(string, tag="1")]
     pub error: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ServerToClientMsg {
+    #[prost(oneof="server_to_client_msg::Message", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13")]
+    pub message: ::core::option::Option<server_to_client_msg::Message>,
+}
+/// Nested message and enum types in `ServerToClientMsg`.
+pub mod server_to_client_msg {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Message {
+        #[prost(message, tag="1")]
+        Render(super::RenderMsg),
+        #[prost(message, tag="2")]
+        UnblockInputThread(super::UnblockInputThreadMsg),
+        #[prost(message, tag="3")]
+        Exit(super::ExitMsg),
+        #[prost(message, tag="4")]
+        Connected(super::ConnectedMsg),
+        #[prost(message, tag="5")]
+        Log(super::LogMsg),
+        #[prost(message, tag="6")]
+        LogError(super::LogErrorMsg),
+        #[prost(message, tag="7")]
+        SwitchSession(super::SwitchSessionMsg),
+        #[prost(message, tag="8")]
+        UnblockCliPipeInput(super::UnblockCliPipeInputMsg),
+        #[prost(message, tag="9")]
+        CliPipeOutput(super::CliPipeOutputMsg),
+        #[prost(message, tag="10")]
+        QueryTerminalSize(super::QueryTerminalSizeMsg),
+        #[prost(message, tag="11")]
+        StartWebServer(super::StartWebServerMsg),
+        #[prost(message, tag="12")]
+        RenamedSession(super::RenamedSessionMsg),
+        #[prost(message, tag="13")]
+        ConfigFileUpdated(super::ConfigFileUpdatedMsg),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RenderMsg {
+    #[prost(string, tag="1")]
+    pub content: ::prost::alloc::string::String,
+}
+/// Empty message
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UnblockInputThreadMsg {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ExitMsg {
+    #[prost(enumeration="ExitReason", tag="1")]
+    pub exit_reason: i32,
+    #[prost(string, optional, tag="2")]
+    pub payload: ::core::option::Option<::prost::alloc::string::String>,
+}
+/// Empty message
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ConnectedMsg {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LogMsg {
+    #[prost(string, repeated, tag="1")]
+    pub lines: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LogErrorMsg {
+    #[prost(string, repeated, tag="1")]
+    pub lines: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SwitchSessionMsg {
+    #[prost(message, optional, tag="1")]
+    pub connect_to_session: ::core::option::Option<ConnectToSession>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UnblockCliPipeInputMsg {
+    #[prost(string, tag="1")]
+    pub pipe_name: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CliPipeOutputMsg {
+    #[prost(string, tag="1")]
+    pub pipe_name: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub output: ::prost::alloc::string::String,
+}
+/// Empty message
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct QueryTerminalSizeMsg {
+}
+/// Empty message
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StartWebServerMsg {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RenamedSessionMsg {
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+}
+/// Empty message
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ConfigFileUpdatedMsg {
 }

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -3461,6 +3461,9 @@ pub enum PluginCommand {
     OpenCommandPaneInPlaceOfPaneId(PaneId, CommandToRun, bool, Context), // bool = close_replaced_pane
     OpenTerminalPaneInPlaceOfPaneId(PaneId, FileToOpen, bool),
     OpenEditPaneInPlaceOfPaneId(PaneId, FileToOpen, bool, Context),
+    OpenExternal {
+        url: String,
+    },
 }
 
 // Response type for plugin API methods that open a pane in a new tab

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -581,6 +581,7 @@ pub enum BackgroundJobContext {
     HighlightPanesWithMessage,
     QueryZellijWebServerStatus,
     ClearHelpText,
+    OpenExternal,
     Exit,
 }
 

--- a/zellij-utils/src/plugin_api/plugin_command.proto
+++ b/zellij-utils/src/plugin_api/plugin_command.proto
@@ -185,17 +185,18 @@ enum CommandName {
   GetPaneRunningCommand = 190;
   GetPaneCwd = 191;
   SwitchTabToId = 192;
-  GoToTabWithId = 193;
-  CloseTabWithId = 194;
-  RenameTabWithId = 195;
-  BreakPanesToTabWithId = 196;
-  GetSessionEnvironmentVariables = 197;
-  OpenCommandPaneInNewTab = 198;
-  OpenPluginPaneInNewTab = 199;
-  OpenEditorPaneInNewTab = 200;
-  OpenCommandPaneInPlaceOfPaneId = 201;
-  OpenTerminalPaneInPlaceOfPaneId = 202;
-  OpenEditPaneInPlaceOfPaneId = 203;
+   GoToTabWithId = 193;
+   CloseTabWithId = 194;
+   RenameTabWithId = 195;
+   BreakPanesToTabWithId = 196;
+   GetSessionEnvironmentVariables = 197;
+   OpenCommandPaneInNewTab = 198;
+   OpenPluginPaneInNewTab = 199;
+   OpenEditorPaneInNewTab = 200;
+   OpenCommandPaneInPlaceOfPaneId = 201;
+   OpenTerminalPaneInPlaceOfPaneId = 202;
+   OpenEditPaneInPlaceOfPaneId = 203;
+   OpenExternal = 204;
 }
 
 message PluginCommand {
@@ -341,7 +342,12 @@ message PluginCommand {
     OpenCommandPaneInPlaceOfPaneIdPayload open_command_pane_in_place_of_pane_id_payload = 152;
     OpenTerminalPaneInPlaceOfPaneIdPayload open_terminal_pane_in_place_of_pane_id_payload = 153;
     OpenEditPaneInPlaceOfPaneIdPayload open_edit_pane_in_place_of_pane_id_payload = 154;
+    OpenExternalPayload open_external_payload = 155;
   }
+}
+
+message OpenExternalPayload {
+  string url = 1;
 }
 
 message NewTabPayload {

--- a/zellij-utils/src/plugin_api/plugin_command.proto
+++ b/zellij-utils/src/plugin_api/plugin_command.proto
@@ -185,18 +185,18 @@ enum CommandName {
   GetPaneRunningCommand = 190;
   GetPaneCwd = 191;
   SwitchTabToId = 192;
-   GoToTabWithId = 193;
-   CloseTabWithId = 194;
-   RenameTabWithId = 195;
-   BreakPanesToTabWithId = 196;
-   GetSessionEnvironmentVariables = 197;
-   OpenCommandPaneInNewTab = 198;
-   OpenPluginPaneInNewTab = 199;
-   OpenEditorPaneInNewTab = 200;
-   OpenCommandPaneInPlaceOfPaneId = 201;
-   OpenTerminalPaneInPlaceOfPaneId = 202;
-   OpenEditPaneInPlaceOfPaneId = 203;
-   OpenExternal = 204;
+  GoToTabWithId = 193;
+  CloseTabWithId = 194;
+  RenameTabWithId = 195;
+  BreakPanesToTabWithId = 196;
+  GetSessionEnvironmentVariables = 197;
+  OpenCommandPaneInNewTab = 198;
+  OpenPluginPaneInNewTab = 199;
+  OpenEditorPaneInNewTab = 200;
+  OpenCommandPaneInPlaceOfPaneId = 201;
+  OpenTerminalPaneInPlaceOfPaneId = 202;
+  OpenEditPaneInPlaceOfPaneId = 203;
+  OpenExternal = 204;
 }
 
 message PluginCommand {

--- a/zellij-utils/src/plugin_api/plugin_command.rs
+++ b/zellij-utils/src/plugin_api/plugin_command.rs
@@ -66,7 +66,7 @@ pub use super::generated_api::api::{
         OpenCommandPanePayload, OpenCommandPaneResponse as ProtobufOpenCommandPaneResponse,
         OpenEditPaneInPlaceOfPaneIdPayload,
         OpenEditPaneInPlaceOfPaneIdResponse as ProtobufOpenEditPaneInPlaceOfPaneIdResponse,
-        OpenFileFloatingNearPluginPayload,
+        OpenExternalPayload, OpenFileFloatingNearPluginPayload,
         OpenFileFloatingNearPluginResponse as ProtobufOpenFileFloatingNearPluginResponse,
         OpenFileFloatingResponse as ProtobufOpenFileFloatingResponse,
         OpenFileInPlaceOfPluginPayload,
@@ -2401,6 +2401,14 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
                     _ => Err("Mismatched payload for OpenEditPaneInPlaceOfPaneId"),
                 }
             },
+            Some(CommandName::OpenExternal) => match protobuf_plugin_command.payload {
+                Some(Payload::OpenExternalPayload(open_external_payload)) => {
+                    Ok(PluginCommand::OpenExternal {
+                        url: open_external_payload.url,
+                    })
+                },
+                _ => Err("Mismatched payload for OpenExternal"),
+            },
             None => Err("Unrecognized plugin command"),
         }
     }
@@ -3937,6 +3945,10 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
                     )),
                 })
             },
+            PluginCommand::OpenExternal { url } => Ok(ProtobufPluginCommand {
+                name: CommandName::OpenExternal as i32,
+                payload: Some(Payload::OpenExternalPayload(OpenExternalPayload { url })),
+            }),
         }
     }
 }


### PR DESCRIPTION
Add a new OpenExternal plugin command that allows plugins to open URLs or file paths in the user's default external application. On macOS this uses `open`, on Linux it uses `xdg-open` (or `xdg-email` for mailto: URLs). The command requires RunCommands permission and operates as a fire-and-forget operation with no result returned to the plugin.