### PR TITLE
perf(plugins): optimize session update handling to reduce unnecessary re-renders

### DIFF
--- a/default-plugins/session-manager/src/new_session_info.rs
+++ b/default-plugins/session-manager/src/new_session_info.rs
@@ -137,8 +137,9 @@ impl NewSessionInfo {
             },
         }
     }
-    pub fn update_layout_list(&mut self, layout_info: Vec<LayoutInfo>) {
-        self.layout_list.update_layout_list(layout_info);
+    /// Returns a boolean indicating whether the layout list has changed
+    pub fn update_layout_list(&mut self, layout_list: Vec<LayoutInfo>) -> bool {
+        self.layout_list.update_layout_list(layout_list)
     }
     pub fn layout_list(&self, max_rows: usize) -> Vec<(LayoutInfo, bool)> {
         // bool - is_selected
@@ -263,13 +264,18 @@ pub struct LayoutList {
 }
 
 impl LayoutList {
-    pub fn update_layout_list(&mut self, layout_list: Vec<LayoutInfo>) {
+    /// Returns a boolean indicating whether the layout list has changed
+    pub fn update_layout_list(&mut self, layout_list: Vec<LayoutInfo>) -> bool {
+        if self.layout_list == layout_list {
+            return false;
+        }
         let old_layout_length = self.layout_list.len();
         self.layout_list = layout_list;
         if old_layout_length != self.layout_list.len() {
             // honestly, this is just the UX choice that sucks the least...
             self.clear_selection();
         }
+        true
     }
     pub fn selected_layout_info(&self) -> Option<LayoutInfo> {
         if !self.layout_search_term.is_empty() {

--- a/default-plugins/session-manager/src/resurrectable_sessions.rs
+++ b/default-plugins/session-manager/src/resurrectable_sessions.rs
@@ -18,12 +18,17 @@ pub struct ResurrectableSessions {
 }
 
 impl ResurrectableSessions {
-    pub fn update(&mut self, mut list: Vec<(String, Duration)>) {
+    /// Returns a boolean indicating whether the list of resurrectable sessions has changed
+    pub fn update(&mut self, mut list: Vec<(String, Duration)>) -> bool {
         list.sort_by(|a, b| a.1.cmp(&b.1));
+        if self.all_resurrectable_sessions == list {
+            return false;
+        }
         self.all_resurrectable_sessions = list;
         if self.is_searching {
             self.update_search_term();
         }
+        true
     }
     pub fn render(&self, rows: usize, columns: usize, x: usize, y: usize) {
         if self.delete_all_dead_sessions_warning {

--- a/default-plugins/session-manager/src/session_list.rs
+++ b/default-plugins/session-manager/src/session_list.rs
@@ -17,11 +17,12 @@ pub struct SessionList {
 }
 
 impl SessionList {
+    /// Returns a boolean indicating whether the sessions have changed
     pub fn set_sessions(
         &mut self,
         mut session_ui_infos: Vec<SessionUiInfo>,
         mut forbidden_sessions: Vec<SessionUiInfo>,
-    ) {
+    ) -> bool {
         session_ui_infos.sort_unstable_by(|a, b| {
             if a.is_current_session {
                 std::cmp::Ordering::Less
@@ -32,8 +33,12 @@ impl SessionList {
             }
         });
         forbidden_sessions.sort_unstable_by(|a, b| a.name.cmp(&b.name));
+        if self.session_ui_infos == session_ui_infos && self.forbidden_sessions == forbidden_sessions {
+            return false;
+        }
         self.session_ui_infos = session_ui_infos;
         self.forbidden_sessions = forbidden_sessions;
+        true
     }
     pub fn update_search_term(&mut self, search_term: &str, colors: &Colors) {
         let mut flattened_assets = self.flatten_assets(colors);

--- a/default-plugins/session-manager/src/ui/mod.rs
+++ b/default-plugins/session-manager/src/ui/mod.rs
@@ -221,7 +221,7 @@ impl SessionList {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SessionUiInfo {
     pub name: String,
     pub tabs: Vec<TabUiInfo>,
@@ -278,7 +278,7 @@ impl SessionUiInfo {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TabUiInfo {
     pub name: String,
     pub panes: Vec<PaneUiInfo>,
@@ -335,7 +335,7 @@ impl TabUiInfo {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PaneUiInfo {
     pub name: String,
     pub exit_code: Option<i32>,


### PR DESCRIPTION
This commit optimizes the 'plugin-manager' and 'session-manager' default plugins to avoid re-rendering when receiving 'SessionUpdate' events that do not contain actual state changes.

This fixes an issue where SSH connections would break with a 'broken pipe' error when the client machine sleeps for an extended period (>10 minutes).

The root cause was a constant stream of screen updates sent to all connected clients, even when they were idle. This stream was triggered by the 'ReadAllSessionInfosOnMachine' background job, which runs every second and broadcasts a 'SessionUpdate' event. Plugins subscribing to this event (like the session-manager) would request a render, causing 'render_to_clients' to send VTE bytes to the client.

When a client sleeps, it stops reading from the socket. The server's OS network buffer fills up with these 1Hz updates. Eventually, the connection times out or the buffer overflows, causing the pipe to break. When the client wakes up and tries to send a keepalive or ACK, it receives a RST.

This prevents the network buffer from filling up during sleep while maintaining a responsive experience upon wake-up.