### PR TITLE
feat: add support for binding mouse scroll events to keybinding actions

### DIFF
--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -314,8 +314,13 @@ impl InputHandler {
         }
     }
     fn handle_mouse_event(&mut self, mouse_event: &MouseEvent) {
-        // This dispatch handles all of the output(s) to terminal
-        // pane(s).
+        // If this is a modifier+scroll event, route through the keybinding system
+        // so users can bind e.g. "Ctrl ScrollUp" to GoToPreviousTab
+        if let Some(key) = mouse_event.to_key_with_modifier() {
+            self.handle_key(&key, vec![], false);
+            return;
+        }
+        // Otherwise, dispatch as a regular mouse event to the terminal pane(s)
         self.dispatch_action(
             Action::MouseEvent {
                 event: *mouse_event,

--- a/zellij-utils/assets/prost/api.action.rs
+++ b/zellij-utils/assets/prost/api.action.rs
@@ -1384,6 +1384,8 @@ pub enum BareKey {
     PrintScreen = 31,
     Pause = 32,
     Menu = 33,
+    ScrollUp = 34,
+    ScrollDown = 35,
 }
 impl BareKey {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -1426,6 +1428,8 @@ impl BareKey {
             BareKey::PrintScreen => "BARE_KEY_PRINT_SCREEN",
             BareKey::Pause => "BARE_KEY_PAUSE",
             BareKey::Menu => "BARE_KEY_MENU",
+            BareKey::ScrollUp => "BARE_KEY_SCROLL_UP",
+            BareKey::ScrollDown => "BARE_KEY_SCROLL_DOWN",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -1465,6 +1469,8 @@ impl BareKey {
             "BARE_KEY_PRINT_SCREEN" => Some(Self::PrintScreen),
             "BARE_KEY_PAUSE" => Some(Self::Pause),
             "BARE_KEY_MENU" => Some(Self::Menu),
+            "BARE_KEY_SCROLL_UP" => Some(Self::ScrollUp),
+            "BARE_KEY_SCROLL_DOWN" => Some(Self::ScrollDown),
             _ => None,
         }
     }

--- a/zellij-utils/assets/prost/api.key.rs
+++ b/zellij-utils/assets/prost/api.key.rs
@@ -77,6 +77,8 @@ pub mod key {
         Pause = 29,
         Menu = 30,
         Enter = 31,
+        ScrollUp = 32,
+        ScrollDown = 33,
     }
     impl NamedKey {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -117,6 +119,8 @@ pub mod key {
                 NamedKey::Pause => "Pause",
                 NamedKey::Menu => "Menu",
                 NamedKey::Enter => "Enter",
+                NamedKey::ScrollUp => "ScrollUp",
+                NamedKey::ScrollDown => "ScrollDown",
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
@@ -154,6 +158,8 @@ pub mod key {
                 "Pause" => Some(Self::Pause),
                 "Menu" => Some(Self::Menu),
                 "Enter" => Some(Self::Enter),
+                "ScrollUp" => Some(Self::ScrollUp),
+                "ScrollDown" => Some(Self::ScrollDown),
                 _ => None,
             }
         }

--- a/zellij-utils/assets/prost_ipc/client_server_contract.rs
+++ b/zellij-utils/assets/prost_ipc/client_server_contract.rs
@@ -1877,6 +1877,8 @@ pub enum BareKey {
     PrintScreen = 31,
     Pause = 32,
     Menu = 33,
+    ScrollUp = 34,
+    ScrollDown = 35,
 }
 impl BareKey {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -1919,6 +1921,8 @@ impl BareKey {
             BareKey::PrintScreen => "BARE_KEY_PRINT_SCREEN",
             BareKey::Pause => "BARE_KEY_PAUSE",
             BareKey::Menu => "BARE_KEY_MENU",
+            BareKey::ScrollUp => "BARE_KEY_SCROLL_UP",
+            BareKey::ScrollDown => "BARE_KEY_SCROLL_DOWN",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -1958,6 +1962,8 @@ impl BareKey {
             "BARE_KEY_PRINT_SCREEN" => Some(Self::PrintScreen),
             "BARE_KEY_PAUSE" => Some(Self::Pause),
             "BARE_KEY_MENU" => Some(Self::Menu),
+            "BARE_KEY_SCROLL_UP" => Some(Self::ScrollUp),
+            "BARE_KEY_SCROLL_DOWN" => Some(Self::ScrollDown),
             _ => None,
         }
     }

--- a/zellij-utils/src/client_server_contract/common_types.proto
+++ b/zellij-utils/src/client_server_contract/common_types.proto
@@ -67,6 +67,8 @@ enum BareKey {
   BARE_KEY_PRINT_SCREEN = 31;
   BARE_KEY_PAUSE = 32;
   BARE_KEY_MENU = 33;
+  BARE_KEY_SCROLL_UP = 34;
+  BARE_KEY_SCROLL_DOWN = 35;
 }
 
 message CharKey {

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -207,6 +207,8 @@ pub enum BareKey {
     PrintScreen,
     Pause,
     Menu,
+    ScrollUp,
+    ScrollDown,
 }
 
 impl fmt::Display for BareKey {
@@ -235,6 +237,8 @@ impl fmt::Display for BareKey {
             BareKey::PrintScreen => write!(f, "PRINTSCREEN"),
             BareKey::Pause => write!(f, "PAUSE"),
             BareKey::Menu => write!(f, "MENU"),
+            BareKey::ScrollUp => write!(f, "SCROLLUP"),
+            BareKey::ScrollDown => write!(f, "SCROLLDOWN"),
         }
     }
 }
@@ -275,6 +279,8 @@ impl FromStr for BareKey {
             "printscreen" => Ok(BareKey::PrintScreen),
             "pause" => Ok(BareKey::Pause),
             "menu" => Ok(BareKey::Menu),
+            "scrollup" => Ok(BareKey::ScrollUp),
+            "scrolldown" => Ok(BareKey::ScrollDown),
             "space" => Ok(BareKey::Char(' ')),
             _ => {
                 if key_str.chars().count() == 1 {
@@ -573,6 +579,10 @@ impl KeyWithModifier {
             BareKey::PrintScreen => KeyCode::PrintScreen,
             BareKey::Pause => KeyCode::Pause,
             BareKey::Menu => KeyCode::Menu,
+            // ScrollUp/ScrollDown are virtual keys for mouse scroll bindings;
+            // they have no termwiz KeyCode equivalent, so we map to a no-op char
+            BareKey::ScrollUp => KeyCode::Char('\0'),
+            BareKey::ScrollDown => KeyCode::Char('\0'),
         }
     }
     #[cfg(not(target_family = "wasm"))]

--- a/zellij-utils/src/input/mouse.rs
+++ b/zellij-utils/src/input/mouse.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+use crate::data::{BareKey, KeyModifier, KeyWithModifier};
 use crate::position::Position;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
@@ -358,10 +359,192 @@ impl MouseEvent {
         };
         event
     }
+    /// Converts a modifier+scroll mouse event into a KeyWithModifier for keybinding matching.
+    /// Returns None for non-scroll events or scroll events without modifiers.
+    pub fn to_key_with_modifier(&self) -> Option<KeyWithModifier> {
+        let bare_key = if self.wheel_up {
+            BareKey::ScrollUp
+        } else if self.wheel_down {
+            BareKey::ScrollDown
+        } else {
+            return None;
+        };
+
+        let has_modifier = self.ctrl || self.alt || self.shift;
+        if !has_modifier {
+            return None;
+        }
+
+        let mut key = KeyWithModifier::new(bare_key);
+        if self.ctrl {
+            key.key_modifiers.insert(KeyModifier::Ctrl);
+        }
+        if self.alt {
+            key.key_modifiers.insert(KeyModifier::Alt);
+        }
+        if self.shift {
+            key.key_modifiers.insert(KeyModifier::Shift);
+        }
+        Some(key)
+    }
 }
 
 impl Default for MouseEvent {
     fn default() -> Self {
         MouseEvent::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::{BareKey, KeyModifier, KeyWithModifier};
+
+    #[test]
+    fn ctrl_scroll_up_converts_to_key_with_modifier() {
+        let event = MouseEvent::new_ctrl_scroll_up_event(Position::new(0, 0));
+        let key = event.to_key_with_modifier();
+        assert_eq!(
+            key,
+            Some(KeyWithModifier::new(BareKey::ScrollUp).with_ctrl_modifier()),
+        );
+    }
+
+    #[test]
+    fn ctrl_scroll_down_converts_to_key_with_modifier() {
+        let event = MouseEvent::new_ctrl_scroll_down_event(Position::new(0, 0));
+        let key = event.to_key_with_modifier();
+        assert_eq!(
+            key,
+            Some(KeyWithModifier::new(BareKey::ScrollDown).with_ctrl_modifier()),
+        );
+    }
+
+    #[test]
+    fn alt_scroll_up_converts_to_key_with_modifier() {
+        let mut event = MouseEvent::new_scroll_up_event(Position::new(0, 0));
+        event.alt = true;
+        let key = event.to_key_with_modifier();
+        assert_eq!(
+            key,
+            Some(KeyWithModifier::new(BareKey::ScrollUp).with_alt_modifier()),
+        );
+    }
+
+    #[test]
+    fn shift_scroll_down_converts_to_key_with_modifier() {
+        let mut event = MouseEvent::new_scroll_down_event(Position::new(0, 0));
+        event.shift = true;
+        let key = event.to_key_with_modifier();
+        assert_eq!(
+            key,
+            Some(KeyWithModifier::new(BareKey::ScrollDown).with_shift_modifier()),
+        );
+    }
+
+    #[test]
+    fn ctrl_alt_scroll_up_converts_with_both_modifiers() {
+        let mut event = MouseEvent::new_ctrl_scroll_up_event(Position::new(0, 0));
+        event.alt = true;
+        let key = event.to_key_with_modifier();
+        assert_eq!(
+            key,
+            Some(
+                KeyWithModifier::new(BareKey::ScrollUp)
+                    .with_ctrl_modifier()
+                    .with_alt_modifier()
+            ),
+        );
+    }
+
+    #[test]
+    fn plain_scroll_up_returns_none() {
+        let event = MouseEvent::new_scroll_up_event(Position::new(0, 0));
+        let key = event.to_key_with_modifier();
+        assert_eq!(key, None);
+    }
+
+    #[test]
+    fn plain_scroll_down_returns_none() {
+        let event = MouseEvent::new_scroll_down_event(Position::new(0, 0));
+        let key = event.to_key_with_modifier();
+        assert_eq!(key, None);
+    }
+
+    #[test]
+    fn left_click_returns_none() {
+        let event = MouseEvent::new_left_press_event(Position::new(0, 0));
+        let key = event.to_key_with_modifier();
+        assert_eq!(key, None);
+    }
+
+    #[test]
+    fn motion_event_returns_none() {
+        let event = MouseEvent::new_buttonless_motion(Position::new(0, 0));
+        let key = event.to_key_with_modifier();
+        assert_eq!(key, None);
+    }
+
+    #[test]
+    fn ctrl_scroll_matches_configured_keybinding() {
+        use crate::input::config::Config;
+        use crate::data::InputMode;
+        use crate::input::actions::Action;
+
+        let config_contents = r#"
+            keybinds {
+                shared_except "locked" {
+                    bind "Ctrl ScrollUp" { GoToPreviousTab; }
+                    bind "Ctrl ScrollDown" { GoToNextTab; }
+                }
+            }
+        "#;
+        let config = Config::from_kdl(config_contents, None).unwrap();
+
+        // Simulate a Ctrl+ScrollUp mouse event
+        let event = MouseEvent::new_ctrl_scroll_up_event(Position::new(5, 10));
+        let key = event.to_key_with_modifier().unwrap();
+        let action = config
+            .keybinds
+            .get_actions_for_key_in_mode(&InputMode::Normal, &key);
+        assert_eq!(
+            action,
+            Some(&vec![Action::GoToPreviousTab]),
+            "Ctrl+ScrollUp mouse event resolves to GoToPreviousTab via keybinding"
+        );
+
+        // Simulate a Ctrl+ScrollDown mouse event
+        let event = MouseEvent::new_ctrl_scroll_down_event(Position::new(5, 10));
+        let key = event.to_key_with_modifier().unwrap();
+        let action = config
+            .keybinds
+            .get_actions_for_key_in_mode(&InputMode::Normal, &key);
+        assert_eq!(
+            action,
+            Some(&vec![Action::GoToNextTab]),
+            "Ctrl+ScrollDown mouse event resolves to GoToNextTab via keybinding"
+        );
+    }
+
+    #[test]
+    fn plain_scroll_does_not_match_modifier_keybinding() {
+        use crate::input::config::Config;
+
+        let config_contents = r#"
+            keybinds {
+                normal {
+                    bind "Ctrl ScrollUp" { GoToPreviousTab; }
+                }
+            }
+        "#;
+        let _config = Config::from_kdl(config_contents, None).unwrap();
+
+        // Plain scroll (no modifier) should return None, not matching keybindings
+        let event = MouseEvent::new_scroll_up_event(Position::new(5, 10));
+        assert_eq!(
+            event.to_key_with_modifier(),
+            None,
+            "Plain scroll does not produce a keybinding key"
+        );
     }
 }

--- a/zellij-utils/src/input/unit/keybinds_test.rs
+++ b/zellij-utils/src/input/unit/keybinds_test.rs
@@ -3,6 +3,7 @@ use super::super::keybinds::*;
 use crate::data::{BareKey, Direction, KeyWithModifier};
 use crate::input::config::Config;
 use insta::assert_snapshot;
+use std::str::FromStr;
 use strum::IntoEnumIterator;
 
 #[test]
@@ -593,4 +594,189 @@ fn error_received_on_unknown_key_instruction() {
     "#;
     let config_error = Config::from_kdl(config_contents, None).unwrap_err();
     assert_snapshot!(format!("{:?}", config_error));
+}
+
+#[test]
+fn bare_key_parses_scrollup() {
+    let key = BareKey::from_str("ScrollUp").unwrap();
+    assert_eq!(key, BareKey::ScrollUp, "ScrollUp parsed correctly");
+}
+
+#[test]
+fn bare_key_parses_scrolldown() {
+    let key = BareKey::from_str("ScrollDown").unwrap();
+    assert_eq!(key, BareKey::ScrollDown, "ScrollDown parsed correctly");
+}
+
+#[test]
+fn bare_key_parses_scrollup_case_insensitive() {
+    let key = BareKey::from_str("scrollup").unwrap();
+    assert_eq!(key, BareKey::ScrollUp, "scrollup (lowercase) parsed correctly");
+}
+
+#[test]
+fn bare_key_parses_scrolldown_case_insensitive() {
+    let key = BareKey::from_str("scrolldown").unwrap();
+    assert_eq!(key, BareKey::ScrollDown, "scrolldown (lowercase) parsed correctly");
+}
+
+#[test]
+fn key_with_modifier_parses_ctrl_scrollup() {
+    let key = KeyWithModifier::from_str("Ctrl ScrollUp").unwrap();
+    assert_eq!(
+        key,
+        KeyWithModifier::new(BareKey::ScrollUp).with_ctrl_modifier(),
+        "Ctrl ScrollUp parsed correctly"
+    );
+}
+
+#[test]
+fn key_with_modifier_parses_ctrl_scrolldown() {
+    let key = KeyWithModifier::from_str("Ctrl ScrollDown").unwrap();
+    assert_eq!(
+        key,
+        KeyWithModifier::new(BareKey::ScrollDown).with_ctrl_modifier(),
+        "Ctrl ScrollDown parsed correctly"
+    );
+}
+
+#[test]
+fn key_with_modifier_parses_alt_scrollup() {
+    let key = KeyWithModifier::from_str("Alt ScrollUp").unwrap();
+    assert_eq!(
+        key,
+        KeyWithModifier::new(BareKey::ScrollUp).with_alt_modifier(),
+        "Alt ScrollUp parsed correctly"
+    );
+}
+
+#[test]
+fn can_bind_ctrl_scrollup_to_action_in_config() {
+    let config_contents = r#"
+        keybinds {
+            normal {
+                bind "Ctrl ScrollUp" { GoToPreviousTab; }
+            }
+        }
+    "#;
+    let config = Config::from_kdl(config_contents, None).unwrap();
+    let action = config.keybinds.get_actions_for_key_in_mode(
+        &InputMode::Normal,
+        &KeyWithModifier::new(BareKey::ScrollUp).with_ctrl_modifier(),
+    );
+    assert_eq!(
+        action,
+        Some(&vec![Action::GoToPreviousTab]),
+        "Ctrl ScrollUp bound to GoToPreviousTab"
+    );
+}
+
+#[test]
+fn can_bind_ctrl_scrolldown_to_action_in_config() {
+    let config_contents = r#"
+        keybinds {
+            normal {
+                bind "Ctrl ScrollDown" { GoToNextTab; }
+            }
+        }
+    "#;
+    let config = Config::from_kdl(config_contents, None).unwrap();
+    let action = config.keybinds.get_actions_for_key_in_mode(
+        &InputMode::Normal,
+        &KeyWithModifier::new(BareKey::ScrollDown).with_ctrl_modifier(),
+    );
+    assert_eq!(
+        action,
+        Some(&vec![Action::GoToNextTab]),
+        "Ctrl ScrollDown bound to GoToNextTab"
+    );
+}
+
+#[test]
+fn can_bind_scroll_in_shared_except_mode() {
+    let config_contents = r#"
+        keybinds {
+            shared_except "locked" {
+                bind "Ctrl ScrollUp" { GoToPreviousTab; }
+                bind "Ctrl ScrollDown" { GoToNextTab; }
+            }
+        }
+    "#;
+    let config = Config::from_kdl(config_contents, None).unwrap();
+    for mode in InputMode::iter() {
+        let up_action = config.keybinds.get_actions_for_key_in_mode(
+            &mode,
+            &KeyWithModifier::new(BareKey::ScrollUp).with_ctrl_modifier(),
+        );
+        let down_action = config.keybinds.get_actions_for_key_in_mode(
+            &mode,
+            &KeyWithModifier::new(BareKey::ScrollDown).with_ctrl_modifier(),
+        );
+        if mode == InputMode::Locked {
+            assert_eq!(up_action, None, "ScrollUp unbound in locked mode");
+            assert_eq!(down_action, None, "ScrollDown unbound in locked mode");
+        } else {
+            assert_eq!(
+                up_action,
+                Some(&vec![Action::GoToPreviousTab]),
+                "ScrollUp bound in {:?}",
+                mode
+            );
+            assert_eq!(
+                down_action,
+                Some(&vec![Action::GoToNextTab]),
+                "ScrollDown bound in {:?}",
+                mode
+            );
+        }
+    }
+}
+
+#[test]
+fn can_unbind_scroll_keys() {
+    let default_config_contents = r#"
+        keybinds {
+            normal {
+                bind "Ctrl ScrollUp" { GoToPreviousTab; }
+                bind "Ctrl ScrollDown" { GoToNextTab; }
+            }
+        }
+    "#;
+    let config_contents = r#"
+        keybinds {
+            normal {
+                unbind "Ctrl ScrollUp"
+            }
+        }
+    "#;
+    let default_config = Config::from_kdl(default_config_contents, None).unwrap();
+    let config = Config::from_kdl(config_contents, Some(default_config)).unwrap();
+    let up_action = config.keybinds.get_actions_for_key_in_mode(
+        &InputMode::Normal,
+        &KeyWithModifier::new(BareKey::ScrollUp).with_ctrl_modifier(),
+    );
+    let down_action = config.keybinds.get_actions_for_key_in_mode(
+        &InputMode::Normal,
+        &KeyWithModifier::new(BareKey::ScrollDown).with_ctrl_modifier(),
+    );
+    assert_eq!(up_action, None, "ScrollUp was unbound");
+    assert_eq!(
+        down_action,
+        Some(&vec![Action::GoToNextTab]),
+        "ScrollDown still bound"
+    );
+}
+
+#[test]
+fn scroll_keys_serialize_back_to_kdl() {
+    let key_up = KeyWithModifier::new(BareKey::ScrollUp).with_ctrl_modifier();
+    let key_down = KeyWithModifier::new(BareKey::ScrollDown);
+    assert_eq!(key_up.to_kdl(), "Ctrl ScrollUp");
+    assert_eq!(key_down.to_kdl(), "ScrollDown");
+}
+
+#[test]
+fn scroll_keys_display_correctly() {
+    assert_eq!(format!("{}", BareKey::ScrollUp), "SCROLLUP");
+    assert_eq!(format!("{}", BareKey::ScrollDown), "SCROLLDOWN");
 }

--- a/zellij-utils/src/ipc/enum_conversions.rs
+++ b/zellij-utils/src/ipc/enum_conversions.rs
@@ -44,7 +44,8 @@ impl From<BareKey> for ProtoBareKey {
             BareKey::PrintScreen => ProtoBareKey::PrintScreen,
             BareKey::Pause => ProtoBareKey::Pause,
             BareKey::Menu => ProtoBareKey::Menu,
-            BareKey::ScrollUp | BareKey::ScrollDown => ProtoBareKey::Unspecified,
+            BareKey::ScrollUp => ProtoBareKey::ScrollUp,
+            BareKey::ScrollDown => ProtoBareKey::ScrollDown,
         }
     }
 }
@@ -87,6 +88,8 @@ impl TryFrom<ProtoBareKey> for BareKey {
             ProtoBareKey::PrintScreen => Ok(BareKey::PrintScreen),
             ProtoBareKey::Pause => Ok(BareKey::Pause),
             ProtoBareKey::Menu => Ok(BareKey::Menu),
+            ProtoBareKey::ScrollUp => Ok(BareKey::ScrollUp),
+            ProtoBareKey::ScrollDown => Ok(BareKey::ScrollDown),
             ProtoBareKey::Unspecified => Err(anyhow!("Unspecified bare key")),
         }
     }

--- a/zellij-utils/src/ipc/enum_conversions.rs
+++ b/zellij-utils/src/ipc/enum_conversions.rs
@@ -44,6 +44,7 @@ impl From<BareKey> for ProtoBareKey {
             BareKey::PrintScreen => ProtoBareKey::PrintScreen,
             BareKey::Pause => ProtoBareKey::Pause,
             BareKey::Menu => ProtoBareKey::Menu,
+            BareKey::ScrollUp | BareKey::ScrollDown => ProtoBareKey::Unspecified,
         }
     }
 }

--- a/zellij-utils/src/ipc/tests/roundtrip_tests.rs
+++ b/zellij-utils/src/ipc/tests/roundtrip_tests.rs
@@ -3055,6 +3055,71 @@ fn test_client_messages() {
         raw_bytes: "raw_bytes".as_bytes().to_vec(),
         is_kitty_keyboard_protocol: false,
     });
+    test_client_roundtrip!(ClientToServerMsg::Key {
+        key: KeyWithModifier {
+            bare_key: BareKey::ScrollUp,
+            key_modifiers: BTreeSet::new(),
+        },
+        raw_bytes: "raw_bytes".as_bytes().to_vec(),
+        is_kitty_keyboard_protocol: false,
+    });
+    test_client_roundtrip!(ClientToServerMsg::Key {
+        key: KeyWithModifier {
+            bare_key: BareKey::ScrollDown,
+            key_modifiers: BTreeSet::new(),
+        },
+        raw_bytes: "raw_bytes".as_bytes().to_vec(),
+        is_kitty_keyboard_protocol: false,
+    });
+    // ScrollUp/ScrollDown with modifiers (used for modifier+scroll keybindings)
+    test_client_roundtrip!(ClientToServerMsg::Key {
+        key: KeyWithModifier {
+            bare_key: BareKey::ScrollUp,
+            key_modifiers: {
+                let mut m = BTreeSet::new();
+                m.insert(KeyModifier::Ctrl);
+                m
+            },
+        },
+        raw_bytes: vec![],
+        is_kitty_keyboard_protocol: false,
+    });
+    test_client_roundtrip!(ClientToServerMsg::Key {
+        key: KeyWithModifier {
+            bare_key: BareKey::ScrollDown,
+            key_modifiers: {
+                let mut m = BTreeSet::new();
+                m.insert(KeyModifier::Ctrl);
+                m
+            },
+        },
+        raw_bytes: vec![],
+        is_kitty_keyboard_protocol: false,
+    });
+    test_client_roundtrip!(ClientToServerMsg::Key {
+        key: KeyWithModifier {
+            bare_key: BareKey::ScrollUp,
+            key_modifiers: {
+                let mut m = BTreeSet::new();
+                m.insert(KeyModifier::Alt);
+                m
+            },
+        },
+        raw_bytes: vec![],
+        is_kitty_keyboard_protocol: false,
+    });
+    test_client_roundtrip!(ClientToServerMsg::Key {
+        key: KeyWithModifier {
+            bare_key: BareKey::ScrollDown,
+            key_modifiers: {
+                let mut m = BTreeSet::new();
+                m.insert(KeyModifier::Alt);
+                m
+            },
+        },
+        raw_bytes: vec![],
+        is_kitty_keyboard_protocol: false,
+    });
     test_client_roundtrip!(ClientToServerMsg::ClientExited);
     test_client_roundtrip!(ClientToServerMsg::KillSession);
     test_client_roundtrip!(ClientToServerMsg::ConnStatus);

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -4754,6 +4754,8 @@ impl BareKey {
             BareKey::PrintScreen => format!("printscreen"),
             BareKey::Pause => format!("pause"),
             BareKey::Menu => format!("menu"),
+            BareKey::ScrollUp => format!("ScrollUp"),
+            BareKey::ScrollDown => format!("ScrollDown"),
         }
     }
 }

