### PR TITLE
fix(windows): allow session access across logon sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4996,6 +4996,7 @@ dependencies = [
  "unicode-width 0.1.10",
  "url",
  "uuid",
+ "widestring",
  "winapi",
  "windows-sys 0.52.0",
 ]

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -62,10 +62,13 @@ nix = { workspace = true }
 crossterm = { workspace = true, features = ["events"] }
 windows-sys = { workspace = true, features = [
     "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
     "Win32_System_Threading",
 ] }
 winapi = { version = "0.3.9", default-features = false }
 dunce = "1.0"
+widestring = "1.0"
 
 [dev-dependencies]
 insta = { version = "1.6.0", features = ["backtrace"] }

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -205,9 +205,19 @@ pub fn ipc_bind(path: &std::path::Path) -> std::io::Result<interprocess::local_s
 #[cfg(windows)]
 pub fn ipc_bind(path: &std::path::Path) -> std::io::Result<interprocess::local_socket::Listener> {
     use interprocess::local_socket::{prelude::*, GenericNamespaced, ListenerOptions};
+    use interprocess::os::windows::local_socket::ListenerOptionsExt;
     let name = path.to_string_lossy().to_string();
     let ns_name = name.to_ns_name::<GenericNamespaced>()?;
-    let listener = ListenerOptions::new().name(ns_name).create_sync()?;
+    // Set a security descriptor that grants access to the current user's SID
+    // across all logon sessions. Without this, sessions created from SSH
+    // cannot be attached to from an interactive desktop (or vice versa)
+    // because the default pipe DACL only grants access to the creating
+    // logon session's token.
+    let mut opts = ListenerOptions::new().name(ns_name);
+    if let Some(sd) = current_user_security_descriptor() {
+        opts = opts.security_descriptor(sd);
+    }
+    let listener = opts.create_sync()?;
     std::fs::write(path, std::process::id().to_string())?;
     Ok(listener)
 }
@@ -231,9 +241,14 @@ pub fn ipc_bind_async(
     path: &std::path::Path,
 ) -> std::io::Result<interprocess::local_socket::tokio::Listener> {
     use interprocess::local_socket::{prelude::*, GenericNamespaced, ListenerOptions};
+    use interprocess::os::windows::local_socket::ListenerOptionsExt;
     let name = path.to_string_lossy().to_string();
     let ns_name = name.to_ns_name::<GenericNamespaced>()?;
-    let listener = ListenerOptions::new().name(ns_name).create_tokio()?;
+    let mut opts = ListenerOptions::new().name(ns_name);
+    if let Some(sd) = current_user_security_descriptor() {
+        opts = opts.security_descriptor(sd);
+    }
+    let listener = opts.create_tokio()?;
     std::fs::write(path, std::process::id().to_string())?;
     Ok(listener)
 }
