### PR TITLE
Add per-command pane synchronized-output opt-out

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -425,6 +425,9 @@ impl SessionMetaData {
                     client_id,
                     default_editor: new_config.options.scrollback_editor,
                     post_command_discovery_hook: new_config.options.post_command_discovery_hook,
+                    pane_synchronized_output_ignore_commands: new_config
+                        .options
+                        .pane_synchronized_output_ignore_commands,
                 })
                 .unwrap();
         }
@@ -1816,6 +1819,9 @@ fn init_session(
                 cli_assets.is_debug,
                 config_options.scrollback_editor.clone(),
                 config_options.post_command_discovery_hook.clone(),
+                config_options
+                    .pane_synchronized_output_ignore_commands
+                    .clone(),
             );
 
             move || pty_thread_main(pty, layout.clone()).fatal()

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -93,6 +93,35 @@ pub(crate) fn command_exists(cmd: &RunCommand) -> bool {
     resolve_command(cmd).is_some()
 }
 
+pub(crate) fn current_terminal_command(
+    os_input: &dyn ServerOsApi,
+    child_pid: u32,
+    post_command_discovery_hook: &Option<String>,
+) -> Option<Vec<String>> {
+    let ppids_to_cmds = os_input.get_all_cmds_by_ppid(post_command_discovery_hook);
+    let cmd_ps = ppids_to_cmds.get(&child_pid.to_string());
+    let (_cwds, cmds) = os_input.get_cwds(vec![child_pid]);
+    let cmd_sysinfo = cmds.get(&child_pid);
+
+    cmd_ps.cloned().or_else(|| cmd_sysinfo.cloned())
+}
+
+pub(crate) fn command_matches_path_or_basename(
+    command_args: &[String],
+    candidates: &[String],
+) -> bool {
+    let Some(command) = command_args.first() else {
+        return false;
+    };
+    let basename = std::path::Path::new(command)
+        .file_name()
+        .and_then(|name| name.to_str());
+
+    candidates
+        .iter()
+        .any(|candidate| candidate == command || basename == Some(candidate.as_str()))
+}
+
 // this is a utility method to separate the arguments from a pathbuf before we turn it into a
 // Command. eg. "/usr/bin/vim -e" ==> "/usr/bin/vim" + "-e" (the latter will be pushed to args)
 fn separate_command_arguments(command: &mut PathBuf, args: &mut Vec<String>) {

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -504,6 +504,7 @@ pub struct Grid {
     pub changed_colors: Option<[Option<AnsiCode>; 256]>,
     pub should_render: bool,
     pub lock_renders: bool,
+    pub ignore_pane_synchronized_output: bool,
     pub cursor_key_mode: bool, // DECCKM - when set, cursor keys should send ANSI direction codes (eg. "OD") instead of the arrow keys (eg. "[D")
     pub bracketed_paste_mode: bool, // when set, paste instructions to the terminal should be escaped with a special sequence
     pub erasure_mode: bool,         // ERM
@@ -817,6 +818,7 @@ impl Grid {
             styled_underlines,
             osc8_hyperlinks,
             lock_renders: false,
+            ignore_pane_synchronized_output: false,
             supports_kitty_keyboard_protocol: false,
             explicitly_disable_kitty_keyboard_protocol,
             click: Click::default(),
@@ -3074,6 +3076,12 @@ impl Grid {
     pub fn unlock_renders(&mut self) {
         self.lock_renders = false;
     }
+    pub fn set_ignore_pane_synchronized_output(&mut self, should_ignore: bool) {
+        self.ignore_pane_synchronized_output = should_ignore;
+        if should_ignore {
+            self.unlock_renders();
+        }
+    }
     pub fn update_theme(&mut self, theme: Styling) {
         self.style.colors = theme.clone();
     }
@@ -3583,7 +3591,9 @@ impl Perform for Grid {
                 for param in params_iter.map(|param| param[0]) {
                     match param {
                         2026 => {
-                            self.unlock_renders();
+                            if !self.ignore_pane_synchronized_output {
+                                self.unlock_renders();
+                            }
                         },
                         2004 => {
                             self.bracketed_paste_mode = false;
@@ -3682,7 +3692,9 @@ impl Perform for Grid {
                             self.mark_for_rerender();
                         },
                         2026 => {
-                            self.lock_renders();
+                            if !self.ignore_pane_synchronized_output {
+                                self.lock_renders();
+                            }
                         },
                         2004 => {
                             self.bracketed_paste_mode = true;
@@ -3783,7 +3795,11 @@ impl Perform for Grid {
                 for param in params_iter.map(|param| param[0]) {
                     match param {
                         2026 => {
-                            let response = "\u{1b}[?2026;2$y";
+                            let response = if self.ignore_pane_synchronized_output {
+                                "\u{1b}[?2026;0$y"
+                            } else {
+                                "\u{1b}[?2026;2$y"
+                            };
                             self.pending_messages_to_pty
                                 .push(response.as_bytes().to_vec());
                         },

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -823,6 +823,9 @@ impl Pane for TerminalPane {
     fn set_title(&mut self, title: String) {
         self.pane_title = title;
     }
+    fn set_ignore_pane_synchronized_output(&mut self, should_ignore: bool) {
+        self.grid.set_ignore_pane_synchronized_output(should_ignore);
+    }
     fn current_title(&self) -> String {
         if self.pane_name.is_empty() {
             self.grid

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -5365,3 +5365,57 @@ fn layer_ordering() {
     assert!(HighlightLayer::Hint < HighlightLayer::Tool);
     assert!(HighlightLayer::Tool < HighlightLayer::ActionFeedback);
 }
+
+fn create_test_grid() -> Grid {
+    let sixel_image_store = Rc::new(RefCell::new(SixelImageStore::default()));
+    let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
+    Grid::new(
+        10,
+        10,
+        Rc::new(RefCell::new(Palette::default())),
+        terminal_emulator_color_codes,
+        Rc::new(RefCell::new(LinkHandler::new())),
+        Rc::new(RefCell::new(Some(SizeInPixels {
+            width: 10,
+            height: 20,
+        }))),
+        sixel_image_store,
+        Style::default(),
+        false,
+        true,
+        true,
+        true,
+        false,
+    )
+}
+
+#[test]
+fn pane_sync_ignore_reports_no_support_and_keeps_renders_unlocked() {
+    let mut vte_parser = vte::Parser::new();
+    let mut grid = create_test_grid();
+    grid.set_ignore_pane_synchronized_output(true);
+
+    for byte in "\u{1b}[?2026h\u{1b}[?2026$p".bytes() {
+        vte_parser.advance(&mut grid, byte);
+    }
+
+    assert!(!grid.lock_renders);
+    assert_eq!(
+        grid.pending_messages_to_pty,
+        vec!["\u{1b}[?2026;0$y".as_bytes().to_vec()]
+    );
+}
+
+#[test]
+fn enabling_pane_sync_ignore_unlocks_an_in_progress_frame() {
+    let mut vte_parser = vte::Parser::new();
+    let mut grid = create_test_grid();
+
+    for byte in "\u{1b}[?2026h".bytes() {
+        vte_parser.advance(&mut grid, byte);
+    }
+
+    assert!(grid.lock_renders);
+    grid.set_ignore_pane_synchronized_output(true);
+    assert!(!grid.lock_renders);
+}

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -1,7 +1,7 @@
 use crate::background_jobs::write_session_state_to_disk;
 use crate::background_jobs::BackgroundJob;
 use crate::global_async_runtime::get_tokio_runtime as async_runtime;
-use crate::os_input_output::{AsyncReader, NullAsyncReader};
+use crate::os_input_output::{current_terminal_command, AsyncReader, NullAsyncReader};
 use crate::route::NotificationEnd;
 use crate::terminal_bytes::TerminalBytes;
 use crate::{
@@ -12,7 +12,7 @@ use crate::{
     thread_bus::{Bus, ThreadSenders},
     ClientId, ServerInstruction,
 };
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::{collections::HashMap, path::PathBuf};
 use tokio::task::JoinHandle;
 use zellij_utils::{
@@ -136,6 +136,7 @@ pub enum PtyInstruction {
         client_id: ClientId,
         default_editor: Option<PathBuf>,
         post_command_discovery_hook: Option<String>,
+        pane_synchronized_output_ignore_commands: Option<Vec<String>>,
     },
     ListClientsToPlugin(SessionLayoutMetadata, PluginId, ClientId),
     ReportPluginCwd(PluginId, PathBuf),
@@ -191,6 +192,35 @@ impl From<&PtyInstruction> for PtyContext {
     }
 }
 
+#[derive(Debug, Default)]
+pub(crate) struct PtyRuntimeConfiguration {
+    pub post_command_discovery_hook: Option<String>,
+    pub pane_synchronized_output_ignore_commands: Vec<String>,
+}
+
+impl PtyRuntimeConfiguration {
+    fn new(
+        post_command_discovery_hook: Option<String>,
+        pane_synchronized_output_ignore_commands: Option<Vec<String>>,
+    ) -> Self {
+        Self {
+            post_command_discovery_hook,
+            pane_synchronized_output_ignore_commands: pane_synchronized_output_ignore_commands
+                .unwrap_or_default(),
+        }
+    }
+
+    fn reconfigure(
+        &mut self,
+        post_command_discovery_hook: Option<String>,
+        pane_synchronized_output_ignore_commands: Option<Vec<String>>,
+    ) {
+        self.post_command_discovery_hook = post_command_discovery_hook;
+        self.pane_synchronized_output_ignore_commands =
+            pane_synchronized_output_ignore_commands.unwrap_or_default();
+    }
+}
+
 pub(crate) struct Pty {
     pub active_panes: HashMap<ClientId, PaneId>,
     pub bus: Bus<PtyInstruction>,
@@ -199,7 +229,7 @@ pub(crate) struct Pty {
     debug_to_file: bool,
     task_handles: HashMap<u32, JoinHandle<()>>, // terminal_id to join-handle
     default_editor: Option<PathBuf>,
-    post_command_discovery_hook: Option<String>,
+    runtime_configuration: Arc<RwLock<PtyRuntimeConfiguration>>,
     plugin_cwds: HashMap<u32, PathBuf>,   // plugin_id -> cwd
     terminal_cwds: HashMap<u32, PathBuf>, // terminal_id -> cwd
 }
@@ -852,9 +882,14 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
             PtyInstruction::Reconfigure {
                 default_editor,
                 post_command_discovery_hook,
+                pane_synchronized_output_ignore_commands,
                 client_id: _,
             } => {
-                pty.reconfigure(default_editor, post_command_discovery_hook);
+                pty.reconfigure(
+                    default_editor,
+                    post_command_discovery_hook,
+                    pane_synchronized_output_ignore_commands,
+                );
             },
             PtyInstruction::SendSigintToPaneId(pane_id) => {
                 pty.send_sigint_to_pane(pane_id);
@@ -898,6 +933,7 @@ impl Pty {
         debug_to_file: bool,
         default_editor: Option<PathBuf>,
         post_command_discovery_hook: Option<String>,
+        pane_synchronized_output_ignore_commands: Option<Vec<String>>,
     ) -> Self {
         Pty {
             active_panes: HashMap::new(),
@@ -907,7 +943,10 @@ impl Pty {
             task_handles: HashMap::new(),
             default_editor,
             originating_plugins: HashMap::new(),
-            post_command_discovery_hook,
+            runtime_configuration: Arc::new(RwLock::new(PtyRuntimeConfiguration::new(
+                post_command_discovery_hook,
+                pane_synchronized_output_ignore_commands,
+            ))),
             plugin_cwds: HashMap::new(),
             terminal_cwds: HashMap::new(),
         }
@@ -1119,12 +1158,22 @@ impl Pty {
                 |terminal_id: u32| format!("failed to run async task for terminal {terminal_id}");
             let senders = self.bus.senders.clone();
             let debug_to_file = self.debug_to_file;
+            let os_input = self.bus.os_input.clone();
+            let runtime_configuration = self.runtime_configuration.clone();
             async move {
-                TerminalBytes::new(terminal_id, reader, senders, debug_to_file)
-                    .listen()
-                    .await
-                    .with_context(|| err_context(terminal_id))
-                    .fatal();
+                TerminalBytes::new(
+                    terminal_id,
+                    reader,
+                    senders,
+                    os_input,
+                    child_pid,
+                    runtime_configuration,
+                    debug_to_file,
+                )
+                .listen()
+                .await
+                .with_context(|| err_context(terminal_id))
+                .fatal();
             }
         });
 
@@ -1317,12 +1366,23 @@ impl Pty {
                     let terminal_bytes = async_runtime().spawn({
                         let senders = self.bus.senders.clone();
                         let debug_to_file = self.debug_to_file;
+                        let os_input = self.bus.os_input.clone();
+                        let child_pid = self.id_to_child_pid.get(&terminal_id).copied();
+                        let runtime_configuration = self.runtime_configuration.clone();
                         async move {
-                            TerminalBytes::new(terminal_id, reader, senders, debug_to_file)
-                                .listen()
-                                .await
-                                .context("failed to spawn terminals for layout")
-                                .fatal();
+                            TerminalBytes::new(
+                                terminal_id,
+                                reader,
+                                senders,
+                                os_input,
+                                child_pid,
+                                runtime_configuration,
+                                debug_to_file,
+                            )
+                            .listen()
+                            .await
+                            .context("failed to spawn terminals for layout")
+                            .fatal();
                         }
                     });
                     self.task_handles.insert(terminal_id, terminal_bytes);
@@ -1485,12 +1545,23 @@ impl Pty {
                     let terminal_bytes = async_runtime().spawn({
                         let senders = self.bus.senders.clone();
                         let debug_to_file = self.debug_to_file;
+                        let os_input = self.bus.os_input.clone();
+                        let child_pid = self.id_to_child_pid.get(&terminal_id).copied();
+                        let runtime_configuration = self.runtime_configuration.clone();
                         async move {
-                            TerminalBytes::new(terminal_id, reader, senders, debug_to_file)
-                                .listen()
-                                .await
-                                .context("failed to spawn terminals for layout")
-                                .fatal();
+                            TerminalBytes::new(
+                                terminal_id,
+                                reader,
+                                senders,
+                                os_input,
+                                child_pid,
+                                runtime_configuration,
+                                debug_to_file,
+                            )
+                            .listen()
+                            .await
+                            .context("failed to spawn terminals for layout")
+                            .fatal();
                         }
                     });
                     self.task_handles.insert(terminal_id, terminal_bytes);
@@ -1866,12 +1937,22 @@ impl Pty {
                         |pane_id| format!("failed to run async task for pane {pane_id:?}");
                     let senders = self.bus.senders.clone();
                     let debug_to_file = self.debug_to_file;
+                    let os_input = self.bus.os_input.clone();
+                    let runtime_configuration = self.runtime_configuration.clone();
                     async move {
-                        TerminalBytes::new(id, reader, senders, debug_to_file)
-                            .listen()
-                            .await
-                            .with_context(|| err_context(pane_id))
-                            .fatal();
+                        TerminalBytes::new(
+                            id,
+                            reader,
+                            senders,
+                            os_input,
+                            child_pid,
+                            runtime_configuration,
+                            debug_to_file,
+                        )
+                        .listen()
+                        .await
+                        .with_context(|| err_context(pane_id))
+                        .fatal();
                     }
                 });
 
@@ -1914,11 +1995,17 @@ impl Pty {
             .as_ref()
             .map(|os_input| os_input.get_cwds(pids))
             .unwrap_or_default();
+        let post_command_discovery_hook = self
+            .runtime_configuration
+            .read()
+            .unwrap()
+            .post_command_discovery_hook
+            .clone();
         let ppids_to_cmds = self
             .bus
             .os_input
             .as_ref()
-            .map(|os_input| os_input.get_all_cmds_by_ppid(&self.post_command_discovery_hook))
+            .map(|os_input| os_input.get_all_cmds_by_ppid(&post_command_discovery_hook))
             .unwrap_or_default();
 
         for terminal_id in terminal_ids {
@@ -2065,9 +2152,13 @@ impl Pty {
         &mut self,
         default_editor: Option<PathBuf>,
         post_command_discovery_hook: Option<String>,
+        pane_synchronized_output_ignore_commands: Option<Vec<String>>,
     ) {
         self.default_editor = default_editor;
-        self.post_command_discovery_hook = post_command_discovery_hook;
+        self.runtime_configuration.write().unwrap().reconfigure(
+            post_command_discovery_hook,
+            pane_synchronized_output_ignore_commands,
+        );
     }
 
     pub fn send_sigint_to_pane(&self, pane_id: PaneId) {
@@ -2137,21 +2228,20 @@ impl Pty {
         match pane_id {
             PaneId::Terminal(terminal_id) => {
                 if let Some(&child_pid) = self.id_to_child_pid.get(&terminal_id) {
-                    // Query OS for current running command
                     if let Some(os_input) = self.bus.os_input.as_ref() {
-                        // First, try to get child process command (e.g., nvim running in bash)
-                        let ppids_to_cmds =
-                            os_input.get_all_cmds_by_ppid(&self.post_command_discovery_hook);
-                        let cmd_ps = ppids_to_cmds.get(&format!("{}", child_pid));
+                        let post_command_discovery_hook = self
+                            .runtime_configuration
+                            .read()
+                            .unwrap()
+                            .post_command_discovery_hook
+                            .clone();
 
-                        // If no child process, fall back to parent process (e.g., the shell itself)
-                        let (_cwds, cmds) = os_input.get_cwds(vec![child_pid]);
-                        let cmd_sysinfo = cmds.get(&child_pid);
-
-                        if let Some(command_args) = cmd_ps {
-                            GetPaneRunningCommandResponse::Ok(command_args.clone())
-                        } else if let Some(command_args) = cmd_sysinfo {
-                            GetPaneRunningCommandResponse::Ok(command_args.clone())
+                        if let Some(command_args) = current_terminal_command(
+                            os_input.as_ref(),
+                            child_pid,
+                            &post_command_discovery_hook,
+                        ) {
+                            GetPaneRunningCommandResponse::Ok(command_args)
                         } else {
                             GetPaneRunningCommandResponse::Err(format!(
                                 "Could not retrieve running command for terminal pane {}",

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -351,6 +351,7 @@ pub enum ScreenInstruction {
     ToggleActiveTerminalFullscreen(ClientId, Option<NotificationEnd>),
     TogglePaneFrames(Option<NotificationEnd>),
     SetSelectable(PaneId, bool),
+    SetPaneSynchronizedOutputIgnore(PaneId, bool),
     ShowPluginCursor(u32, ClientId, Option<(usize, usize)>),
     ClosePane(
         PaneId,
@@ -816,6 +817,9 @@ impl From<&ScreenInstruction> for ScreenContext {
             },
             ScreenInstruction::TogglePaneFrames(..) => ScreenContext::TogglePaneFrames,
             ScreenInstruction::SetSelectable(..) => ScreenContext::SetSelectable,
+            ScreenInstruction::SetPaneSynchronizedOutputIgnore(..) => {
+                ScreenContext::SetPaneSynchronizedOutputIgnore
+            },
             ScreenInstruction::ShowPluginCursor(..) => ScreenContext::ShowPluginCursor,
             ScreenInstruction::ClosePane(..) => ScreenContext::ClosePane,
             ScreenInstruction::HoldPane(..) => ScreenContext::HoldPane,
@@ -5860,6 +5864,22 @@ pub(crate) fn screen_thread_main(
                 }
                 screen.render(None)?;
                 screen.log_and_report_session_state()?;
+            },
+            ScreenInstruction::SetPaneSynchronizedOutputIgnore(pid, should_ignore) => {
+                let all_tabs = screen.get_tabs_mut();
+                let mut found_pane = false;
+                for tab in all_tabs.values_mut() {
+                    if tab.has_pane_with_pid(&pid) {
+                        tab.set_pane_synchronized_output_ignore(pid, should_ignore);
+                        found_pane = true;
+                        break;
+                    }
+                }
+                if !found_pane {
+                    pending_events_waiting_for_tab.push(
+                        ScreenInstruction::SetPaneSynchronizedOutputIgnore(pid, should_ignore),
+                    );
+                }
             },
             ScreenInstruction::ShowPluginCursor(pid, client_id, cursor_position) => {
                 let all_tabs = screen.get_tabs_mut();

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -147,6 +147,7 @@ pub type SuppressedPanes = HashMap<PaneId, (bool, Box<dyn Pane>)>; // bool => is
 
 enum BufferedTabInstruction {
     SetPaneSelectable(PaneId, bool),
+    SetPaneSynchronizedOutputIgnore(PaneId, bool),
     HandlePtyBytes(u32, VteBytes),
     HoldPane(PaneId, Option<i32>, bool, RunCommand), // Option<i32> is the exit status, bool is is_first_run
 }
@@ -567,6 +568,7 @@ pub trait Pane {
     fn frame_color_override(&self) -> Option<PaletteColor>;
     fn invoked_with(&self) -> &Option<Run>;
     fn set_title(&mut self, title: String);
+    fn set_ignore_pane_synchronized_output(&mut self, _should_ignore: bool) {}
     fn update_loading_indication(&mut self, _loading_indication: LoadingIndication) {} // only relevant for plugins
     fn start_loading_indication(&mut self, _loading_indication: LoadingIndication) {} // only relevant for plugins
     fn progress_animation_offset(&mut self) {} // only relevant for plugins
@@ -1118,6 +1120,9 @@ impl Tab {
             match buffered_instruction {
                 BufferedTabInstruction::SetPaneSelectable(pane_id, selectable) => {
                     self.set_pane_selectable(pane_id, selectable);
+                },
+                BufferedTabInstruction::SetPaneSynchronizedOutputIgnore(pane_id, should_ignore) => {
+                    self.set_pane_synchronized_output_ignore(pane_id, should_ignore);
                 },
                 BufferedTabInstruction::HandlePtyBytes(terminal_id, bytes) => {
                     self.handle_pty_bytes(terminal_id, bytes)?;
@@ -3798,6 +3803,25 @@ impl Tab {
             &mut self.tiled_panes,
             self.draw_pane_frames,
         );
+    }
+    pub fn set_pane_synchronized_output_ignore(&mut self, id: PaneId, should_ignore: bool) {
+        if self.is_pending {
+            self.pending_instructions.push(
+                BufferedTabInstruction::SetPaneSynchronizedOutputIgnore(id, should_ignore),
+            );
+            return;
+        }
+        if let Some(pane) = self.tiled_panes.get_pane_mut(id) {
+            pane.set_ignore_pane_synchronized_output(should_ignore);
+        } else if let Some(pane) = self.floating_panes.get_pane_mut(id) {
+            pane.set_ignore_pane_synchronized_output(should_ignore);
+        } else if let Some((_is_scrollback_editor, pane)) = self
+            .suppressed_panes
+            .values_mut()
+            .find(|suppressed_pane| suppressed_pane.1.pid() == id)
+        {
+            pane.set_ignore_pane_synchronized_output(should_ignore);
+        }
     }
     pub fn set_mouse_selection_support(&mut self, pane_id: PaneId, selection_support: bool) {
         MouseHandler::set_mouse_selection_support(self, pane_id, selection_support);

--- a/zellij-server/src/terminal_bytes.rs
+++ b/zellij-server/src/terminal_bytes.rs
@@ -1,5 +1,16 @@
-use crate::{os_input_output::AsyncReader, screen::ScreenInstruction, thread_bus::ThreadSenders};
-use std::time::{Duration, Instant};
+use crate::{
+    os_input_output::{
+        command_matches_path_or_basename, current_terminal_command, AsyncReader, ServerOsApi,
+    },
+    panes::PaneId,
+    pty::PtyRuntimeConfiguration,
+    screen::ScreenInstruction,
+    thread_bus::ThreadSenders,
+};
+use std::{
+    sync::{Arc, RwLock},
+    time::{Duration, Instant},
+};
 use tokio::task;
 use zellij_utils::{
     errors::{get_current_ctx, prelude::*, ContextType},
@@ -10,6 +21,10 @@ pub(crate) struct TerminalBytes {
     terminal_id: u32,
     senders: ThreadSenders,
     async_reader: Box<dyn AsyncReader>,
+    os_input: Option<Box<dyn ServerOsApi>>,
+    child_pid: Option<u32>,
+    runtime_configuration: Arc<RwLock<PtyRuntimeConfiguration>>,
+    ignore_pane_synchronized_output: bool,
     debug: bool,
 }
 
@@ -18,13 +33,20 @@ impl TerminalBytes {
         terminal_id: u32,
         async_reader: Box<dyn AsyncReader>,
         senders: ThreadSenders,
+        os_input: Option<Box<dyn ServerOsApi>>,
+        child_pid: Option<u32>,
+        runtime_configuration: Arc<RwLock<PtyRuntimeConfiguration>>,
         debug: bool,
     ) -> Self {
         TerminalBytes {
             terminal_id,
             senders,
-            debug,
             async_reader,
+            os_input,
+            child_pid,
+            runtime_configuration,
+            ignore_pane_synchronized_output: false,
+            debug,
         }
     }
     pub async fn listen(&mut self) -> Result<()> {
@@ -56,6 +78,22 @@ impl TerminalBytes {
                     if self.debug {
                         let _ = debug_to_file(bytes, self.terminal_id as i32);
                     }
+                    let should_ignore_pane_synchronized_output =
+                        self.pane_synchronized_output_should_be_ignored();
+                    if should_ignore_pane_synchronized_output
+                        != self.ignore_pane_synchronized_output
+                    {
+                        self.async_send_to_screen(
+                            ScreenInstruction::SetPaneSynchronizedOutputIgnore(
+                                PaneId::Terminal(self.terminal_id),
+                                should_ignore_pane_synchronized_output,
+                            ),
+                        )
+                        .await
+                        .with_context(err_context)?;
+                        self.ignore_pane_synchronized_output =
+                            should_ignore_pane_synchronized_output;
+                    }
                     self.async_send_to_screen(ScreenInstruction::PtyBytes(
                         self.terminal_id,
                         bytes.to_vec(),
@@ -84,6 +122,34 @@ impl TerminalBytes {
 
         Ok(())
     }
+
+    fn pane_synchronized_output_should_be_ignored(&self) -> bool {
+        let Some(child_pid) = self.child_pid else {
+            return false;
+        };
+        let Some(os_input) = self.os_input.as_ref() else {
+            return false;
+        };
+        let runtime_configuration = self.runtime_configuration.read().unwrap();
+        if runtime_configuration
+            .pane_synchronized_output_ignore_commands
+            .is_empty()
+        {
+            return false;
+        }
+        let Some(current_command) = current_terminal_command(
+            os_input.as_ref(),
+            child_pid,
+            &runtime_configuration.post_command_discovery_hook,
+        ) else {
+            return false;
+        };
+        command_matches_path_or_basename(
+            &current_command,
+            &runtime_configuration.pane_synchronized_output_ignore_commands,
+        )
+    }
+
     async fn async_send_to_screen(
         &self,
         screen_instruction: ScreenInstruction,

--- a/zellij-server/src/unit/os_input_output_tests.rs
+++ b/zellij-server/src/unit/os_input_output_tests.rs
@@ -63,6 +63,31 @@ fn stdin_reader_cmd() -> Command {
 }
 
 #[test]
+fn command_match_checks_full_path_and_basename() {
+    let command = vec![
+        String::from("/opt/homebrew/bin/codex"),
+        String::from("--full-auto"),
+    ];
+
+    assert!(command_matches_path_or_basename(
+        &command,
+        &[String::from("codex")],
+    ));
+    assert!(command_matches_path_or_basename(
+        &command,
+        &[String::from("/opt/homebrew/bin/codex")],
+    ));
+    assert!(!command_matches_path_or_basename(
+        &command,
+        &[String::from("pi")],
+    ));
+    assert!(!command_matches_path_or_basename(
+        &[],
+        &[String::from("codex")]
+    ));
+}
+
+#[test]
 fn get_cwd() {
     let server = make_server();
 

--- a/zellij-utils/assets/config/default.kdl
+++ b/zellij-utils/assets/config/default.kdl
@@ -532,6 +532,12 @@ load_plugins {
 //
 // post_command_discovery_hook "echo $RESURRECT_COMMAND | sed <your_regex_here>"
 
+// Ignore pane-emitted synchronized output for panes whose current foreground command matches one
+// of the following values. Matching checks both the full command path and the executable name.
+// Useful for streaming apps that should repaint immediately even inside a multiplexer.
+//
+// pane_synchronized_output_ignore_commands "pi" "codex"
+
 // Number of async worker tasks to spawn per active client.
 //
 // Allocating few tasks may result in resource contention and lags. Small values (around 4) should

--- a/zellij-utils/assets/prost_ipc/client_server_contract.rs
+++ b/zellij-utils/assets/prost_ipc/client_server_contract.rs
@@ -1895,6 +1895,8 @@ pub struct Options {
     pub focus_follows_mouse: ::core::option::Option<bool>,
     #[prost(bool, optional, tag="45")]
     pub mouse_click_through: ::core::option::Option<bool>,
+    #[prost(string, repeated, tag="46")]
+    pub pane_synchronized_output_ignore_commands: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Pane-targeting action messages
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/zellij-utils/src/client_server_contract/common_types.proto
+++ b/zellij-utils/src/client_server_contract/common_types.proto
@@ -1150,6 +1150,7 @@ message Options {
   optional bool visual_bell = 43;
   optional bool focus_follows_mouse = 44;
   optional bool mouse_click_through = 45;
+  repeated string pane_synchronized_output_ignore_commands = 46;
 }
 
 enum OnForceClose {

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -281,6 +281,7 @@ pub enum ScreenContext {
     ToggleActiveTerminalFullscreen,
     TogglePaneFrames,
     SetSelectable,
+    SetPaneSynchronizedOutputIgnore,
     ShowPluginCursor,
     SetInvisibleBorders,
     SetFixedHeight,

--- a/zellij-utils/src/input/config.rs
+++ b/zellij-utils/src/input/config.rs
@@ -669,6 +669,7 @@ mod config_test {
             scrollback_editor "/path/to/my/scrollback-editor"
             session_name "my awesome session"
             attach_to_session true
+            pane_synchronized_output_ignore_commands "pi" "codex"
         "#;
         let config = Config::from_kdl(config_contents, None).unwrap();
         assert_eq!(
@@ -764,6 +765,11 @@ mod config_test {
         assert_eq!(
             config.options.attach_to_session,
             Some(true),
+            "Option set in config"
+        );
+        assert_eq!(
+            config.options.pane_synchronized_output_ignore_commands,
+            Some(vec![String::from("pi"), String::from("codex")]),
             "Option set in config"
         );
     }

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -261,6 +261,12 @@ pub struct Options {
     #[clap(long, value_parser)]
     pub post_command_discovery_hook: Option<String>,
 
+    /// Ignore pane-emitted synchronized output for panes whose current foreground command matches
+    /// one of these values. Matching checks both the full command path and the executable name.
+    #[clap(long, value_parser)]
+    #[serde(default)]
+    pub pane_synchronized_output_ignore_commands: Option<Vec<String>>,
+
     /// Number of async worker tasks to spawn per active client.
     ///
     /// Allocating few tasks may result in resource contention and lags. Small values (around 4)
@@ -369,6 +375,9 @@ impl Options {
         let post_command_discovery_hook = other
             .post_command_discovery_hook
             .or(self.post_command_discovery_hook.clone());
+        let pane_synchronized_output_ignore_commands = other
+            .pane_synchronized_output_ignore_commands
+            .or_else(|| self.pane_synchronized_output_ignore_commands.clone());
         let client_async_worker_tasks = other
             .client_async_worker_tasks
             .or(self.client_async_worker_tasks);
@@ -418,6 +427,7 @@ impl Options {
             web_server_key,
             enforce_https_for_localhost,
             post_command_discovery_hook,
+            pane_synchronized_output_ignore_commands,
             client_async_worker_tasks,
         }
     }
@@ -500,6 +510,9 @@ impl Options {
         let post_command_discovery_hook = other
             .post_command_discovery_hook
             .or_else(|| self.post_command_discovery_hook.clone());
+        let pane_synchronized_output_ignore_commands = other
+            .pane_synchronized_output_ignore_commands
+            .or_else(|| self.pane_synchronized_output_ignore_commands.clone());
         let client_async_worker_tasks = other
             .client_async_worker_tasks
             .or(self.client_async_worker_tasks);
@@ -549,6 +562,7 @@ impl Options {
             web_server_key,
             enforce_https_for_localhost,
             post_command_discovery_hook,
+            pane_synchronized_output_ignore_commands,
             client_async_worker_tasks,
         }
     }

--- a/zellij-utils/src/ipc/protobuf_conversion.rs
+++ b/zellij-utils/src/ipc/protobuf_conversion.rs
@@ -674,6 +674,9 @@ impl From<crate::input::options::Options>
                 .map(|p| p.to_string_lossy().to_string()),
             enforce_https_for_localhost: options.enforce_https_for_localhost,
             post_command_discovery_hook: options.post_command_discovery_hook,
+            pane_synchronized_output_ignore_commands: options
+                .pane_synchronized_output_ignore_commands
+                .unwrap_or_default(),
             client_async_worker_tasks: options.client_async_worker_tasks.map(|v| v as u64),
             visual_bell: options.visual_bell,
             focus_follows_mouse: options.focus_follows_mouse,
@@ -769,6 +772,14 @@ impl TryFrom<crate::client_server_contract::client_server_contract::Options>
             web_server_key: options.web_server_key.map(std::path::PathBuf::from),
             enforce_https_for_localhost: options.enforce_https_for_localhost,
             post_command_discovery_hook: options.post_command_discovery_hook,
+            pane_synchronized_output_ignore_commands: if options
+                .pane_synchronized_output_ignore_commands
+                .is_empty()
+            {
+                None
+            } else {
+                Some(options.pane_synchronized_output_ignore_commands)
+            },
             client_async_worker_tasks: options.client_async_worker_tasks.map(|v| v as usize),
             visual_bell: options.visual_bell,
             focus_follows_mouse: options.focus_follows_mouse,

--- a/zellij-utils/src/ipc/tests/roundtrip_tests.rs
+++ b/zellij-utils/src/ipc/tests/roundtrip_tests.rs
@@ -471,6 +471,10 @@ fn test_client_messages() {
                 web_server_key: Some(PathBuf::from("web_server_key")),
                 enforce_https_for_localhost: Some(true),
                 post_command_discovery_hook: Some("post_command_discovery_hook".to_owned()),
+                pane_synchronized_output_ignore_commands: Some(vec![
+                    "pi".to_owned(),
+                    "codex".to_owned(),
+                ]),
                 client_async_worker_tasks: Some(16),
                 mouse_hover_effects: Some(false),
                 visual_bell: Some(true),

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -2781,6 +2781,10 @@ impl Options {
         let post_command_discovery_hook =
             kdl_property_first_arg_as_string_or_error!(kdl_options, "post_command_discovery_hook")
                 .map(|(hook, _entry)| hook.to_string());
+        let pane_synchronized_output_ignore_commands = kdl_options
+            .get("pane_synchronized_output_ignore_commands")
+            .map(|commands| kdl_arguments_that_are_strings(commands.entries().iter()))
+            .transpose()?;
         let client_async_worker_tasks =
             match kdl_property_first_arg_as_i64_or_error!(kdl_options, "client_async_worker_tasks")
             {
@@ -2850,6 +2854,7 @@ impl Options {
             web_server_key,
             enforce_https_for_localhost,
             post_command_discovery_hook,
+            pane_synchronized_output_ignore_commands,
             client_async_worker_tasks,
         })
     }
@@ -4140,6 +4145,38 @@ impl Options {
             None
         }
     }
+    fn pane_synchronized_output_ignore_commands_to_kdl(
+        &self,
+        add_comments: bool,
+    ) -> Option<KdlNode> {
+        let comment_text = r#"
+// Ignore pane-emitted synchronized output for panes whose current foreground command matches one
+// of the following values. Matching checks both the full command path and the executable name.
+// Useful for streaming apps that should repaint immediately even inside a multiplexer.
+// Examples:
+// pane_synchronized_output_ignore_commands "pi" "codex"
+// pane_synchronized_output_ignore_commands "/opt/homebrew/bin/codex""#;
+        let create_node = |node_values: &[String]| -> KdlNode {
+            let mut node = KdlNode::new("pane_synchronized_output_ignore_commands");
+            for node_value in node_values {
+                node.push(node_value.to_owned());
+            }
+            node
+        };
+        if let Some(commands) = &self.pane_synchronized_output_ignore_commands {
+            let mut node = create_node(commands);
+            if add_comments {
+                node.set_leading(format!("{}\n", comment_text));
+            }
+            Some(node)
+        } else if add_comments {
+            let mut node = create_node(&["pi".to_owned(), "codex".to_owned()]);
+            node.set_leading(format!("{}\n// ", comment_text));
+            Some(node)
+        } else {
+            None
+        }
+    }
     fn client_async_worker_tasks_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
         let comment_text = r#"
 // Number of async worker tasks to spawn per active client.
@@ -4307,6 +4344,11 @@ impl Options {
             self.post_command_discovery_hook_to_kdl(add_comments)
         {
             nodes.push(post_command_discovery_hook);
+        }
+        if let Some(pane_synchronized_output_ignore_commands) =
+            self.pane_synchronized_output_ignore_commands_to_kdl(add_comments)
+        {
+            nodes.push(pane_synchronized_output_ignore_commands);
         }
         if let Some(client_async_worker_tasks) = self.client_async_worker_tasks_to_kdl(add_comments)
         {
@@ -7027,6 +7069,7 @@ fn config_options_to_string() {
         support_kitty_keyboard_protocol false
         web_server true
         web_sharing "disabled"
+        pane_synchronized_output_ignore_commands "pi" "codex"
     "##;
     let document: KdlDocument = fake_config.parse().unwrap();
     let deserialized = Options::from_kdl(&document).unwrap();
@@ -7074,6 +7117,7 @@ fn config_options_to_string_with_comments() {
         support_kitty_keyboard_protocol false
         web_server true
         web_sharing "disabled"
+        pane_synchronized_output_ignore_commands "pi" "codex"
     "##;
     let document: KdlDocument = fake_config.parse().unwrap();
     let deserialized = Options::from_kdl(&document).unwrap();

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__config_options_to_string.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__config_options_to_string.snap
@@ -31,3 +31,4 @@ disable_session_metadata true
 support_kitty_keyboard_protocol false
 web_server true
 web_sharing "disabled"
+pane_synchronized_output_ignore_commands "pi" "codex"

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__config_options_to_string_with_comments.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__config_options_to_string_with_comments.snap
@@ -285,6 +285,14 @@ web_sharing "disabled"
 // Note: be sure to escape backslashes and similar characters properly
 // post_command_discovery_hook "echo $RESURRECT_COMMAND | sed <your_regex_here>"
 
+// Ignore pane-emitted synchronized output for panes whose current foreground command matches one
+// of the following values. Matching checks both the full command path and the executable name.
+// Useful for streaming apps that should repaint immediately even inside a multiplexer.
+// Examples:
+// pane_synchronized_output_ignore_commands "pi" "codex"
+// pane_synchronized_output_ignore_commands "/opt/homebrew/bin/codex"
+pane_synchronized_output_ignore_commands "pi" "codex"
+
 // Number of async worker tasks to spawn per active client.
 //
 // Allocating few tasks may result in resource contention and lags. Small values (around 4) should


### PR DESCRIPTION
## Summary
- add `pane_synchronized_output_ignore_commands` as a config option that matches the current foreground command by full path or executable basename
- ignore pane-emitted DECSET 2026 synchronized-output requests for matching commands and report synchronized output as unsupported for those panes
- plumb the option through config/KDL/proto reload paths and add focused tests for command matching, grid behavior, config parsing, and IPC roundtrips

## Testing
- cargo test -p zellij-server command_match_checks_full_path_and_basename
- cargo test -p zellij-server pane_sync_ignore
- cargo test -p zellij-utils can_define_options_in_configfile
- cargo test -p zellij-utils config_options_to_string
- cargo test -p zellij-utils roundtrip