### PR TITLE
Add --header (-H) option to `zellij attach` for custom HTTP headers

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -752,6 +752,7 @@ pub(crate) fn start_client(opts: CliArgs) {
             forget,
             ca_cert,
             insecure,
+            headers,
         })) = opts.command.clone()
         {
             if let Some(remote_session_url) = session_name.as_ref().and_then(|s| {
@@ -780,6 +781,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                     forget,
                     ca_cert,
                     insecure,
+                    headers,
                     config_options.client_async_worker_tasks,
                 ) {
                     eprintln!("{}", e);

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -92,6 +92,7 @@ pub enum RemoteClientError {
     ConnectionFailed(String),
     UrlParseError(url::ParseError),
     IoError(std::io::Error),
+    InvalidHeader(String),
     Other(Box<dyn std::error::Error + Send + Sync>),
 }
 
@@ -104,6 +105,7 @@ impl std::fmt::Display for RemoteClientError {
             RemoteClientError::ConnectionFailed(msg) => write!(f, "Connection failed: {}", msg),
             RemoteClientError::UrlParseError(e) => write!(f, "Invalid URL: {}", e),
             RemoteClientError::IoError(e) => write!(f, "IO error: {}", e),
+            RemoteClientError::InvalidHeader(msg) => write!(f, "Invalid header: {}", msg),
             RemoteClientError::Other(e) => write!(f, "{}", e),
         }
     }
@@ -572,6 +574,22 @@ pub async fn run_remote_client_terminal_loop(
 }
 
 #[cfg(feature = "web_server_capability")]
+fn parse_custom_headers(headers: &[String]) -> Result<Vec<(String, String)>, RemoteClientError> {
+    headers
+        .iter()
+        .map(|h| {
+            let (name, value) = h.split_once(':').ok_or_else(|| {
+                RemoteClientError::InvalidHeader(format!(
+                    "expected \"Name: Value\" format, got {:?}",
+                    h
+                ))
+            })?;
+            Ok((name.trim().to_string(), value.trim().to_string()))
+        })
+        .collect()
+}
+
+#[cfg(feature = "web_server_capability")]
 pub fn start_remote_client(
     mut os_input: Box<dyn ClientOsApi>,
     remote_session_url: &str,
@@ -580,11 +598,14 @@ pub fn start_remote_client(
     forget: bool,
     ca_cert: Option<std::path::PathBuf>,
     insecure: bool,
+    headers: Vec<String>,
     async_worker_tasks: Option<usize>,
 ) -> Result<Option<ConnectToSession>, RemoteClientError> {
     info!("Starting Zellij client!");
 
     let runtime = crate::async_runtime(async_worker_tasks);
+
+    let custom_headers = parse_custom_headers(&headers)?;
 
     let connections = remote_attach::attach_to_remote_session(
         runtime.clone(),
@@ -595,6 +616,7 @@ pub fn start_remote_client(
         forget,
         ca_cert.as_deref(),
         insecure,
+        &custom_headers,
     )?;
 
     let reconnect_to_session = None;

--- a/zellij-client/src/remote_attach/auth.rs
+++ b/zellij-client/src/remote_attach/auth.rs
@@ -21,8 +21,9 @@ pub async fn authenticate(
     remember_me: bool,
     ca_cert: Option<&std::path::Path>,
     insecure: bool,
+    custom_headers: &[(String, String)],
 ) -> Result<(String, HttpClientWithCookies, Option<String>), RemoteClientError> {
-    let http_client = HttpClientWithCookies::new(ca_cert, insecure)
+    let http_client = HttpClientWithCookies::new(ca_cert, insecure, custom_headers)
         .map_err(|e| RemoteClientError::Other(Box::new(e)))?;
 
     // Step 1: Login with auth token
@@ -109,8 +110,9 @@ pub async fn validate_session_token(
     session_token: &str,
     ca_cert: Option<&std::path::Path>,
     insecure: bool,
+    custom_headers: &[(String, String)],
 ) -> Result<(String, HttpClientWithCookies), RemoteClientError> {
-    let http_client = HttpClientWithCookies::new(ca_cert, insecure)
+    let http_client = HttpClientWithCookies::new(ca_cert, insecure, custom_headers)
         .map_err(|e| RemoteClientError::Other(Box::new(e)))?;
 
     // Pre-populate the session_token cookie

--- a/zellij-client/src/remote_attach/http_client.rs
+++ b/zellij-client/src/remote_attach/http_client.rs
@@ -31,13 +31,19 @@ pub fn create_http_client(
 pub struct HttpClientWithCookies {
     client: HttpClient,
     cookies: Arc<Mutex<HashMap<String, String>>>,
+    custom_headers: Vec<(String, String)>,
 }
 
 impl HttpClientWithCookies {
-    pub fn new(ca_cert: Option<&Path>, insecure: bool) -> Result<Self, isahc::Error> {
+    pub fn new(
+        ca_cert: Option<&Path>,
+        insecure: bool,
+        custom_headers: &[(String, String)],
+    ) -> Result<Self, isahc::Error> {
         Ok(Self {
             client: create_http_client(ca_cert, insecure)?,
             cookies: Arc::new(Mutex::new(HashMap::new())),
+            custom_headers: custom_headers.to_vec(),
         })
     }
 
@@ -46,6 +52,16 @@ impl HttpClientWithCookies {
         request: T,
     ) -> Result<Response<AsyncBody>, isahc::Error> {
         let mut req = request.into();
+
+        // Add custom headers
+        for (name, value) in &self.custom_headers {
+            if let (Ok(header_name), Ok(header_value)) = (
+                name.parse::<isahc::http::header::HeaderName>(),
+                value.parse::<isahc::http::header::HeaderValue>(),
+            ) {
+                req.headers_mut().insert(header_name, header_value);
+            }
+        }
 
         // Add cookies to request
         if let Ok(cookies) = self.cookies.lock() {
@@ -119,4 +135,5 @@ impl HttpClientWithCookies {
             cookies.insert(name, value);
         }
     }
+
 }

--- a/zellij-client/src/remote_attach/mod.rs
+++ b/zellij-client/src/remote_attach/mod.rs
@@ -40,6 +40,7 @@ pub fn attach_to_remote_session(
     forget: bool,
     ca_cert: Option<&std::path::Path>,
     insecure: bool,
+    custom_headers: &[(String, String)],
 ) -> Result<WebSocketConnections, RemoteClientError> {
     // Extract server URL for token management
     let server_url = extract_server_url(remote_session_url)?;
@@ -61,6 +62,7 @@ pub fn attach_to_remote_session(
             &server_url,
             ca_cert,
             insecure,
+            custom_headers,
         )? {
             return Ok(connections);
         }
@@ -74,6 +76,7 @@ pub fn attach_to_remote_session(
         remember,
         ca_cert,
         insecure,
+        custom_headers,
     )
 }
 
@@ -85,16 +88,19 @@ fn try_to_connect_with_saved_session_token(
     server_url: &str,
     ca_cert: Option<&std::path::Path>,
     insecure: bool,
+    custom_headers: &[(String, String)],
 ) -> Result<Option<WebSocketConnections>, RemoteClientError> {
     if let Ok(Some(saved_session_token)) = remote_session_tokens::get_session_token(server_url) {
         // we have a saved session token, let's try to authenticate with it
         let ca_cert_owned = ca_cert.map(|p| p.to_path_buf());
+        let custom_headers = custom_headers.to_vec();
         match runtime.block_on(async move {
             remote_attach_with_session_token(
                 remote_session_url,
                 &saved_session_token,
                 ca_cert_owned.as_deref(),
                 insecure,
+                &custom_headers,
             )
             .await
         }) {
@@ -122,6 +128,7 @@ fn authenticate_with_retry(
     remember: bool,
     ca_cert: Option<&std::path::Path>,
     insecure: bool,
+    custom_headers: &[(String, String)],
 ) -> Result<WebSocketConnections, RemoteClientError> {
     use dialoguer::{Confirm, Password};
 
@@ -140,6 +147,7 @@ fn authenticate_with_retry(
         };
 
         let ca_cert_owned = ca_cert.map(|p| p.to_path_buf());
+        let custom_headers = custom_headers.to_vec();
         match runtime.block_on(async move {
             remote_attach(
                 remote_session_url,
@@ -147,6 +155,7 @@ fn authenticate_with_retry(
                 remember,
                 ca_cert_owned.as_deref(),
                 insecure,
+                &custom_headers,
             )
             .await
         }) {
@@ -199,11 +208,12 @@ async fn remote_attach(
     remember_me: bool,
     ca_cert: Option<&std::path::Path>,
     insecure: bool,
+    custom_headers: &[(String, String)],
 ) -> Result<(websockets::WebSocketConnections, Option<String>), RemoteClientError> {
     let server_base_url = extract_server_url(server_url)?;
     let session_name = extract_session_name(server_url)?;
     let (web_client_id, http_client, session_token) =
-        auth::authenticate(&server_base_url, auth_token, remember_me, ca_cert, insecure).await?;
+        auth::authenticate(&server_base_url, auth_token, remember_me, ca_cert, insecure, custom_headers).await?;
     let connections = websockets::establish_websocket_connections(
         &web_client_id,
         &http_client,
@@ -211,6 +221,7 @@ async fn remote_attach(
         &session_name,
         ca_cert,
         insecure,
+        custom_headers,
     )
     .await
     .map_err(|e| RemoteClientError::ConnectionFailed(e.to_string()))?;
@@ -222,11 +233,12 @@ async fn remote_attach_with_session_token(
     session_token: &str,
     ca_cert: Option<&std::path::Path>,
     insecure: bool,
+    custom_headers: &[(String, String)],
 ) -> Result<websockets::WebSocketConnections, RemoteClientError> {
     let server_base_url = extract_server_url(server_url)?;
     let session_name = extract_session_name(server_url)?;
     let (web_client_id, http_client) =
-        auth::validate_session_token(&server_base_url, session_token, ca_cert, insecure).await?;
+        auth::validate_session_token(&server_base_url, session_token, ca_cert, insecure, custom_headers).await?;
     let connections = websockets::establish_websocket_connections(
         &web_client_id,
         &http_client,
@@ -234,6 +246,7 @@ async fn remote_attach_with_session_token(
         &session_name,
         ca_cert,
         insecure,
+        custom_headers,
     )
     .await
     .map_err(|e| RemoteClientError::ConnectionFailed(e.to_string()))?;

--- a/zellij-client/src/remote_attach/unit/remote_attach_tests.rs
+++ b/zellij-client/src/remote_attach/unit/remote_attach_tests.rs
@@ -316,6 +316,7 @@ mod tests {
                 forget,
                 None,
                 true, // insecure for tests
+                &[],  // no custom headers
             )
         })
         .await

--- a/zellij-client/src/remote_attach/websockets.rs
+++ b/zellij-client/src/remote_attach/websockets.rs
@@ -27,6 +27,7 @@ pub async fn establish_websocket_connections(
     session_name: &str,
     ca_cert: Option<&Path>,
     insecure: bool,
+    custom_headers: &[(String, String)],
 ) -> Result<WebSocketConnections, Box<dyn std::error::Error>> {
     let ws_protocol = if server_base_url.starts_with("https") {
         "wss"
@@ -81,6 +82,12 @@ pub async fn establish_websocket_connections(
             tokio_tungstenite::tungstenite::handshake::client::generate_key(),
         )
         .header("Sec-WebSocket-Version", "13");
+
+    // Add custom headers
+    for (name, value) in custom_headers {
+        terminal_request = terminal_request.header(name.as_str(), value.as_str());
+        control_request = control_request.header(name.as_str(), value.as_str());
+    }
 
     // Add cookies if available
     if let Some(cookie_header) = http_client.get_cookie_header() {

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -342,6 +342,12 @@ pub enum Sessions {
         /// Skip TLS certificate validation (DANGEROUS — development only)
         #[clap(long, value_parser)]
         insecure: bool,
+
+        /// Custom HTTP header to include in remote session requests (can be repeated).
+        /// Format: "Name: Value"
+        /// Example: --header "CF-Access-Client-Id: xxx" --header "CF-Access-Client-Secret: yyy"
+        #[clap(long = "header", short('H'), value_parser, number_of_values = 1)]
+        headers: Vec<String>,
     },
 
     /// Watch a session (read-only)


### PR DESCRIPTION
When connecting to a remote Zellij web server behind an authenticating reverse proxy (e.g. Cloudflare Zero Trust), the proxy may require custom HTTP headers before it will forward the request. This adds a repeatable --header / -H flag that injects arbitrary headers into every HTTP and WebSocket request made during the remote-attach flow.

Usage example — Cloudflare Access service tokens:

```
zellij attach https://terminal.example.com \
  -H "CF-Access-Client-Id: <id>.access" \
  -H "CF-Access-Client-Secret: <secret>"
```

The headers are applied to:
  - Authentication requests (login + session endpoints)
  - WebSocket upgrade requests (terminal + control connections)