### PR TITLE
fix: resolve Windows compilation warnings

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -9,5 +9,5 @@ fn main() {
 
     // Embed the application icon into the Windows executable.
     #[cfg(target_os = "windows")]
-    embed_resource::compile("assets/zellij.rc", embed_resource::NONE);
+    let _ = embed_resource::compile("assets/zellij.rc", embed_resource::NONE);
 }

--- a/zellij-client/src/web_client/mod.rs
+++ b/zellij-client/src/web_client/mod.rs
@@ -35,6 +35,7 @@ use interprocess::unnamed_pipe::pipe;
 #[cfg(unix)]
 use nix::sys::stat::{umask, Mode};
 
+#[cfg(unix)]
 use std::io::prelude::*;
 #[cfg(unix)]
 use std::io::{BufRead, BufReader};


### PR DESCRIPTION
- Consume unused `CompilationResult` from `embed_resource::compile` in `build.rs`
- Gate `std::io::prelude` import with `#[cfg(unix)]` since it's only used by `daemonize_web_server` which is unix-only