### PR TITLE
fix(web-client): prevent IME input text repetition

### DIFF
--- a/zellij-client/src/web_client/message_handlers.rs
+++ b/zellij-client/src/web_client/message_handlers.rs
@@ -112,13 +112,33 @@ pub fn parse_stdin(
         maybe_more,
     );
 
+    let single_event = events.len() == 1;
     for (_i, input_event) in events.into_iter().enumerate() {
         match input_event {
             InputEvent::Key(key_event) => {
-                let key = cast_termwiz_key(key_event.clone(), &buf, None);
+                // When the buffer contains multiple characters (e.g. from IME
+                // composition like Chinese input), InputParser produces one
+                // KeyEvent per character.  Previously we sent the entire `buf`
+                // as `raw_bytes` for *every* event, which caused the full
+                // string to be written N times (once per character).
+                //
+                // Fix: when there are multiple events, encode each individual
+                // character's bytes instead of the whole buffer.
+                let raw_bytes = if single_event {
+                    buf.to_vec()
+                } else {
+                    match &key_event.key {
+                        zellij_utils::vendored::termwiz::input::KeyCode::Char(c) => {
+                            let mut char_buf = [0u8; 4];
+                            c.encode_utf8(&mut char_buf).as_bytes().to_vec()
+                        },
+                        _ => buf.to_vec(),
+                    }
+                };
+                let key = cast_termwiz_key(key_event.clone(), &raw_bytes, None);
                 os_input.send_to_server(ClientToServerMsg::Key {
                     key: key.clone(),
-                    raw_bytes: buf.to_vec(),
+                    raw_bytes,
                     is_kitty_keyboard_protocol: false,
                 });
             },

--- a/zellij-client/src/web_client/message_handlers.rs
+++ b/zellij-client/src/web_client/message_handlers.rs
@@ -186,3 +186,125 @@ pub fn parse_stdin(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::parse_stdin;
+    use crate::os_input_output::ClientOsApi;
+    use std::io::{BufRead, Cursor, Write};
+    use std::path::Path;
+    use std::sync::{Arc, Mutex};
+    use zellij_utils::{
+        data::Palette,
+        errors::ErrorContext,
+        input::mouse::MouseEvent,
+        ipc::{ClientToServerMsg, ServerToClientMsg},
+        pane_size::Size,
+    };
+
+    #[derive(Clone, Debug, Default)]
+    struct RecordingOsInput {
+        sent_messages: Arc<Mutex<Vec<ClientToServerMsg>>>,
+    }
+
+    impl RecordingOsInput {
+        fn take_sent_messages(&self) -> Vec<ClientToServerMsg> {
+            self.sent_messages.lock().unwrap().clone()
+        }
+    }
+
+    impl ClientOsApi for RecordingOsInput {
+        fn get_terminal_size(&self) -> Size {
+            Size::default()
+        }
+        fn set_raw_mode(&mut self) {}
+        fn unset_raw_mode(&self) -> Result<(), std::io::Error> {
+            Ok(())
+        }
+        fn get_stdout_writer(&self) -> Box<dyn Write> {
+            Box::new(std::io::sink())
+        }
+        fn get_stdin_reader(&self) -> Box<dyn BufRead> {
+            Box::new(Cursor::new(Vec::<u8>::new()))
+        }
+        fn update_session_name(&mut self, _new_session_name: String) {}
+        fn read_from_stdin(&mut self) -> Result<Vec<u8>, &'static str> {
+            Ok(vec![])
+        }
+        fn box_clone(&self) -> Box<dyn ClientOsApi> {
+            Box::new(self.clone())
+        }
+        fn send_to_server(&self, msg: ClientToServerMsg) {
+            self.sent_messages.lock().unwrap().push(msg);
+        }
+        fn recv_from_server(&self) -> Option<(ServerToClientMsg, ErrorContext)> {
+            None
+        }
+        fn handle_signals(
+            &self,
+            _sigwinch_cb: Box<dyn Fn()>,
+            _quit_cb: Box<dyn Fn()>,
+            _resize_receiver: Option<std::sync::mpsc::Receiver<()>>,
+        ) {
+        }
+        fn connect_to_server(&self, _path: &Path) {}
+        fn load_palette(&self) -> Palette {
+            Palette::default()
+        }
+        fn enable_mouse(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn disable_mouse(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn ime_multi_char_input_uses_per_char_raw_bytes() {
+        let os_input = RecordingOsInput::default();
+        let mut mouse_old_event = MouseEvent::new();
+
+        parse_stdin(
+            "你好".as_bytes(),
+            Box::new(os_input.clone()),
+            &mut mouse_old_event,
+            false,
+        );
+
+        let sent_messages = os_input.take_sent_messages();
+        assert_eq!(sent_messages.len(), 2);
+
+        let raw_bytes: Vec<Vec<u8>> = sent_messages
+            .into_iter()
+            .map(|message| match message {
+                ClientToServerMsg::Key { raw_bytes, .. } => raw_bytes,
+                other => panic!("expected key message, got {other:?}"),
+            })
+            .collect();
+
+        assert_eq!(raw_bytes, vec!["你".as_bytes().to_vec(), "好".as_bytes().to_vec()]);
+    }
+
+    #[test]
+    fn single_char_input_keeps_original_raw_bytes() {
+        let os_input = RecordingOsInput::default();
+        let mut mouse_old_event = MouseEvent::new();
+
+        parse_stdin(
+            "a".as_bytes(),
+            Box::new(os_input.clone()),
+            &mut mouse_old_event,
+            false,
+        );
+
+        let sent_messages = os_input.take_sent_messages();
+        assert_eq!(sent_messages.len(), 1);
+
+        match &sent_messages[0] {
+            ClientToServerMsg::Key { raw_bytes, .. } => {
+                assert_eq!(raw_bytes, &b"a".to_vec());
+            },
+            other => panic!("expected key message, got {other:?}"),
+        }
+    }
+}

--- a/zellij-client/src/web_client/message_handlers.rs
+++ b/zellij-client/src/web_client/message_handlers.rs
@@ -116,19 +116,15 @@ pub fn parse_stdin(
     for (_i, input_event) in events.into_iter().enumerate() {
         match input_event {
             InputEvent::Key(key_event) => {
-                // When the buffer contains multiple characters (e.g. from IME
-                // composition like Chinese input), InputParser produces one
-                // KeyEvent per character.  Previously we sent the entire `buf`
-                // as `raw_bytes` for *every* event, which caused the full
-                // string to be written N times (once per character).
-                //
-                // Fix: when there are multiple events, encode each individual
-                // character's bytes instead of the whole buffer.
+                // For multi-event buffers (e.g. IME composition), avoid
+                // duplicating the full buffer for each unmodified Char event.
+                // Non-Char or modified keys still use the original buffer.
                 let raw_bytes = if single_event {
                     buf.to_vec()
                 } else {
-                    match &key_event.key {
-                        zellij_utils::vendored::termwiz::input::KeyCode::Char(c) => {
+                    use zellij_utils::vendored::termwiz::input::{KeyCode, Modifiers};
+                    match (&key_event.key, key_event.modifiers) {
+                        (KeyCode::Char(c), m) if m == Modifiers::NONE => {
                             let mut char_buf = [0u8; 4];
                             c.encode_utf8(&mut char_buf).as_bytes().to_vec()
                         },

--- a/zellij-client/src/web_client/message_handlers.rs
+++ b/zellij-client/src/web_client/message_handlers.rs
@@ -282,7 +282,10 @@ mod tests {
             })
             .collect();
 
-        assert_eq!(raw_bytes, vec!["你".as_bytes().to_vec(), "好".as_bytes().to_vec()]);
+        assert_eq!(
+            raw_bytes,
+            vec!["你".as_bytes().to_vec(), "好".as_bytes().to_vec()]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #4974

Fix bug where composing multi-character strings via IME (e.g. Chinese input method) causes the entire string to be written N times for N characters.

## Changes

Previously, `parse_stdin` sent the entire input buffer as `raw_bytes` for each `KeyEvent` parsed from that buffer. When IME composes "你好" (2 chars), `InputParser` creates 2 KeyEvents, but both carried the full "你好" bytes, causing it to be written twice to the terminal.

Now, when multiple events are parsed from one buffer, each `Char` KeyEvent carries only its own UTF-8 bytes. Single-event buffers (most ASCII input) remain unchanged.

## Testing

Tested on Chrome browser with Chinese IME - multi-character composition now works correctly without repetition.