### PR TITLE
fix: Sessions are not persisted (#3663)

### DIFF
--- a/zellij-server/src/background_jobs.rs
+++ b/zellij-server/src/background_jobs.rs
@@ -233,6 +233,18 @@ pub(crate) fn background_jobs_main(
                     continue;
                 }
                 running_jobs.insert(job, Instant::now());
+                if let Ok(current_session_name) = current_session_name.lock() {
+                    let current_session_name = current_session_name.to_string();
+                    let current_session_info = current_session_info.lock().unwrap().clone();
+                    let current_session_layout = current_session_layout.lock().unwrap().clone();
+                    if !disable_session_metadata {
+                        write_session_state_to_disk(
+                            current_session_name.clone(),
+                            current_session_info,
+                            current_session_layout,
+                        );
+                    }
+                }
                 runtime.spawn({
                     let senders = bus.senders.clone();
                     let current_session_info = current_session_info.clone();


### PR DESCRIPTION
Fixes #3663

## Summary

Addresses #3663 in zellij-org/zellij with a minimal, targeted change.

## Problem

I have been using zellij for a couple of months now (with default settings, no plugins etc.) and noticed recently that changes to sessions are not persisted. I have version 0.40.1 installed and for testing purposes I compiled zellij from main branch. The same issue occurred with the version compiled from repository head.

## What changed

- zellij-server/src/background_jobs.rs

## Solution

Apply focused code changes in `zellij-server/src/background_jobs.rs` to remove the reported behavior from #3663.

## Why

Before: users hit the behavior described in #3663. After: behavior should follow issue expectations while keeping changes minimal and auditable.

## Tests

- `env CARGO_TARGET_DIR=target cargo xtask build --no-web`
- `cargo test -p zellij-server --lib -- --nocapture`

## Scope

- Changed files (1): `zellij-server/src/background_jobs.rs`
- Root-cause gate verdict: `unclear_but_non_regressing`
- Replay stability: `not_run`

## Validation Evidence

- Local validation gate verdict: `confirmed` (risk: `low`).
- Passed check in 284.7s: `env CARGO_TARGET_DIR=target cargo xtask build --no-web`
- Passed check in 23.6s: `cargo test -p zellij-server --lib -- --nocapture`

## Known Limitations

Deterministic multi-replay was not executed in this run (`replay_stability_status=not_run`).
