### PR TITLE
refactor: replace nix::Error with std::io::Error in public APIs

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -5,7 +5,6 @@ use std::{fs::File, io::prelude::*, path::PathBuf, process, time::Duration};
 #[cfg(feature = "web_server_capability")]
 use isahc::{config::RedirectPolicy, prelude::*, HttpClient, Request};
 
-use nix;
 use zellij_client::{
     old_config_converter::{
         config_yaml_to_config_kdl, convert_old_yaml_files, layout_yaml_to_layout_kdl,
@@ -147,7 +146,7 @@ pub(crate) fn delete_session(target_session: &Option<String>, force: bool) {
 }
 
 fn get_os_input<OsInputOutput>(
-    fn_get_os_input: fn() -> Result<OsInputOutput, nix::Error>,
+    fn_get_os_input: fn() -> Result<OsInputOutput, std::io::Error>,
 ) -> OsInputOutput {
     match fn_get_os_input() {
         Ok(os_input) => os_input,

--- a/zellij-client/src/remote_attach/unit/remote_attach_tests.rs
+++ b/zellij-client/src/remote_attach/unit/remote_attach_tests.rs
@@ -235,7 +235,7 @@ impl crate::os_input_output::ClientOsApi for MockClientOsApi {
 
     fn set_raw_mode(&mut self, _fd: i32) {}
 
-    fn unset_raw_mode(&self, _fd: i32) -> Result<(), nix::Error> {
+    fn unset_raw_mode(&self, _fd: i32) -> Result<(), std::io::Error> {
         Ok(())
     }
 

--- a/zellij-client/src/unit/terminal_loop_tests.rs
+++ b/zellij-client/src/unit/terminal_loop_tests.rs
@@ -83,7 +83,7 @@ impl ClientOsApi for TestClientOsApi {
 
     fn set_raw_mode(&mut self, _fd: RawFd) {}
 
-    fn unset_raw_mode(&self, _fd: RawFd) -> Result<(), nix::Error> {
+    fn unset_raw_mode(&self, _fd: RawFd) -> Result<(), std::io::Error> {
         Ok(())
     }
 

--- a/zellij-client/src/web_client/unit/web_client_tests.rs
+++ b/zellij-client/src/web_client/unit/web_client_tests.rs
@@ -1895,7 +1895,7 @@ impl ClientOsApi for MockClientOsApi {
         self.terminal_size
     }
     fn set_raw_mode(&mut self, _fd: std::os::unix::io::RawFd) {}
-    fn unset_raw_mode(&self, _fd: std::os::unix::io::RawFd) -> Result<(), nix::Error> {
+    fn unset_raw_mode(&self, _fd: std::os::unix::io::RawFd) -> Result<(), std::io::Error> {
         Ok(())
     }
     fn get_stdout_writer(&self) -> Box<dyn std::io::Write> {

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -916,7 +916,7 @@ impl Clone for Box<dyn ServerOsApi> {
     }
 }
 
-pub fn get_server_os_input() -> Result<ServerOsInputOutput, nix::Error> {
+pub fn get_server_os_input() -> Result<ServerOsInputOutput, std::io::Error> {
     let current_termios = termios::tcgetattr(0).ok();
     if current_termios.is_none() {
         log::warn!("Starting a server without a controlling terminal, using the default termios configuration.");


### PR DESCRIPTION
## Summary
   - Replace `nix::Error` with `std::io::Error` in public API return types across `zellij-client` and `zellij-server`
   - This is a prerequisite for cross-platform support — `std::io::Error` is portable while `nix::Error` is Unix-only
   - No behavioral changes: `nix::Error` already converts to `std::io::Error` via `Into`

   ## Changes
   - `ClientOsApi::unset_raw_mode()`: `Result<(), nix::Error>` → `Result<(), std::io::Error>`
   - `get_client_os_input()`, `get_cli_client_os_input()`, `get_server_os_input()`: same change
   - `get_os_input()` in `commands.rs`: updated generic constraint
   - Updated all mock implementations in test files
   - Removed unused `use nix` from `commands.rs`

   ## Test plan
   - [ ] `cargo check` passes for all crates
   - [ ] All existing tests pass (no behavioral change)
   - [ ] E2E tests pass

   🤖 Generated with [Claude Code](https://claude.com/claude-code)