--- a/zellij-utils/src/plugin_api/action.proto
+++ b/zellij-utils/src/plugin_api/action.proto
@@ -638,6 +638,8 @@ enum BareKey {
   BARE_KEY_PRINT_SCREEN = 31;
   BARE_KEY_PAUSE = 32;
   BARE_KEY_MENU = 33;
+  BARE_KEY_SCROLL_UP = 34;
+  BARE_KEY_SCROLL_DOWN = 35;
 }
 
 enum KeyModifier {

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -2126,6 +2126,8 @@ impl TryFrom<ProtobufKeyWithModifier> for KeyWithModifier {
             Some(ProtobufBareKey::PrintScreen) => crate::data::BareKey::PrintScreen,
             Some(ProtobufBareKey::Pause) => crate::data::BareKey::Pause,
             Some(ProtobufBareKey::Menu) => crate::data::BareKey::Menu,
+            Some(ProtobufBareKey::ScrollUp) => crate::data::BareKey::ScrollUp,
+            Some(ProtobufBareKey::ScrollDown) => crate::data::BareKey::ScrollDown,
             _ => return Err("Unknown BareKey"),
         };
 
@@ -2185,6 +2187,8 @@ impl TryFrom<KeyWithModifier> for ProtobufKeyWithModifier {
             crate::data::BareKey::PrintScreen => (ProtobufBareKey::PrintScreen as i32, None),
             crate::data::BareKey::Pause => (ProtobufBareKey::Pause as i32, None),
             crate::data::BareKey::Menu => (ProtobufBareKey::Menu as i32, None),
+            crate::data::BareKey::ScrollUp => (ProtobufBareKey::ScrollUp as i32, None),
+            crate::data::BareKey::ScrollDown => (ProtobufBareKey::ScrollDown as i32, None),
             _ => return Err("Unsupported BareKey"),
         };
 

--- a/zellij-utils/src/plugin_api/key.proto
+++ b/zellij-utils/src/plugin_api/key.proto
@@ -43,6 +43,8 @@ message Key {
     Pause = 29;
     Menu = 30;
     Enter = 31;
+    ScrollUp = 32;
+    ScrollDown = 33;
   }
 
   enum Char {

--- a/zellij-utils/src/plugin_api/key.rs
+++ b/zellij-utils/src/plugin_api/key.rs
@@ -49,9 +49,8 @@ impl TryFrom<BareKey> for ProtobufMainKey {
             BareKey::PrintScreen => Ok(ProtobufMainKey::Key(ProtobufNamedKey::PrintScreen as i32)),
             BareKey::Pause => Ok(ProtobufMainKey::Key(ProtobufNamedKey::Pause as i32)),
             BareKey::Menu => Ok(ProtobufMainKey::Key(ProtobufNamedKey::Menu as i32)),
-            // ScrollUp/ScrollDown are virtual keys for mouse scroll bindings;
-            // they don't have protobuf representations as they are handled client-side
-            BareKey::ScrollUp | BareKey::ScrollDown => Err("ScrollUp/ScrollDown not supported in protobuf"),
+            BareKey::ScrollUp => Ok(ProtobufMainKey::Key(ProtobufNamedKey::ScrollUp as i32)),
+            BareKey::ScrollDown => Ok(ProtobufMainKey::Key(ProtobufNamedKey::ScrollDown as i32)),
         }
     }
 }
