### PR TITLE
Fix tab sizing so multi-client sessions only use the minimum size per tab

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -557,34 +557,6 @@ impl SessionState {
     pub fn set_client_data(&mut self, client_id: ClientId, size: Size, is_web_client: bool) {
         self.clients.insert(client_id, Some((size, is_web_client)));
     }
-    pub fn min_client_terminal_size(&self) -> Option<Size> {
-        // None if there are no client sizes
-        let mut rows: Vec<usize> = self
-            .clients
-            .values()
-            .filter_map(|size_and_is_web_client| {
-                size_and_is_web_client.map(|(size, _is_web_client)| size.rows)
-            })
-            .collect();
-        rows.sort_unstable();
-        let mut cols: Vec<usize> = self
-            .clients
-            .values()
-            .filter_map(|size_and_is_web_client| {
-                size_and_is_web_client.map(|(size, _is_web_client)| size.cols)
-            })
-            .collect();
-        cols.sort_unstable();
-        let min_rows = rows.first();
-        let min_cols = cols.first();
-        match (min_rows, min_cols) {
-            (Some(min_rows), Some(min_cols)) => Some(Size {
-                rows: *min_rows,
-                cols: *min_cols,
-            }),
-            _ => None,
-        }
-    }
     pub fn client_ids(&self) -> Vec<ClientId> {
         self.clients.keys().copied().collect()
     }
@@ -980,20 +952,12 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                     client_attributes.size,
                     is_web_client,
                 );
-                let min_size = session_state
-                    .read()
-                    .unwrap()
-                    .min_client_terminal_size()
-                    .unwrap();
-                session_data
-                    .senders
-                    .send_to_screen(ScreenInstruction::TerminalResize(min_size))
-                    .unwrap();
                 session_data
                     .senders
                     .send_to_screen(ScreenInstruction::AddClient(
                         client_id,
                         is_web_client,
+                        client_attributes.size,
                         tab_position_to_focus,
                         pane_id_to_focus,
                     ))
@@ -1149,17 +1113,6 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                     // Handle regular client removal
                     remove_client!(client_id, os_input, session_state);
                     drop(completion_tx); // prevent deadlock with route thread
-                    if let Some(min_size) = session_state.read().unwrap().min_client_terminal_size()
-                    {
-                        session_data
-                            .write()
-                            .unwrap()
-                            .as_ref()
-                            .unwrap()
-                            .senders
-                            .send_to_screen(ScreenInstruction::TerminalResize(min_size))
-                            .unwrap();
-                    }
                     session_data
                         .write()
                         .unwrap()
@@ -1223,17 +1176,6 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                 } else {
                     // Handle regular client removal
                     remove_client!(client_id, os_input, session_state);
-                    if let Some(min_size) = session_state.read().unwrap().min_client_terminal_size()
-                    {
-                        session_data
-                            .write()
-                            .unwrap()
-                            .as_ref()
-                            .unwrap()
-                            .senders
-                            .send_to_screen(ScreenInstruction::TerminalResize(min_size))
-                            .unwrap();
-                    }
                     session_data
                         .write()
                         .unwrap()
@@ -1260,16 +1202,6 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                     },
                 );
                 remove_client!(client_id, os_input, session_state);
