### PR TITLE
[Windows port PR4] refactor: split client signal handling into platform files

### DIFF
--- a/zellij-client/Cargo.toml
+++ b/zellij-client/Cargo.toml
@@ -36,7 +36,6 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { version = "0.8", default-features = false }
-signal-hook = { workspace = true }
 termwiz = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
@@ -48,6 +47,9 @@ isahc = { workspace = true }
 tokio-tungstenite = { version = "0.20", features = ["native-tls"] } #TODO: see about this native-tls...
 futures-util = "0.3"
 urlencoding = "2.1"
+
+[target.'cfg(not(windows))'.dependencies]
+signal-hook = { workspace = true }
 
 [dev-dependencies]
 insta = "1.6.0"

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -1,5 +1,12 @@
 pub mod os_input_output;
 
+#[cfg(not(windows))]
+#[path = "os_input_output_unix.rs"]
+mod os_input_output_unix;
+#[cfg(windows)]
+#[path = "os_input_output_windows.rs"]
+mod os_input_output_windows;
+
 pub mod cli_client;
 mod command_is_executing;
 mod input_handler;

--- a/zellij-client/src/os_input_output.rs
+++ b/zellij-client/src/os_input_output.rs
@@ -1,11 +1,14 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use interprocess;
-use signal_hook;
 use zellij_utils::pane_size::Size;
 
+#[cfg(not(windows))]
+use crate::os_input_output_unix::{AsyncSignalListener, BlockingSignalIterator};
+#[cfg(windows)]
+use crate::os_input_output_windows::{AsyncSignalListener, BlockingSignalIterator};
+
 use interprocess::local_socket::LocalSocketStream;
-use signal_hook::{consts::signal::*, iterator::Signals};
 use std::io::prelude::*;
 use std::io::IsTerminal;
 use std::path::Path;
