### PR TITLE
fix(panes): guard close-pane split path for fixed-size pane panic (#4880)

### DIFF
--- a/zellij-server/src/panes/tiled_panes/tiled_pane_grid.rs
+++ b/zellij-server/src/panes/tiled_panes/tiled_pane_grid.rs
@@ -1176,7 +1176,7 @@ impl<'a> TiledPaneGrid<'a> {
 
             let panes_to_the_left = self
                 .pane_ids_directly_next_to(&id, &Direction::Left)
-                .unwrap();
+                .ok()?;
             let mut selectable_panes: Vec<_> = panes_to_the_left
                 .into_iter()
                 .filter(|pid| panes.get(pid).unwrap().selectable())
@@ -1232,7 +1232,7 @@ impl<'a> TiledPaneGrid<'a> {
             let left_close_border = pane.x();
             let right_close_border = pane.x() + pane.cols();
 
-            let panes_above = self.pane_ids_directly_next_to(&id, &Direction::Up).unwrap();
+            let panes_above = self.pane_ids_directly_next_to(&id, &Direction::Up).ok()?;
             let mut selectable_panes: Vec<_> = panes_above
                 .into_iter()
                 .filter(|pid| panes.get(pid).unwrap().selectable())
@@ -1257,7 +1257,7 @@ impl<'a> TiledPaneGrid<'a> {
 
             let panes_below = self
                 .pane_ids_directly_next_to(&id, &Direction::Down)
-                .unwrap();
+                .ok()?;
             let mut selectable_panes: Vec<_> = panes_below
                 .into_iter()
                 .filter(|pid| panes[pid].selectable())


### PR DESCRIPTION
Fixes #4880

## Summary

Adds a targeted guard in tiled pane grid close/split handling to prevent the ClosePane panic when operating on panes split from fixed-size panes.

## Problem

Closing a pane split from a fixed-size pane can hit an unwrap path in tiled_pane_grid.rs and panic with 'failed to find panes'.

## What changed

- Handle the fixed-size split close path without unwrap-on-missing-pane.
- Keep the change scoped to tiled pane grid logic in zellij-server.

## Solution

Make pane lookup/update in the close/split path tolerant to missing pane state instead of panicking.

## Why

This preserves runtime stability for the reported reproduction and avoids crashing the screen thread during pane close operations.

## Tests

- `cargo test -p zellij-server tiled_pane_grid -- --nocapture`
- `cargo test -p zellij-server --lib tab::unit::tab_tests::cannot_split_panes_vertically_when_active_pane_has_fixed_columns -- --nocapture`
- `cargo test -p zellij-server --lib -- --nocapture tiled_pane_grid`
