### PR TITLE
fix: session names exceeding socket path limit hang instead of erroring

### DIFF
--- a/default-plugins/session-manager/src/main.rs
+++ b/default-plugins/session-manager/src/main.rs
@@ -492,12 +492,9 @@ impl State {
     fn handle_selection(&mut self) {
         match self.active_screen {
             ActiveScreen::NewSession => {
-                if self.new_session_info.name().len() >= 108 {
-                    // this is due to socket path limitations
-                    // TODO: get this from Zellij (for reference: this is part of the interprocess
-                    // package, we should get if from there if possible because it's configurable
-                    // through the package)
-                    self.show_error("Session name must be shorter than 108 bytes");
+                if self.new_session_info.name().len() >= 80 {
+                    // conservative guard; the server does the exact socket path validation
+                    self.show_error("Session name is too long (must be under 80 characters)");
                     return;
                 } else if self.new_session_info.name().contains('/') {
                     self.show_error("Session name cannot contain '/'");

--- a/zellij-client/src/os_input_output.rs
+++ b/zellij-client/src/os_input_output.rs
@@ -260,18 +260,23 @@ impl ClientOsApi for ClientOsInputOutput {
         let fs_name = path
             .to_fs_name::<GenericFilePath>()
             .expect("failed to convert path to socket name");
-        let socket;
-        loop {
+        let timeout = std::time::Duration::from_secs(10);
+        let start = std::time::Instant::now();
+        let socket = loop {
             match LocalSocketStream::connect(fs_name.clone()) {
-                Ok(sock) => {
-                    socket = sock;
-                    break;
-                },
-                Err(_) => {
+                Ok(sock) => break sock,
+                Err(e) => {
+                    if start.elapsed() >= timeout {
+                        eprintln!(
+                            "Failed to connect to server at {:?} after {:?}: {}",
+                            path, timeout, e,
+                        );
+                        std::process::exit(1);
+                    }
                     std::thread::sleep(std::time::Duration::from_millis(50));
                 },
             }
-        }
+        };
         let sender = IpcSenderWithContext::new(socket);
         let receiver = sender.get_receiver();
         *self.send_instructions_to_server.lock().unwrap() = Some(sender);

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -19,14 +19,15 @@ fn validate_session(name: &str) -> Result<String, String> {
         socket_path.push(name);
 
         if socket_path.as_os_str().len() >= ZELLIJ_SOCK_MAX_LENGTH {
-            // socket path must be less than 108 bytes
+            let sock_dir = crate::consts::ZELLIJ_SOCK_DIR.as_os_str().len();
+            // +1 for the path separator between directory and session name
             let available_length = ZELLIJ_SOCK_MAX_LENGTH
-                .saturating_sub(socket_path.as_os_str().len())
+                .saturating_sub(sock_dir + 1)
                 .saturating_sub(1);
 
             return Err(format!(
                 "session name must be less than {} characters",
-                available_length
+                available_length,
             ));
         };
     };
@@ -1350,4 +1351,47 @@ tail -f /tmp/my-live-logfile | zellij action pipe --name logs --plugin https://e
         #[clap(short, long, value_parser)]
         cwd: Option<PathBuf>,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_session_accepts_short_name() {
+        let result = validate_session("foo");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "foo");
+    }
+
+    #[test]
+    fn validate_session_rejects_name_exceeding_limit() {
+        let long_name: String = "a".repeat(200);
+        assert!(validate_session(&long_name).is_err());
+    }
+
+    #[test]
+    fn validate_session_rejects_at_platform_boundary() {
+        #[cfg(target_os = "macos")]
+        const PLATFORM_LIMIT: usize = 104;
+        #[cfg(target_os = "linux")]
+        const PLATFORM_LIMIT: usize = 108;
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        const PLATFORM_LIMIT: usize = 108;
+
+        let sock_dir_len = crate::consts::ZELLIJ_SOCK_DIR.as_os_str().len();
+        let max_name_len = PLATFORM_LIMIT.saturating_sub(sock_dir_len + 1);
+        let boundary_name: String = "a".repeat(max_name_len);
+        assert!(
+            validate_session(&boundary_name).is_err(),
+            "name at platform socket path limit should be rejected"
+        );
+    }
+
+    #[test]
+    fn validate_session_error_message_reports_available_length() {
+        let long_name: String = "a".repeat(200);
+        let err_msg = validate_session(&long_name).unwrap_err();
+        assert!(!err_msg.contains("less than 0"), "{}", err_msg);
+    }
 }

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -171,6 +171,10 @@ mod unix_only {
     use nix::unistd::Uid;
     use std::env::temp_dir;
 
+    // macOS sun_path is 104 bytes, Linux is 108 bytes
+    #[cfg(target_os = "macos")]
+    pub const ZELLIJ_SOCK_MAX_LENGTH: usize = 104;
+    #[cfg(not(target_os = "macos"))]
     pub const ZELLIJ_SOCK_MAX_LENGTH: usize = 108;
 
     lazy_static! {

--- a/zellij-utils/src/sessions.rs
+++ b/zellij-utils/src/sessions.rs
@@ -457,6 +457,21 @@ pub fn validate_session_name(name: &str) -> Result<(), String> {
     if name.contains('/') {
         return Err("Session name cannot contain '/'.".to_string());
     }
+    #[cfg(unix)]
+    {
+        use crate::consts::ZELLIJ_SOCK_MAX_LENGTH;
+        let socket_path = ZELLIJ_SOCK_DIR.join(name);
+        if socket_path.as_os_str().len() >= ZELLIJ_SOCK_MAX_LENGTH {
+            let sock_dir_len = ZELLIJ_SOCK_DIR.as_os_str().len();
+            let available = ZELLIJ_SOCK_MAX_LENGTH
+                .saturating_sub(sock_dir_len + 1)
+                .saturating_sub(1);
+            return Err(format!(
+                "Session name must be less than {} characters.",
+                available,
+            ));
+        }
+    }
     Ok(())
 }
 
@@ -658,3 +673,39 @@ const NOUNS: &[&'static str] = &[
     "yak",
     "zebra",
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_session_name_rejects_empty() {
+        assert!(validate_session_name("").is_err());
+        assert!(validate_session_name("   ").is_err());
+    }
+
+    #[test]
+    fn validate_session_name_rejects_dot_names() {
+        assert!(validate_session_name(".").is_err());
+        assert!(validate_session_name("..").is_err());
+    }
+
+    #[test]
+    fn validate_session_name_rejects_slash() {
+        assert!(validate_session_name("foo/bar").is_err());
+        assert!(validate_session_name("/").is_err());
+    }
+
+    #[test]
+    fn validate_session_name_accepts_valid() {
+        assert!(validate_session_name("my-session").is_ok());
+        assert!(validate_session_name("test_123").is_ok());
+        assert!(validate_session_name("a").is_ok());
+    }
+
+    #[test]
+    fn validate_session_name_rejects_long_names() {
+        let long_name: String = "a".repeat(200);
+        assert!(validate_session_name(&long_name).is_err());
+    }
+}


### PR DESCRIPTION

Fixes #4627

On macOS, `sun_path` is 104 bytes but the validation was using Linux's
108-byte limit for all Unix systems. Session names that produce socket
paths between 104-107 bytes pass validation, the server silently crashes
after daemonizing, and the client spins forever trying to connect.


The specific threshold depends on the user's socket directory length
on a typical macOS setup it's around 25-36 characters.

Ran into this issue while setting up tooling that was using LLM generated session names based on the JIRA ticket.

Changes:

- Use platform-correct `ZELLIJ_SOCK_MAX_LENGTH` (104 on macOS, 108 on Linux)
- Fix the error message calculation that reported "less than 0 characters"
- Add a 10s timeout to `connect_to_server` so it exits instead of hanging
  if the server fails to start for any reason
- Add socket path length check to `validate_session_name` so config-based
  names and renames go through the same validation
- Lower the session-manager plugin's hardcoded name length guard

Added unit tests for `validate_session` and `validate_session_name`,
there were none before. All existing tests pass.