### PR TITLE
[Windows port PR1] refactor: replace nix::Error with std::io::Error in public APIs

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -5,7 +5,6 @@ use std::{fs::File, io::prelude::*, path::PathBuf, process, time::Duration};
 #[cfg(feature = "web_server_capability")]
 use isahc::{config::RedirectPolicy, prelude::*, HttpClient, Request};
 
-use nix;
 use zellij_client::{
     old_config_converter::{
         config_yaml_to_config_kdl, convert_old_yaml_files, layout_yaml_to_layout_kdl,
@@ -147,7 +146,7 @@ pub(crate) fn delete_session(target_session: &Option<String>, force: bool) {
 }
 
 fn get_os_input<OsInputOutput>(
-    fn_get_os_input: fn() -> Result<OsInputOutput, nix::Error>,
+    fn_get_os_input: fn() -> Result<OsInputOutput, std::io::Error>,
 ) -> OsInputOutput {
     match fn_get_os_input() {
         Ok(os_input) => os_input,

--- a/zellij-client/src/os_input_output.rs
+++ b/zellij-client/src/os_input_output.rs
@@ -127,8 +127,12 @@ fn into_raw_mode(pid: RawFd) {
     };
 }
 
-fn unset_raw_mode(pid: RawFd, orig_termios: termios::Termios) -> Result<(), nix::Error> {
-    termios::tcsetattr(pid, termios::SetArg::TCSANOW, &orig_termios)
+fn unset_raw_mode(pid: RawFd, orig_termios: termios::Termios) -> Result<(), std::io::Error> {
+    Ok(termios::tcsetattr(
+        pid,
+        termios::SetArg::TCSANOW,
+        &orig_termios,
+    )?)
 }
 
 pub(crate) fn get_terminal_size_using_fd(fd: RawFd) -> Size {
@@ -192,7 +196,7 @@ pub trait ClientOsApi: Send + Sync + std::fmt::Debug {
     fn set_raw_mode(&mut self, fd: RawFd);
     /// Set the terminal associated to file descriptor `fd` to
     /// [cooked mode](https://en.wikipedia.org/wiki/Terminal_mode).
-    fn unset_raw_mode(&self, fd: RawFd) -> Result<(), nix::Error>;
+    fn unset_raw_mode(&self, fd: RawFd) -> Result<(), std::io::Error>;
     /// Returns the writer that allows writing to standard output.
     fn get_stdout_writer(&self) -> Box<dyn io::Write>;
     /// Returns a BufReader that allows to read from STDIN line by line, also locks STDIN
@@ -239,7 +243,7 @@ impl ClientOsApi for ClientOsInputOutput {
     fn set_raw_mode(&mut self, fd: RawFd) {
         into_raw_mode(fd);
     }
-    fn unset_raw_mode(&self, fd: RawFd) -> Result<(), nix::Error> {
+    fn unset_raw_mode(&self, fd: RawFd) -> Result<(), std::io::Error> {
         match &self.orig_termios {
             Some(orig_termios) => {
                 let orig_termios = orig_termios.lock().unwrap();
@@ -417,7 +421,7 @@ impl Clone for Box<dyn ClientOsApi> {
     }
 }
 
-pub fn get_client_os_input() -> Result<ClientOsInputOutput, nix::Error> {
+pub fn get_client_os_input() -> Result<ClientOsInputOutput, std::io::Error> {
     let current_termios = termios::tcgetattr(0).ok();
     let orig_termios = current_termios.map(|termios| Arc::new(Mutex::new(termios)));
     let reading_from_stdin = Arc::new(Mutex::new(None));
@@ -430,7 +434,7 @@ pub fn get_client_os_input() -> Result<ClientOsInputOutput, nix::Error> {
     })
 }
 
-pub fn get_cli_client_os_input() -> Result<ClientOsInputOutput, nix::Error> {
+pub fn get_cli_client_os_input() -> Result<ClientOsInputOutput, std::io::Error> {
     let orig_termios = None; // not a terminal
     let reading_from_stdin = Arc::new(Mutex::new(None));
     Ok(ClientOsInputOutput {

--- a/zellij-client/src/remote_attach/unit/remote_attach_tests.rs
+++ b/zellij-client/src/remote_attach/unit/remote_attach_tests.rs
@@ -235,7 +235,7 @@ impl crate::os_input_output::ClientOsApi for MockClientOsApi {
 
     fn set_raw_mode(&mut self, _fd: i32) {}
 
-    fn unset_raw_mode(&self, _fd: i32) -> Result<(), nix::Error> {
+    fn unset_raw_mode(&self, _fd: i32) -> Result<(), std::io::Error> {
         Ok(())
     }
 

--- a/zellij-client/src/unit/terminal_loop_tests.rs
+++ b/zellij-client/src/unit/terminal_loop_tests.rs
@@ -83,7 +83,7 @@ impl ClientOsApi for TestClientOsApi {
 
     fn set_raw_mode(&mut self, _fd: RawFd) {}
 
-    fn unset_raw_mode(&self, _fd: RawFd) -> Result<(), nix::Error> {
+    fn unset_raw_mode(&self, _fd: RawFd) -> Result<(), std::io::Error> {
         Ok(())
     }
 

--- a/zellij-client/src/web_client/unit/web_client_tests.rs
+++ b/zellij-client/src/web_client/unit/web_client_tests.rs
@@ -1895,7 +1895,7 @@ impl ClientOsApi for MockClientOsApi {
         self.terminal_size
     }
     fn set_raw_mode(&mut self, _fd: std::os::unix::io::RawFd) {}
-    fn unset_raw_mode(&self, _fd: std::os::unix::io::RawFd) -> Result<(), nix::Error> {
+    fn unset_raw_mode(&self, _fd: std::os::unix::io::RawFd) -> Result<(), std::io::Error> {
         Ok(())
     }
     fn get_stdout_writer(&self) -> Box<dyn std::io::Write> {

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -916,7 +916,7 @@ impl Clone for Box<dyn ServerOsApi> {
     }
 }
 
-pub fn get_server_os_input() -> Result<ServerOsInputOutput, nix::Error> {
+pub fn get_server_os_input() -> Result<ServerOsInputOutput, std::io::Error> {
     let current_termios = termios::tcgetattr(0).ok();
     if current_termios.is_none() {
         log::warn!("Starting a server without a controlling terminal, using the default termios configuration.");


### PR DESCRIPTION
[PR 1](https://github.com/zellij-org/zellij/issues/316#issuecomment-3920047803) of the Windows port.

- Replace `nix::Error` with `std::io::Error`
- change in `zellij-client/src/os_input_output.rs` l130 is due to formatting