@@ -63,53 +66,6 @@ pub enum SignalEvent {
 #[async_trait]
 pub trait AsyncSignals: Send {
     async fn recv(&mut self) -> Option<SignalEvent>;
-}
-
-pub struct AsyncSignalListener {
-    sigwinch: tokio::signal::unix::Signal,
-    sigterm: tokio::signal::unix::Signal,
-    sigint: tokio::signal::unix::Signal,
-    sigquit: tokio::signal::unix::Signal,
-    sighup: tokio::signal::unix::Signal,
-}
-
-impl AsyncSignalListener {
-    pub fn new() -> io::Result<Self> {
-        use tokio::signal::unix::{signal, SignalKind};
-        Ok(Self {
-            sigwinch: signal(SignalKind::window_change())?,
-            sigterm: signal(SignalKind::terminate())?,
-            sigint: signal(SignalKind::interrupt())?,
-            sigquit: signal(SignalKind::quit())?,
-            sighup: signal(SignalKind::hangup())?,
-        })
-    }
-
-    pub async fn recv_resize(&mut self) -> Option<()> {
-        self.sigwinch.recv().await
-    }
-
-    pub async fn recv_quit(&mut self) -> Option<()> {
-        tokio::select! {
-            result = self.sigterm.recv() => result,
-            result = self.sigint.recv() => result,
-            result = self.sigquit.recv() => result,
-            result = self.sighup.recv() => result,
-        }
-    }
-}
-
-#[async_trait]
-impl AsyncSignals for AsyncSignalListener {
-    async fn recv(&mut self) -> Option<SignalEvent> {
-        tokio::select! {
-            result = self.sigwinch.recv() => result.map(|_| SignalEvent::Resize),
-            result = self.sigterm.recv() => result.map(|_| SignalEvent::Quit),
-            result = self.sigint.recv() => result.map(|_| SignalEvent::Quit),
-            result = self.sigquit.recv() => result.map(|_| SignalEvent::Quit),
-            result = self.sighup.recv() => result.map(|_| SignalEvent::Quit),
-        }
-    }
 }
 
 pub(crate) fn get_terminal_size() -> Size {
@@ -282,10 +238,10 @@ impl ClientOsApi for ClientOsInputOutput {
     }
     fn handle_signals(&self, sigwinch_cb: Box<dyn Fn()>, quit_cb: Box<dyn Fn()>) {
         let mut sigwinch_cb_timestamp = time::Instant::now();
-        let mut signals = Signals::new(&[SIGWINCH, SIGTERM, SIGINT, SIGQUIT, SIGHUP]).unwrap();
-        for signal in signals.forever() {
-            match signal {
-                SIGWINCH => {
+        let signals = BlockingSignalIterator::new().unwrap();
+        for event in signals {
+            match event {
+                SignalEvent::Resize => {
                     // throttle sigwinch_cb calls, reduce excessive renders while resizing
                     if sigwinch_cb_timestamp.elapsed() < SIGWINCH_CB_THROTTLE_DURATION {
                         thread::sleep(SIGWINCH_CB_THROTTLE_DURATION);
@@ -293,11 +249,10 @@ impl ClientOsApi for ClientOsInputOutput {
                     sigwinch_cb_timestamp = time::Instant::now();
                     sigwinch_cb();
                 },
-                SIGTERM | SIGINT | SIGQUIT | SIGHUP => {
+                SignalEvent::Quit => {
                     quit_cb();
                     break;
                 },
-                _ => unreachable!(),
             }
         }
     }

--- a/zellij-client/src/os_input_output_unix.rs
+++ b/zellij-client/src/os_input_output_unix.rs
@@ -1,0 +1,70 @@
+use crate::os_input_output::SignalEvent;
+
+use async_trait::async_trait;
+use signal_hook::consts::signal::*;
+use signal_hook::iterator::Signals;
+use tokio::signal::unix::{signal, SignalKind};
+
+use std::io;
+
+/// Async signal listener that maps Unix signals to `SignalEvent` variants.
+pub(crate) struct AsyncSignalListener {
+    sigwinch: tokio::signal::unix::Signal,
+    sigterm: tokio::signal::unix::Signal,
+    sigint: tokio::signal::unix::Signal,
+    sigquit: tokio::signal::unix::Signal,
+    sighup: tokio::signal::unix::Signal,
+}
+
+impl AsyncSignalListener {
+    pub fn new() -> io::Result<Self> {
+        Ok(Self {
+            sigwinch: signal(SignalKind::window_change())?,
+            sigterm: signal(SignalKind::terminate())?,
+            sigint: signal(SignalKind::interrupt())?,
+            sigquit: signal(SignalKind::quit())?,
+            sighup: signal(SignalKind::hangup())?,
+        })
+    }
+}
+
+#[async_trait]
+impl crate::os_input_output::AsyncSignals for AsyncSignalListener {
+    async fn recv(&mut self) -> Option<SignalEvent> {
+        tokio::select! {
+            result = self.sigwinch.recv() => result.map(|_| SignalEvent::Resize),
+            result = self.sigterm.recv() => result.map(|_| SignalEvent::Quit),
+            result = self.sigint.recv() => result.map(|_| SignalEvent::Quit),
+            result = self.sigquit.recv() => result.map(|_| SignalEvent::Quit),
+            result = self.sighup.recv() => result.map(|_| SignalEvent::Quit),
+        }
+    }
+}
+
+/// Blocking signal iterator that maps Unix signals to `SignalEvent` variants.
+/// Used by `handle_signals()` on a dedicated thread.
+pub(crate) struct BlockingSignalIterator {
+    signals: Signals,
+}
+
+impl BlockingSignalIterator {
+    pub fn new() -> io::Result<Self> {
+        let signals = Signals::new([SIGWINCH, SIGTERM, SIGINT, SIGQUIT, SIGHUP])?;
+        Ok(Self { signals })
+    }
+}
+
+impl Iterator for BlockingSignalIterator {
+    type Item = SignalEvent;
+
+    fn next(&mut self) -> Option<SignalEvent> {
+        for signal in self.signals.forever() {
+            match signal {
+                SIGWINCH => return Some(SignalEvent::Resize),
+                SIGTERM | SIGINT | SIGQUIT | SIGHUP => return Some(SignalEvent::Quit),
+                _ => {},
+            }
+        }
+        None
+    }
+}

--- a/zellij-client/src/os_input_output_windows.rs
+++ b/zellij-client/src/os_input_output_windows.rs
@@ -1,0 +1,38 @@
+use crate::os_input_output::SignalEvent;
+
+use async_trait::async_trait;
+
+use std::io;
+
+/// Windows async signal listener stub. Not yet implemented.
+pub(crate) struct AsyncSignalListener;
+
+impl AsyncSignalListener {
+    pub fn new() -> io::Result<Self> {
+        unimplemented!("Windows AsyncSignalListener not yet implemented")
+    }
+}
+
+#[async_trait]
+impl crate::os_input_output::AsyncSignals for AsyncSignalListener {
+    async fn recv(&mut self) -> Option<SignalEvent> {
+        unimplemented!("Windows AsyncSignalListener not yet implemented")
+    }
+}
+
+/// Windows blocking signal iterator stub. Not yet implemented.
+pub(crate) struct BlockingSignalIterator;
+
+impl BlockingSignalIterator {
+    pub fn new() -> io::Result<Self> {
+        unimplemented!("Windows BlockingSignalIterator not yet implemented")
+    }
+}
+
+impl Iterator for BlockingSignalIterator {
+    type Item = SignalEvent;
+
+    fn next(&mut self) -> Option<SignalEvent> {
+        unimplemented!("Windows BlockingSignalIterator not yet implemented")
+    }
+}


### PR DESCRIPTION
[PR4](https://github.com/zellij-org/zellij/issues/316#issuecomment-3920047803) of the Windows port.

Extract signal handling from os_input_output.rs into platform-specific files, mirroring the server-side architecture from PR3:

- os_input_output_unix.rs: AsyncSignalListener (tokio unix signals), BlockingSignalIterator (signal_hook)
- os_input_output_windows.rs: stubs (unimplemented)
- os_input_output.rs: shared SignalEvent enum, AsyncSignals trait, handle_signals() now uses BlockingSignalIterator + SignalEvent

Moved signal-hook to cfg(unix)-only dependency in zellij-client.