### PR TITLE
fix: respect --name flag when creating new panes

### DIFF
--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -939,15 +939,6 @@ pub(crate) fn route_action(
                 ))
                 .with_context(err_context)?;
         },
-        Action::RenameActivePane { name } => {
-            senders
-                .send_to_screen(ScreenInstruction::RenameActivePane(
-                    name,
-                    client_id,
-                    Some(NotificationEnd::new(completion_tx)),
-                ))
-                .with_context(err_context)?;
-        },
         Action::Run {
             command,
             near_current_pane,
@@ -1990,12 +1981,20 @@ pub(crate) fn route_action(
                 .with_context(err_context)?;
         },
         Action::RenamePaneByPaneId { pane_id, name } => {
-            senders
-                .send_to_screen(ScreenInstruction::RenamePaneWithPaneId(
+            let instruction = match pane_id {
+                Some(pane_id) => ScreenInstruction::RenamePaneWithPaneId(
                     pane_id.into(),
                     name,
                     Some(NotificationEnd::new(completion_tx)),
-                ))
+                ),
+                None => ScreenInstruction::RenameActivePane(
+                    name,
+                    client_id,
+                    Some(NotificationEnd::new(completion_tx)),
+                ),
+            };
+            senders
+                .send_to_screen(instruction)
                 .with_context(err_context)?;
         },
         Action::UndoRenamePaneByPaneId { pane_id } => {

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -15588,9 +15588,6 @@ pub fn scroll_up_nonexistent_pane_id_does_not_panic() {
     tab.scroll_up_by_pane_id(pane_id);
 }
 
-// ========== Pane/Tab Rename Semantic Tests ==========
-// See docs/pane-tab-renaming-spec.md for the full feature spec.
-
 #[test]
 pub fn rename_pane_sets_current_title() {
     let size = Size {
@@ -15895,10 +15892,6 @@ pub fn cli_rename_then_undo_clears_to_fallback() {
     let pane = tab.get_pane_with_id(pane_id).unwrap();
     assert_eq!(pane.current_title(), fallback_title);
 }
-
-// ========== Focused-pane CLI rename tests ==========
-// These test the path used by `zellij action rename-pane "name"` without
-// --pane-id, which goes through rename_active_pane (full replacement).
 
 #[test]
 pub fn cli_rename_active_pane_replaces_name() {

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -8078,12 +8078,6 @@ pub fn send_cli_new_pane_action_with_tab_id_and_stacked() {
     );
 }
 
-// ========== Focused-pane CLI rename routing tests ==========
-// These test the screen-level rename behavior to verify that CLI rename
-// without --pane-id correctly replaces the pane name (not appends).
-// The routing from PaneNameInput → RenameActivePane vs UpdatePaneName
-// is in route.rs, but we verify the end result here.
-
 #[test]
 fn cli_rename_active_pane_via_screen_replaces_name() {
     let size = Size {

--- a/zellij-utils/assets/prost/api.action.rs
+++ b/zellij-utils/assets/prost/api.action.rs
@@ -422,8 +422,6 @@ pub mod action {
         HideFloatingPanesPayload(super::HideFloatingPanesPayload),
         #[prost(message, tag="60")]
         AreFloatingPanesVisiblePayload(super::AreFloatingPanesVisiblePayload),
-        #[prost(message, tag="61")]
-        RenameActivePanePayload(super::RenameActivePanePayload),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -471,12 +469,6 @@ pub struct HideFloatingPanesPayload {
 pub struct AreFloatingPanesVisiblePayload {
     #[prost(uint32, optional, tag="1")]
     pub tab_id: ::core::option::Option<u32>,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RenameActivePanePayload {
-    #[prost(bytes="vec", tag="1")]
-    pub name: ::prost::alloc::vec::Vec<u8>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1125,7 +1117,6 @@ pub enum ActionName {
     ShowFloatingPanes = 98,
     HideFloatingPanes = 99,
     AreFloatingPanesVisible = 100,
-    RenameActivePane = 101,
 }
 impl ActionName {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -1232,7 +1223,6 @@ impl ActionName {
             ActionName::ShowFloatingPanes => "ShowFloatingPanes",
             ActionName::HideFloatingPanes => "HideFloatingPanes",
             ActionName::AreFloatingPanesVisible => "AreFloatingPanesVisible",
-            ActionName::RenameActivePane => "RenameActivePane",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -1336,7 +1326,6 @@ impl ActionName {
             "ShowFloatingPanes" => Some(Self::ShowFloatingPanes),
             "HideFloatingPanes" => Some(Self::HideFloatingPanes),
             "AreFloatingPanesVisible" => Some(Self::AreFloatingPanesVisible),
-            "RenameActivePane" => Some(Self::RenameActivePane),
             _ => None,
         }
     }

--- a/zellij-utils/assets/prost_ipc/client_server_contract.rs
+++ b/zellij-utils/assets/prost_ipc/client_server_contract.rs
@@ -119,7 +119,7 @@ pub struct RgbColor {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Action {
-    #[prost(oneof="action::ActionType", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137")]
+    #[prost(oneof="action::ActionType", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136")]
     pub action_type: ::core::option::Option<action::ActionType>,
 }
 /// Nested message and enum types in `Action`.
@@ -401,8 +401,6 @@ pub mod action {
         FocusPaneByPaneId(super::FocusPaneByPaneIdAction),
         #[prost(message, tag="136")]
         AreFloatingPanesVisible(super::AreFloatingPanesVisibleAction),
-        #[prost(message, tag="137")]
-        RenameActivePane(super::PaneNameInputAction),
     }
 }
 // Action message definitions (all 92 variants)

--- a/zellij-utils/src/client_server_contract/common_types.proto
+++ b/zellij-utils/src/client_server_contract/common_types.proto
@@ -274,7 +274,6 @@ message Action {
     MoveTabByTabIdAction move_tab_by_tab_id = 134;
     FocusPaneByPaneIdAction focus_pane_by_pane_id = 135;
     AreFloatingPanesVisibleAction are_floating_panes_visible = 136;
-    PaneNameInputAction rename_active_pane = 137;
   }
 }
 

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -305,11 +305,6 @@ pub enum Action {
         input: Vec<u8>,
     },
     UndoRenamePane,
-    /// Rename the focused pane, fully replacing any existing name.
-    /// Used by CLI `rename-pane` without `--pane-id`.
-    RenameActivePane {
-        name: Vec<u8>,
-    },
     /// Create a new tab, optionally with a specified tab layout.
     NewTab {
         tiled_layout: Option<TiledPaneLayout>,
@@ -614,7 +609,7 @@ pub enum Action {
         pane_id: PaneId,
     },
     RenamePaneByPaneId {
-        pane_id: PaneId,
+        pane_id: Option<PaneId>,
         name: Vec<u8>,
     },
     UndoRenamePaneByPaneId {
@@ -1328,20 +1323,19 @@ impl Action {
                 },
                 None => Ok(vec![Action::CloseFocus]),
             },
-            CliAction::RenamePane { name, pane_id } => match pane_id {
-                Some(pane_id_str) => {
-                    let pane_id = PaneId::from_str(&pane_id_str)
-                        .map_err(|_| format!(
+            CliAction::RenamePane { name, pane_id } => {
+                let pane_id = match pane_id {
+                    Some(pane_id_str) => Some(
+                        PaneId::from_str(&pane_id_str).map_err(|_| format!(
                             "Malformed pane id: {pane_id_str}, expecting either a bare integer (eg. 1), a terminal pane id (eg. terminal_1) or a plugin pane id (eg. plugin_1)"
-                        ))?;
-                    Ok(vec![Action::RenamePaneByPaneId {
-                        pane_id,
-                        name: name.as_bytes().to_vec(),
-                    }])
-                },
-                None => Ok(vec![Action::RenameActivePane {
+                        ))?,
+                    ),
+                    None => None,
+                };
+                Ok(vec![Action::RenamePaneByPaneId {
+                    pane_id,
                     name: name.as_bytes().to_vec(),
-                }]),
+                }])
             },
             CliAction::UndoRenamePane { pane_id } => match pane_id {
                 Some(pane_id_str) => {
@@ -2901,7 +2895,7 @@ mod tests {
         assert_eq!(actions.len(), 1);
         match &actions[0] {
             Action::RenamePaneByPaneId { pane_id, name } => {
-                assert!(matches!(pane_id, PaneId::Terminal(19)));
+                assert!(matches!(pane_id, Some(PaneId::Terminal(19))));
                 assert_eq!(name, &"my-pane".as_bytes().to_vec());
             },
             _ => panic!("Expected RenamePaneByPaneId action"),
@@ -2918,7 +2912,13 @@ mod tests {
         assert!(result.is_ok());
         let actions = result.unwrap();
         assert_eq!(actions.len(), 1);
-        assert!(matches!(actions[0], Action::RenameActivePane { .. }));
+        match &actions[0] {
+            Action::RenamePaneByPaneId { pane_id, name } => {
+                assert!(pane_id.is_none());
+                assert_eq!(name, &"my-pane".as_bytes().to_vec());
+            },
+            _ => panic!("Expected RenamePaneByPaneId action"),
+        }
     }
 
     // 18. UndoRenamePane

--- a/zellij-utils/src/ipc/protobuf_conversion.rs
+++ b/zellij-utils/src/ipc/protobuf_conversion.rs
@@ -1214,11 +1214,6 @@ impl From<crate::input::actions::Action>
             crate::input::actions::Action::UndoRenamePane => {
                 ActionType::UndoRenamePane(UndoRenamePaneAction {})
             },
-            crate::input::actions::Action::RenameActivePane { name } => {
-                ActionType::RenameActivePane(PaneNameInputAction {
-                    input: name.iter().map(|b| *b as u32).collect(),
-                })
-            },
             crate::input::actions::Action::NewTab {
                 tiled_layout,
                 floating_layouts,
@@ -1730,7 +1725,7 @@ impl From<crate::input::actions::Action>
             },
             crate::input::actions::Action::RenamePaneByPaneId { pane_id, name } => {
                 ActionType::RenamePaneByPaneId(RenamePaneByPaneIdAction {
-                    pane_id: Some(pane_id.into()),
+                    pane_id: pane_id.map(|id| id.into()),
                     name,
                 })
             },
@@ -2054,15 +2049,6 @@ impl TryFrom<crate::client_server_contract::client_server_contract::Action>
             ActionType::PaneNameInput(pane_name_action) => {
                 Ok(crate::input::actions::Action::PaneNameInput {
                     input: pane_name_action
-                        .input
-                        .into_iter()
-                        .map(|b| b as u8)
-                        .collect(),
-                })
-            },
-            ActionType::RenameActivePane(pane_name_action) => {
-                Ok(crate::input::actions::Action::RenameActivePane {
-                    name: pane_name_action
                         .input
                         .into_iter()
                         .map(|b| b as u8)
@@ -2655,10 +2641,7 @@ impl TryFrom<crate::client_server_contract::client_server_contract::Action>
             },
             ActionType::RenamePaneByPaneId(a) => {
                 Ok(crate::input::actions::Action::RenamePaneByPaneId {
-                    pane_id: a
-                        .pane_id
-                        .ok_or_else(|| anyhow!("RenamePaneByPaneId missing pane_id"))?
-                        .try_into()?,
+                    pane_id: a.pane_id.map(|p| p.try_into()).transpose()?,
                     name: a.name,
                 })
             },

--- a/zellij-utils/src/ipc/tests/roundtrip_tests.rs
+++ b/zellij-utils/src/ipc/tests/roundtrip_tests.rs
@@ -1481,7 +1481,8 @@ fn test_client_messages() {
         is_cli_client: true,
     });
     test_client_roundtrip!(ClientToServerMsg::Action {
-        action: Action::RenameActivePane {
+        action: Action::RenamePaneByPaneId {
+            pane_id: None,
             name: "spark".as_bytes().to_vec(),
         },
         terminal_id: Some(1),
@@ -1489,7 +1490,8 @@ fn test_client_messages() {
         is_cli_client: true,
     });
     test_client_roundtrip!(ClientToServerMsg::Action {
-        action: Action::RenameActivePane {
+        action: Action::RenamePaneByPaneId {
+            pane_id: None,
             name: "x".as_bytes().to_vec(),
         },
         terminal_id: Some(1),
@@ -3465,7 +3467,7 @@ fn test_client_messages() {
     });
     test_client_roundtrip!(ClientToServerMsg::Action {
         action: Action::RenamePaneByPaneId {
-            pane_id: PaneId::Terminal(1),
+            pane_id: Some(PaneId::Terminal(1)),
             name: "test-name".as_bytes().to_vec(),
         },
         terminal_id: Some(1),
@@ -3711,7 +3713,8 @@ fn set_pane_color_wire_roundtrip() {
     assert_eq!(original, roundtrip);
 }
 
-/// Tests that RenameActivePane survives a full wire-level round-trip
+/// Tests that RenamePaneByPaneId with `pane_id: None` (the active-pane CLI
+/// rename case) survives a full wire-level round-trip
 /// (Rust → proto struct → bytes → proto struct → Rust).
 ///
 /// The struct-level round-trip in `test_client_roundtrip!` doesn't catch
@@ -3723,7 +3726,8 @@ fn rename_active_pane_wire_roundtrip() {
     use prost::Message;
 
     let original = ClientToServerMsg::Action {
-        action: Action::RenameActivePane {
+        action: Action::RenamePaneByPaneId {
+            pane_id: None,
             name: "x".as_bytes().to_vec(),
         },
         terminal_id: Some(1),

--- a/zellij-utils/src/plugin_api/action.proto
+++ b/zellij-utils/src/plugin_api/action.proto
@@ -245,7 +245,6 @@ message Action {
     ShowFloatingPanesPayload show_floating_panes_payload = 58;
     HideFloatingPanesPayload hide_floating_panes_payload = 59;
     AreFloatingPanesVisiblePayload are_floating_panes_visible_payload = 60;
-    RenameActivePanePayload rename_active_pane_payload = 61;
   }
 }
 
@@ -276,10 +275,6 @@ message HideFloatingPanesPayload {
 
 message AreFloatingPanesVisiblePayload {
   optional uint32 tab_id = 1;
-}
-
-message RenameActivePanePayload {
-  bytes name = 1;
 }
 
 message PaneIdAndShouldFloat {
@@ -495,7 +490,6 @@ enum ActionName {
     ShowFloatingPanes = 98;
     HideFloatingPanes = 99;
     AreFloatingPanesVisible = 100;
-    RenameActivePane = 101;
 }
 
 message Position {

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -49,7 +49,6 @@ pub use super::generated_api::api::{
         PluginTag as ProtobufPluginTag,
         PluginUserConfiguration as ProtobufPluginUserConfiguration,
         Position as ProtobufPosition,
-        RenameActivePanePayload,
         RunCommandAction as ProtobufRunCommandAction,
         RunEditFileAction as ProtobufRunEditFileAction,
         RunPlugin as ProtobufRunPlugin,
@@ -455,12 +454,6 @@ impl TryFrom<ProtobufAction> for Action {
             Some(ProtobufActionName::UndoRenamePane) => match protobuf_action.optional_payload {
                 Some(_) => Err("UndoRenamePane should not have a payload"),
                 None => Ok(Action::UndoRenamePane),
-            },
-            Some(ProtobufActionName::RenameActivePane) => match protobuf_action.optional_payload {
-                Some(OptionalPayload::RenameActivePanePayload(payload)) => {
-                    Ok(Action::RenameActivePane { name: payload.name })
-                },
-                _ => Err("RenameActivePane requires a payload"),
             },
             Some(ProtobufActionName::NewTab) => {
                 match protobuf_action.optional_payload {
@@ -1435,12 +1428,6 @@ impl TryFrom<Action> for ProtobufAction {
             Action::UndoRenamePane => Ok(ProtobufAction {
                 name: ProtobufActionName::UndoRenamePane as i32,
                 optional_payload: None,
-            }),
-            Action::RenameActivePane { name } => Ok(ProtobufAction {
-                name: ProtobufActionName::RenameActivePane as i32,
-                optional_payload: Some(OptionalPayload::RenameActivePanePayload(
-                    RenameActivePanePayload { name },
-                )),
             }),
             Action::NewTab {
                 tiled_layout,


### PR DESCRIPTION
The user-provided pane name (`--name`) was being discarded for default shell panes because `use_terminal_title` was set to true, which caused `pane_title` to be set to `None`. The name was also never passed as `pane_name` to `TerminalPane` — it was always hardcoded to empty string.

Three issues fixed:

1. Pane creation: `--name` was silently discarded for default shell panes because `use_terminal_title` was true. Now user-provided names take priority. Also pass `initial_pane_title` as `pane_name` to `TerminalPane` constructor (was hardcoded to empty string).

2. CLI rename without `--pane-id`: was routed through `PaneNameInput` which appends to existing name. Now uses a dedicated `RenameActivePane` action that fully replaces the name, working for any name length including single characters.

3. Interactive rename: entering rename mode preserves the existing name for editing (append/backspace). Esc reverts to the name before rename mode was entered.

Adds 28 tests covering rename semantics, interactive editing, undo, OSC title interaction, and a wire-level IPC round-trip test.

Fixes https://github.com/zellij-org/zellij/issues/4973