### PR TITLE
feat: add tab_cycle_wrap config option

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -406,6 +406,7 @@ impl SessionMetaData {
                         .unwrap_or(true),
                     mouse_hover_effects: new_config.options.mouse_hover_effects.unwrap_or(true),
                     visual_bell: new_config.options.visual_bell.unwrap_or(true),
+                    tab_cycle_wrap: new_config.options.tab_cycle_wrap.unwrap_or(true),
                 })
                 .unwrap();
             self.senders

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -596,6 +596,7 @@ pub enum ScreenInstruction {
         advanced_mouse_actions: bool,
         mouse_hover_effects: bool,
         visual_bell: bool,
+        tab_cycle_wrap: bool,
     },
     RerunCommandPane(u32, Option<NotificationEnd>), // u32 - terminal pane id
     ResizePaneWithId(ResizeStrategy, PaneId),
@@ -1124,6 +1125,7 @@ pub(crate) struct Screen {
     advanced_mouse_actions: bool,
     mouse_hover_effects: bool,
     visual_bell: bool,
+    tab_cycle_wrap: bool,
     currently_marking_pane_group: Rc<RefCell<HashMap<ClientId, bool>>>,
     // the below are the configured values - the ones that will be set if and when the web server
     // is brought online
@@ -1166,6 +1168,7 @@ impl Screen {
         advanced_mouse_actions: bool,
         mouse_hover_effects: bool,
         visual_bell: bool,
+        tab_cycle_wrap: bool,
         web_server_ip: IpAddr,
         web_server_port: u16,
     ) -> Self {
@@ -1221,6 +1224,7 @@ impl Screen {
             advanced_mouse_actions,
             mouse_hover_effects,
             visual_bell,
+            tab_cycle_wrap,
             web_server_ip,
             web_server_port,
             render_blocker: RenderBlocker::new(100),
@@ -1527,7 +1531,11 @@ impl Screen {
             match self.get_active_tab(client_id) {
                 Ok(active_tab) => {
                     let active_tab_pos = active_tab.position;
-                    let new_tab_pos = (active_tab_pos + 1) % self.tabs.len();
+                    let new_tab_pos = if self.tab_cycle_wrap {
+                        (active_tab_pos + 1) % self.tabs.len()
+                    } else {
+                        (active_tab_pos + 1).min(self.tabs.len() - 1)
+                    };
                     return self.switch_active_tab(
                         new_tab_pos,
                         should_change_pane_focus,
@@ -1561,7 +1569,11 @@ impl Screen {
                 Ok(active_tab) => {
                     let active_tab_pos = active_tab.position;
                     let new_tab_pos = if active_tab_pos == 0 {
-                        self.tabs.len() - 1
+                        if self.tab_cycle_wrap {
+                            self.tabs.len() - 1
+                        } else {
+                            0
+                        }
                     } else {
                         active_tab_pos - 1
                     };
@@ -3611,11 +3623,13 @@ impl Screen {
         advanced_mouse_actions: bool,
         mouse_hover_effects: bool,
         visual_bell: bool,
+        tab_cycle_wrap: bool,
         client_id: ClientId,
     ) -> Result<()> {
         let should_support_arrow_fonts = !simplified_ui;
 
         // global configuration
+        self.tab_cycle_wrap = tab_cycle_wrap;
         self.default_mode_info.update_theme(theme);
         self.default_mode_info
             .update_rounded_corners(rounded_corners);
@@ -4351,6 +4365,7 @@ pub(crate) fn screen_thread_main(
     let advanced_mouse_actions = config_options.advanced_mouse_actions.unwrap_or(true);
     let mouse_hover_effects = config_options.mouse_hover_effects.unwrap_or(true);
     let visual_bell = config_options.visual_bell.unwrap_or(true);
+    let tab_cycle_wrap = config_options.tab_cycle_wrap.unwrap_or(true);
 
     let thread_senders = bus.senders.clone();
     let mut screen = Screen::new(
@@ -4390,6 +4405,7 @@ pub(crate) fn screen_thread_main(
         advanced_mouse_actions,
         mouse_hover_effects,
         visual_bell,
+        tab_cycle_wrap,
         web_server_ip,
         web_server_port,
     );
@@ -7104,6 +7120,7 @@ pub(crate) fn screen_thread_main(
                 advanced_mouse_actions,
                 mouse_hover_effects,
                 visual_bell,
+                tab_cycle_wrap,
             } => {
                 screen
                     .reconfigure(
@@ -7124,6 +7141,7 @@ pub(crate) fn screen_thread_main(
                         advanced_mouse_actions,
                         mouse_hover_effects,
                         visual_bell,
+                        tab_cycle_wrap,
                         client_id,
                     )
                     .non_fatal();

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -292,6 +292,7 @@ fn create_new_screen(
     let web_server_ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let web_server_port = 8080;
     let visual_bell = true;
+    let tab_cycle_wrap = true;
     let screen = Screen::new(
         bus,
         &client_attributes,
@@ -320,6 +321,7 @@ fn create_new_screen(
         advanced_mouse_actions,
         mouse_hover_effects,
         visual_bell,
+        tab_cycle_wrap,
         web_server_ip,
         web_server_port,
     );

--- a/zellij-utils/assets/prost_ipc/client_server_contract.rs
+++ b/zellij-utils/assets/prost_ipc/client_server_contract.rs
@@ -1821,6 +1821,8 @@ pub struct Options {
     pub client_async_worker_tasks: ::core::option::Option<u64>,
     #[prost(bool, optional, tag="43")]
     pub visual_bell: ::core::option::Option<bool>,
+    #[prost(bool, optional, tag="44")]
+    pub tab_cycle_wrap: ::core::option::Option<bool>,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/zellij-utils/src/client_server_contract/common_types.proto
+++ b/zellij-utils/src/client_server_contract/common_types.proto
@@ -1110,6 +1110,7 @@ message Options {
   optional bool mouse_hover_effects = 41;
   optional uint64 client_async_worker_tasks = 42;
   optional bool visual_bell = 43;
+  optional bool tab_cycle_wrap = 44;
 }
 
 enum OnForceClose {

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -256,6 +256,12 @@ pub struct Options {
     /// NOTE: This only applies to web clients at the moment.
     #[clap(long)]
     pub client_async_worker_tasks: Option<usize>,
+
+    /// Whether to wrap around when switching to the next/previous tab
+    /// Default: true
+    #[clap(long, value_parser)]
+    #[serde(default)]
+    pub tab_cycle_wrap: Option<bool>,
 }
 
 #[derive(ArgEnum, Deserialize, Serialize, Debug, Clone, Copy, PartialEq)]
@@ -358,6 +364,7 @@ impl Options {
         let client_async_worker_tasks = other
             .client_async_worker_tasks
             .or(self.client_async_worker_tasks);
+        let tab_cycle_wrap = other.tab_cycle_wrap.or(self.tab_cycle_wrap);
 
         Options {
             simplified_ui,
@@ -403,6 +410,7 @@ impl Options {
             enforce_https_for_localhost,
             post_command_discovery_hook,
             client_async_worker_tasks,
+            tab_cycle_wrap,
         }
     }
 
@@ -485,6 +493,7 @@ impl Options {
         let client_async_worker_tasks = other
             .client_async_worker_tasks
             .or(self.client_async_worker_tasks);
+        let tab_cycle_wrap = other.tab_cycle_wrap.or(self.tab_cycle_wrap);
 
         Options {
             simplified_ui,
@@ -530,6 +539,7 @@ impl Options {
             enforce_https_for_localhost,
             post_command_discovery_hook,
             client_async_worker_tasks,
+            tab_cycle_wrap,
         }
     }
 

--- a/zellij-utils/src/ipc/protobuf_conversion.rs
+++ b/zellij-utils/src/ipc/protobuf_conversion.rs
@@ -616,6 +616,7 @@ impl From<crate::input::options::Options>
             post_command_discovery_hook: options.post_command_discovery_hook,
             client_async_worker_tasks: options.client_async_worker_tasks.map(|v| v as u64),
             visual_bell: options.visual_bell,
+            tab_cycle_wrap: options.tab_cycle_wrap,
         }
     }
 }
@@ -709,6 +710,7 @@ impl TryFrom<crate::client_server_contract::client_server_contract::Options>
             post_command_discovery_hook: options.post_command_discovery_hook,
             client_async_worker_tasks: options.client_async_worker_tasks.map(|v| v as usize),
             visual_bell: options.visual_bell,
+            tab_cycle_wrap: options.tab_cycle_wrap,
         })
     }
 }

--- a/zellij-utils/src/ipc/tests/roundtrip_tests.rs
+++ b/zellij-utils/src/ipc/tests/roundtrip_tests.rs
@@ -474,6 +474,7 @@ fn test_client_messages() {
                 client_async_worker_tasks: Some(16),
                 mouse_hover_effects: Some(false),
                 visual_bell: Some(true),
+                tab_cycle_wrap: Some(false),
             }),
             layout: None,
             terminal_window_size: Size { rows: 80, cols: 42 },

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -2783,6 +2783,8 @@ impl Options {
             };
         let visual_bell =
             kdl_property_first_arg_as_bool_or_error!(kdl_options, "visual_bell").map(|(v, _)| v);
+        let tab_cycle_wrap =
+            kdl_property_first_arg_as_bool_or_error!(kdl_options, "tab_cycle_wrap").map(|(v, _)| v);
 
         Ok(Options {
             simplified_ui,
@@ -2828,6 +2830,7 @@ impl Options {
             enforce_https_for_localhost,
             post_command_discovery_hook,
             client_async_worker_tasks,
+            tab_cycle_wrap,
         })
     }
     pub fn from_string(stringified_keybindings: &String) -> Result<Self, ConfigError> {
@@ -4091,6 +4094,34 @@ impl Options {
             None
         }
     }
+    fn tab_cycle_wrap_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
+        let comment_text = format!(
+            "{}\n{}\n{}\n{}",
+            " ",
+            "// Whether to wrap around when switching to the next/previous tab",
+            "// Default: true",
+            "// ",
+        );
+
+        let create_node = |node_value: bool| -> KdlNode {
+            let mut node = KdlNode::new("tab_cycle_wrap");
+            node.push(KdlValue::Bool(node_value));
+            node
+        };
+        if let Some(tab_cycle_wrap) = self.tab_cycle_wrap {
+            let mut node = create_node(tab_cycle_wrap);
+            if add_comments {
+                node.set_leading(format!("{}\n", comment_text));
+            }
+            Some(node)
+        } else if add_comments {
+            let mut node = create_node(true);
+            node.set_leading(format!("{}\n// ", comment_text));
+            Some(node)
+        } else {
+            None
+        }
+    }
     pub fn to_kdl(&self, add_comments: bool) -> Vec<KdlNode> {
         let mut nodes = vec![];
         if let Some(simplified_ui_node) = self.simplified_ui_to_kdl(add_comments) {
@@ -4230,6 +4261,9 @@ impl Options {
         if let Some(client_async_worker_tasks) = self.client_async_worker_tasks_to_kdl(add_comments)
         {
             nodes.push(client_async_worker_tasks);
+        }
+        if let Some(tab_cycle_wrap) = self.tab_cycle_wrap_to_kdl(add_comments) {
+            nodes.push(tab_cycle_wrap);
         }
         nodes
     }

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__bare_config_from_default_assets_to_string_with_comments.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__bare_config_from_default_assets_to_string_with_comments.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/kdl/mod.rs
+assertion_line: 7090
 expression: fake_config_stringified
 ---
 keybinds clear-defaults=true {
@@ -564,3 +565,9 @@ web_client {
 // typically work best. Set to 0 to use the number of (physical) CPU cores.
 // Note: This only applies to web clients at the moment.
 // client_async_worker_tasks 4
+ 
+// Whether to wrap around when switching to the next/previous tab
+// Default: true
+// 
+// tab_cycle_wrap true
+

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__config_options_to_string_with_comments.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__config_options_to_string_with_comments.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/kdl/mod.rs
+assertion_line: 7029
 expression: fake_document.to_string()
 ---
  
@@ -283,3 +284,9 @@ web_sharing "disabled"
 // typically work best. Set to 0 to use the number of (physical) CPU cores.
 // Note: This only applies to web clients at the moment.
 // client_async_worker_tasks 4
+ 
+// Whether to wrap around when switching to the next/previous tab
+// Default: true
+// 
+// tab_cycle_wrap true
+

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 766
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -48,4 +49,5 @@ Options {
     enforce_https_for_localhost: None,
     post_command_discovery_hook: None,
     client_async_worker_tasks: None,
+    tab_cycle_wrap: None,
 }

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 800
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -48,4 +49,5 @@ Options {
     enforce_https_for_localhost: None,
     post_command_discovery_hook: None,
     client_async_worker_tasks: None,
+    tab_cycle_wrap: None,
 }

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 756
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -46,4 +47,5 @@ Options {
     enforce_https_for_localhost: None,
     post_command_discovery_hook: None,
     client_async_worker_tasks: None,
+    tab_cycle_wrap: None,
 }

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 754
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -6015,6 +6016,7 @@ Config {
         enforce_https_for_localhost: None,
         post_command_discovery_hook: None,
         client_async_worker_tasks: None,
+        tab_cycle_wrap: None,
     },
     themes: {},
     plugins: PluginAliases {

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 824
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -6015,6 +6016,7 @@ Config {
         enforce_https_for_localhost: None,
         post_command_discovery_hook: None,
         client_async_worker_tasks: None,
+        tab_cycle_wrap: None,
     },
     themes: {},
     plugins: PluginAliases {

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 866
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -133,6 +134,7 @@ Config {
         enforce_https_for_localhost: None,
         post_command_discovery_hook: None,
         client_async_worker_tasks: None,
+        tab_cycle_wrap: None,
     },
     themes: {},
     plugins: PluginAliases {

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 776
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -48,4 +49,5 @@ Options {
     enforce_https_for_localhost: None,
     post_command_discovery_hook: None,
     client_async_worker_tasks: None,
+    tab_cycle_wrap: None,
 }

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 852
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -6015,6 +6016,7 @@ Config {
         enforce_https_for_localhost: None,
         post_command_discovery_hook: None,
         client_async_worker_tasks: None,
+        tab_cycle_wrap: None,
     },
     themes: {
         "other-theme-from-config": Theme {

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 838
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -6015,6 +6016,7 @@ Config {
         enforce_https_for_localhost: None,
         post_command_discovery_hook: None,
         client_async_worker_tasks: None,
+        tab_cycle_wrap: None,
     },
     themes: {},
     plugins: PluginAliases {


### PR DESCRIPTION
  ## Summary
  - Adds a `tab_cycle_wrap` config option (default: `true`) that controls whether
    next/previous tab navigation wraps around at the edges
  - When `false`, navigating past the last tab stays on the last tab and
    navigating before the first tab stays on the first tab

  ## Config example
  ```kdl
  tab_cycle_wrap false