### PR TITLE
feat: enhance shell completions for zellij(bash, zsh, fish)

### DIFF
--- a/zellij-utils/assets/completions/comp.bash
+++ b/zellij-utils/assets/completions/comp.bash
@@ -1,13 +1,78 @@
+__zellij_session_subcommands="attach a kill-session k watch w delete-session d"
+__zellij_completion_shells="bash elvish fish zsh powershell"
+
+# This file is appended after clap output. Keep clap's original _zellij
+# completer so we can delegate all non-dynamic contexts to it.
+if declare -F _zellij >/dev/null 2>&1; then
+  __zellij_clap_def="$(declare -f _zellij)"
+  __zellij_clap_def="${__zellij_clap_def/#_zellij/__zellij_clap_complete}"
+  eval "${__zellij_clap_def}"
+  unset __zellij_clap_def
+fi
+
+function _zellij () {
+  local cur prev i word
+  local sessions
+  local has_session_subcommand=0
+  local has_setup=0
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=()
+
+  # Inspect already typed words (excluding the current one) to detect context.
+  for (( i = 1; i < COMP_CWORD; i++ )); do
+    word="${COMP_WORDS[i]}"
+    case "${word}" in
+      setup)
+        has_setup=1
+      ;;
+    esac
+    case " ${__zellij_session_subcommands} " in
+      *" ${word} "*)
+        has_session_subcommand=1
+      ;;
+    esac
+  done
+
+  # Keep the previous token handy for option-value completion.
+  prev=""
+  if (( COMP_CWORD > 0 )); then
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+  fi
+
+  # Keep dynamic value completion for setup --generate-completion.
+  if (( has_setup )) && [ "${prev}" = "--generate-completion" ]; then
+    COMPREPLY=($(compgen -W "${__zellij_completion_shells}" -- "${cur}"))
+    return 0
+  fi
+
+  # Session names are dynamic. Prefer them for non-option argument positions.
+  if (( has_session_subcommand )) && [[ "${cur}" != -* ]]; then
+    sessions="$(zellij list-sessions --short --no-formatting 2>/dev/null)"
+    COMPREPLY=($(compgen -W "${sessions}" -- "${cur}"))
+    return 0
+  fi
+
+  # Fallback to clap-generated completion for subcommands, flags and options.
+  if declare -F __zellij_clap_complete >/dev/null 2>&1; then
+    __zellij_clap_complete "$@"
+    return $?
+  fi
+
+  return 0
+}
+
+complete -F _zellij zellij
+
 function zr () { zellij run --name "$*" -- bash -ic "$*";}
 function zrf () { zellij run --name "$*" --floating -- bash -ic "$*";}
 function zri () { zellij run --name "$*" --in-place -- bash -ic "$*";}
 function ze () { zellij edit "$*";}
 function zef () { zellij edit --floating "$*";}
 function zei () { zellij edit --in-place "$*";}
