### PR TITLE
fix(share): URL-encode session name in share URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3455,6 +3455,7 @@ dependencies = [
 name = "share"
 version = "0.1.0"
 dependencies = [
+ "percent-encoding",
  "rand 0.9.0",
  "url",
  "zellij-tile",

--- a/default-plugins/share/Cargo.toml
+++ b/default-plugins/share/Cargo.toml
@@ -8,4 +8,5 @@ license.workspace = true
 [dependencies]
 zellij-tile = { path = "../../zellij-tile" }
 url = "2.0"
+percent-encoding = "2.3"
 rand = "0.9.0"

--- a/default-plugins/share/src/ui_components.rs
+++ b/default-plugins/share/src/ui_components.rs
@@ -2,6 +2,7 @@ use std::net::IpAddr;
 use zellij_tile::prelude::*;
 
 use crate::CoordinatesInLine;
+use percent_encoding::{percent_encode, NON_ALPHANUMERIC};
 use std::collections::HashMap;
 
 pub const USAGE_TITLE: &str = "How it works:";
@@ -589,10 +590,11 @@ impl CurrentSessionSection {
     }
 
     fn session_url(&self) -> String {
-        let web_server_ip = self
-            .web_server_ip
-            .map(|i| i.to_string())
-            .unwrap_or_else(|| "UNDEFINED".to_owned());
+        let web_server_ip = match self.web_server_ip {
+            Some(IpAddr::V6(v6)) => format!("[{}]", v6),
+            Some(ip) => ip.to_string(),
+            None => "UNDEFINED".to_owned(),
+        };
         let web_server_port = self
             .web_server_port
             .map(|p| p.to_string())
@@ -604,10 +606,20 @@ impl CurrentSessionSection {
         };
         let session_name = self.session_name.as_deref().unwrap_or("");
 
-        format!(
-            "{}://{}:{}/{}",
-            prefix, web_server_ip, web_server_port, session_name
-        )
+        let base = format!("{}://{}:{}/", prefix, web_server_ip, web_server_port);
+        match url::Url::parse(&base) {
+            Ok(mut url) => {
+                url.path_segments_mut()
+                    .expect("base URL is valid")
+                    .pop_if_empty()
+                    .push(session_name);
+                url.to_string()
+            },
+            Err(_) => {
+                let encoded_name = percent_encode(session_name.as_bytes(), NON_ALPHANUMERIC);
+                format!("{}{}", base, encoded_name)
+            },
+        }
     }
 
     fn press_space_to_share(&self) -> (Text, usize) {


### PR DESCRIPTION
## Summary

Session names containing spaces or special characters produce broken share URLs because the name is interpolated without percent-encoding. For example, a session named "Development Session" generates `http://localhost:8082/Development Session`, which browsers truncate at the space.

- Use `url::Url` `path_segments_mut()` to properly percent-encode the session name (e.g. `Development%20Session`)
- Wrap IPv6 addresses in brackets so `Url::parse` succeeds for `[::1]`-style hosts
- Add `percent-encoding` fallback in the unlikely case `Url::parse` fails

## Changes

- `default-plugins/share/Cargo.toml`: add `percent-encoding` dependency
- `default-plugins/share/src/ui_components.rs`: update `session_url()` to encode session name and handle IPv6

## Test plan

- [x] `cargo check -p share` passes
- [x] `cargo fmt -- --check` passes
- [ ] Create a session with spaces in the name (e.g. `zellij --session "Development Session"`)
- [ ] Verify the share URL shows `Development%20Session` instead of `Development Session`
- [ ] Verify the URL is clickable and opens correctly in a browser

Fixes #4775