### PR TITLE
fix(windows): respect SHELL fallback for pane spawn (#4897)

### DIFF
--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -93,6 +93,23 @@ pub(crate) fn command_exists(cmd: &RunCommand) -> bool {
     resolve_command(cmd).is_some()
 }
 
+#[cfg(windows)]
+fn shell_from_env() -> Option<PathBuf> {
+    env::var_os("SHELL")
+        .map(PathBuf::from)
+        .filter(|shell| shell.exists() && shell.is_file())
+}
+
+#[cfg(windows)]
+pub(crate) fn default_shell_command() -> Option<RunCommand> {
+    shell_from_env().map(|command| RunCommand {
+        command,
+        args: vec![],
+        cwd: None,
+        env: None,
+    })
+}
+
 // this is a utility method to separate the arguments from a pathbuf before we turn it into a
 // Command. eg. "/usr/bin/vim -e" ==> "/usr/bin/vim" + "-e" (the latter will be pushed to args)
 fn separate_command_arguments(command: &mut PathBuf, args: &mut Vec<String>) {

--- a/zellij-server/src/os_input_output_windows.rs
+++ b/zellij-server/src/os_input_output_windows.rs
@@ -478,13 +478,18 @@ impl WindowsPtyBackend {
         Ok((reader, child_pid))
     }
 
-    pub fn spawn_terminal(
+pub fn spawn_terminal(
         &self,
         mut cmd: RunCommand,
         failover_cmd: Option<RunCommand>,
         quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>,
         terminal_id: u32,
     ) -> Result<(Box<dyn AsyncReader>, u32)> {
+        if cmd.command.as_os_str().is_empty() {
+            if let Some(default_shell) = crate::os_input_output::default_shell_command() {
+                cmd = default_shell;
+            }
+        }
         if let Some(resolved) = resolve_command(&cmd) {
             cmd.command = resolved;
             return self.do_spawn(cmd, quit_cb, terminal_id);


### PR DESCRIPTION
Fixes #4897

## Summary

Fixes inconsistent shell selection on Windows when launching Zellij from Windows Terminal/Git Bash by preserving SHELL fallback in the Windows spawn path.

## Problem

In some Windows Terminal/Git Bash startup paths Zellij spawned panes with cmd.exe instead of the launching shell environment, causing inconsistent shell behavior.

## What changed

- Update Windows pane spawn path to keep SHELL fallback behavior for empty/new-pane commands.
- Touch shared os input/output entry points used by Windows shell startup.

## Solution

Use SHELL-based fallback in the shared Windows spawn path when no explicit command is provided, so pane startup stays aligned with the parent shell context.

## Why

This keeps shell behavior consistent across launch scenarios and avoids unexpected cmd.exe fallback when users start from Git Bash/Windows Terminal.

## Tests

- `cargo test -p zellij-server os_input_output_tests -- --nocapture`
- `cargo test -p zellij-server os_input_output_tests -- --nocapture && cargo test -p zellij-client stdin_handler -- --nocapture`