-function zpipe () { 
+function zpipe () {
   if [ -z "$1" ]; then
     zellij pipe;
-  else 
+  else
     zellij pipe -p $1;
   fi
 }

--- a/zellij-utils/assets/completions/comp.fish
+++ b/zellij-utils/assets/completions/comp.fish
@@ -1,11 +1,12 @@
+set -g __zellij_session_subcommands attach a kill-session k watch w delete-session d
+set -g __zellij_completion_shells bash elvish fish zsh powershell
+
 function __fish_complete_sessions
     zellij list-sessions --short --no-formatting 2>/dev/null
 end
-complete -c zellij -n "__fish_seen_subcommand_from attach" -f -a "(__fish_complete_sessions)" -d "Session"
-complete -c zellij -n "__fish_seen_subcommand_from a" -f -a "(__fish_complete_sessions)" -d "Session"
-complete -c zellij -n "__fish_seen_subcommand_from kill-session" -f -a "(__fish_complete_sessions)" -d "Session"
-complete -c zellij -n "__fish_seen_subcommand_from k" -f -a "(__fish_complete_sessions)" -d "Session"
-complete -c zellij -n "__fish_seen_subcommand_from setup" -l "generate-completion" -x -a "bash elvish fish zsh powershell" -d "Shell"
+
+complete -c zellij -n "__fish_seen_subcommand_from $__zellij_session_subcommands" -f -a "(__fish_complete_sessions)" -d "Session"
+complete -c zellij -n "__fish_seen_subcommand_from setup" -l "generate-completion" -x -a "$__zellij_completion_shells" -d "Shell"
 function zr
   command zellij run --name "$argv" -- fish -c "$argv"
 end

--- a/zellij-utils/assets/completions/comp.zsh
+++ b/zellij-utils/assets/completions/comp.zsh
@@ -1,13 +1,73 @@
+typeset -ga __zellij_session_subcommands
+__zellij_session_subcommands=(attach a kill-session k watch w delete-session d)
+
+typeset -ga __zellij_completion_shells
+__zellij_completion_shells=(bash elvish fish zsh powershell)
+
+# This file is appended after clap output. Preserve clap's original _zellij
+# completer so we can delegate non-dynamic contexts to it.
+if (( $+functions[_zellij] )); then
+  functions[__zellij_clap_complete]="${functions[_zellij]}"
+fi
+
+function _zellij () {
+  local -a sessions
+  local cur word
+  local i has_session_subcommand=0 has_setup=0
+  cur="${words[CURRENT]}"
+
+  # Inspect already typed words (excluding the current one) to detect context.
+  for (( i = 2; i < CURRENT; i++ )); do
+    word="${words[i]}"
+    case "${word}" in
+      setup)
+        has_setup=1
+      ;;
+    esac
+    if (( ${__zellij_session_subcommands[(I)$word]} )); then
+      has_session_subcommand=1
+    fi
+  done
+
+  # Keep dynamic value completion for setup --generate-completion.
+  if (( has_setup )) && (( CURRENT > 1 )) && [[ "${words[CURRENT-1]}" == "--generate-completion" ]]; then
+    compadd -- "${__zellij_completion_shells[@]}"
+    return 0
+  fi
+
+  # Session names are dynamic. Prefer them for non-option argument positions.
+  if (( has_session_subcommand )) && [[ "${cur}" != -* ]]; then
+    sessions=("${(@f)$(zellij list-sessions --short --no-formatting 2>/dev/null)}")
+    (( ${#sessions[@]} )) && compadd -- "${sessions[@]}"
+    return 0
+  fi
+
+  # Fallback to clap-generated completion for subcommands, flags and options.
+  if (( $+functions[__zellij_clap_complete] )); then
+    __zellij_clap_complete "$@"
+    return $?
+  fi
+
+  return 0
+}
+
+if (( $+functions[compdef] )); then
+  compdef _zellij zellij
+fi
+
+# Convenience wrappers for running/editing commands in zellij panes.
 function zr () { zellij run --name "$*" -- zsh -ic "$*";}
 function zrf () { zellij run --name "$*" --floating -- zsh -ic "$*";}
 function zri () { zellij run --name "$*" --in-place -- zsh -ic "$*";}
 function ze () { zellij edit "$*";}
 function zef () { zellij edit --floating "$*";}
 function zei () { zellij edit --in-place "$*";}
-function zpipe () { 
+
+# Pipe helper: with argument -> `-p <alias>`, without argument -> plain `pipe`.
+function zpipe () {
   if [ -z "$1" ]; then
     zellij pipe;
-  else 
+  else
     zellij pipe -p $1;
   fi
 }

--- a/zellij-utils/assets/completions/test_comp.py
+++ b/zellij-utils/assets/completions/test_comp.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Behavior tests for zellij completion assets (bash, zsh and fish).
+
+Run directly:
+  python3 test_comp.py
+  python3 test_comp.py --shell fish
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+COMP_FILES = {
+    "bash": SCRIPT_DIR / "comp.bash",
+    "zsh": SCRIPT_DIR / "comp.zsh",
+    "fish": SCRIPT_DIR / "comp.fish",
+}
+
+DEFAULT_SESSIONS = ["vitreous-galaxy", "work", "alpha"]
+_active_shell = "bash"
+
+
+class TestFailure(AssertionError):
+    pass
+
+
+def _quote_words(words: Iterable[str]) -> str:
+    return " ".join(shlex.quote(w) for w in words)
+
+
+def _run_bash(words: Sequence[str], sessions: list[str]) -> list[str]:
+    words_expr = _quote_words(words)
+    sessions_lines = "".join(
+        f"    printf '%s\\n' {shlex.quote(s)}\n" for s in sessions
+    )
+    if not sessions_lines:
+        sessions_lines = "    :\n"
+
+    line = " ".join(words)
+    script = f"""
+source {shlex.quote(str(COMP_FILES['bash']))}
+
+zellij() {{
+  if [ "$1" = "list-sessions" ]; then
+{sessions_lines}  fi
+}}
+
+COMP_WORDS=({words_expr})
+COMP_CWORD=$((${{#COMP_WORDS[@]}} - 1))
+COMP_LINE={shlex.quote(line)}
+COMP_POINT=${{#COMP_LINE}}
+COMPREPLY=()
+_zellij zellij
+printf '%s\\n' "${{COMPREPLY[@]}}"
+"""
+
+    result = subprocess.run(
+        ["bash", "--noprofile", "--norc", "-c", script],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise TestFailure(
+            f"bash scenario failed\\nwords={words}\\n"
+            f"stdout:\\n{result.stdout}\\nstderr:\\n{result.stderr}\\n"
+        )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def _run_zsh(words: Sequence[str], sessions: list[str]) -> list[str]:
+    words_expr = " ".join(shlex.quote(w) for w in words)
+    sessions_arr = " ".join(shlex.quote(s) for s in sessions)
+
+    script = f"""
+emulate -L zsh
+
+typeset -ga __collected
+__collected=()
+typeset -ga words
+words=(zellij "")
+CURRENT=${{#words}}
+
+# Collect candidates and apply simple prefix filtering.
+compadd() {{
+  while [[ $# -gt 0 && "$1" != "--" ]]; do shift; done
+  [[ "$1" == "--" ]] && shift
+  local __prefix="${{words[CURRENT]}}"
+  local __w
+  for __w in "$@"; do
+    [[ -z "$__prefix" || "$__w" == "${{__prefix}}"* ]] && __collected+=("$__w")
+  done
+}}
+
+source {shlex.quote(str(COMP_FILES['zsh']))}
+
+zellij() {{
+  if [[ "$1" == "list-sessions" ]]; then
+    local __s
+    for __s in {sessions_arr}; do
+      print -r -- "$__s"
+    done
+  fi
+}}
+
+words=({words_expr})
+CURRENT=${{#words}}
+__collected=()
+
+_zellij
+
+printf '%s\\n' "${{__collected[@]}}"
+"""
+
+    result = subprocess.run(
+        ["zsh", "--no-rcs", "-c", script],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise TestFailure(
+            f"zsh scenario failed\\nwords={words}\\n"
+            f"stdout:\\n{result.stdout}\\nstderr:\\n{result.stderr}\\n"
+        )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def _run_fish(words: Sequence[str], sessions: list[str]) -> list[str]:
+    sessions_echo = "\n".join(f"        echo {shlex.quote(s)}" for s in sessions)
+    if not sessions_echo:
+        sessions_echo = "        true"
+
+    if words[-1] == "":
+        cmdline = " ".join(words[:-1]) + " "
+    else:
+        cmdline = " ".join(words)
+
+    script = f"""
+function zellij
+    if test "$argv[1]" = "list-sessions"
+{sessions_echo}
+    end
+end
+
+source {shlex.quote(str(COMP_FILES['fish']))}
+
+complete -C {shlex.quote(cmdline)}
+"""
+
+    result = subprocess.run(
+        ["fish", "--no-config", "-c", script],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise TestFailure(
+            f"fish scenario failed\\nwords={words}\\n"
+            f"stdout:\\n{result.stdout}\\nstderr:\\n{result.stderr}\\n"
+        )
+
+    completions: list[str] = []
+    for line in result.stdout.splitlines():
+        if line:
+            completions.append(line.split("\t")[0])
+    return completions
+
+
+def run_completion(words: Sequence[str], sessions: Sequence[str] | None = None) -> list[str]:
+    ss = list(sessions) if sessions is not None else list(DEFAULT_SESSIONS)
+    if _active_shell == "fish":
+        return _run_fish(words, ss)
+    if _active_shell == "zsh":
+        return _run_zsh(words, ss)
+    return _run_bash(words, ss)
+
+
+@dataclass
+class Case:
+    words: Sequence[str]
+    expected: Sequence[str] | None = None
+    sessions: Sequence[str] | None = None
+    contains: Sequence[str] = ()
+    excludes: Sequence[str] = ()
+    sort: bool = False
+    shells: tuple[str, ...] = ("bash", "zsh", "fish")
+
+    def _ctx(self, shell: str) -> str:
+        parts = [f"  shell:        {shell}", f"  words:        {list(self.words)}"]
+        if self.sessions is not None:
+            parts.append(f"  sessions:     {list(self.sessions)}")
+        return "\n".join(parts)
+
+    @property
+    def label(self) -> str:
+        return " ".join(self.words)
+
+    def run(self, shell: str) -> None:
+        completions = run_completion(self.words, self.sessions)
+
+        if self.expected is not None:
+            actual = sorted(completions) if self.sort else completions
+            expected = sorted(self.expected) if self.sort else list(self.expected)
+            if actual != expected:
+                raise TestFailure(
+                    f"exact match failed\\n{self._ctx(shell)}\\n"
+                    f"  expected: {expected}\\n  actual:   {actual}"
+                )
+
+        for item in self.excludes:
+            if item in completions:
+                raise TestFailure(
+                    f"unexpected item {item!r} present\\n{self._ctx(shell)}\\n"
+                    f"  actual: {completions}"
+                )
+
+        missing = [item for item in self.contains if item not in completions]
+        if missing:
+            raise TestFailure(
+                f"missing items\\n{self._ctx(shell)}\\n"
+                f"  missing:  {missing}\\n  actual:   {completions}"
+            )
+
+
+CASES: list[Case] = [
+    # Session completion in target subcommands.
+    Case(["zellij", "attach", "v"], ["vitreous-galaxy"]),
+    Case(["zellij", "a", "w"], ["work"]),
+    Case(["zellij", "kill-session", "w"], ["work"]),
+    Case(["zellij", "k", "w"], ["work"]),
+    Case(["zellij", "watch", "a"], ["alpha"]),
+    Case(["zellij", "w", "a"], ["alpha"]),
+    Case(["zellij", "delete-session", "v"], ["vitreous-galaxy"]),
+    Case(["zellij", "d", "v"], ["vitreous-galaxy"]),
+    Case(["zellij", "--debug", "attach", "w"], ["work"]),
+    Case(["zellij", "attach", ""], ["alpha", "vitreous-galaxy", "work"], sort=True),
+    # Non-target context does not complete sessions.
+    Case(["zellij", "ls", "v"], None, excludes=["vitreous-galaxy", "work", "alpha"]),
+    Case(["zellij", "setup", ""], None, excludes=["vitreous-galaxy", "work", "alpha"]),
+    Case(["zellij", ""], None, excludes=["vitreous-galaxy", "work", "alpha"]),
+    # setup --generate-completion value completion.
+    Case(["zellij", "setup", "--generate-completion", "b"], ["bash"]),
+    Case(
+        ["zellij", "setup", "--generate-completion", ""],
+        ["bash", "elvish", "fish", "zsh", "powershell"],
+        sort=True,
+    ),
+    # Custom session fixtures.
+    Case(["zellij", "attach", "work"], ["work", "work-dev"], sessions=["work", "work-dev", "alpha"]),
+    Case(["zellij", "k", "x"], [], sessions=["work", "alpha"]),
+]
+
+
+def test_user_requested_assertion_format() -> None:
+    completions = run_completion(["zellij", "a", "v"])
+    if len(completions) != 1:
+        raise TestFailure(f"zellij a v<TAB> should yield 1 completion, got {completions}")
+    if f"zellij a {completions[0]}" != "zellij a vitreous-galaxy":
+        raise TestFailure(
+            f"expected 'zellij a vitreous-galaxy', got 'zellij a {completions[0]}'"
+        )
+
+
+def run_suite(selected: str, shells: list[str]) -> int:
+    global _active_shell
+
+    failures: list[tuple[str, str]] = []
+    ran = 0
+
+    for shell in shells:
+        _active_shell = shell
+        print(f"\n--- {shell} ---")
+
+        for i, case in enumerate(CASES, 1):
+            if shell not in case.shells:
+                continue
+            label = f"[{shell}] case {i}: {case.label}"
+            if selected != "all" and selected not in label:
+                continue
+            ran += 1
+            try:
+                case.run(shell)
+                print(f"  PASS: case {i}: {case.label}")
+            except Exception as exc:  # noqa: BLE001 - test runner
+                failures.append((label, str(exc)))
+                print(f"  FAIL: case {i}: {case.label}")
+                print(exc, file=sys.stderr)
+
+        label = f"[{shell}] user requested assertion format"
+        if selected == "all" or selected in label:
+            ran += 1
+            try:
+                test_user_requested_assertion_format()
+                print("  PASS: user requested assertion format")
+            except Exception as exc:  # noqa: BLE001 - test runner
+                failures.append((label, str(exc)))
+                print("  FAIL: user requested assertion format")
+                print(exc, file=sys.stderr)
+
+    if failures:
+        print(f"\n{len(failures)} failure(s).", file=sys.stderr)
+        return 1
+
+    print(f"\nAll {ran} test(s) passed.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--shell",
+        choices=["bash", "zsh", "fish", "all"],
+        default="all",
+        help="which shell to test (default: all)",
+    )
+    parser.add_argument(
+        "--only",
+        default="all",
+        help="substring filter for test names (default: all)",
+    )
+    args = parser.parse_args()
+
+    shells = ["bash", "zsh", "fish"] if args.shell == "all" else [args.shell]
+    for shell in shells:
+        if not COMP_FILES[shell].exists():
+            print(f"FAIL: completion file not found: {COMP_FILES[shell]}", file=sys.stderr)
+            return 1
+
+    return run_suite(args.only, shells)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
1. Implement session completions for bash and zsh, which I frequently use. e.g. `zellij attach b<tab>` -> `zellij attach brave-lemon`
2. Optimize fish shell completion scripts.
3. Add a test script for these three shells(for behavior checking and alignment).
![20260302-192520](https://github.com/user-attachments/assets/5d7793fe-a685-4b1f-a285-8425db5e7352)
![20260302-204847](https://github.com/user-attachments/assets/952cd371-ce88-410f-b224-c81e78530d96)
