### PR TITLE
feat: configurable word boundary characters for text selection

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -54,7 +54,8 @@ use route::{route_thread_main, NotificationEnd};
 use zellij_utils::{
     channels::{self, ChannelWithContext, SenderWithContext},
     consts::{
-        DEFAULT_SCROLL_BUFFER_SIZE, SCROLL_BUFFER_SIZE, ZELLIJ_SEEN_RELEASE_NOTES_CACHE_FILE,
+        DEFAULT_SCROLL_BUFFER_SIZE, DEFAULT_SELECT_BY_WORD_CHARACTERS, SCROLL_BUFFER_SIZE,
+        SELECT_BY_WORD_CHARACTERS, ZELLIJ_SEEN_RELEASE_NOTES_CACHE_FILE,
     },
     data::{
         ConnectToSession, InputMode, KeyWithModifier, LayoutInfo, LayoutWithError, Style,
@@ -1935,6 +1936,12 @@ fn init_session(
         config_options
             .scroll_buffer_size
             .unwrap_or(DEFAULT_SCROLL_BUFFER_SIZE),
+    );
+    let _ = SELECT_BY_WORD_CHARACTERS.set(
+        config_options
+            .select_by_word_characters
+            .clone()
+            .unwrap_or_else(|| DEFAULT_SELECT_BY_WORD_CHARACTERS.to_string()),
     );
 
     let (to_screen, screen_receiver): ChannelWithContext<ScreenInstruction> = channels::unbounded();

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -19,7 +19,10 @@ use std::{
 
 use vte;
 use zellij_utils::{
-    consts::{DEFAULT_SCROLL_BUFFER_SIZE, SCROLL_BUFFER_SIZE},
+    consts::{
+        DEFAULT_SCROLL_BUFFER_SIZE, DEFAULT_SELECT_BY_WORD_CHARACTERS, SCROLL_BUFFER_SIZE,
+        SELECT_BY_WORD_CHARACTERS,
+    },
     data::{Palette, PaletteColor, Styling},
     input::mouse::{MouseEvent, MouseEventType},
     pane_size::SizeInPixels,
@@ -4979,15 +4982,17 @@ impl Row {
 }
 
 fn is_selection_boundary_character(character: char) -> bool {
-    character.is_ascii_whitespace()
-        || character == '['
-        || character == ']'
-        || character == '{'
-        || character == '}'
-        || character == '<'
-        || character == '>'
-        || character == '('
-        || character == ')'
+    if character.is_ascii_whitespace() {
+        return true;
+    }
+    if character.is_alphanumeric() {
+        return false;
+    }
+    let word_chars = SELECT_BY_WORD_CHARACTERS
+        .get()
+        .map(|s| s.as_str())
+        .unwrap_or(DEFAULT_SELECT_BY_WORD_CHARACTERS);
+    !word_chars.contains(character)
 }
 
 #[cfg(test)]

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -6102,3 +6102,48 @@ fn csi_5n_status_query_still_handled_locally() {
         "DSR 5 must still produce its local 'all good' reply"
     );
 }
+
+#[test]
+fn double_click_word_selection_stops_at_asterisk() {
+    // '*' is not in DEFAULT_SELECT_BY_WORD_CHARACTERS, so it acts as a boundary
+    let content = "foo*bar\n";
+    let mut grid = create_grid_with_content(content);
+    let pos = Position::new(0, 1); // click on 'o' in "foo"
+    grid.start_selection(&pos);
+    grid.start_selection(&pos); // second click triggers double-click word selection
+    assert_eq!(grid.get_selected_text(), Some("foo".to_string()));
+}
+
+#[test]
+fn double_click_word_selection_includes_hyphen() {
+    // '-' is in DEFAULT_SELECT_BY_WORD_CHARACTERS, so it is NOT a boundary
+    let content = "git-branch\n";
+    let mut grid = create_grid_with_content(content);
+    let pos = Position::new(0, 1); // click on 'i' in "git"
+    grid.start_selection(&pos);
+    grid.start_selection(&pos);
+    assert_eq!(grid.get_selected_text(), Some("git-branch".to_string()));
+}
+
+#[test]
+fn double_click_word_selection_includes_at_sign() {
+    // '@' is in DEFAULT_SELECT_BY_WORD_CHARACTERS, so it is NOT a boundary
+    let content = "user@host\n";
+    let mut grid = create_grid_with_content(content);
+    let pos = Position::new(0, 1); // click on 's' in "user"
+    grid.start_selection(&pos);
+    grid.start_selection(&pos);
+    assert_eq!(grid.get_selected_text(), Some("user@host".to_string()));
+}
+
+#[test]
+fn double_click_word_selection_stops_at_colon() {
+    // ':' is not in DEFAULT_SELECT_BY_WORD_CHARACTERS, so it acts as a boundary
+    // Tests the common grep output case: "file.py:42"
+    let content = "file.py:42\n";
+    let mut grid = create_grid_with_content(content);
+    let pos = Position::new(0, 1); // click on 'i' in "file"
+    grid.start_selection(&pos);
+    grid.start_selection(&pos);
+    assert_eq!(grid.get_selected_text(), Some("file.py".to_string()));
+}

--- a/zellij-utils/assets/config/default.kdl
+++ b/zellij-utils/assets/config/default.kdl
@@ -393,6 +393,13 @@ load_plugins {
 //
 // copy_on_select false
 
+// Characters considered part of a word for double-click selection,
+// in addition to alphanumeric characters. Characters not in this list
+// (and not alphanumeric) are treated as word boundaries.
+// Default: "@-./_~?&=%+#"
+//
+// select_by_word_characters "@-./_~?&=%+#"
+
 // Path to the default editor to use to edit pane scrollbuffer
 // Default: $EDITOR or $VISUAL
 //

--- a/zellij-utils/assets/prost_ipc/client_server_contract.rs
+++ b/zellij-utils/assets/prost_ipc/client_server_contract.rs
@@ -1965,6 +1965,8 @@ pub struct Options {
     pub mobile_threshold_cols: ::core::option::Option<u32>,
     #[prost(uint32, optional, tag="50")]
     pub mobile_threshold_rows: ::core::option::Option<u32>,
+    #[prost(string, optional, tag="51")]
+    pub select_by_word_characters: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// Pane-targeting action messages
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/zellij-utils/src/client_server_contract/common_types.proto
+++ b/zellij-utils/src/client_server_contract/common_types.proto
@@ -1181,6 +1181,7 @@ message Options {
   optional MobileLayout mobile_layout = 48;
   optional uint32 mobile_threshold_cols = 49;
   optional uint32 mobile_threshold_rows = 50;
+  optional string select_by_word_characters = 51;
 }
 
 enum OnForceClose {

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -14,6 +14,8 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const DEFAULT_SCROLL_BUFFER_SIZE: usize = 10_000;
 pub static SCROLL_BUFFER_SIZE: OnceLock<usize> = OnceLock::new();
 pub static DEBUG_MODE: OnceLock<bool> = OnceLock::new();
+pub const DEFAULT_SELECT_BY_WORD_CHARACTERS: &str = "@-./_~?&=%+#";
+pub static SELECT_BY_WORD_CHARACTERS: OnceLock<String> = OnceLock::new();
 
 #[cfg(not(windows))]
 pub const SYSTEM_DEFAULT_CONFIG_DIR: &str = "/etc/zellij";

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -318,6 +318,13 @@ pub struct Options {
     #[serde(default)]
     pub mouse_click_through: Option<bool>,
 
+    /// Characters considered part of a word for double-click selection,
+    /// in addition to alphanumeric characters.
+    /// Default: "@-./_~?&=%+#"
+    #[clap(long, value_parser)]
+    #[serde(default)]
+    pub select_by_word_characters: Option<String>,
+
     // these are intentionally excluded from the CLI options as they must be specified in the
     // configuration file
     pub web_server_ip: Option<IpAddr>,
@@ -443,6 +450,9 @@ impl Options {
         let visual_bell = other.visual_bell.or(self.visual_bell);
         let focus_follows_mouse = other.focus_follows_mouse.or(self.focus_follows_mouse);
         let mouse_click_through = other.mouse_click_through.or(self.mouse_click_through);
+        let select_by_word_characters = other
+            .select_by_word_characters
+            .or_else(|| self.select_by_word_characters.clone());
         let web_server_ip = other.web_server_ip.or(self.web_server_ip);
         let web_server_port = other.web_server_port.or(self.web_server_port);
         let web_server_cert = other
@@ -503,6 +513,7 @@ impl Options {
             visual_bell,
             focus_follows_mouse,
             mouse_click_through,
+            select_by_word_characters,
             web_server_ip,
             web_server_port,
             web_server_cert,
@@ -584,6 +595,9 @@ impl Options {
         let visual_bell = other.visual_bell.or(self.visual_bell);
         let focus_follows_mouse = merge_bool(other.focus_follows_mouse, self.focus_follows_mouse);
         let mouse_click_through = merge_bool(other.mouse_click_through, self.mouse_click_through);
+        let select_by_word_characters = other
+            .select_by_word_characters
+            .or_else(|| self.select_by_word_characters.clone());
         let web_server_ip = other.web_server_ip.or(self.web_server_ip);
         let web_server_port = other.web_server_port.or(self.web_server_port);
         let web_server_cert = other
@@ -644,6 +658,7 @@ impl Options {
             visual_bell,
             focus_follows_mouse,
             mouse_click_through,
+            select_by_word_characters,
             web_server_ip,
             web_server_port,
             web_server_cert,

--- a/zellij-utils/src/ipc/protobuf_conversion.rs
+++ b/zellij-utils/src/ipc/protobuf_conversion.rs
@@ -766,6 +766,7 @@ impl From<crate::input::options::Options>
             }),
             mobile_threshold_cols: options.mobile_threshold_cols.map(|v| v as u32),
             mobile_threshold_rows: options.mobile_threshold_rows.map(|v| v as u32),
+            select_by_word_characters: options.select_by_word_characters,
         }
     }
 }
@@ -880,6 +881,7 @@ impl TryFrom<crate::client_server_contract::client_server_contract::Options>
                 .transpose()?,
             mobile_threshold_cols: options.mobile_threshold_cols.map(|v| v as u16),
             mobile_threshold_rows: options.mobile_threshold_rows.map(|v| v as u16),
+            select_by_word_characters: options.select_by_word_characters,
         })
     }
 }

--- a/zellij-utils/src/ipc/tests/roundtrip_tests.rs
+++ b/zellij-utils/src/ipc/tests/roundtrip_tests.rs
@@ -482,6 +482,7 @@ fn test_client_messages() {
                 mobile_layout: Some(MobileLayoutConfiguration::Always),
                 mobile_threshold_cols: Some(72),
                 mobile_threshold_rows: Some(40),
+                select_by_word_characters: Some("@-./_~?&=%+#".to_string()),
             }),
             layout: None,
             terminal_window_size: Size { rows: 80, cols: 42 },

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -2862,6 +2862,9 @@ impl Options {
                 },
                 None => None,
             };
