### PR TITLE
Fix debug-mode stack overflow on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "zellij"
+build = "src/build.rs"
 authors = ["Aram Drevekenin <aram@poor.dev>"]
 description = "A terminal workspace with batteries included"
 homepage = "https://zellij.dev"

--- a/src/build.rs
+++ b/src/build.rs
@@ -2,8 +2,8 @@ fn main() {
     // The clap-derived `augment_subcommands` for `CliAction` (~70 variants)
     // produces a >1 MB stack frame in debug mode, overflowing the Windows
     // default 1 MB main-thread stack.  Increase it to 8 MB to match Linux.
-    // Release builds optimize the frame down, so this is only needed for debug.
-    if cfg!(target_os = "windows") && std::env::var("PROFILE").unwrap_or_default() == "debug" {
+    // Release builds optimize the frame down, so this is only needed for non-release profiles.
+    if cfg!(target_os = "windows") && std::env::var("PROFILE").unwrap_or_default() != "release" {
         println!("cargo:rustc-link-arg=/STACK:8388608");
     }
 }


### PR DESCRIPTION
The clap-derived augment_subcommands for CliAction (~70 variants) produces a >1 MB stack frame in debug mode, overflowing the Windows default 1 MB main-thread stack. Increase it to 8 MB via linker flag to match Linux. Only applies to debug builds; release optimizes the frame down and doesn't need it.

Stack overflow reported [here](https://github.com/zellij-org/zellij/issues/4745#issuecomment-4029203844)