### PR TITLE
fix: change layout manager override key

### DIFF
--- a/default-plugins/layout-manager/src/screens/layout_list/mod.rs
+++ b/default-plugins/layout-manager/src/screens/layout_list/mod.rs
@@ -101,7 +101,7 @@ impl LayoutListScreen {
                     self.open_selected_layout(display_layouts);
                     KeyResponse::none()
                 },
-                BareKey::Char('o') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
+                BareKey::Char('w') if key.has_modifiers(&[KeyModifier::Alt]) => {
                     self.apply_selected_layout(display_layouts);
                     KeyResponse::none()
                 },
@@ -138,7 +138,7 @@ impl LayoutListScreen {
         key: KeyWithModifier,
         display_layouts: &[DisplayLayout],
     ) -> KeyResponse {
-        // Search-first mode: Enter opens, Ctrl+O applies, Tab autocompletes,
+        // Search-first mode: Enter opens, Alt+W applies, Tab autocompletes,
         // arrows navigate, Esc exits to management mode
         match key.bare_key {
             BareKey::Esc if key.has_no_modifiers() => {
@@ -156,7 +156,7 @@ impl LayoutListScreen {
                 self.open_selected_layout(display_layouts);
                 return KeyResponse::none();
             },
-            BareKey::Char('o') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
+            BareKey::Char('w') if key.has_modifiers(&[KeyModifier::Alt]) => {
                 // Apply/override the currently selected layout to the session
                 self.apply_selected_layout(display_layouts);
                 return KeyResponse::none();

--- a/default-plugins/layout-manager/src/ui/layout_table.rs
+++ b/default-plugins/layout-manager/src/ui/layout_table.rs
@@ -185,9 +185,9 @@ impl Controls {
 
     fn get_typing_filter_controls(&self, max_cols: usize) -> (&str, &[&str]) {
         let long_text =
-            "- <↑↓> Navigate, <Tab> Complete, <Enter> Open, <Ctrl+o> Apply, <Esc> Manage & New";
-        let short_text = "<↑↓>/<Tab>/<Enter>/<Ctrl+o>/<Esc> Nav/Complete/Open/Apply/Manage";
-        let minimum_text = "<↑↓>/<Tab>/<Enter>/<Ctrl+o> ...";
+            "- <↑↓> Navigate, <Tab> Complete, <Enter> Open, <Alt+w> Apply, <Esc> Manage & New";
+        let short_text = "<↑↓>/<Tab>/<Enter>/<Alt+w>/<Esc> Nav/Complete/Open/Apply/Manage";
+        let minimum_text = "<↑↓>/<Tab>/<Enter>/<Alt+w> ...";
         let text = if max_cols >= long_text.chars().count() {
             long_text
         } else if max_cols >= short_text.chars().count() {
@@ -195,14 +195,13 @@ impl Controls {
         } else {
             minimum_text
         };
-        (text, &["<↑↓>", "<Tab>", "<Enter>", "<Ctrl+o>", "<Esc>"])
+        (text, &["<↑↓>", "<Tab>", "<Enter>", "<Alt+w>", "<Esc>"])
     }
 
     fn get_filter_active_controls(&self, max_cols: usize) -> (&str, &[&str]) {
-        let long_text =
-            "- <Enter> Open, <↓↑> Nav, <Ctrl+o> Apply, <e> Edit, <r> Rename, <Del> Delete";
-        let short_text = "<Enter>/<↓↑>/<Ctrl+o>/<e>/<r>/<Del> Open/Nav/Apply/Edit/Rename/Del";
-        let minimum_text = "<Enter>/<↓↑>/<Ctrl+o>/<e>/<r>/<Del> ...";
+        let long_text = "- <Enter> Open, <↓↑> Nav, <e> Edit, <r> Rename, <Del> Delete";
+        let short_text = "<Enter>/<↓↑>/<e>/<r>/<Del> Open/Nav/Edit/Rename/Del";
+        let minimum_text = "<Enter>/<↓↑>/<e>/<r>/<Del> ...";
         let text = if max_cols >= long_text.chars().count() {
             long_text
         } else if max_cols >= short_text.chars().count() {
@@ -210,18 +209,13 @@ impl Controls {
         } else {
             minimum_text
         };
-        (
-            text,
-            &["<Enter>", "<↓↑>", "<Ctrl+o>", "<e>", "<r>", "<Del>"],
-        )
+        (text, &["<Enter>", "<↓↑>", "<e>", "<r>", "<Del>"])
     }
 
     fn get_default_controls(&self, max_cols: usize) -> (&str, &[&str]) {
-        let long_text =
-            "- <Enter> Open, <↓↑> Nav, </> Search, <Ctrl+o> Apply, <e> Edit, <r> Rename, <Del> Del";
-        let short_text =
-            "<Enter>/<↓↑>/</>/<Ctrl+o>/<e>/<r>/<Del> Open/Nav/Search/Apply/Edit/Rename/Del";
-        let minimum_text = "<Enter>/<↓↑>/</>/<Ctrl+o>/<e>/<r>/<Del> ...";
+        let long_text = "- <Enter> Open, <↓↑> Nav, </> Search, <e> Edit, <r> Rename, <Del> Del";
+        let short_text = "<Enter>/<↓↑>/</>/<e>/<r>/<Del> Open/Nav/Search/Edit/Rename/Del";
+        let minimum_text = "<Enter>/<↓↑>/</>/<e>/<r>/<Del> ...";
         let text = if max_cols >= long_text.chars().count() {
             long_text
         } else if max_cols >= short_text.chars().count() {
@@ -229,10 +223,7 @@ impl Controls {
         } else {
             minimum_text
         };
-        (
-            text,
-            &["<Enter>", "<↓↑>", "</>", "<Ctrl+o>", "<e>", "<r>", "<Del>"],
-        )
+        (text, &["<Enter>", "<↓↑>", "</>", "<e>", "<r>", "<Del>"])
     }
 
     fn get_basic_controls_text_and_keys(&self, max_cols: usize) -> (&str, &[&str]) {
@@ -250,11 +241,11 @@ impl Controls {
             "more"
         };
         let long_text = format!(
-            "- <Ctrl+o> Override Session Layout, <?> {} options",
+            "- <Alt+w> Override Session Layout, <?> {} options",
             toggle_word
         );
-        let short_text = format!("<Ctrl+o> Override, <?> {} options", toggle_word);
-        let minimum_text = format!("<Ctrl+o>/<?> ...");
+        let short_text = format!("<Alt+w> Override, <?> {} options", toggle_word);
+        let minimum_text = format!("<Alt+w>/<?> ...");
         let text = if max_cols >= long_text.chars().count() {
             long_text
         } else if max_cols >= short_text.chars().count() {
@@ -262,7 +253,7 @@ impl Controls {
         } else {
             minimum_text
         };
-        (text, &["<Ctrl+o>", "<?>"])
+        (text, &["<Alt+w>", "<?>"])
     }
 
     fn get_new_layout_text_and_keys(&self, max_cols: usize) -> (&str, &[&str]) {

--- a/zellij-server/src/os_input_output_unix.rs
+++ b/zellij-server/src/os_input_output_unix.rs
@@ -17,7 +17,7 @@ use signal_hook;
 use signal_hook::consts::*;
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeMap,
     fs::File,
     io,
     os::fd::FromRawFd,


### PR DESCRIPTION
I realized that `Ctrl o` is used in the default keybindings to get into session mode, so it might not be a good idea to also use it in the session manager. Changed it to `Alt w`. I didn't notice this before because I personally use "non-colliding" :sweat_smile: 