+        let select_by_word_characters =
+            kdl_property_first_arg_as_string_or_error!(kdl_options, "select_by_word_characters")
+                .map(|(s, _entry)| s.to_string());
 
         Ok(Options {
             simplified_ui,
@@ -2904,6 +2907,7 @@ impl Options {
             visual_bell,
             focus_follows_mouse,
             mouse_click_through,
+            select_by_word_characters,
             web_server_ip,
             web_server_port,
             web_server_cert,
@@ -4373,6 +4377,36 @@ impl Options {
             None
         }
     }
+    fn select_by_word_characters_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
+        let comment_text = format!(
+            "{}\n{}\n{}\n{}\n{}\n{}",
+            " ",
+            "// Characters considered part of a word for double-click selection,",
+            "// in addition to alphanumeric characters. Characters not in this list",
+            "// (and not alphanumeric) are treated as word boundaries.",
+            "// Default: \"@-./_~?&=%+#\"",
+            "// ",
+        );
+
+        let create_node = |node_value: &str| -> KdlNode {
+            let mut node = KdlNode::new("select_by_word_characters");
+            node.push(node_value.to_owned());
+            node
+        };
+        if let Some(ref chars) = self.select_by_word_characters {
+            let mut node = create_node(chars);
+            if add_comments {
+                node.set_leading(format!("{}\n", comment_text));
+            }
+            Some(node)
+        } else if add_comments {
+            let mut node = create_node("@-./_~?&=%+#");
+            node.set_leading(format!("{}\n// ", comment_text));
+            Some(node)
+        } else {
+            None
+        }
+    }
     pub fn to_kdl(&self, add_comments: bool) -> Vec<KdlNode> {
         let mut nodes = vec![];
         if let Some(simplified_ui_node) = self.simplified_ui_to_kdl(add_comments) {
@@ -4533,6 +4567,10 @@ impl Options {
         }
         if let Some(mobile_threshold_rows) = self.mobile_threshold_rows_to_kdl(add_comments) {
             nodes.push(mobile_threshold_rows);
+        }
+        if let Some(select_by_word_characters) = self.select_by_word_characters_to_kdl(add_comments)
+        {
+            nodes.push(select_by_word_characters);
         }
         nodes
     }

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__bare_config_from_default_assets_to_string_with_comments.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__bare_config_from_default_assets_to_string_with_comments.snap
@@ -599,3 +599,11 @@ web_client {
 // Row breakpoint for mobile_layout (web/always). 0 = always match.
 // Default: 30
 // mobile_threshold_rows 30
+ 
+// Characters considered part of a word for double-click selection,
+// in addition to alphanumeric characters. Characters not in this list
+// (and not alphanumeric) are treated as word boundaries.
+// Default: "@-./_~?&=%+#"
+// 
+// select_by_word_characters "@-./_~?&=%+#"
+

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__config_options_to_string_with_comments.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__config_options_to_string_with_comments.snap
@@ -317,3 +317,11 @@ mobile_threshold_cols 72
 // Row breakpoint for mobile_layout (web/always). 0 = always match.
 // Default: 30
 mobile_threshold_rows 0
+ 
+// Characters considered part of a word for double-click selection,
+// in addition to alphanumeric characters. Characters not in this list
+// (and not alphanumeric) are treated as word boundaries.
+// Default: "@-./_~?&=%+#"
+// 
+// select_by_word_characters "@-./_~?&=%+#"
+

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
@@ -45,6 +45,7 @@ Options {
     visual_bell: None,
     focus_follows_mouse: None,
     mouse_click_through: None,
+    select_by_word_characters: None,
     web_server_ip: None,
     web_server_port: None,
     web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
@@ -45,6 +45,7 @@ Options {
     visual_bell: None,
     focus_follows_mouse: None,
     mouse_click_through: None,
+    select_by_word_characters: None,
     web_server_ip: None,
     web_server_port: None,
     web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
@@ -43,6 +43,7 @@ Options {
     visual_bell: None,
     focus_follows_mouse: None,
     mouse_click_through: None,
+    select_by_word_characters: None,
     web_server_ip: None,
     web_server_port: None,
     web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
@@ -6021,6 +6021,7 @@ Config {
         visual_bell: None,
         focus_follows_mouse: None,
         mouse_click_through: None,
+        select_by_word_characters: None,
         web_server_ip: None,
         web_server_port: None,
         web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
@@ -6021,6 +6021,7 @@ Config {
         visual_bell: None,
         focus_follows_mouse: None,
         mouse_click_through: None,
+        select_by_word_characters: None,
         web_server_ip: None,
         web_server_port: None,
         web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
@@ -130,6 +130,7 @@ Config {
         visual_bell: None,
         focus_follows_mouse: None,
         mouse_click_through: None,
+        select_by_word_characters: None,
         web_server_ip: None,
         web_server_port: None,
         web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
@@ -45,6 +45,7 @@ Options {
     visual_bell: None,
     focus_follows_mouse: None,
     mouse_click_through: None,
+    select_by_word_characters: None,
     web_server_ip: None,
     web_server_port: None,
     web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
@@ -6021,6 +6021,7 @@ Config {
         visual_bell: None,
         focus_follows_mouse: None,
         mouse_click_through: None,
+        select_by_word_characters: None,
         web_server_ip: None,
         web_server_port: None,
         web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
@@ -6021,6 +6021,7 @@ Config {
         visual_bell: None,
         focus_follows_mouse: None,
         mouse_click_through: None,
+        select_by_word_characters: None,
         web_server_ip: None,
         web_server_port: None,
         web_server_cert: None,


### PR DESCRIPTION
## Summary
This PR adds a new configuration option `select_by_word_characters` that allows users to customize which characters are considered part of a word during double-click text selection. Previously, word boundaries were hardcoded to specific punctuation characters. The original implementation was https://github.com/zellij-org/zellij/pull/3996 motivated by https://github.com/zellij-org/zellij/issues/1258. This PR builds on the original implementation, but is motivated by https://github.com/zellij-org/zellij/issues/4166

| Example | Before | After|
|:-|:-|:-|
| `*` is not a word character | <img width="632" height="211" alt="2026-03-30T22:01:15,257409093-04:00" src="https://github.com/user-attachments/assets/abddaf6c-9fb2-4de4-80b7-c0fafb24cf3a" /> | <img width="625" height="208" alt="2026-03-30T22:22:20,549720063-04:00" src="https://github.com/user-attachments/assets/ef7ff3d5-f44b-42c7-93d9-b157a81e15e6" /> |
| `"` is not a word character | <img width="231" height="48" alt="2026-03-30T22:24:22,986053316-04:00" src="https://github.com/user-attachments/assets/499bb5f9-03ec-43f9-bee5-021dbe3a459c" /> | <img width="188" height="60" alt="2026-03-30T22:22:50,017576515-04:00" src="https://github.com/user-attachments/assets/9ea5e50c-16d2-4a23-9aa3-010ef97dcc6d" /> |
|Can use entirely custom list | <img width="221" height="50" alt="2026-03-30T22:38:15,758352179-04:00" src="https://github.com/user-attachments/assets/755b97eb-3e47-4e5b-b303-856ef40ec32b" /> | <img width="522" height="113" alt="2026-03-30T22:37:24,749081879-04:00" src="https://github.com/user-attachments/assets/181bf2f6-7323-4ca1-8355-874e85badaf7" /> |



## Key Changes
`is_selection_boundary_character()` in `grid.rs` now uses a configurable character set instead of the previously hardcoded list. This character set is stored in a global singleton `SELECT_BY_WORD_CHARACTERS`. 

- The default I've taken from kitty: `@-./_~?&=%+#`
- The new selection boundary logic checks characters in this order:
  1. Whitespace characters are always boundaries
  2. Alphanumeric characters are never boundaries
  3. Other characters are boundaries only if they're NOT in the configured `select_by_word_characters` set

## Questions

#### Configuration Semantic?

I copied the kitty style where the characters you provide are the ones that _are words_ but the issue's example & the way this function is implemented now are describing character sets that _are boundaries_. Is it preferred to define a boundary list instead?

#### Breaking Change?
The new default is slightly more restrictive than before, do I need to maintain existing behavior or can this be "breaking"?

Before it was whitespace + `[](){}<>` that made boundaries, now it's whitespace  + the defaults above. So while `[](){}<>` are not part of a word (and thus form a boundary), many other characters now create a boundary. I assume it's reasonable to become more restrictive, but open to thoughts. It may be a little trickier to maintain existing behavior, but if paramount could be done by changing the behavior of `is_selection_boundary_character` when the configuration is _not_ set.