### PR TITLE
fix(client): enable CSI synchronized output by default to prevent render corruption

### DIFF
--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -281,7 +281,7 @@ pub async fn run_remote_client_terminal_loop(
 
     let synchronised_output = match os_input.env_variable("TERM").as_deref() {
         Some("alacritty") => Some(SyncOutput::DCS),
-        _ => None,
+        _ => Some(SyncOutput::CSI),
     };
 
     let mut async_stdin: Box<dyn AsyncStdin> = os_input.get_async_stdin_reader();
@@ -950,7 +950,7 @@ pub fn start_client(
     let mut pending_instructions = vec![];
     let mut synchronised_output = match os_input.env_variable("TERM").as_deref() {
         Some("alacritty") => Some(SyncOutput::DCS),
-        _ => None,
+        _ => Some(SyncOutput::CSI),
     };
 
     let mut stdout = os_input.get_stdout_writer();


### PR DESCRIPTION
## Summary

- Enable CSI synchronized output (`?2026h`/`?2026l`) by default for all non-Alacritty terminals, preventing UI corruption (duplicate pane rendering) over SSH
- Change `_ => None` to `_ => Some(SyncOutput::CSI)` in two locations in `zellij-client/src/lib.rs`

Fixes #4693

## Problem

When using Zellij over SSH with `TERM=xterm-256color`, pane rendering gradually becomes corrupted — panes appear duplicated/overlapping. This happens because:

1. Zellij uses differential rendering (only changed lines are sent)
2. After reading changes, the output buffer is immediately cleared
3. Over SSH, TCP buffering splits large render frames into segments
4. Partial frames cause the terminal to draw content at wrong positions
5. The cleared buffer means corrupted lines won't be re-sent until next change
6. Drift accumulates over time → duplicate pane display

Synchronized output wraps each frame in begin/end markers (`\x1b[?2026h` ... `\x1b[?2026l`), causing the terminal to buffer and render atomically — preventing partial frame display.

## Why this was disabled

The current code only enables synchronized output for Alacritty (using DCS mode). For all other terminals, it falls through to `None`. The CSI implementation (`SyncOutput::CSI`) already exists in the codebase and was added in #2798, but was never made the default.

## Safety

CSI private mode `?2026` is a well-established standard:
- **Supported by**: Ghostty, kitty, iTerm2, WezTerm, foot, contour, rio, and others
- **Unsupported terminals**: Simply ignore the private mode sequences (no side effects)
- **Alacritty**: Continues to use DCS mode as before (no change to Alacritty behavior)

## Test plan

- [ ] Verify `cargo build` succeeds (CI)
- [ ] Verify `cargo xtask clippy` passes (CI)
- [ ] Test over SSH: confirm pane rendering remains stable over extended use
- [ ] Test with `TERM=alacritty`: confirm DCS mode still works
- [ ] Test with older terminals: confirm no visual side effects from ignored `?2026` sequences

🤖 Generated with [Claude Code](https://claude.com/claude-code)