### PR TITLE
ci: add Winget Releaser workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,6 +217,14 @@ jobs:
           asset_name: zellij-${{ matrix.target }}-installer.sha256sum
           asset_content_type: text/plain
 
+      - name: Publish to Winget
+        if: runner.os == 'Windows'
+        uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: Zellij.Zellij
+          release-tag: ${{ env.RELEASE_TAG }}
+          token: ${{ secrets.WINGET_TOKEN }}
+
   build-release-noweb:
     needs: create-release
     name: build-release-noweb


### PR DESCRIPTION
[This action](https://github.com/vedantmgoyal9/winget-releaser) automatically generates manifests for Winget Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.

Zellij has been added to Winget (https://github.com/zellij-org/zellij/issues/316#issuecomment-4111167553), and this workflow will be used to update it.

**Before merging this:**
1. Add a **classic** PAT with `public_repo` scope as a repository secret named `WINGET_TOKEN`.

![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)

2. Fork https://github.com/microsoft/winget-pkgs under @zellij-org. The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
3. Install [Pull](https://github.com/apps/pull) on the winget-pkgs fork to ensure that it is constantly updated.

If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been created with WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+created+with+WinGet+Releaser).
