### PR TITLE
fix(panes): clear `window_title` cache when switching tabs

### DIFF
--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -358,6 +358,7 @@ impl FloatingPanes {
             pane.set_should_render_boundaries(true);
             pane.render_full_viewport();
         }
+        self.window_title = None;
     }
     pub fn set_pane_frames(&mut self) -> Result<()> {
         let err_context =

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -408,6 +408,7 @@ impl FloatingPanes {
             pane.set_should_render_boundaries(true);
             pane.render_full_viewport();
         }
+        self.window_title = None;
     }
     pub fn set_pane_frames(&mut self) -> Result<()> {
         let err_context =

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -991,6 +991,7 @@ impl TiledPanes {
             pane.render_full_viewport();
         }
         self.reset_boundaries();
+        self.window_title = None;
     }
     pub fn has_active_panes(&self) -> bool {
         !self.active_panes.is_empty()

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -1116,6 +1116,7 @@ impl TiledPanes {
             pane.render_full_viewport();
         }
         self.reset_boundaries();
+        self.window_title = None;
     }
     pub fn has_active_panes(&self) -> bool {
         !self.active_panes.is_empty()


### PR DESCRIPTION
Fixes #2614.

When switching between tabs, the terminal emulator's window title is not updated to reflect the focused pane in the newly active tab. The title remains stale, showing the pane name from the previously active tab.

For example:
- Tab 1 has pane "a" focused, terminal title shows `session-name | a`
- Switch to Tab 2, terminal title stays as `session-name | a` instead of updating to Tab 2's focused pane

This PR clear the `window_title` cache in `set_force_render()` for both `TiledPanes` and `FloatingPanes`. This method is already called on the destination tab during tab switches (via `move_clients_between_tabs`), so clearing the cache here ensures the terminal title OSC sequence is always re-emitted after a tab switch.

![](https://github.com/user-attachments/assets/0c9a976b-b7a1-423a-8143-6b1697d99245)
