### PR TITLE
feat: add Kitty graphics protocol passthrough

### DIFF
--- a/zellij-server/src/output/mod.rs
+++ b/zellij-server/src/output/mod.rs
@@ -161,7 +161,7 @@ fn serialize_chunks_with_newlines(
         let mut character_styles = DEFAULT_STYLES.enable_styled_underlines(styled_underlines);
         vte_output.push_str("\n\r");
         let mut chunk_width = character_chunk.x;
-        for t_character in character_chunk.terminal_characters.iter() {
+        for (col_idx, t_character) in character_chunk.terminal_characters.iter().enumerate() {
             // Stop rendering if the next character would exceed max_size.cols
             if let Some(size) = max_size {
                 if chunk_width + t_character.width() > size.cols {
@@ -190,6 +190,11 @@ fn serialize_chunks_with_newlines(
             .with_context(err_context)?;
             chunk_width += t_character.width();
             vte_output.push(t_character.character);
+            if let Some(combiners) = character_chunk.combining_chars.get(&col_idx) {
+                for &c in combiners {
+                    vte_output.push(c);
+                }
+            }
         }
     }
     Ok(vte_output)
@@ -226,7 +231,7 @@ fn serialize_chunks(
         vte_goto_instruction(character_chunk.x, character_chunk.y, &mut vte_output)
             .with_context(err_context)?;
         let mut chunk_width = character_chunk.x;
-        for t_character in character_chunk.terminal_characters.iter() {
+        for (col_idx, t_character) in character_chunk.terminal_characters.iter().enumerate() {
             // Stop rendering if the next character would exceed max_size.cols
             if let Some(size) = max_size {
                 if chunk_width + t_character.width() > size.cols {
@@ -255,6 +260,11 @@ fn serialize_chunks(
             .with_context(err_context)?;
             chunk_width += t_character.width();
             vte_output.push(t_character.character);
+            if let Some(combiners) = character_chunk.combining_chars.get(&col_idx) {
+                for &c in combiners {
+                    vte_output.push(c);
+                }
+            }
         }
     }
     if let Some(sixel_image_store) = sixel_image_store {
@@ -1007,6 +1017,8 @@ pub struct CharacterChunk {
     pub pane_default_fg: Option<AnsiCode>,
     pub pane_default_bg: Option<AnsiCode>,
     selection_and_colors: Vec<HighlightSelection>,
+    /// Combining characters (diacritics etc.) keyed by column offset within this chunk
+    pub combining_chars: HashMap<usize, Vec<char>>,
 }
 
 #[derive(Debug, Clone, Copy, Default)]

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -534,6 +534,15 @@ pub struct Grid {
     // key: plugin_id (u32), inner vec: (pattern, compiled) pairs
     pub hover_position: Option<Position>, // pane-relative cursor cell; None when outside pane
     pub cached_hover_tooltip: Option<String>,
+    /// APCs for the frame currently being assembled (may be incomplete)
+    kitty_apc_building: Vec<Vec<u8>>,
+    /// Running byte total of kitty_apc_building to avoid O(n) sum per push
+    kitty_apc_building_size: usize,
+    /// Last fully complete frame (terminated with m=0), ready to emit
+    kitty_apc_ready: Option<Vec<Vec<u8>>>,
+    /// True when kitty_apc_ready needs to be (re-)emitted
+    kitty_apc_dirty: bool,
+    combining_chars: HashMap<(usize, usize), Vec<char>>, // (viewport_row, col) -> combining marks
 }
 
 impl Grid {
@@ -817,10 +826,68 @@ impl Grid {
             plugin_highlights: HashMap::new(),
             hover_position: None,
             cached_hover_tooltip: None,
+            kitty_apc_building: Vec::new(),
+            kitty_apc_building_size: 0,
+            kitty_apc_ready: None,
+            kitty_apc_dirty: false,
+            combining_chars: HashMap::new(),
+        }
+    }
+    pub fn push_kitty_apc(&mut self, data: Vec<u8>) {
+        // Parse comma-separated key=value params before the ';' payload separator.
+        // Starts after the leading 'G' byte (data[0]).
+        let params_end = data.iter().position(|&b| b == b';').unwrap_or(data.len());
+        let params_str = &data[1..params_end]; // skip leading 'G'
+
+        let mut is_transmit = false;
+        let mut has_m = false;
+        let mut m_is_zero = false;
+        for param in params_str.split(|&b| b == b',') {
+            match param {
+                b"a=T" | b"a=t" => is_transmit = true,
+                b"m=0" => {
+                    has_m = true;
+                    m_is_zero = true;
+                },
+                p if p.starts_with(b"m=") => has_m = true,
+                _ => {},
+            }
+        }
+
+        if is_transmit {
+            self.kitty_apc_building.clear();
+            self.kitty_apc_building_size = 0;
+        }
+
+        let is_final = m_is_zero || !has_m;
+
+        // Cap in-progress frame at 64 MB to prevent unbounded memory growth
+        if self.kitty_apc_building_size + data.len() > 64 * 1024 * 1024 {
+            self.kitty_apc_building.clear();
+            self.kitty_apc_building_size = 0;
+            return;
+        }
+
+        self.kitty_apc_building_size += data.len();
+        self.kitty_apc_building.push(data);
+
+        if is_final {
+            // Frame complete -> promote to ready; recycle old ready's allocation for next frame
+            let complete_frame = std::mem::take(&mut self.kitty_apc_building);
+            self.kitty_apc_building_size = 0;
+            if let Some(mut old) = self.kitty_apc_ready.take() {
+                old.clear();
+                self.kitty_apc_building = old;
+            }
+            self.kitty_apc_ready = Some(complete_frame);
+            self.kitty_apc_dirty = true;
         }
     }
     pub fn render_full_viewport(&mut self) {
         self.output_buffer.update_all_lines();
+        if self.kitty_apc_ready.is_some() {
+            self.kitty_apc_dirty = true;
+        }
     }
     pub fn update_line_for_rendering(&mut self, line_index: usize) {
         self.output_buffer.update_line(line_index);
@@ -1330,13 +1397,26 @@ impl Grid {
         x_offset: usize,
         y_offset: usize,
     ) -> (Vec<CharacterChunk>, Vec<SixelImageChunk>) {
-        let changed_character_chunks = self.output_buffer.changed_chunks_in_viewport(
+        let mut changed_character_chunks = self.output_buffer.changed_chunks_in_viewport(
             self.viewport.make_contiguous(),
             self.width,
             self.height,
             x_offset,
             y_offset,
         );
+        // Attach combining characters to their respective chunks.
+        // Use direct HashMap::get per cell (O(1) each) rather than iterating
+        // the full map per chunk, which is O(map_size × chunks) for dense data.
+        if !self.combining_chars.is_empty() {
+            for chunk in &mut changed_character_chunks {
+                let viewport_row = chunk.y.saturating_sub(y_offset);
+                for col in 0..chunk.terminal_characters.len() {
+                    if let Some(combiners) = self.combining_chars.get(&(viewport_row, col)) {
+                        chunk.combining_chars.insert(col, combiners.clone());
+                    }
+                }
+            }
+        }
         let changed_rects = self
             .output_buffer
             .changed_rects_in_viewport(self.viewport.len());
@@ -1476,11 +1556,32 @@ impl Grid {
                 }
             }
         }
-        return Ok(Some((
-            character_chunks,
-            Some(raw_vte_output),
-            sixel_image_chunks,
-        )));
+        // Emit Kitty graphics frame only when dirty (new frame or full re-render like tab switch)
+        if self.kitty_apc_dirty {
+            if let Some(frame) = self.kitty_apc_ready.as_ref() {
+                let total_len: usize = frame.iter().map(|d| d.len() + 4).sum();
+                raw_vte_output.reserve(total_len);
+                for apc_data in frame {
+                    raw_vte_output.push_str("\x1b_");
+                    if let Ok(s) = std::str::from_utf8(apc_data) {
+                        raw_vte_output.push_str(s);
+                    } else {
+                        for &b in apc_data {
+                            raw_vte_output.push(b as char);
+                        }
+                    }
+                    raw_vte_output.push_str("\x1b\\");
+                }
+            }
+            self.kitty_apc_dirty = false;
+        }
+
+        let raw_vte = if raw_vte_output.is_empty() {
+            None
+        } else {
+            Some(raw_vte_output)
+        };
+        return Ok(Some((character_chunks, raw_vte, sixel_image_chunks)));
     }
     pub fn cursor_coordinates(&self) -> Option<(usize, usize)> {
         if self.cursor_is_hidden || self.cursor.x >= self.width || self.cursor.y >= self.height {
@@ -1597,6 +1698,24 @@ impl Grid {
         }
         self.output_buffer.update_all_lines();
     }
+    /// Shift combining_chars keys up by 1 within [region_top, region_bottom],
+    /// discarding row region_top (scrolled out).
+    fn scroll_combining_chars(&mut self, region_top: usize, region_bottom: usize) {
+        if self.combining_chars.is_empty() {
+            return;
+        }
+        let old = std::mem::take(&mut self.combining_chars);
+        self.combining_chars = old
+            .into_iter()
+            .filter_map(|((row, col), val)| {
+                if row >= region_top && row <= region_bottom {
+                    (row > region_top).then(|| ((row - 1, col), val))
+                } else {
+                    Some(((row, col), val))
+                }
+            })
+            .collect();
+    }
     pub fn add_canonical_line(&mut self) {
         let (scroll_region_top, scroll_region_bottom) = self.scroll_region;
         self.hyperlink_tracker.update(
@@ -1626,6 +1745,7 @@ impl Grid {
 
                 self.viewport.push_back(Row::new().canonical());
                 self.selection.move_up(1);
+                self.scroll_combining_chars(0, scroll_region_bottom);
             } else {
                 if scroll_region_top < self.viewport.len() {
                     self.viewport.remove(scroll_region_top);
@@ -1636,6 +1756,7 @@ impl Grid {
                 } else {
                     self.viewport.push_back(Row::new().canonical());
                 }
+                self.scroll_combining_chars(scroll_region_top, scroll_region_bottom);
             }
             self.output_buffer.update_all_lines(); // TODO: only update scroll region lines
             return;
@@ -1717,12 +1838,21 @@ impl Grid {
     }
     pub fn add_character(&mut self, terminal_character: TerminalCharacter) {
         let character_width = terminal_character.width();
-        // Drop zero-width Unicode/UTF-8 codepoints, like for example Variation Selectors.
-        // This breaks unicode grapheme segmentation, and is the reason why some characters
-        // aren't displayed correctly. Refer to this issue for more information:
-        //     https://github.com/zellij-org/zellij/issues/1538
         if character_width == 0 {
+            // Combining character: attach to the preceding cell
+            if self.cursor.x > 0 {
+                let row = self.cursor.y;
+                let col = self.cursor.x - 1;
+                self.combining_chars
+                    .entry((row, col))
+                    .or_default()
+                    .push(terminal_character.character);
+                self.output_buffer.update_line(row);
+            }
             return;
+        }
+        if !self.combining_chars.is_empty() {
+            self.combining_chars.remove(&(self.cursor.y, self.cursor.x));
         }
         if self.cursor.x + character_width > self.width {
             if self.disable_linewrap {
@@ -1766,6 +1896,9 @@ impl Grid {
             for row in self.viewport.iter_mut().skip(self.cursor.y + 1) {
                 row.replace_columns(replace_with_columns.clone());
             }
+            self.combining_chars.retain(|&(row, col), _| {
+                row < self.cursor.y || (row == self.cursor.y && col < self.cursor.x)
+            });
             self.output_buffer.update_all_lines(); // TODO: only update the changed lines
         }
     }
@@ -1776,12 +1909,17 @@ impl Grid {
             for row in self.viewport.iter_mut().take(self.cursor.y) {
                 row.replace_columns(replace_with_columns.clone());
             }
+            self.combining_chars.retain(|&(row, col), _| {
+                row > self.cursor.y || (row == self.cursor.y && col >= self.cursor.x)
+            });
             self.output_buffer.update_all_lines(); // TODO: only update the changed lines
         }
     }
     pub fn clear_cursor_line(&mut self) {
         if let Some(viewport_line) = self.viewport.get_mut(self.cursor.y) {
             viewport_line.truncate(0);
+            let cursor_y = self.cursor.y;
+            self.combining_chars.retain(|&(row, _), _| row != cursor_y);
             self.output_buffer.update_line(self.cursor.y);
         }
     }
@@ -1791,6 +1929,7 @@ impl Grid {
         for row in &mut self.viewport {
             row.replace_columns(replace_with_columns.clone());
         }
+        self.combining_chars.clear();
         self.output_buffer.update_all_lines();
     }
     fn line_wrap(&mut self) {
@@ -1805,6 +1944,7 @@ impl Grid {
             let wrapped_row = Row::new();
             self.viewport.push_back(wrapped_row);
             self.selection.move_up(1);
+            self.scroll_combining_chars(0, self.height.saturating_sub(1));
             self.output_buffer.update_all_lines();
         } else {
             self.cursor.y += 1;
@@ -1954,6 +2094,7 @@ impl Grid {
                     self.viewport
                         .push_back(Row::from_columns(columns).canonical());
                 }
+                self.scroll_combining_chars(current_line_index, scroll_region_bottom);
             }
             self.output_buffer.update_all_lines(); // TODO: move accurately
         }
@@ -1977,6 +2118,7 @@ impl Grid {
                 let columns = VecDeque::from(vec![pad_character.clone(); self.width]);
                 self.viewport
                     .insert(current_line_index, Row::from_columns(columns).canonical());
+                self.scroll_combining_chars(current_line_index, scroll_region_bottom);
             }
             self.output_buffer.update_all_lines(); // TODO: move accurately
         }
@@ -2067,6 +2209,14 @@ impl Grid {
         if let Some(images_to_reap) = self.sixel_grid.clear() {
             self.sixel_grid.reap_images(images_to_reap);
         }
+        self.reset_kitty_state();
+    }
+    fn reset_kitty_state(&mut self) {
+        self.kitty_apc_building.clear();
+        self.kitty_apc_building_size = 0;
+        self.kitty_apc_ready = None;
+        self.kitty_apc_dirty = false;
+        self.combining_chars.clear();
     }
     fn set_preceding_character(&mut self, terminal_character: TerminalCharacter) {
         self.preceding_char = Some(terminal_character);
@@ -3520,6 +3670,7 @@ impl Perform for Grid {
                                 );
                             }
                             self.alternate_screen_state = None;
+                            self.reset_kitty_state();
                             self.clear_viewport_before_rendering = true;
                             self.force_change_size(self.height, self.width); // the alternative_viewport might have been of a different size...
                             self.mark_for_rerender();
@@ -3628,6 +3779,7 @@ impl Perform for Grid {
                                 alternate_sixelgrid,
                                 current_supports_kitty_keyboard_protocol,
                             ));
+                            self.combining_chars.clear();
                             self.clear_viewport_before_rendering = true;
                             self.scrollback_buffer_lines =
                                 self.recalculate_scrollback_buffer_count();

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -36,6 +36,139 @@ use crate::ui::pane_boundaries_frame::{FrameParams, PaneFrame};
 
 pub const SELECTION_SCROLL_INTERVAL_MS: u64 = 10;
 
+/// Pre-parser that intercepts Kitty graphics APC sequences (`\x1b_G...\x1b\\`)
+/// before they reach the vte parser (which silently discards all APC content).
+///
+/// Returns zero-allocation (ApcAction, Option<ApcAction>) tuples instead of Vec.
+enum ApcScanState {
+    Normal,
+    SeenEsc,
+    SeenEscUnderscore,
+    InKittyApc(Vec<u8>),
+    InKittyApcSeenEsc(Vec<u8>),
+    InOtherApc,
+    InOtherApcSeenEsc,
+}
+
+enum ApcAction {
+    Feed(u8),
+    KittyApcComplete(Vec<u8>),
+    Buffering,
+}
+
+struct KittyApcScanner {
+    state: ApcScanState,
+}
+
+impl KittyApcScanner {
+    fn new() -> Self {
+        Self {
+            state: ApcScanState::Normal,
+        }
+    }
+
+    #[inline]
+    fn is_normal(&self) -> bool {
+        matches!(self.state, ApcScanState::Normal)
+    }
+
+    #[inline]
+    fn extend_apc_buffer(&mut self, bytes: &[u8]) {
+        match self.state {
+            ApcScanState::InKittyApc(ref mut buf) => buf.extend_from_slice(bytes),
+            _ => debug_assert!(false, "extend_apc_buffer called outside InKittyApc state"),
+        }
+    }
+
+    #[inline]
+    fn is_in_kitty_apc(&self) -> bool {
+        matches!(self.state, ApcScanState::InKittyApc(_))
+    }
+
+    #[inline]
+    fn advance(&mut self, byte: u8) -> (ApcAction, Option<ApcAction>) {
+        // Handle buffer-carrying states without moving the Vec out of the enum
+        match &mut self.state {
+            ApcScanState::InKittyApc(buf) => {
+                if byte == 0x1b {
+                    // Need to transition to InKittyApcSeenEsc - must move buf
+                    let buf = std::mem::take(buf);
+                    self.state = ApcScanState::InKittyApcSeenEsc(buf);
+                } else {
+                    buf.push(byte);
+                }
+                return (ApcAction::Buffering, None);
+            },
+            ApcScanState::InKittyApcSeenEsc(buf) => {
+                if byte == b'\\' {
+                    let buf = std::mem::take(buf);
+                    self.state = ApcScanState::Normal;
+                    return (ApcAction::KittyApcComplete(buf), None);
+                } else {
+                    buf.push(0x1b);
+                    buf.push(byte);
+                    let buf = std::mem::take(buf);
+                    self.state = ApcScanState::InKittyApc(buf);
+                    return (ApcAction::Buffering, None);
+                }
+            },
+            _ => {},
+        }
+        // Non-buffer states: cheap enum transitions
+        let state = std::mem::replace(&mut self.state, ApcScanState::Normal);
+        match state {
+            ApcScanState::Normal => {
+                if byte == 0x1b {
+                    self.state = ApcScanState::SeenEsc;
+                    (ApcAction::Buffering, None)
+                } else {
+                    (ApcAction::Feed(byte), None)
+                }
+            },
+            ApcScanState::SeenEsc => {
+                if byte == b'_' {
+                    self.state = ApcScanState::SeenEscUnderscore;
+                    (ApcAction::Buffering, None)
+                } else {
+                    (ApcAction::Feed(0x1b), Some(ApcAction::Feed(byte)))
+                }
+            },
+            ApcScanState::SeenEscUnderscore => {
+                if byte == b'G' {
+                    let mut buf = Vec::with_capacity(4096);
+                    buf.push(b'G');
+                    self.state = ApcScanState::InKittyApc(buf);
+                    (ApcAction::Buffering, None)
+                } else if byte == 0x1b {
+                    self.state = ApcScanState::SeenEsc;
+                    (ApcAction::Buffering, None)
+                } else {
+                    self.state = ApcScanState::InOtherApc;
+                    (ApcAction::Buffering, None)
+                }
+            },
+            ApcScanState::InOtherApc => {
+                if byte == 0x1b {
+                    self.state = ApcScanState::InOtherApcSeenEsc;
+                } else {
+                    self.state = ApcScanState::InOtherApc;
+                }
+                (ApcAction::Buffering, None)
+            },
+            ApcScanState::InOtherApcSeenEsc => {
+                if byte != b'\\' {
+                    self.state = ApcScanState::InOtherApc;
+                }
+                (ApcAction::Buffering, None)
+            },
+            // Already handled above via &mut match
+            ApcScanState::InKittyApc(_) | ApcScanState::InKittyApcSeenEsc(_) => {
+                unreachable!()
+            },
+        }
+    }
+}
+
 // Some keys in different formats but are used in the code
 const LEFT_ARROW: &[u8] = &[27, 91, 68];
 const RIGHT_ARROW: &[u8] = &[27, 91, 67];
@@ -153,6 +286,7 @@ pub struct TerminalPane {
     #[allow(dead_code)]
     arrow_fonts: bool,
     notification_end: Option<NotificationEnd>,
+    apc_scanner: KittyApcScanner,
 }
 
 impl Pane for TerminalPane {
@@ -203,8 +337,39 @@ impl Pane for TerminalPane {
     }
     fn handle_pty_bytes(&mut self, bytes: VteBytes) {
         self.set_should_render(true);
-        for &byte in &bytes {
-            self.vte_parser.advance(&mut self.grid, byte);
+        let mut i = 0;
+        while i < bytes.len() {
+            // Fast path: feed non-ESC bytes directly to vte, skipping the APC scanner
+            if self.apc_scanner.is_normal() {
+                let start = i;
+                while i < bytes.len() && bytes[i] != 0x1b {
+                    i += 1;
+                }
+                for j in start..i {
+                    self.vte_parser.advance(&mut self.grid, bytes[j]);
+                }
+                if i >= bytes.len() {
+                    break;
+                }
+            }
+            // Fast path: when inside a Kitty APC, batch all non-ESC bytes into the buffer
+            if self.apc_scanner.is_in_kitty_apc() {
+                let start = i;
+                while i < bytes.len() && bytes[i] != 0x1b {
+                    i += 1;
+                }
+                self.apc_scanner.extend_apc_buffer(&bytes[start..i]);
+                if i >= bytes.len() {
+                    break;
+                }
+            }
+            // Slow path: process ESC and state transitions byte-by-byte
+            let (action, extra) = self.apc_scanner.advance(bytes[i]);
+            self.dispatch_apc_action(action);
+            if let Some(action) = extra {
+                self.dispatch_apc_action(action);
+            }
+            i += 1;
         }
     }
     fn cursor_coordinates(&self, _client_id: Option<ClientId>) -> Option<(usize, usize)> {
@@ -1065,6 +1230,15 @@ impl TerminalPane {
             invoked_with,
             arrow_fonts,
             notification_end,
+            apc_scanner: KittyApcScanner::new(),
+        }
+    }
+    #[inline]
+    fn dispatch_apc_action(&mut self, action: ApcAction) {
+        match action {
+            ApcAction::Feed(b) => self.vte_parser.advance(&mut self.grid, b),
+            ApcAction::KittyApcComplete(data) => self.grid.push_kitty_apc(data),
+            ApcAction::Buffering => {},
         }
     }
     pub fn get_x(&self) -> usize {


### PR DESCRIPTION
## Summary

Adds passthrough support for the Kitty graphics protocol, enabling image display in terminals that support it (Ghostty, Kitty, etc.) when running Kitty-graphics-aware applications inside Zellij.

- Intercept Kitty graphics APC sequences (`\x1b_G...\x1b\\`) before vte silently discards them, and re-emit them as raw VTE output
- Store combining characters (width-0 Unicode) per cell so Kitty unicode placements (`\u{10EEEE}` + diacritics) pass through correctly
- Double-buffered frame handling ensures only complete frames are emitted, with a dirty flag for efficient re-emission on tab switch

This is a passthrough-only approach (~350 lines across 3 files) — Zellij does not parse or understand the image data, it just relays it. Applications that use quiet mode (`q=2`) with unicode placements work out of the box, including image viewers and streaming video tools.

Closes #2814. Related: #3954, #4500, #4336.

## Design

**APC interception** (`terminal_pane.rs`): A pre-parser state machine intercepts `\x1b_G...\x1b\\` sequences before they reach the vte parser (which silently discards all APC content in v0.11). Batch fast paths skip the scanner entirely for non-ESC byte runs in both Normal and InKittyApc states.

**Frame management** (`grid.rs`): APC chunks are accumulated in a building buffer and promoted to a ready buffer when the frame is complete (`m=0`). A dirty flag controls emission — set on new frame arrival or full viewport re-render (tab switch), cleared after emission. This avoids redundant output while ensuring static images survive tab switches.

**Combining characters** (`grid.rs` + `output/mod.rs`): Width-0 characters are now stored as combining marks on the preceding cell instead of being dropped. These are attached to `CharacterChunk`s during change detection and emitted inline during serialization. Scroll operations adjust the combining chars HashMap via single-pass drain+collect.

**Safety bounds**: In-progress frame data is capped at 64 MB to prevent unbounded memory growth. APC parameter parsing uses proper comma-delimited key=value matching.

## What works

Applications that use **quiet mode (`q=2`) with unicode placements (`U=1`)** work correctly. This includes tools that transmit image data inline and use `\u{10EEEE}` diacritics for positioning, such as:
- Custom Kitty-graphics-aware applications
- Tools using `ratatui-image` with Kitty protocol
- Streaming video at 12+ FPS with minimal overhead vs native terminal

## Limitations

- **No reverse APC passthrough**: The Kitty protocol includes a response channel (terminal → application) for detection queries and error reporting. This implementation only handles the forward direction (application → terminal). Applications like `kitten icat` that rely on graphics query responses will not work — they need the terminal's APC responses forwarded back through the PTY. This would require changes to Zellij's client input handling path and is left as future work.
- **Floating pane artifacts**: When a floating pane partially obscures a pane displaying Kitty graphics, image fragments may appear at the visible edges of the background pane. Closing the floating pane restores correct rendering. This is inherent to the passthrough approach — the terminal renders the image wherever placeholder characters exist.
- **Combining chars not preserved in scrollback history**: Combining characters are adjusted for viewport scrolling but not stored in `lines_above`. This is fine for alternate-screen applications (the primary use case) but means images won't survive scrollback in normal-screen mode.
- **Non-Kitty APC sequences** are silently dropped (same as vte's existing behavior, no regression).

## Test plan

- [x] `cargo test` — all 862 existing tests pass
- [x] `cargo xtask format` — passes
- [x] Tested with Kitty-graphics-aware application displaying static images inside Zellij panes (Ghostty terminal)
- [x] Tested with streaming video at 12+ FPS with <0.1 FPS variance vs native Ghostty
- [x] Verified images survive tab switch and return
- [x] Verified multi-pane with different image streams (no cross-contamination)
- [x] Verified no garbage output after application exit (alternate screen cleanup)
- [x] Verified `kitten icat` fails gracefully (known limitation — no reverse passthrough)
- [ ] Test with Kitty terminal
- [ ] Test with `yazi` image previews (may need `q=2` support)
- [ ] Test with `timg`, `chafa --format=kitty`