### PR TITLE
fix(stdin): preserve non-zellij ANSI bytes during startup parsing (#4093)

### DIFF
--- a/zellij-client/src/stdin_ansi_parser.rs
+++ b/zellij-client/src/stdin_ansi_parser.rs
@@ -105,6 +105,19 @@ impl StdinAnsiParser {
         }
         self.drain_pending_events()
     }
+    pub fn parse_with_leftovers(
+        &mut self,
+        mut raw_bytes: Vec<u8>,
+    ) -> (Vec<AnsiStdinInstruction>, Vec<u8>) {
+        let mut leftover_bytes = vec![];
+        for byte in raw_bytes.drain(..) {
+            if let Some(leftovers) = self.parse_byte(byte) {
+                leftover_bytes.extend(leftovers);
+            }
+        }
+        leftover_bytes.append(&mut self.raw_buffer);
+        (self.drain_pending_events(), leftover_bytes)
+    }
     pub fn read_cache(&self) -> Option<Vec<AnsiStdinInstruction>> {
         match OpenOptions::new()
             .read(true)
@@ -137,16 +150,17 @@ impl StdinAnsiParser {
             }
         };
     }
-    fn parse_byte(&mut self, byte: u8) {
+    fn parse_byte(&mut self, byte: u8) -> Option<Vec<u8>> {
         if byte == b't' {
             self.raw_buffer.push(byte);
             match AnsiStdinInstruction::pixel_dimensions_from_bytes(&self.raw_buffer) {
                 Ok(ansi_sequence) => {
                     self.pending_events.push(ansi_sequence);
                     self.raw_buffer.clear();
+                    None
                 },
                 Err(_) => {
-                    self.raw_buffer.clear();
+                    Some(self.raw_buffer.drain(..).collect())
                 },
             }
         } else if byte == b'\\' {
@@ -154,14 +168,16 @@ impl StdinAnsiParser {
             if let Ok(ansi_sequence) = AnsiStdinInstruction::bg_or_fg_from_bytes(&self.raw_buffer) {
                 self.pending_events.push(ansi_sequence);
                 self.raw_buffer.clear();
+                None
             } else if let Ok((color_register, color_sequence)) =
                 color_sequence_from_bytes(&self.raw_buffer)
             {
                 self.raw_buffer.clear();
                 self.pending_color_sequences
                     .push((color_register, color_sequence));
+                None
             } else {
-                self.raw_buffer.clear();
+                Some(self.raw_buffer.drain(..).collect())
             }
         } else if byte == b'y' {
             self.raw_buffer.push(byte);
@@ -170,9 +186,13 @@ impl StdinAnsiParser {
             {
                 self.pending_events.push(ansi_sequence);
                 self.raw_buffer.clear();
+                None
+            } else {
+                Some(self.raw_buffer.drain(..).collect())
             }
         } else {
             self.raw_buffer.push(byte);
+            None
         }
     }
 }
@@ -315,5 +335,32 @@ fn color_sequence_from_bytes(bytes: &[u8]) -> Result<(usize, String), &'static s
         }
     } else {
         Err("invalid_instruction")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_with_leftovers_preserves_non_zellij_sequences() {
+        let mut parser = StdinAnsiParser::new();
+        let (events, leftover_bytes) = parser.parse_with_leftovers(b"\x1b[?1u".to_vec());
+
+        assert!(events.is_empty());
+        assert_eq!(leftover_bytes, b"\x1b[?1u".to_vec());
+    }
+
+    #[test]
+    fn parse_with_leftovers_still_parses_known_sequences() {
+        let mut parser = StdinAnsiParser::new();
+        let (events, leftover_bytes) = parser.parse_with_leftovers(b"\x1b[4;21;8t".to_vec());
+
+        assert!(leftover_bytes.is_empty());
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            AnsiStdinInstruction::PixelDimensions(_)
+        ));
     }
 }

--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -150,13 +150,19 @@ pub(crate) fn stdin_loop(
                             // receive on STDIN during that timeout is unceremoniously dropped
                             let mut stdin_ansi_parser = stdin_ansi_parser.lock().unwrap();
                             if stdin_ansi_parser.should_parse() {
-                                let events = stdin_ansi_parser.parse(buf);
+                                let (events, leftover_bytes) =
+                                    stdin_ansi_parser.parse_with_leftovers(buf.to_vec());
                                 if !events.is_empty() {
                                     ansi_stdin_events.append(&mut events.clone());
                                     let _ = send_input_instructions
                                         .send(InputInstruction::AnsiStdinInstructions(events));
                                 }
-                                continue;
+                                if leftover_bytes.is_empty() {
+                                    continue;
+                                }
+                                current_buffer.append(&mut leftover_bytes.clone());
+                            } else {
+                                current_buffer.append(&mut buf.to_vec());
                             }
                         }
                         if !ansi_stdin_events.is_empty() {
@@ -165,8 +171,6 @@ pub(crate) fn stdin_loop(
                                 .unwrap()
                                 .write_cache(ansi_stdin_events.drain(..).collect());
                         }
-                        current_buffer.append(&mut buf.to_vec());
-
                         if !explicitly_disable_kitty_keyboard_protocol {
                             // first we try to parse with the KittyKeyboardParser
                             // if we fail, we try to parse normally


### PR DESCRIPTION
Fixes #4093

## Summary

Prevent SSH kitten startup hangs by preserving non-zellij ANSI bytes while still parsing zellij startup queries.

## Problem

When stdin startup ANSI parsing is enabled, unknown/non-zellij ANSI bytes can be dropped, which can stall kitty +kitten ssh protocol exchanges.

## What changed

- add parse_with_leftovers() in stdin_ansi_parser to return unrecognized bytes instead of dropping them
- forward leftover bytes through normal input parsing path in stdin_handler
- add unit tests for preserving non-zellij sequences and parsing known zellij sequences

## Solution

Make startup ANSI parsing extraction non-destructive: consume known zellij responses, keep and forward unknown bytes.

## Why

This keeps zellij startup capability detection intact while avoiding data loss for external terminal protocol traffic used by kitty ssh kitten.

## Tests

- `cargo test -p zellij-client parse_with_leftovers -- --nocapture`
- `cargo test -p zellij-client --lib stdin_ansi_parser -- --nocapture`
- `cargo check -p zellij-client`
