### PR TITLE
fix: infinite hang post wezterm crash in windows (#4915)

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -18,6 +18,7 @@ use zellij_utils::sessions::{
     generate_unique_session_name, get_active_session, get_resurrectable_sessions, get_sessions,
     get_sessions_sorted_by_mtime, kill_session as kill_session_impl, match_session_name,
     print_sessions, print_sessions_with_index, resurrection_layout, session_exists,
+    session_or_resurrectable_exists,
     validate_session_name, ActiveSession, SessionNameMatch,
 };
 
@@ -803,7 +804,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                 } else {
                     let session_exists = session_name
                         .as_ref()
-                        .and_then(|s| session_exists(&s).ok())
+                        .and_then(|s| session_or_resurrectable_exists(&s).ok())
                         .unwrap_or(false);
                     let resurrection_layout =
                         session_name

--- a/zellij-utils/src/sessions.rs
+++ b/zellij-utils/src/sessions.rs
@@ -438,6 +438,10 @@ pub fn session_exists(name: &str) -> Result<bool, io::ErrorKind> {
     }
 }
 
+pub fn session_or_resurrectable_exists(name: &str) -> Result<bool, io::ErrorKind> {
+    Ok(session_exists(name)? || get_resurrectable_session_names().iter().any(|s| s == name))
+}
+
 // if the session is resurrecable, the returned layout is the one to be used to resurrect it
 pub fn resurrection_layout(session_name_to_resurrect: &str) -> Result<Option<Layout>, String> {
     let layout_file_name = session_layout_cache_file_name(&session_name_to_resurrect);


### PR DESCRIPTION
Fixes #4915

## Summary

Addresses #4915 in zellij-org/zellij with a minimal, targeted change.

## Problem

1. Wezterm Crashed

## What changed

- src/commands.rs
- zellij-utils/src/sessions.rs

## Solution

Apply focused code changes in `src/commands.rs`, `zellij-utils/src/sessions.rs` to remove the reported behavior from #4915.

## Why

Before: users hit the behavior described in #4915. After: behavior should follow issue expectations while keeping changes minimal and auditable.

## Tests

- `env CARGO_TARGET_DIR=target cargo xtask build --no-web`

## Scope

- Changed files (2): `src/commands.rs`, `zellij-utils/src/sessions.rs`
- Root-cause gate verdict: `unclear_but_non_regressing`
- Replay stability: `not_run`

## Validation Evidence

- Local validation gate verdict: `confirmed` (risk: `low`).
- Passed check in 200.5s: `env CARGO_TARGET_DIR=target cargo xtask build --no-web`

## Known Limitations

Deterministic multi-replay was not executed in this run (`replay_stability_status=not_run`).
