### PR TITLE
fix: prevent watchers from stealing renders from non-watchers

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1706,6 +1706,8 @@ impl Screen {
         // Track whether non-watcher output was dirty for conditional watcher rendering
         let non_watcher_output_was_dirty;
 
+        let mut tabs_to_close = vec![];
+
         // === PHASE 1: Render for regular clients ===
         if has_regular_clients {
             let mut output = Output::new(
@@ -1715,7 +1717,6 @@ impl Screen {
                 self.osc8_hyperlinks,
             );
 
-            let mut tabs_to_close = vec![];
             for (tab_index, tab) in &mut self.tabs {
                 if tab.has_selectable_tiled_panes() {
                     // Pass None for normal client rendering
@@ -1723,11 +1724,6 @@ impl Screen {
                 } else if !tab.is_pending() {
                     tabs_to_close.push(*tab_index);
                 }
-            }
-            for tab_index in tabs_to_close {
-                self.close_tab_by_id(tab_index)
-                    .context(err_context)
-                    .non_fatal();
             }
 
             let pane_render_report = output.drain_pane_render_report();
@@ -1823,6 +1819,11 @@ impl Screen {
                     }
                 }
             }
+        }
+        for tab_index in tabs_to_close {
+            self.close_tab_by_id(tab_index)
+                .context(err_context)
+                .non_fatal();
         }
 
         Ok(())


### PR DESCRIPTION
This fixes a minor issue with the yet-to-be-introduced "watcher" feature, where if a tab would be closed in the render function (as a cleanup mechanism if it's dead) watchers would "steal" renders from non-watcher clients. This was happening because the tab would be closed *before* watchers would get their rendered assets, and so the watcher would get the new non-closed tab rendered to them before the non-watcher had time to render it, thus stealing the render and leaving garbage on the non-watcher client's screen.