### PR TITLE
fix(ansi): reset bold should not entail reset underline

### DIFF
--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -693,16 +693,11 @@ impl Display for CharacterStyles {
                     write!(f, "\u{1b}[1m")?;
                 },
                 AnsiCode::Reset => {
-                    write!(f, "\u{1b}[22m\u{1b}[24m")?;
-                    // TODO: this cancels bold + underline, if this behaviour is indeed correct, we
-                    // need to properly handle it in the struct methods etc like dim
+                    write!(f, "\u{1b}[22m")?;
                 },
                 _ => {},
             }
         }
-        // notice the order is important here, bold must be before underline
-        // because the bold reset also resets underline, and would override it
-        // otherwise
         if let Some(ansi_code) = self.underline {
             match ansi_code {
                 AnsiCode::Underline(None) => {


### PR DESCRIPTION
Fixes: https://github.com/zellij-org/zellij/issues/4961

According to [ANSI Escape Sequences cheatsheet](https://gist.github.com/ConnerWill/d4b6c776b509add763e17f9f113fd25b#colors--graphics-mode):

- the escape code for reset bold is `ESC[22m` and shouldn't entail `ESC[24m` reset underline
- my change fixes that behavior
- fixing that those comments are not needed.

I tested my change. Maybe I also need to adjust unit tests?