@@ -259,9 +274,81 @@ pub fn ipc_bind_reply(
     path: &std::path::Path,
 ) -> std::io::Result<interprocess::local_socket::Listener> {
     use interprocess::local_socket::{prelude::*, GenericNamespaced, ListenerOptions};
+    use interprocess::os::windows::local_socket::ListenerOptionsExt;
     let name = format!("{}-reply", path.to_string_lossy());
     let ns_name = name.to_ns_name::<GenericNamespaced>()?;
-    ListenerOptions::new().name(ns_name).create_sync()
+    let mut opts = ListenerOptions::new().name(ns_name);
+    if let Some(sd) = current_user_security_descriptor() {
+        opts = opts.security_descriptor(sd);
+    }
+    opts.create_sync()
+}
+
+/// Build a security descriptor that grants full access to the current user's
+/// SID. This allows named pipes to be accessed across different Windows logon
+/// sessions (e.g., SSH vs interactive desktop) for the same user account,
+/// without exposing them to other users.
+///
+/// Returns `None` if the user SID cannot be determined (falls back to default
+/// pipe security).
+#[cfg(windows)]
+fn current_user_security_descriptor(
+) -> Option<interprocess::os::windows::security_descriptor::SecurityDescriptor> {
+    use interprocess::os::windows::security_descriptor::SecurityDescriptor;
+    use windows_sys::Win32::Foundation::{CloseHandle, LocalFree};
+    use windows_sys::Win32::Security::Authorization::ConvertSidToStringSidW;
+    use windows_sys::Win32::Security::{GetTokenInformation, TokenUser, TOKEN_QUERY, TOKEN_USER};
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    unsafe {
+        // Get current process token.
+        let mut token_handle = 0isize;
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token_handle) == 0 {
+            return None;
+        }
+
+        // Query token for user SID.
+        let mut token_info_len: u32 = 0;
+        GetTokenInformation(
+            token_handle,
+            TokenUser,
+            std::ptr::null_mut(),
+            0,
+            &mut token_info_len,
+        );
+        let mut token_info_buf = vec![0u8; token_info_len as usize];
+        if GetTokenInformation(
+            token_handle,
+            TokenUser,
+            token_info_buf.as_mut_ptr().cast(),
+            token_info_len,
+            &mut token_info_len,
+        ) == 0
+        {
+            CloseHandle(token_handle);
+            return None;
+        }
+
+        let token_user = &*(token_info_buf.as_ptr() as *const TOKEN_USER);
+        let sid = token_user.User.Sid;
+
+        // Convert SID to string (e.g., "S-1-5-21-...").
+        let mut sid_string_ptr: *mut u16 = std::ptr::null_mut();
+        if ConvertSidToStringSidW(sid, &mut sid_string_ptr) == 0 {
+            CloseHandle(token_handle);
+            return None;
+        }
+
+        // Build SDDL: grant Generic All to this specific user SID.
+        let sid_string = widestring::U16CStr::from_ptr_str(sid_string_ptr);
+        let sddl_str = format!("D:(A;;GA;;;{})", sid_string.to_string_lossy());
+        let sddl_wide = widestring::U16CString::from_str(&sddl_str).ok();
+
+        LocalFree(sid_string_ptr as *mut std::ffi::c_void);
+        CloseHandle(token_handle);
+
+        sddl_wide.and_then(|s| SecurityDescriptor::deserialize(&s).ok())
+    }
 }
 
 #[cfg(unix)]

--- a/zellij-utils/src/sessions.rs
+++ b/zellij-utils/src/sessions.rs
@@ -167,9 +167,16 @@ fn assert_socket(name: &str) -> bool {
 
 /// On Windows, reads the server PID from the marker file and checks whether
 /// the process is still alive via `OpenProcess`. Cleans up stale marker files.
+///
+/// Note: `OpenProcess` can fail with `ERROR_ACCESS_DENIED` for processes in a
+/// different logon session (e.g., a session created via SSH when listing from
+/// an interactive desktop, or vice versa). This is NOT the same as the process
+/// being dead — the process exists but the caller's security token can't open
+/// it. We treat this as alive to avoid deleting the marker and orphaning the
+/// session.
 #[cfg(windows)]
 fn assert_socket(name: &str) -> bool {
-    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, ERROR_ACCESS_DENIED};
     use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
 
     let path = &*ZELLIJ_SOCK_DIR.join(name);
@@ -192,7 +199,8 @@ fn assert_socket(name: &str) -> bool {
     let alive = unsafe {
         let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
         if handle == 0 {
-            false
+            // Process exists but we can't open it (different logon session).
+            GetLastError() == ERROR_ACCESS_DENIED
         } else {
             CloseHandle(handle);
             true


### PR DESCRIPTION
On Windows, sessions created in one logon context (e.g., SSH) could not be listed or attached from a different logon context (e.g., interactive desktop) for the same user. Two issues:

1. assert_socket treated OpenProcess ERROR_ACCESS_DENIED as "process dead" and deleted the marker file, orphaning the session. Now checks GetLastError to distinguish access denied (alive, different logon session) from invalid parameter (genuinely dead).

2. Named pipes inherited the creating logon session's default DACL, blocking cross-session connections. Now sets an explicit DACL granting access to the current user's SID, allowing the same user to connect from any logon session without exposing pipes to other users.

Fixes https://github.com/zellij-org/zellij/issues/4930