### PR TITLE
Add verify cli test

### DIFF
--- a/src/tests/cli.rs
+++ b/src/tests/cli.rs
@@ -1,7 +1,12 @@
 use std::net::{IpAddr, Ipv4Addr};
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use zellij_utils::cli::{CliArgs, Command};
+
+#[test]
+fn verify_cli() {
+    CliArgs::command().debug_assert();
+}
 
 #[test]
 fn web_cli_status_alone_works() {


### PR DESCRIPTION
This is a super minor addition of a clap "verify_cli" test that just makes sure we test all the clap errors that can happen at runtime (eg. conflicting short flags).