### PR TITLE
fix: prevent web client freeze during heavy terminal output

### DIFF
--- a/zellij-client/src/web_client/connection_manager.rs
+++ b/zellij-client/src/web_client/connection_manager.rs
@@ -124,8 +124,16 @@ impl ClientConnectionBus {
                 self.get_control_channel_tx();
                 if let Some(control_channel_tx) = self.control_channel_tx.as_ref() {
                     let _ = control_channel_tx.send(message);
+                } else if self.pending_control_messages.len() < 100 {
+                    log::warn!(
+                        "Control channel not yet available, buffering message ({} pending)",
+                        self.pending_control_messages.len() + 1
+                    );
+                    self.pending_control_messages.push(message);
                 } else {
-                    log::error!("Failed to send control message to client");
+                    log::error!(
+                        "Pending control message buffer full (100), dropping message"
+                    );
                 }
             },
         }
@@ -186,6 +194,17 @@ impl ClientConnectionBus {
             .unwrap()
             .get_client_control_tx(&self.web_client_id)
         {
+            // Flush any messages that were buffered while the channel was unavailable
+            if !self.pending_control_messages.is_empty() {
+                let pending = std::mem::take(&mut self.pending_control_messages);
+                log::info!(
+                    "Control channel now available, flushing {} pending messages",
+                    pending.len()
+                );
+                for msg in pending {
+                    let _ = control_channel_tx.send(msg);
+                }
+            }
             self.control_channel_tx = Some(control_channel_tx);
         }
     }

--- a/zellij-client/src/web_client/session_management.rs
+++ b/zellij-client/src/web_client/session_management.rs
@@ -48,11 +48,11 @@ pub fn spawn_new_session(
     session_name: &str,
     mut os_input: Box<dyn ClientOsApi>,
     zellij_ipc_pipe: &PathBuf,
-) {
+) -> Result<(), std::io::Error> {
     let debug = false;
     envs::set_session_name(session_name.to_owned());
     os_input.update_session_name(session_name.to_owned());
-    spawn_server(&*zellij_ipc_pipe, debug).unwrap();
+    spawn_server(&*zellij_ipc_pipe, debug)
 }
 
 pub fn create_first_message(

--- a/zellij-client/src/web_client/types.rs
+++ b/zellij-client/src/web_client/types.rs
@@ -74,7 +74,10 @@ impl SessionManager for RealSessionManager {
         first_message: ClientToServerMsg,
     ) {
         if !session_exists {
-            spawn_new_session(session_name, os_input.clone(), zellij_ipc_pipe);
+            if let Err(e) = spawn_new_session(session_name, os_input.clone(), zellij_ipc_pipe) {
+                log::error!("Failed to spawn new session '{}': {}", session_name, e);
+                return;
+            }
         }
         os_input.connect_to_server(&zellij_ipc_pipe);
         os_input.send_to_server(first_message);
@@ -137,6 +140,7 @@ pub struct ClientConnectionBus {
     pub stdout_channel_tx: Option<UnboundedSender<String>>,
     pub control_channel_tx: Option<UnboundedSender<Message>>,
     pub web_client_id: String,
+    pending_control_messages: Vec<Message>,
 }
 
 impl ClientConnectionBus {
@@ -155,6 +159,7 @@ impl ClientConnectionBus {
             stdout_channel_tx,
             control_channel_tx,
             web_client_id,
+            pending_control_messages: Vec::new(),
         }
     }
 }

--- a/zellij-client/src/web_client/websocket_handlers.rs
+++ b/zellij-client/src/web_client/websocket_handlers.rs
@@ -18,6 +18,7 @@ use axum::{
 };
 use futures::StreamExt;
 use std::sync::{atomic::AtomicBool, Arc};
+use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 use zellij_utils::{input::mouse::MouseEvent, ipc::ClientToServerMsg};
 
@@ -80,6 +81,10 @@ async fn handle_ws_control(
     };
 
     let mut set_client_control_channel = false;
+    // Throttle resize events to avoid overwhelming the server, matching the
+    // native client's SIGWINCH_CB_THROTTLE_DURATION of 50ms.
+    const RESIZE_THROTTLE_DURATION: Duration = Duration::from_millis(50);
+    let mut last_resize_at: Option<Instant> = None;
 
     while let Some(Ok(msg)) = control_socket_rx.next().await {
         match msg {
@@ -113,6 +118,19 @@ async fn handle_ws_control(
                                     &deserialized_msg.web_client_id,
                                     control_channel_tx.clone(),
                                 );
+                        }
+                        // Throttle resize messages to prevent flooding the
+                        // server during rapid browser window resizing.
+                        if matches!(
+                            deserialized_msg.payload,
+                            WebClientToWebServerControlMessagePayload::TerminalResize(_)
+                        ) {
+                            if let Some(last) = last_resize_at {
+                                if last.elapsed() < RESIZE_THROTTLE_DURATION {
+                                    continue;
+                                }
+                            }
+                            last_resize_at = Some(Instant::now());
                         }
                         send_message_to_server(deserialized_msg);
                     },

--- a/zellij-server/src/os_input_output_unix.rs
+++ b/zellij-server/src/os_input_output_unix.rs
@@ -366,7 +366,13 @@ impl UnixPtyBackend {
                     set_terminal_size_using_fd(*fd, cols, rows, width_in_pixels, height_in_pixels);
                 }
             },
-            _ => {
+            Some(None) => {
+                log::debug!(
+                    "Ignoring resize for terminal {} — PTY not yet spawned",
+                    terminal_id
+                );
+            },
+            None => {
                 Err::<(), _>(anyhow!("failed to find terminal fd for id {terminal_id}"))
                     .with_context(err_context)
                     .non_fatal();


### PR DESCRIPTION
## Summary

The web client freezes when running programs that perform heavy terminal manipulation (e.g. TUI apps like Claude Code, interactive CLIs). This patch fixes four interacting issues:

- **Race condition in `set_terminal_size`**: Resize events arriving between `reserve_terminal_id()` and `spawn_terminal()` hit a catch-all error path that logged errors for the benign `Some(None)` case (PTY reserved but not yet spawned). Split the match arm to silently skip this case with a debug log.
- **Missing resize throttle for web client**: The native client debounces SIGWINCH at 50ms via `SIGWINCH_CB_THROTTLE_DURATION`, but the web client forwarded every resize event immediately, flooding the server during rapid browser window changes. Added a matching 50ms throttle.
- **Control messages dropped before WebSocket connects**: The server sends `QueryTerminalSize` during session init, but the web client's control WebSocket may not be established yet. Messages were silently dropped, leaving the initial browser tab with no terminal size. Added a buffer (up to 100 messages) that flushes when the channel becomes available.
- **Thread panic on `spawn_server` failure**: `spawn_new_session()` called `.unwrap()` on `spawn_server()`, panicking the `server_listener` thread and severing all server-client communication. Changed to return `Result` with graceful error handling.

## Test plan

- [x] Start Zellij via web client (`zellij web`), open browser, run a heavy TUI app — verify no freeze
- [x] Verify initial browser tab connects without needing a page refresh
- [x] Check logs: no "failed to find terminal fd" error spam, "flushing N pending messages" appears on connect
- [x] Rapidly resize browser window — verify server stays responsive
- [x] `cargo check -p zellij-server -p zellij-client` passes with no new warnings

## Related issues

- #3059 (Zellij Freezes on Start)
- #4452 (After some time of usage zellij crashes)
- #2924 (Frozen zellij session following input/output OS error 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)