### PR TITLE
fix: forward unbound keys in Normal mode regardless of default input mode

### DIFF
--- a/zellij-utils/src/input/keybinds.rs
+++ b/zellij-utils/src/input/keybinds.rs
@@ -76,11 +76,20 @@ impl Keybinds {
         key_is_kitty_protocol: bool,
     ) -> Action {
         match *mode {
+            // In Locked mode, unbound keys are always forwarded to the pane
             InputMode::Locked => Action::Write {
                 key_with_modifier: key_with_modifier.cloned(),
                 bytes: raw_bytes,
                 is_kitty_keyboard_protocol: key_is_kitty_protocol,
             },
+            // In Normal mode, unbound keys are always forwarded to the pane
+            // (regardless of whether Normal is the default_input_mode)
+            InputMode::Normal => Action::Write {
+                key_with_modifier: key_with_modifier.cloned(),
+                bytes: raw_bytes,
+                is_kitty_keyboard_protocol: key_is_kitty_protocol,
+            },
+            // In the user's configured default input mode, forward unbound keys
             mode if mode == default_input_mode => Action::Write {
                 key_with_modifier: key_with_modifier.cloned(),
                 bytes: raw_bytes,


### PR DESCRIPTION
When users configure Zellij with clear-defaults=true and set Locked as their default_input_mode, unbound keys in Normal mode were being silently consumed (NoOp) instead of forwarded to the pane.

This happened because default_action_for_mode() only forwarded unbound keys when in Locked mode OR when the current mode equaled the user's default_input_mode. When default_input_mode was Locked, Normal mode fell through to NoOp.

Now Normal mode explicitly forwards unbound keys to the pane, matching the documented behavior that "input is always written to the terminal, except for the shortcuts leading to other modes."

Fixes: https://github.com/zellij-org/zellij/issues/775#issuecomment-2472786982