### PR TITLE
Add dynamic session name completion for bash and zsh

### DIFF
--- a/zellij-utils/assets/completions/comp.bash
+++ b/zellij-utils/assets/completions/comp.bash
@@ -1,13 +1,30 @@
+# Dynamic session name completion for attach, kill-session, delete-session, watch
+eval "$(declare -f _zellij | sed '1s/_zellij/_zellij_clap/')"
+_zellij() {
+    _zellij_clap
+    local cur="${COMP_WORDS[$COMP_CWORD]}"
+    [[ "$cur" == -* ]] && return
+    local i
+    for ((i=1; i < COMP_CWORD; i++)); do
+        case "${COMP_WORDS[$i]}" in
+            attach|a|kill-session|k|delete-session|d|watch|w)
+                COMPREPLY+=($(compgen -W "$(zellij list-sessions --short --no-formatting 2>/dev/null)" -- "$cur"))
+                return
+                ;;
+        esac
+    done
+}
+
 function zr () { zellij run --name "$*" -- bash -ic "$*";}
 function zrf () { zellij run --name "$*" --floating -- bash -ic "$*";}
 function zri () { zellij run --name "$*" --in-place -- bash -ic "$*";}
 function ze () { zellij edit "$*";}
 function zef () { zellij edit --floating "$*";}
 function zei () { zellij edit --in-place "$*";}
-function zpipe () { 
+function zpipe () {
   if [ -z "$1" ]; then
     zellij pipe;
-  else 
+  else
     zellij pipe -p $1;
   fi
 }

--- a/zellij-utils/assets/completions/comp.fish
+++ b/zellij-utils/assets/completions/comp.fish
@@ -5,6 +5,10 @@ complete -c zellij -n "__fish_seen_subcommand_from attach" -f -a "(__fish_comple
 complete -c zellij -n "__fish_seen_subcommand_from a" -f -a "(__fish_complete_sessions)" -d "Session"
 complete -c zellij -n "__fish_seen_subcommand_from kill-session" -f -a "(__fish_complete_sessions)" -d "Session"
 complete -c zellij -n "__fish_seen_subcommand_from k" -f -a "(__fish_complete_sessions)" -d "Session"
+complete -c zellij -n "__fish_seen_subcommand_from delete-session" -f -a "(__fish_complete_sessions)" -d "Session"
+complete -c zellij -n "__fish_seen_subcommand_from d" -f -a "(__fish_complete_sessions)" -d "Session"
+complete -c zellij -n "__fish_seen_subcommand_from watch" -f -a "(__fish_complete_sessions)" -d "Session"
+complete -c zellij -n "__fish_seen_subcommand_from w" -f -a "(__fish_complete_sessions)" -d "Session"
 complete -c zellij -n "__fish_seen_subcommand_from setup" -l "generate-completion" -x -a "bash elvish fish zsh powershell" -d "Shell"
 function zr
   command zellij run --name "$argv" -- fish -c "$argv"

--- a/zellij-utils/assets/completions/comp.zsh
+++ b/zellij-utils/assets/completions/comp.zsh
@@ -1,13 +1,34 @@
+# Dynamic session name completion for attach, kill-session, delete-session, watch
+functions[_zellij_clap]=$functions[_zellij]
+_zellij() {
+    # For session subcommands, complete session names directly (skip clap
+    # for the session name position so that a unique match auto-inserts)
+    local cur="${words[$CURRENT]}"
+    if [[ "$cur" != -* ]]; then
+        local subcmd
+        for subcmd in "${words[@]}"; do
+            case "$subcmd" in
+                attach|a|kill-session|k|delete-session|d|watch|w)
+                    local -a sessions=(${(f)"$(zellij list-sessions --short --no-formatting 2>/dev/null)"})
+                    [[ ${#sessions} -gt 0 ]] && compadd -- "${sessions[@]}"
+                    return
+                    ;;
+            esac
+        done
+    fi
+    _zellij_clap "$@"
+}
+
 function zr () { zellij run --name "$*" -- zsh -ic "$*";}
 function zrf () { zellij run --name "$*" --floating -- zsh -ic "$*";}
 function zri () { zellij run --name "$*" --in-place -- zsh -ic "$*";}
 function ze () { zellij edit "$*";}
 function zef () { zellij edit --floating "$*";}
 function zei () { zellij edit --in-place "$*";}
-function zpipe () { 
+function zpipe () {
   if [ -z "$1" ]; then
     zellij pipe;
-  else 
+  else
     zellij pipe -p $1;
   fi
 }


### PR DESCRIPTION
Add tab-completion of session names for the `attach`, `kill-session`, `delete-session`, and `watch` subcommands (including their short aliases) in bash and zsh. Fish already had this for `attach` and `kill-session`; this also adds the missing `delete-session`/`d` and `watch`/`w` entries there.

The approach wraps the clap-generated `_zellij` completion function:

- **Bash**: Uses `declare -f` + `sed` to rename the clap-generated `_zellij` to `_zellij_clap`, then defines a new `_zellij` that delegates to it and appends session names (via `zellij list-sessions --short --no-formatting`) when the current subcommand accepts a session name.

- **Zsh**: Copies the clap-generated function via `functions[_zellij_clap]=$functions[_zellij]`, then defines a new `_zellij` that checks for session subcommands first. When completing a session name, it calls `compadd` directly (bypassing clap) so that a unique match auto-inserts on the first TAB press. Flag completion (e.g. `--create`) still delegates to the clap-generated function.

- **Fish**: Adds `complete` entries for the previously missing `delete-session`/`d` and `watch`/`w` subcommands, using the existing `__fish_complete_sessions` helper.