-                if let Some(min_size) = session_state.read().unwrap().min_client_terminal_size() {
-                    session_data
-                        .write()
-                        .unwrap()
-                        .as_ref()
-                        .unwrap()
-                        .senders
-                        .send_to_screen(ScreenInstruction::TerminalResize(min_size))
-                        .unwrap();
-                }
             },
             ServerInstruction::KillSession => {
                 let client_ids = session_state.read().unwrap().client_ids();
@@ -1318,17 +1250,6 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                                      // by us having to wait for session_data to send cleanup
                                      // signals to the various threads
                 for client_id in client_ids {
-                    if let Some(min_size) = session_state.read().unwrap().min_client_terminal_size()
-                    {
-                        session_data
-                            .write()
-                            .unwrap()
-                            .as_ref()
-                            .unwrap()
-                            .senders
-                            .send_to_screen(ScreenInstruction::TerminalResize(min_size))
-                            .unwrap();
-                    }
                     session_data
                         .write()
                         .unwrap()
@@ -1468,18 +1389,6 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                     );
                     remove_client!(client_id, os_input, session_state);
                     drop(completion_tx); // do not deadlock with route thread
-
-                    if let Some(min_size) = session_state.read().unwrap().min_client_terminal_size()
-                    {
-                        session_data
-                            .write()
-                            .unwrap()
-                            .as_ref()
-                            .unwrap()
-                            .senders
-                            .send_to_screen(ScreenInstruction::TerminalResize(min_size))
-                            .unwrap();
-                    }
                     session_data
                         .write()
                         .unwrap()

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -2358,26 +2358,11 @@ pub(crate) fn route_thread_main(
                                     .to_anyhow()
                                     .with_context(err_context)?
                                     .set_client_size(client_id, new_size);
-                                // min_client_terminal_size() skips clients whose
-                                // entry is still None — i.e. new_client() was
-                                // called but set_client_data() hasn't been yet.
-                                // set_client_size() above is a no-op in that
-                                // case (it doesn't upgrade None to Some). This
-                                // can happen if a resize arrives before the
-                                // initial connection setup completes; the server
-                                // will query the terminal size once it does.
-                                if let Some(min_size) = session_state
-                                    .read()
-                                    .to_anyhow()
-                                    .with_context(err_context)?
-                                    .min_client_terminal_size()
-                                {
-                                    let _ = senders.as_ref().map(|s| {
-                                        s.send_to_screen(ScreenInstruction::TerminalResize(
-                                            min_size,
-                                        ))
-                                    });
-                                }
+                                let _ = senders.as_ref().map(|s| {
+                                    s.send_to_screen(ScreenInstruction::TerminalResize(
+                                        client_id, new_size,
+                                    ))
+                                });
                             }
                         },
                         ClientToServerMsg::TerminalPixelDimensions { pixel_dimensions } => {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -419,7 +419,7 @@ pub enum ScreenInstruction {
         client_id: ClientId,
         completion_tx: Option<NotificationEnd>,
     },
-    TerminalResize(Size),
+    TerminalResize(ClientId, Size),
     TerminalPixelDimensions(PixelDimensions),
     TerminalBackgroundColor(String),
     TerminalForegroundColor(String),
@@ -431,6 +431,7 @@ pub enum ScreenInstruction {
     AddClient(
         ClientId,
         bool,                // is_web_client
+        Size,                // initial terminal size
         Option<usize>,       // tab position to focus
         Option<(u32, bool)>, // (pane_id, is_plugin) => pane_id to focus
     ),
@@ -1207,6 +1208,7 @@ pub(crate) struct Screen {
     terminal_emulator_colors: Rc<RefCell<Palette>>,
     terminal_emulator_color_codes: Rc<RefCell<HashMap<usize, String>>>,
     connected_clients: Rc<RefCell<HashMap<ClientId, bool>>>, // bool -> is_web_client
+    client_sizes: HashMap<ClientId, Size>,
     /// The indices of this [`Screen`]'s active [`Tab`]s.
     active_tab_ids: BTreeMap<ClientId, usize>,
     global_last_active_tab_id: usize,
@@ -1312,6 +1314,7 @@ impl Screen {
             sixel_image_store: Rc::new(RefCell::new(SixelImageStore::default())),
             style: client_attributes.style,
             connected_clients: Rc::new(RefCell::new(HashMap::new())),
+            client_sizes: HashMap::new(),
             active_tab_ids: BTreeMap::new(),
             global_last_active_tab_id: 0,
             tabs: BTreeMap::new(),
@@ -1610,6 +1613,7 @@ impl Screen {
                             .send_to_background_jobs(BackgroundJob::StopFlashTabBell(tab_id));
                     }
 
+                    self.refresh_visible_tab_sizes().with_context(err_context)?;
                     self.log_and_report_session_state()
                         .with_context(err_context)?;
                     return self.render(None).with_context(err_context);
@@ -1757,6 +1761,7 @@ impl Screen {
                 .with_context(err_context)?;
             self.move_suppressed_panes_from_closed_tab(suppressed_panes)
                 .with_context(err_context)?;
+            self.refresh_visible_tab_sizes().with_context(err_context)?;
             let visible_tab_indices: HashSet<usize> =
                 self.active_tab_ids.values().copied().collect();
             for t in self.tabs.values_mut() {
@@ -1797,22 +1802,89 @@ impl Screen {
         }
     }
 
-    pub fn resize_to_screen(&mut self, new_screen_size: Size) -> Result<()> {
-        let err_context = || format!("failed to resize to screen size: {new_screen_size:#?}");
+    fn min_client_terminal_size_in_tab(&self, tab_id: usize) -> Option<Size> {
+        let mut min_rows = None;
+        let mut min_cols = None;
 
-        if self.size != new_screen_size {
-            self.size = new_screen_size;
-            for tab in self.tabs.values_mut() {
-                tab.resize_whole_tab(new_screen_size)
-                    .with_context(err_context)?;
-                tab.set_force_render();
+        for (client_id, active_tab_id) in &self.active_tab_ids {
+            if *active_tab_id != tab_id {
+                continue;
             }
-            self.log_and_report_session_state()
-                .with_context(err_context)?;
-            self.render(None).with_context(err_context)
-        } else {
-            Ok(())
+            let Some(size) = self.client_sizes.get(client_id) else {
+                continue;
+            };
+            min_rows = Some(min_rows.map_or(size.rows, |rows: usize| rows.min(size.rows)));
+            min_cols = Some(min_cols.map_or(size.cols, |cols: usize| cols.min(size.cols)));
         }
+
+        match (min_rows, min_cols) {
+            (Some(rows), Some(cols)) => Some(Size { rows, cols }),
+            _ => None,
+        }
+    }
+
+    fn tab_size_or_fallback(&self, tab_id: usize) -> Size {
+        self.min_client_terminal_size_in_tab(tab_id)
+            .or_else(|| self.tabs.get(&tab_id).map(|tab| tab.get_display_area()))
+            .unwrap_or(self.size)
+    }
+
+    fn active_tab_size_or_fallback(&self, client_id: ClientId) -> Size {
+        self.active_tab_ids
+            .get(&client_id)
+            .copied()
+            .map(|tab_id| self.tab_size_or_fallback(tab_id))
+            .or_else(|| self.client_sizes.get(&client_id).copied())
+            .unwrap_or(self.size)
+    }
+
+    fn initial_size_for_new_tab(&self, client_id: Option<ClientId>) -> Size {
+        match client_id {
+            Some(client_id) if self.session_is_mirrored => self
+                .active_tab_ids
+                .get(&client_id)
+                .copied()
+                .map(|tab_id| self.tab_size_or_fallback(tab_id))
+                .or_else(|| self.client_sizes.get(&client_id).copied())
+                .unwrap_or(self.size),
+            Some(client_id) => self
+                .client_sizes
+                .get(&client_id)
+                .copied()
+                .unwrap_or(self.size),
+            None => self.size,
+        }
+    }
+
+    fn refresh_visible_tab_sizes(&mut self) -> Result<()> {
+        let err_context = || "failed to refresh visible tab sizes";
+        let visible_tab_ids: HashSet<usize> = self.active_tab_ids.values().copied().collect();
+        let tab_sizes: Vec<(usize, Size)> = visible_tab_ids
+            .iter()
+            .copied()
+            .map(|tab_id| (tab_id, self.tab_size_or_fallback(tab_id)))
+            .collect();
+
+        for (tab_id, tab_size) in tab_sizes {
+            if let Some(tab) = self.tabs.get_mut(&tab_id) {
+                if tab.get_display_area() != tab_size {
+                    tab.resize_whole_tab(tab_size).with_context(err_context)?;
+                    tab.set_force_render();
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn update_client_size(&mut self, client_id: ClientId, new_screen_size: Size) -> Result<()> {
+        if self.client_sizes.get(&client_id) == Some(&new_screen_size) {
+            return Ok(());
+        }
+        self.client_sizes.insert(client_id, new_screen_size);
+        if self.active_tab_ids.contains_key(&client_id) {
+            self.refresh_visible_tab_sizes()?;
+        }
+        Ok(())
     }
 
     pub fn update_pixel_dimensions(&mut self, pixel_dimensions: PixelDimensions) {
@@ -2053,7 +2125,16 @@ impl Screen {
 
                         // Serialize this watcher's output with size constraints (cropping and padding handled inside)
                         let mut serialized_output = watcher_specific_output
-                            .serialize_with_size(Some(watcher_state.size()), Some(self.size))
+                            .serialize_with_size(
+                                Some(watcher_state.size()),
+                                Some(
+                                    self.active_tab_ids
+                                        .get(&followed_client_id)
+                                        .copied()
+                                        .map(|tab_id| self.tab_size_or_fallback(tab_id))
+                                        .unwrap_or(self.size),
+                                ),
+                            )
                             .context(err_context)?;
 
                         // Get the output for the followed client and map it to this watcher
@@ -2276,13 +2357,14 @@ impl Screen {
         });
 
         let tab_name = tab_name.unwrap_or_else(|| String::new());
+        let initial_tab_size = self.initial_size_for_new_tab(client_id);
 
         let position = self.tabs.len();
         let mut tab = Tab::new(
             tab_id,
             position,
             tab_name,
-            self.size,
+            initial_tab_size,
             self.character_cell_size.clone(),
             self.stacked_resize.clone(),
             self.sixel_image_store.clone(),
@@ -2412,6 +2494,7 @@ impl Screen {
         };
 
         // apply the layout to the new tab
+        let tab_size = self.tab_size_or_fallback(tab_id);
         self.tabs
             .get_mut(&tab_id)
             .context("couldn't find tab with index {tab_id}")
@@ -2431,7 +2514,7 @@ impl Screen {
                     tab.visible(true)?;
                     tab.add_multiple_clients(drained_clients)?;
                 }
-                tab.resize_whole_tab(self.size).with_context(err_context)?;
+                tab.resize_whole_tab(tab_size).with_context(err_context)?;
                 tab.set_force_render();
                 Ok(())
             })
@@ -2439,16 +2522,22 @@ impl Screen {
 
         if !self.active_tab_ids.contains_key(&client_id) {
             // this means this is a new client and we need to add it to our state properly
-            self.add_client(client_id, is_web_client)
+            self.add_client(client_id, is_web_client, None)
                 .with_context(err_context)?;
         }
 
+        self.refresh_visible_tab_sizes().with_context(err_context)?;
         self.log_and_report_session_state()
             .and_then(|_| self.render(None))
             .with_context(err_context)
     }
 
-    pub fn add_client(&mut self, client_id: ClientId, is_web_client: bool) -> Result<()> {
+    pub fn add_client(
+        &mut self,
+        client_id: ClientId,
+        is_web_client: bool,
+        size: Option<Size>,
+    ) -> Result<()> {
         let err_context = |tab_index| {
             format!("failed to attach client {client_id} to tab with index {tab_index}")
         };
@@ -2478,6 +2567,9 @@ impl Screen {
         };
 
         self.active_tab_ids.insert(client_id, tab_index);
+        self.client_sizes
+            .entry(client_id)
+            .or_insert(size.unwrap_or(self.size));
         self.connected_clients
             .borrow_mut()
             .insert(client_id, is_web_client);
@@ -2486,6 +2578,8 @@ impl Screen {
             .get_mut(&tab_index)
             .with_context(|| err_context(tab_index))?
             .add_client(client_id, None)
+            .with_context(|| err_context(tab_index))?;
+        self.refresh_visible_tab_sizes()
             .with_context(|| err_context(tab_index))
     }
 
@@ -2519,11 +2613,13 @@ impl Screen {
             self.global_last_active_tab_id = *self.active_tab_ids.get(&client_id).unwrap();
             self.active_tab_ids.remove(&client_id);
         }
+        self.client_sizes.remove(&client_id);
         if self.tab_history.contains_key(&client_id) {
             self.tab_history.remove(&client_id);
         }
         self.connected_clients.borrow_mut().remove(&client_id);
         self.pane_render_subscribers.remove(&client_id);
+        self.refresh_visible_tab_sizes().with_context(err_context)?;
         self.log_and_report_session_state()
             .with_context(err_context)
     }
@@ -3468,6 +3564,7 @@ impl Screen {
         } else {
             self.new_tab(tab_index, swap_layouts, None, None)?;
         }
+        let new_tab_size = self.tab_size_or_fallback(tab_index);
         let tab = self.tabs.get_mut(&tab_index).with_context(err_context)?;
         if let Some(new_tab_name) = new_tab_name {
             tab.name = new_tab_name.clone();
@@ -3481,7 +3578,7 @@ impl Screen {
             // temporarily to the new tab (eg. if it was stacked or had a fixed size), the size
             // will be adjusted before the next render, further down the pipeline, when we apply
             // the layout to this new tab
-            let new_geom = PaneGeom::from(&self.size);
+            let new_geom = PaneGeom::from(&new_tab_size);
             pane.set_geom(new_geom);
 
             // here we pass None instead of the ClientId, because we do not want this pane to be
@@ -3609,8 +3706,12 @@ impl Screen {
             // nothing to do here...
             return Ok(());
         }
-        let screen_size = self.size;
-        if let Some(new_active_tab) = self.get_indexed_tab_mut(tab_index) {
+        let Some(target_tab_id) = self.get_tab_id_at_position(tab_index) else {
+            log::error!("Could not find tab id at position: {:?}", tab_index);
+            return Ok(());
+        };
+        let screen_size = self.tab_size_or_fallback(target_tab_id);
+        if let Some(new_active_tab) = self.get_indexed_tab_mut(target_tab_id) {
             for (pane_was_floating, mut pane) in extracted_panes {
                 let pane_id = pane.pid();
                 if pane_was_floating {
@@ -4257,14 +4358,22 @@ impl Screen {
     fn toggle_pane_id_in_group(&mut self, pane_id: PaneId, client_id: &ClientId) {
         {
             let mut pane_groups = self.current_pane_group.borrow_mut();
-            pane_groups.toggle_pane_id_in_group(pane_id, self.size, client_id);
+            pane_groups.toggle_pane_id_in_group(
+                pane_id,
+                self.active_tab_size_or_fallback(*client_id),
+                client_id,
+            );
         }
         self.retain_only_existing_panes_in_pane_groups();
     }
     fn add_pane_id_to_group(&mut self, pane_id: PaneId, client_id: &ClientId) {
         {
             let mut pane_groups = self.current_pane_group.borrow_mut();
-            pane_groups.add_pane_id_to_group(pane_id, self.size, client_id);
+            pane_groups.add_pane_id_to_group(
+                pane_id,
+                self.active_tab_size_or_fallback(*client_id),
+                client_id,
+            );
         }
         self.retain_only_existing_panes_in_pane_groups();
     }
@@ -4364,7 +4473,7 @@ impl Screen {
                 current_pane_group.group_and_ungroup_panes(
                     pane_ids_to_group,
                     pane_ids_to_ungroup,
-                    self.size,
+                    self.active_tab_size_or_fallback(client_id),
                     &client_id,
                 );
             }
@@ -6306,8 +6415,8 @@ pub(crate) fn screen_thread_main(
                         .push(ScreenInstruction::MoveTabRight(client_id, completion_tx));
                 }
             },
-            ScreenInstruction::TerminalResize(new_size) => {
-                screen.resize_to_screen(new_size)?;
+            ScreenInstruction::TerminalResize(client_id, new_size) => {
+                screen.update_client_size(client_id, new_size)?;
                 screen.log_and_report_session_state()?; // update tabs so that the ui indication will be send to the plugins
                 screen.render(None)?;
             },
@@ -6384,10 +6493,11 @@ pub(crate) fn screen_thread_main(
             ScreenInstruction::AddClient(
                 client_id,
                 is_web_client,
+                size,
                 tab_position_to_focus,
                 pane_id_to_focus,
             ) => {
-                screen.add_client(client_id, is_web_client)?;
+                screen.add_client(client_id, is_web_client, Some(size))?;
                 let pane_id = pane_id_to_focus.map(|(pane_id, is_plugin)| {
                     if is_plugin {
                         PaneId::Plugin(pane_id)

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -257,8 +257,9 @@ impl ServerOsApi for FakeInputOutput {
     }
 }
 
-fn create_new_screen(
+fn create_new_screen_with_session_mode(
     size: Size,
+    session_is_mirrored: bool,
     advanced_mouse_actions: bool,
     mouse_hover_effects: bool,
 ) -> Screen {
@@ -274,7 +275,6 @@ fn create_new_screen(
     mode_info.session_name = Some("zellij-test".into());
     let draw_pane_frames = false;
     let auto_layout = true;
-    let session_is_mirrored = true;
     let copy_options = CopyOptions::default();
     let default_layout = Box::new(Layout::default());
     let default_layout_name = None;
@@ -328,6 +328,14 @@ fn create_new_screen(
         web_server_port,
     );
     screen
+}
+
+fn create_new_screen(
+    size: Size,
+    advanced_mouse_actions: bool,
+    mouse_hover_effects: bool,
+) -> Screen {
+    create_new_screen_with_session_mode(size, true, advanced_mouse_actions, mouse_hover_effects)
 }
 
 struct MockScreen {
@@ -1525,7 +1533,85 @@ fn attach_after_first_tab_closed() {
 
     screen.close_tab_by_id(0).expect("TEST");
     screen.remove_client(1).expect("TEST");
-    screen.add_client(1, false).expect("TEST");
+    screen.add_client(1, false, None).expect("TEST");
+}
+
+#[test]
+fn tab_sizes_follow_only_clients_connected_to_each_tab() {
+    let client_1_size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let client_2_size = Size { cols: 80, rows: 15 };
+    let client_2_resized = Size { cols: 60, rows: 10 };
+    let mut screen = create_new_screen_with_session_mode(client_1_size, false, true, true);
+
+    new_tab(&mut screen, 1, 0);
+    screen
+        .add_client(2, false, Some(client_2_size))
+        .expect("TEST");
+    new_tab(&mut screen, 2, 1);
+
+    assert_eq!(
+        screen.tabs.get(&0).unwrap().get_display_area(),
+        client_2_size,
+        "tab 0 should only track client 2 after client 1 moved away"
+    );
+    assert_eq!(
+        screen.tabs.get(&1).unwrap().get_display_area(),
+        client_1_size,
+        "tab 1 should keep client 1's larger size"
+    );
+
+    screen
+        .update_client_size(2, client_2_resized)
+        .expect("TEST");
+
+    assert_eq!(
+        screen.tabs.get(&0).unwrap().get_display_area(),
+        client_2_resized,
+        "resizing client 2 should only affect tab 0"
+    );
+    assert_eq!(
+        screen.tabs.get(&1).unwrap().get_display_area(),
+        client_1_size,
+        "resizing client 2 should not affect tab 1"
+    );
+}
+
+#[test]
+fn tab_sizes_recompute_when_clients_switch_tabs() {
+    let client_1_size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let client_2_size = Size { cols: 80, rows: 15 };
+    let mut screen = create_new_screen_with_session_mode(client_1_size, false, true, true);
+
+    new_tab(&mut screen, 1, 0);
+    screen
+        .add_client(2, false, Some(client_2_size))
+        .expect("TEST");
+    new_tab(&mut screen, 2, 1);
+
+    screen.go_to_tab(2, 2).expect("TEST");
+    assert_eq!(
+        screen.tabs.get(&1).unwrap().get_display_area(),
+        client_2_size,
+        "when both clients share tab 1 it should use their minimum size"
+    );
+
+    screen.go_to_tab(1, 2).expect("TEST");
+    assert_eq!(
+        screen.tabs.get(&0).unwrap().get_display_area(),
+        client_2_size,
+        "tab 0 should restore client 2's size after switching back"
+    );
+    assert_eq!(
+        screen.tabs.get(&1).unwrap().get_display_area(),
+        client_1_size,
+        "tab 1 should restore client 1's size after client 2 leaves"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- make terminal sizing derive from the clients attached to each tab instead of all clients in the session
- update tab sizes when clients resize, attach, detach, switch tabs, close tabs, or when layouts are applied
- add regression tests covering independent tab sizes and tab-size recomputation when clients move between tabs

## Testing
- cargo test -p zellij-server --lib tab_sizes_ -- --nocapture
- cargo test -p zellij-server --lib screen::screen_tests -- --nocapture
- cargo build --release --locked