### PR TITLE
Add support for mouse horizontal scroll

### DIFF
--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -49,9 +49,9 @@ fn termwiz_mouse_convert(original_event: &mut MouseEvent, event: &TermwizMouseEv
         && button_bits.contains(MouseButtons::WHEEL_POSITIVE);
     original_event.wheel_down = button_bits.contains(MouseButtons::VERT_WHEEL)
         && !button_bits.contains(MouseButtons::WHEEL_POSITIVE);
-    original_event.wheel_right = button_bits.contains(MouseButtons::HORZ_WHEEL)
-        && button_bits.contains(MouseButtons::WHEEL_POSITIVE);
     original_event.wheel_left = button_bits.contains(MouseButtons::HORZ_WHEEL)
+        && button_bits.contains(MouseButtons::WHEEL_POSITIVE);
+    original_event.wheel_right = button_bits.contains(MouseButtons::HORZ_WHEEL)
         && !button_bits.contains(MouseButtons::WHEEL_POSITIVE);
 
     let mods = &event.modifiers;

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -3486,6 +3486,10 @@ impl Grid {
             value = 68;
         } else if event.wheel_down {
             value = 69;
+        } else if event.wheel_left {
+            value = 70;
+        } else if event.wheel_right {
+            value = 71;
         }
         if event.event_type == MouseEventType::Motion {
             value += 32;
@@ -3513,6 +3517,10 @@ impl Grid {
             value = 64;
         } else if event.wheel_down {
             value = 65;
+        } else if event.wheel_left {
+            value = 66;
+        } else if event.wheel_right {
+            value = 67;
         }
         if event.event_type == MouseEventType::Motion {
             value += 32;
@@ -3534,7 +3542,13 @@ impl Grid {
             (MouseTracking::AnyEventTracking, _) => true,
             (_, MouseEventType::Press | MouseEventType::Release) => true,
             (MouseTracking::ButtonEventTracking, MouseEventType::Motion) => {
-                event.left | event.right | event.middle | event.wheel_up | event.wheel_down
+                event.left
+                    | event.right
+                    | event.middle
+                    | event.wheel_up
+                    | event.wheel_down
+                    | event.wheel_left
+                    | event.wheel_right
             },
             (_, _) => false,
         };
@@ -3769,6 +3783,49 @@ impl Grid {
             (MouseMode::Sgr, _) => {
                 let mouse_event = format!(
                     "\u{1b}[<65;{:?};{:?}M",
+                    position.column.0 + 1,
+                    position.line.0 + 1
+                );
+                Some(mouse_event)
+            },
+        }
+    }
+    pub fn mouse_scroll_left_signal(&self, position: &Position) -> Option<String> {
+        match (&self.mouse_mode, &self.mouse_tracking) {
+            (_, MouseTracking::Off) => None,
+            (MouseMode::NoEncoding | MouseMode::Utf8, _) => {
+                let mut msg: Vec<u8> = vec![27, b'[', b'M', b'b'];
+                msg.append(&mut utf8_mouse_coordinates(
+                    position.column() + 1,
+                    position.line() + 1,
+                ));
+                Some(String::from_utf8_lossy(&msg).into())
+            },
+            (MouseMode::Sgr, _) => {
+                let mouse_event = format!(
+                    "\u{1b}[<66;{:?};{:?}M",
+                    position.column.0 + 1,
+                    position.line.0 + 1
+                );
+                Some(mouse_event)
+            },
+        }
+    }
+
+    pub fn mouse_scroll_right_signal(&self, position: &Position) -> Option<String> {
+        match (&self.mouse_mode, &self.mouse_tracking) {
+            (_, MouseTracking::Off) => None,
+            (MouseMode::NoEncoding | MouseMode::Utf8, _) => {
+                let mut msg: Vec<u8> = vec![27, b'[', b'M', b'c'];
+                msg.append(&mut utf8_mouse_coordinates(
+                    position.column() + 1,
+                    position.line() + 1,
+                ));
+                Some(String::from_utf8_lossy(&msg).into())
+            },
+            (MouseMode::Sgr, _) => {
+                let mouse_event = format!(
+                    "\u{1b}[<67;{:?};{:?}M",
                     position.column.0 + 1,
                     position.line.0 + 1
                 );

--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -890,7 +890,9 @@ impl Pane for PluginPane {
                     && !event.right
                     && !event.middle
                     && !event.wheel_up
-                    && !event.wheel_down =>
+                    && !event.wheel_down
+                    && !event.wheel_left
+                    && !event.wheel_right =>
             {
                 let _ = self
                     .send_plugin_instructions

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -731,6 +731,8 @@ impl Pane for TerminalPane {
         self.grid.move_viewport_down(count);
         self.set_should_render(true);
     }
+    fn scroll_left(&mut self, _count: usize, _client_id: ClientId) {}
+    fn scroll_right(&mut self, _count: usize, _client_id: ClientId) {}
     fn clear_scroll(&mut self) {
         self.grid.reset_viewport();
         self.set_should_render(true);
@@ -995,6 +997,12 @@ impl Pane for TerminalPane {
     }
     fn mouse_scroll_down(&self, position: &Position) -> Option<String> {
         self.grid.mouse_scroll_down_signal(position)
+    }
+    fn mouse_scroll_left(&self, position: &Position) -> Option<String> {
+        self.grid.mouse_scroll_left_signal(position)
+    }
+    fn mouse_scroll_right(&self, position: &Position) -> Option<String> {
+        self.grid.mouse_scroll_right_signal(position)
     }
     fn focus_event(&self) -> Option<String> {
         self.grid.focus_event()

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -358,8 +358,8 @@ pub trait Pane {
     }
     fn scroll_up(&mut self, count: usize, client_id: ClientId);
     fn scroll_down(&mut self, count: usize, client_id: ClientId);
-    fn scroll_left(&mut self, _count: usize, _client_id: ClientId) {}
-    fn scroll_right(&mut self, _count: usize, _client_id: ClientId) {}
+    fn scroll_left(&mut self, count: usize, client_id: ClientId);
+    fn scroll_right(&mut self, count: usize, client_id: ClientId);
     fn clear_scroll(&mut self);
     fn is_scrolled(&self) -> bool;
     fn active_at(&self) -> Instant;
@@ -646,6 +646,12 @@ pub trait Pane {
         None
     }
     fn mouse_scroll_down(&self, _position: &Position) -> Option<String> {
+        None
+    }
+    fn mouse_scroll_left(&self, _position: &Position) -> Option<String> {
+        None
+    }
+    fn mouse_scroll_right(&self, _position: &Position) -> Option<String> {
         None
     }
     fn focus_event(&self) -> Option<String> {

--- a/zellij-server/src/tab/mouse_handler.rs
+++ b/zellij-server/src/tab/mouse_handler.rs
@@ -827,29 +827,13 @@ impl MouseHandler {
                 Self::handle_scrollwheel_down(tab, &event.position, lines, client_id)
                     .with_context(err_context)
             },
-            MouseAction::ScrollLeft { pane_id, cols } => {
-                let scroll_right = false;
-                Self::handle_scrollwheel_horizontal(
-                    tab,
-                    pane_id,
-                    &event.position,
-                    cols,
-                    scroll_right,
-                    client_id,
-                )
-                .with_context(err_context)
+            MouseAction::ScrollLeft { pane_id: _, cols } => {
+                Self::handle_scrollwheel_left(tab, &event.position, cols, client_id)
+                    .with_context(err_context)
             },
-            MouseAction::ScrollRight { pane_id, cols } => {
-                let scroll_right = true;
-                Self::handle_scrollwheel_horizontal(
-                    tab,
-                    pane_id,
-                    &event.position,
-                    cols,
-                    scroll_right,
-                    client_id,
-                )
-                .with_context(err_context)
+            MouseAction::ScrollRight { pane_id: _, cols } => {
+                Self::handle_scrollwheel_right(tab, &event.position, cols, client_id)
+                    .with_context(err_context)
             },
             MouseAction::ResizeScrollUp { pane_id } => {
                 Self::handle_resize_scroll_up(tab, pane_id, client_id).with_context(err_context)
@@ -1691,32 +1675,79 @@ impl MouseHandler {
         Ok(MouseEffect::default())
     }
 
-    pub(crate) fn handle_scrollwheel_horizontal(
+    pub(crate) fn handle_scrollwheel_left(
         tab: &mut Tab,
-        pane_id: PaneId,
         point: &Position,
         cols: usize,
-        scroll_right: bool,
         client_id: ClientId,
     ) -> Result<MouseEffect> {
         let err_context = || {
             format!(
-                "failed to handle horizontal scrollwheel at position {point:?} for client {client_id}"
+                "failed to handle scrollwheel left at position {point:?} for client {client_id}"
             )
         };
-        if !matches!(pane_id, PaneId::Plugin(_)) {
-            return Ok(MouseEffect::default());
-        }
+
         if let Some(pane) = Self::get_pane_at(tab, point, false).with_context(err_context)? {
-            if scroll_right {
-                pane.scroll_right(cols, client_id);
+            let relative_position = pane.relative_position(point);
+            if let Some(mouse_event) = pane.mouse_scroll_left(&relative_position) {
+                tab.write_to_terminal_at(mouse_event.into_bytes(), point, client_id)
+                    .with_context(err_context)?;
+            } else if pane.is_alternate_mode_active() {
+                // faux scrolling, send LEFT n times
+                // do n separate writes to make sure the sequence gets adjusted for cursor keys mode
+                for _ in 0..cols {
+                    tab.write_to_terminal_at("\u{1b}[D".as_bytes().to_owned(), point, client_id)
+                        .with_context(err_context)?;
+                }
             } else {
                 pane.scroll_left(cols, client_id);
+                if !pane.is_scrolled() {
+                    if let PaneId::Terminal(pid) = pane.pid() {
+                        tab.process_pending_vte_events(pid)
+                            .with_context(err_context)?;
+                    }
+                }
             }
         }
         Ok(MouseEffect::default())
     }
 
+    pub(crate) fn handle_scrollwheel_right(
+        tab: &mut Tab,
+        point: &Position,
+        cols: usize,
+        client_id: ClientId,
+    ) -> Result<MouseEffect> {
+        let err_context = || {
+            format!(
+                "failed to handle scrollwheel right at position {point:?} for client {client_id}"
+            )
+        };
+
+        if let Some(pane) = Self::get_pane_at(tab, point, false).with_context(err_context)? {
+            let relative_position = pane.relative_position(point);
+            if let Some(mouse_event) = pane.mouse_scroll_right(&relative_position) {
+                tab.write_to_terminal_at(mouse_event.into_bytes(), point, client_id)
+                    .with_context(err_context)?;
+            } else if pane.is_alternate_mode_active() {
+                // faux scrolling, send RIGHT n times
+                // do n separate writes to make sure the sequence gets adjusted for cursor keys mode
+                for _ in 0..cols {
+                    tab.write_to_terminal_at("\u{1b}[C".as_bytes().to_owned(), point, client_id)
+                        .with_context(err_context)?;
+                }
+            } else {
+                pane.scroll_right(cols, client_id);
+                if !pane.is_scrolled() {
+                    if let PaneId::Terminal(pid) = pane.pid() {
+                        tab.process_pending_vte_events(pid)
+                            .with_context(err_context)?;
+                    }
+                }
+            }
+        }
+        Ok(MouseEffect::default())
+    }
     fn handle_resize_scroll_up(
         tab: &mut Tab,
         pane_id: PaneId,

--- a/zellij-utils/src/input/mouse.rs
+++ b/zellij-utils/src/input/mouse.rs
@@ -16,9 +16,7 @@ pub struct MouseEvent {
     pub middle: bool,
     pub wheel_up: bool,
     pub wheel_down: bool,
-    #[serde(default)]
     pub wheel_left: bool,
-    #[serde(default)]
     pub wheel_right: bool,
 
     // Keyboard modifier flags can be encoded with events too.  They
@@ -370,6 +368,40 @@ impl MouseEvent {
         };
         event
     }
+    pub fn new_scroll_left_event(position: Position) -> Self {
+        let event = MouseEvent {
+            event_type: MouseEventType::Press,
+            left: false,
+            right: false,
+            middle: false,
+            wheel_up: false,
+            wheel_down: false,
+            wheel_left: true,
+            wheel_right: false,
+            shift: false,
+            alt: false,
+            ctrl: false,
+            position,
+        };
+        event
+    }
+    pub fn new_scroll_right_event(position: Position) -> Self {
+        let event = MouseEvent {
+            event_type: MouseEventType::Press,
+            left: false,
+            right: false,
+            middle: false,
+            wheel_up: false,
+            wheel_down: false,
+            wheel_left: false,
+            wheel_right: true,
+            shift: false,
+            alt: false,
+            ctrl: false,
+            position,
+        };
+        event
+    }
     pub fn new_ctrl_scroll_up_event(position: Position) -> Self {
         let event = MouseEvent {
             event_type: MouseEventType::Press,
@@ -403,38 +435,6 @@ impl MouseEvent {
             position,
         };
         event
-    }
-    pub fn new_scroll_left_event(position: Position) -> Self {
-        MouseEvent {
-            event_type: MouseEventType::Press,
-            left: false,
-            right: false,
-            middle: false,
-            wheel_up: false,
-            wheel_down: false,
-            wheel_left: true,
-            wheel_right: false,
-            shift: false,
-            alt: false,
-            ctrl: false,
-            position,
-        }
-    }
-    pub fn new_scroll_right_event(position: Position) -> Self {
-        MouseEvent {
-            event_type: MouseEventType::Press,
-            left: false,
-            right: false,
-            middle: false,
-            wheel_up: false,
-            wheel_down: false,
-            wheel_left: false,
-            wheel_right: true,
-            shift: false,
-            alt: false,
-            ctrl: false,
-            position,
-        }
     }
 }
 

--- a/zellij-utils/src/plugin_api/event.rs
+++ b/zellij-utils/src/plugin_api/event.rs
@@ -1665,6 +1665,22 @@ impl TryFrom<MouseEventPayload> for Mouse {
                     _ => Err("Malformed payload for mouse scroll down"),
                 }
             },
+            Some(MouseEventName::MouseScrollLeft) => {
+                match mouse_event_payload.mouse_event_payload {
+                    Some(mouse_event_payload::MouseEventPayload::LineCount(line_count)) => {
+                        Ok(Mouse::ScrollLeft(line_count as usize))
+                    },
+                    _ => Err("Malformed payload for mouse scroll left"),
+                }
+            },
+            Some(MouseEventName::MouseScrollRight) => {
+                match mouse_event_payload.mouse_event_payload {
+                    Some(mouse_event_payload::MouseEventPayload::LineCount(line_count)) => {
+                        Ok(Mouse::ScrollRight(line_count as usize))
+                    },
+                    _ => Err("Malformed payload for mouse scroll right"),
+                }
+            },
             Some(MouseEventName::MouseLeftClick) => match mouse_event_payload.mouse_event_payload {
                 Some(mouse_event_payload::MouseEventPayload::Position(position)) => Ok(
                     Mouse::LeftClick(position.line as isize, position.column as usize),
@@ -1697,22 +1713,6 @@ impl TryFrom<MouseEventPayload> for Mouse {
                 ),
                 _ => Err("Malformed payload for mouse hover"),
             },
-            Some(MouseEventName::MouseScrollLeft) => {
-                match mouse_event_payload.mouse_event_payload {
-                    Some(mouse_event_payload::MouseEventPayload::LineCount(line_count)) => {
-                        Ok(Mouse::ScrollLeft(line_count as usize))
-                    },
-                    _ => Err("Malformed payload for mouse scroll left"),
-                }
-            },
-            Some(MouseEventName::MouseScrollRight) => {
-                match mouse_event_payload.mouse_event_payload {
-                    Some(mouse_event_payload::MouseEventPayload::LineCount(line_count)) => {
-                        Ok(Mouse::ScrollRight(line_count as usize))
-                    },
-                    _ => Err("Malformed payload for mouse scroll right"),
-                }
-            },
             None => Err("Malformed payload for MouseEventName"),
         }
     }
@@ -1732,6 +1732,18 @@ impl TryFrom<Mouse> for MouseEventPayload {
                 mouse_event_name: MouseEventName::MouseScrollDown as i32,
                 mouse_event_payload: Some(mouse_event_payload::MouseEventPayload::LineCount(
                     number_of_lines as u32,
+                )),
+            }),
+            Mouse::ScrollLeft(cols) => Ok(MouseEventPayload {
+                mouse_event_name: MouseEventName::MouseScrollLeft as i32,
+                mouse_event_payload: Some(mouse_event_payload::MouseEventPayload::LineCount(
+                    cols as u32,
+                )),
+            }),
+            Mouse::ScrollRight(cols) => Ok(MouseEventPayload {
+                mouse_event_name: MouseEventName::MouseScrollRight as i32,
+                mouse_event_payload: Some(mouse_event_payload::MouseEventPayload::LineCount(
+                    cols as u32,
                 )),
             }),
             Mouse::LeftClick(line, column) => Ok(MouseEventPayload {
@@ -1777,18 +1789,6 @@ impl TryFrom<Mouse> for MouseEventPayload {
                         line: line as i64,
                         column: column as i64,
                     },
-                )),
-            }),
-            Mouse::ScrollLeft(cols) => Ok(MouseEventPayload {
-                mouse_event_name: MouseEventName::MouseScrollLeft as i32,
-                mouse_event_payload: Some(mouse_event_payload::MouseEventPayload::LineCount(
-                    cols as u32,
-                )),
-            }),
-            Mouse::ScrollRight(cols) => Ok(MouseEventPayload {
-                mouse_event_name: MouseEventName::MouseScrollRight as i32,
-                mouse_event_payload: Some(mouse_event_payload::MouseEventPayload::LineCount(
-                    cols as u32,
                 )),
             }),
         }


### PR DESCRIPTION
Adds support for mouse horizontal scroll events, Fix #4628.

https://github.com/user-attachments/assets/55cf689b-30eb-4f45-9b66-079e45ac7e37

### Behavior

- **Mouse tracking enabled**: forwards the event as the appropriate escape sequence (SGR `66`/`67`, legacy `b`/`c` for left/right).
- **Alternate screen, no mouse tracking (faux scrolling)**: falls back to sending `\x1b[D`/`\x1b[C` (Left/Right arrow).
- **Plugin panes**: emits `Mouse::ScrollLeft(count)` / `Mouse::ScrollRight(count)` for plugins to handle directly.
- `scroll_left` / `scroll_right` on `TerminalPane` are no-ops in normal scroll mode.

