### PR TITLE
fix: [zellij 0.44.0] Web server not shown as "RUNNING" in `share` plugin for some port configurations (#4888)

### DIFF
--- a/zellij-server/src/background_jobs.rs
+++ b/zellij-server/src/background_jobs.rs
@@ -804,10 +804,17 @@ fn query_webserver_via_ipc(web_server_base_url: &str) -> Result<WebServerStatus>
 
         match query_webserver_with_response(path_str, InstructionForWebServer::QueryVersion, 500) {
             Ok(WebServerResponse::Version(info)) => {
-                let matches_expected =
-                    info.ip == expected_addr.ip && info.port == expected_addr.port;
+                let matches_expected = info.ip == expected_addr.ip
+                    && info.port == expected_addr.port;
 
-                if !matches_expected {
+                let expected_port_is_reserved = matches!(expected_addr.port, 80 | 443);
+                let reported_port_is_reserved = matches!(info.port, 80 | 443);
+
+                let matches_reserved_port_alias = expected_port_is_reserved
+                    && reported_port_is_reserved
+                    && info.ip == expected_addr.ip;
+
+                if !matches_expected && !matches_reserved_port_alias {
                     continue;
                 }
 


### PR DESCRIPTION
Fixes #4888

## Summary

Addresses #4888 in zellij-org/zellij with a minimal, targeted change.

## Problem

In zellij 0.44.0, when starting a web-server that is bound to port 80 or 443, the server status in the `share` plugin will never show the server as *RUNNING*. When creating the server initially in the `share` plugin, the server status flashed briefly before showing the server as inactive.

## What changed

- zellij-server/src/background_jobs.rs

## Solution

Apply focused code changes in `zellij-server/src/background_jobs.rs` to remove the reported behavior from #4888.

## Why

Before: users hit the behavior described in #4888. After: behavior should follow issue expectations while keeping changes minimal and auditable.

## Tests

- `env CARGO_TARGET_DIR=target cargo xtask build --no-web`
- `cargo test -p zellij-server --lib -- --nocapture`

## Scope

- Changed files (1): `zellij-server/src/background_jobs.rs`
- Root-cause gate verdict: `unclear_but_non_regressing`
- Replay stability: `not_run`

## Validation Evidence

- Local validation gate verdict: `confirmed` (risk: `low`).
- Passed check in 208.5s: `env CARGO_TARGET_DIR=target cargo xtask build --no-web`
- Passed check in 21.7s: `cargo test -p zellij-server --lib -- --nocapture`

## Known Limitations

Deterministic multi-replay was not executed in this run (`replay_stability_status=not_run`).
