### PR TITLE
fix(render): restore cursor position during mid-frame for macOS IME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+* fix: IME candidate window now appears near cursor position on macOS/Alacritty when using apps with synchronized output mode (ESC[?2026h) - during mid-frame rendering, restore last cached cursor position (without showing cursor) so host terminal always has correct position for OS IME system
 * fix: meta key handling in web client (https://github.com/zellij-org/zellij/pull/4376)
 * refactor: move logical structures from client to server (https://github.com/zellij-org/zellij/pull/4383)
 * fix: make sessions compatible across versions (https://github.com/zellij-org/zellij/pull/4439)


### PR DESCRIPTION
## Problem

On macOS + Alacritty + zellij, the IME candidate window appears at the bottom-right corner of the screen instead of near the cursor when typing Japanese (or other IME input) in apps like Neovim.

## Root Cause

TUI apps like Neovim wrap each frame update with synchronized output mode (`ESC[?2026h` ... `ESC[?2026l`). During mid-frame rendering (`lock_renders = true`), `render_cursor()` was a complete no-op — it did not emit any cursor position escape sequence.

This means the host terminal's (Alacritty's) internal cursor position ends up wherever the last character chunk was written, which is often near the bottom-right of the screen. When the user activates IME, Alacritty reports this wrong position to the macOS IME system, causing the candidate window to appear at the bottom-right.

## Fix

During mid-frame, instead of doing nothing, emit `ESC[row;colH` (cursor position only, no visibility change) using the last known stable cursor position from `cursor_positions_and_shape` cache.

- **No visual change**: cursor remains hidden (`ESC[?25l` is still emitted in pre_vte)
- **IME fix**: host terminal's internal cursor position is kept at the correct location
- **Conservative**: if the cache is empty (very first frame is mid-frame), falls back to the previous no-op behavior

## Testing

```bash
cargo test -p zellij-server
```

Manual: macOS + Alacritty → open zellij → open Neovim → Insert mode → activate IME → confirm candidate window appears near cursor (not bottom-right).