### PR TITLE
feat: add ReloadPane action to re-run focused pane in-place

### DIFF
--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -951,6 +951,14 @@ pub(crate) fn route_action(
                 ))
                 .with_context(err_context)?;
         },
+        Action::ReloadPane => {
+            senders
+                .send_to_screen(ScreenInstruction::ReloadFocusedPane(
+                    client_id,
+                    Some(NotificationEnd::new(completion_tx)),
+                ))
+                .with_context(err_context)?;
+        },
         Action::NewTab {
             tiled_layout: tab_layout,
             floating_layouts: floating_panes_layout,

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -348,6 +348,7 @@ pub enum ScreenInstruction {
     HalfPageScrollDown(ClientId, Option<NotificationEnd>),
     ClearScroll(ClientId),
     CloseFocusedPane(ClientId, Option<NotificationEnd>),
+    ReloadFocusedPane(ClientId, Option<NotificationEnd>),
     ToggleActiveTerminalFullscreen(ClientId, Option<NotificationEnd>),
     TogglePaneFrames(Option<NotificationEnd>),
     SetSelectable(PaneId, bool),
@@ -811,6 +812,7 @@ impl From<&ScreenInstruction> for ScreenContext {
             ScreenInstruction::HalfPageScrollDown(..) => ScreenContext::HalfPageScrollDown,
             ScreenInstruction::ClearScroll(..) => ScreenContext::ClearScroll,
             ScreenInstruction::CloseFocusedPane(..) => ScreenContext::CloseFocusedPane,
+            ScreenInstruction::ReloadFocusedPane(..) => ScreenContext::ReloadFocusedPane,
             ScreenInstruction::ToggleActiveTerminalFullscreen(..) => {
                 ScreenContext::ToggleActiveTerminalFullscreen
             },
@@ -5840,6 +5842,15 @@ pub(crate) fn screen_thread_main(
                     screen,
                     client_id,
                     |tab: &mut Tab, client_id: ClientId| tab.close_focused_pane(client_id, completion_tx), ?
+                );
+                screen.render(None)?;
+                screen.log_and_report_session_state()?;
+            },
+            ScreenInstruction::ReloadFocusedPane(client_id, completion_tx) => {
+                active_tab_and_connected_client_id!(
+                    screen,
+                    client_id,
+                    |tab: &mut Tab, client_id: ClientId| tab.reload_focused_pane(client_id, completion_tx), ?
                 );
                 screen.render(None)?;
                 screen.log_and_report_session_state()?;

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -4053,6 +4053,26 @@ impl Tab {
         }
         Ok(())
     }
+    pub fn reload_focused_pane(
+        &mut self,
+        client_id: ClientId,
+        completion_tx: Option<NotificationEnd>,
+    ) -> Result<()> {
+        match self.get_active_pane_id(client_id) {
+            Some(PaneId::Terminal(id)) => {
+                self.rerun_terminal_pane_with_id(id, completion_tx);
+                Ok(())
+            },
+            Some(PaneId::Plugin(_)) => {
+                log::error!("reload_focused_pane: plugin panes cannot be re-run");
+                Ok(())
+            },
+            None => {
+                log::error!("reload_focused_pane: no active pane for client {client_id}");
+                Ok(())
+            },
+        }
+    }
     pub fn clear_active_terminal_screen(&mut self, client_id: ClientId) -> Result<()> {
         if let Some(active_pane) = self.get_active_pane_or_floating_pane_mut(client_id) {
             active_pane.clear_screen();

--- a/zellij-utils/assets/config/default.kdl
+++ b/zellij-utils/assets/config/default.kdl
@@ -198,6 +198,7 @@ keybinds {
         bind "Alt ]" { NextSwapLayout; }
         bind "Alt p" { TogglePaneInGroup; }
         bind "Alt Shift p" { ToggleGroupMarking; }
+        bind "Alt r" { ReloadPane; }
     }
     shared_except "normal" "locked" {
         bind "Enter" "Esc" { SwitchToMode "Normal"; }

--- a/zellij-utils/assets/prost/api.action.rs
+++ b/zellij-utils/assets/prost/api.action.rs
@@ -1108,6 +1108,7 @@ pub enum ActionName {
     RenameTabById = 97,
     ShowFloatingPanes = 98,
     HideFloatingPanes = 99,
+    ReloadPane = 100,
 }
 impl ActionName {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -1213,6 +1214,7 @@ impl ActionName {
             ActionName::RenameTabById => "RenameTabById",
             ActionName::ShowFloatingPanes => "ShowFloatingPanes",
             ActionName::HideFloatingPanes => "HideFloatingPanes",
+            ActionName::ReloadPane => "ReloadPane",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -1315,6 +1317,7 @@ impl ActionName {
             "RenameTabById" => Some(Self::RenameTabById),
             "ShowFloatingPanes" => Some(Self::ShowFloatingPanes),
             "HideFloatingPanes" => Some(Self::HideFloatingPanes),
+            "ReloadPane" => Some(Self::ReloadPane),
             _ => None,
         }
     }

--- a/zellij-utils/assets/prost_ipc/client_server_contract.rs
+++ b/zellij-utils/assets/prost_ipc/client_server_contract.rs
@@ -119,7 +119,7 @@ pub struct RgbColor {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Action {
-    #[prost(oneof="action::ActionType", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134")]
+    #[prost(oneof="action::ActionType", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135")]
     pub action_type: ::core::option::Option<action::ActionType>,
 }
 /// Nested message and enum types in `Action`.
@@ -397,6 +397,8 @@ pub mod action {
         NextSwapLayoutByTabId(super::NextSwapLayoutByTabIdAction),
         #[prost(message, tag="134")]
         MoveTabByTabId(super::MoveTabByTabIdAction),
+        #[prost(message, tag="135")]
+        ReloadPane(super::ReloadPaneAction),
     }
 }
 // Action message definitions (all 92 variants)
@@ -507,6 +509,10 @@ pub struct HideFloatingPanesAction {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CloseFocusAction {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReloadPaneAction {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/zellij-utils/src/client_server_contract/common_types.proto
+++ b/zellij-utils/src/client_server_contract/common_types.proto
@@ -272,6 +272,7 @@ message Action {
     PreviousSwapLayoutByTabIdAction previous_swap_layout_by_tab_id = 132;
     NextSwapLayoutByTabIdAction next_swap_layout_by_tab_id = 133;
     MoveTabByTabIdAction move_tab_by_tab_id = 134;
+    ReloadPaneAction reload_pane = 135;
   }
 }
 

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -277,6 +277,7 @@ pub enum ScreenContext {
     HalfPageScrollDown,
     ClearScroll,
     CloseFocusedPane,
+    ReloadFocusedPane,
     ToggleActiveSyncTab,
     ToggleActiveTerminalFullscreen,
     TogglePaneFrames,

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -291,6 +291,8 @@ pub enum Action {
     },
     /// Close the focus pane.
     CloseFocus,
+    /// Reload the focused pane (re-run its command in-place).
+    ReloadPane,
     PaneNameInput {
         input: Vec<u8>,
     },

--- a/zellij-utils/src/ipc/protobuf_conversion.rs
+++ b/zellij-utils/src/ipc/protobuf_conversion.rs
@@ -792,6 +792,7 @@ impl From<crate::input::actions::Action>
             ClearScreenByPaneIdAction,
             CliPipeAction,
             CloseFocusAction,
+            ReloadPaneAction,
             CloseFocusByPaneIdAction,
             ClosePluginPaneAction,
             CloseTabAction,
@@ -1170,6 +1171,9 @@ impl From<crate::input::actions::Action>
             },
             crate::input::actions::Action::CloseFocus => {
                 ActionType::CloseFocus(CloseFocusAction {})
+            },
+            crate::input::actions::Action::ReloadPane => {
+                ActionType::ReloadPane(ReloadPaneAction {})
             },
             crate::input::actions::Action::PaneNameInput { input } => {
                 ActionType::PaneNameInput(PaneNameInputAction {
@@ -1980,6 +1984,7 @@ impl TryFrom<crate::client_server_contract::client_server_contract::Action>
                 })
             },
             ActionType::CloseFocus(_) => Ok(crate::input::actions::Action::CloseFocus),
+            ActionType::ReloadPane(_) => Ok(crate::input::actions::Action::ReloadPane),
             ActionType::PaneNameInput(pane_name_action) => {
                 Ok(crate::input::actions::Action::PaneNameInput {
                     input: pane_name_action

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -66,6 +66,7 @@ macro_rules! parse_kdl_action_arguments {
                 "ShowFloatingPanes" => Ok(Action::ShowFloatingPanes { tab_id: None }),
                 "HideFloatingPanes" => Ok(Action::HideFloatingPanes { tab_id: None }),
                 "CloseFocus" => Ok(Action::CloseFocus),
+                "ReloadPane" => Ok(Action::ReloadPane),
                 "UndoRenamePane" => Ok(Action::UndoRenamePane),
                 "NoOp" => Ok(Action::NoOp),
                 "GoToNextTab" => Ok(Action::GoToNextTab),
@@ -762,6 +763,7 @@ impl Action {
                 Some(node)
             },
             Action::CloseFocus => Some(KdlNode::new("CloseFocus")),
+            Action::ReloadPane => Some(KdlNode::new("ReloadPane")),
             Action::PaneNameInput { input: bytes } => {
                 let mut node = KdlNode::new("PaneNameInput");
                 for byte in bytes {

--- a/zellij-utils/src/plugin_api/action.proto
+++ b/zellij-utils/src/plugin_api/action.proto
@@ -484,6 +484,7 @@ enum ActionName {
     RenameTabById = 97;
     ShowFloatingPanes = 98;
     HideFloatingPanes = 99;
+    ReloadPane = 100;
 }
 
 message Position {

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -428,6 +428,10 @@ impl TryFrom<ProtobufAction> for Action {
                 Some(_) => Err("CloseFocus should not have a payload"),
                 None => Ok(Action::CloseFocus),
             },
+            Some(ProtobufActionName::ReloadPane) => match protobuf_action.optional_payload {
+                Some(_) => Err("ReloadPane should not have a payload"),
+                None => Ok(Action::ReloadPane),
+            },
             Some(ProtobufActionName::PaneNameInput) => match protobuf_action.optional_payload {
                 Some(OptionalPayload::PaneNameInputPayload(bytes)) => {
                     Ok(Action::PaneNameInput { input: bytes })
@@ -1382,6 +1386,10 @@ impl TryFrom<Action> for ProtobufAction {
             }),
             Action::CloseFocus => Ok(ProtobufAction {
                 name: ProtobufActionName::CloseFocus as i32,
+                optional_payload: None,
+            }),
+            Action::ReloadPane => Ok(ProtobufAction {
+                name: ProtobufActionName::ReloadPane as i32,
                 optional_payload: None,
             }),
             Action::PaneNameInput { input: bytes } => Ok(ProtobufAction {


### PR DESCRIPTION
## Summary

- Adds a new `ReloadPane` action that re-executes the focused terminal pane's original command without closing, moving, or resizing it
- Binds `Alt r` in the `shared_except "locked"` key block (free key, consistent with other Alt bindings)
- Wires the full dispatch chain: `Action::ReloadPane` → `ScreenInstruction::ReloadFocusedPane` → `Tab::reload_focused_pane` → existing `rerun_terminal_pane_with_id` machinery

## Changes

- `zellij-utils/src/input/actions.rs` — new `ReloadPane` variant
- `zellij-utils/src/errors.rs` — new `ReloadFocusedPane` screen context
- `zellij-server/src/screen.rs` — new `ScreenInstruction`, context mapping arm, handler
- `zellij-server/src/tab/mod.rs` — new `reload_focused_pane` method
- `zellij-server/src/route.rs` — new `Action::ReloadPane` route arm
- `zellij-utils/src/plugin_api/action.proto` + generated prost file — `ReloadPane = 100`
- `zellij-utils/src/plugin_api/action.rs` — protobuf ↔ action conversions
- `zellij-utils/src/client_server_contract/common_types.proto` + generated prost file — `ReloadPaneAction` at tag 135
- `zellij-utils/src/ipc/protobuf_conversion.rs` — bidirectional conversion arms
- `zellij-utils/src/kdl/mod.rs` — KDL parse and serialise arms
- `zellij-utils/assets/config/default.kdl` — `bind "Alt r" { ReloadPane; }`

## Test plan

- [ ] `cargo check -p zellij-utils -p zellij-server -p zellij-client` passes with no new errors
- [ ] Manual smoke-test: open a pane running `sleep 100`, press `Alt r`, verify the process restarts
- [ ] Plugin panes and panes with no command log an error and do nothing (no crash)
- [ ] Existing tests unaffected

Fixes #1469