### PR TITLE
fix: Codex Scrollback Bug (#4780)

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -3605,11 +3605,10 @@ impl Perform for Grid {
                                     &mut self.sixel_grid,
                                     &mut self.supports_kitty_keyboard_protocol,
                                 );
+                                self.clear_viewport_before_rendering = true;
+                                self.force_change_size(self.height, self.width); // the alternative_viewport might have been of a different size...
+                                self.mark_for_rerender();
                             }
-                            self.alternate_screen_state = None;
-                            self.clear_viewport_before_rendering = true;
-                            self.force_change_size(self.height, self.width); // the alternative_viewport might have been of a different size...
-                            self.mark_for_rerender();
                         },
                         25 => {
                             self.hide_cursor();


### PR DESCRIPTION
Fixes #4780

## Summary

Addresses #4780 in zellij-org/zellij with a minimal, targeted change.

## Problem

There is a bug in Codex that causes scrollback to be lost when it is run inside a Zellij session. This issue is a summary of all the relevant information, for future reference and for the benefits of the users - as this topic affects many.

## What changed

- zellij-server/src/panes/grid.rs

## Solution

Apply focused code changes in `zellij-server/src/panes/grid.rs` to remove the reported behavior from #4780.

## Why

Before: users hit the behavior described in #4780. After: behavior should follow issue expectations while keeping changes minimal and auditable.

## Tests

- `env CARGO_TARGET_DIR=target cargo xtask build --no-web`
- `cargo test -p zellij-server --lib -- --nocapture`

## Scope

- Changed files (1): `zellij-server/src/panes/grid.rs`
- Root-cause gate verdict: `confirmed`
- Replay stability: `not_run`

## Validation Evidence

- Local validation gate verdict: `confirmed` (risk: `low`).
- Passed check in 207.4s: `env CARGO_TARGET_DIR=target cargo xtask build --no-web`
- Passed check in 17.5s: `cargo test -p zellij-server --lib -- --nocapture`

## Known Limitations

Deterministic multi-replay was not executed in this run (`replay_stability_status=not_run`).
