### PR TITLE
fix(theme::nord): unselected ribbon white -> blue

### DIFF
--- a/zellij-utils/assets/themes/nord.kdl
+++ b/zellij-utils/assets/themes/nord.kdl
@@ -25,12 +25,12 @@ themes {
             emphasis_3 129 161 193
         }
         ribbon_unselected {
-            base 59 66 82
-            background 216 222 233
+            base 46 52 64
+            background 129 161 193
             emphasis_0 191 97 106
-            emphasis_1 229 233 240
-            emphasis_2 129 161 193
-            emphasis_3 180 142 173
+            emphasis_1 136 192 208
+            emphasis_2 180 142 173
+            emphasis_3 163 190 140
         }
         table_title {
             base 163 190 140


### PR DESCRIPTION
Hi,

I allowed myself to replace the nord-theme -> unsel ribbon -> white bg color, since it is kinda, meh and much too bright, also cause the code on the screen is white, my / your eyes are constantly glancing over the not-so-important tab bar.

This gets esp. annoying on the simple ui, cause now you have this, rather ugly white block staring at you.

<img width="216" height="23" alt="Screenshot From 2026-02-20 05-23-52" src="https://github.com/user-attachments/assets/8df2996c-623c-491b-850e-cffac8eb01a2" />
<img width="696" height="23" alt="Screenshot From 2026-02-20 05-24-32" src="https://github.com/user-attachments/assets/8dc5aa69-2774-48e5-801a-b25473fb3632" />

I replaced it with this based blue.
<img width="202" height="25" alt="Screenshot From 2026-02-20 07-02-11" src="https://github.com/user-attachments/assets/02b003c1-c821-4ce4-b45d-1f1fb61fa870" />
<img width="322" height="25" alt="Screenshot From 2026-02-20 07-20-37" src="https://github.com/user-attachments/assets/5019ff9f-9e96-4a71-ada7-24d397d97393" />

Overall, a big W for the team.