@@ -181,5 +180,7 @@ fn named_key_to_bare_key(named_key: ProtobufNamedKey) -> BareKey {
         ProtobufNamedKey::Menu => BareKey::Menu,
         ProtobufNamedKey::NumLock => BareKey::NumLock,
         ProtobufNamedKey::Enter => BareKey::Enter,
+        ProtobufNamedKey::ScrollUp => BareKey::ScrollUp,
+        ProtobufNamedKey::ScrollDown => BareKey::ScrollDown,
     }
 }

--- a/zellij-utils/src/plugin_api/key.rs
+++ b/zellij-utils/src/plugin_api/key.rs
@@ -49,6 +49,9 @@ impl TryFrom<BareKey> for ProtobufMainKey {
             BareKey::PrintScreen => Ok(ProtobufMainKey::Key(ProtobufNamedKey::PrintScreen as i32)),
             BareKey::Pause => Ok(ProtobufMainKey::Key(ProtobufNamedKey::Pause as i32)),
             BareKey::Menu => Ok(ProtobufMainKey::Key(ProtobufNamedKey::Menu as i32)),
+            // ScrollUp/ScrollDown are virtual keys for mouse scroll bindings;
+            // they don't have protobuf representations as they are handled client-side
+            BareKey::ScrollUp | BareKey::ScrollDown => Err("ScrollUp/ScrollDown not supported in protobuf"),
         }
     }
 }


### PR DESCRIPTION
Currently mouse scroll events bypass the keybinding system entirely, so there's no way for users to bind modifier+scroll combinations to actions like switching tabs. This adds ScrollUp and ScrollDown as virtual keys in BareKey and intercepts modifier+scroll mouse events on the client side, routing them through the existing keybinding pipeline. Plain scroll (without modifiers) continues through the normal mouse event path unchanged. Config syntax: `bind "Ctrl ScrollUp" { GoToPreviousTab; }`.

Closes #4838