### PR TITLE
fix: add missing share plugin keybinding to default config

### DIFF
--- a/zellij-utils/assets/config/default.kdl
+++ b/zellij-utils/assets/config/default.kdl
@@ -115,6 +115,13 @@ keybinds {
         bind "Ctrl o" { SwitchToMode "Normal"; }
         bind "Ctrl s" { SwitchToMode "Scroll"; }
         bind "d" { Detach; }
+        bind "s" {
+            LaunchOrFocusPlugin "zellij:share" {
+                floating true
+                move_to_focused_tab true
+            };
+            SwitchToMode "Normal"
+        }
         bind "w" {
             LaunchOrFocusPlugin "session-manager" {
                 floating true


### PR DESCRIPTION
## Problem
  The documentation states that pressing `Ctrl+o` followed by `s`
   should launch the share plugin, but this keybinding was
  missing from the default configuration.

  Fixes #4707

  ## Solution
  Add the `bind "s"` keybinding in session mode to the default
  KDL configuration file.

  ## Changes
  - Added share plugin keybinding in
  `zellij-utils/assets/config/default.kdl`
  - Configuration:
    - `floating: true` opens in a floating window
    - `move_to_focused_tab: true`  moves shared session to the focused tab