### PR TITLE
docs: update install instructions for Fedora Linux

### DIFF
--- a/docs/THIRD_PARTY_INSTALL.md
+++ b/docs/THIRD_PARTY_INSTALL.md
@@ -26,10 +26,10 @@ paru -S zellij-git
 ```
 
 ### Fedora Linux
-You can install the `zellij` package from the [COPR](https://copr.fedorainfracloud.org/coprs/varlad/zellij/)
+You can install the `zellij` package from the [COPR](https://copr.fedorainfracloud.org/coprs/frodo/zellij/)
 
 ```
-sudo dnf copr enable varlad/zellij 
+sudo dnf copr enable frodo/zellij 
 sudo dnf install zellij
 ```
 


### PR DESCRIPTION
## Problem
- old COPR repo was no longer maintained (last version 0.42.2)
- newer zellij versions were not distributed

## What changed?
- the link now refers to a maintained repository