### PR TITLE
add ToggleView action to show/hide panes/tab bars

### DIFF
--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -511,6 +511,18 @@ impl TiledPanes {
             })
             .collect()
     }
+    pub fn non_selectable_pane_ids(&self) -> Vec<PaneId> {
+        self.panes
+            .iter()
+            .filter_map(|(id, p)| {
+                if !p.selectable() {
+                    Some(*id)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
     pub fn first_selectable_pane_id(&self) -> Option<PaneId> {
         self.panes
             .iter()

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1310,6 +1310,8 @@ pub(crate) struct Screen {
     default_mode_info: ModeInfo, // TODO: restructure ModeInfo to prevent this duplication
     style: Style,
     draw_pane_frames: bool,
+    draw_pane_frames_before_lock: Option<bool>, // Save pane frames state before entering lock mode
+    lock_hide_toggle: bool, // Whether to hide UI elements in lock mode
     auto_layout: bool,
     session_serialization: bool,
     serialize_pane_viewport: bool,
@@ -1390,6 +1392,7 @@ impl Screen {
         mouse_click_through: bool,
         web_server_ip: IpAddr,
         web_server_port: u16,
+        lock_hide_toggle: bool,
     ) -> Self {
         let session_name = mode_info.session_name.clone().unwrap_or_default();
         let session_info = SessionInfo::new(session_name.clone());
@@ -1417,6 +1420,8 @@ impl Screen {
             mode_info: BTreeMap::new(),
             default_mode_info: mode_info,
             draw_pane_frames,
+            draw_pane_frames_before_lock: None,
+            lock_hide_toggle,
             auto_layout,
             session_is_mirrored,
             copy_options,
@@ -3262,6 +3267,29 @@ impl Screen {
         }
 
         self.style = mode_info.style;
+        
+        // Handle pane frames show/hide for lock mode (only effective when lock_hide_toggle is true)
+        if self.lock_hide_toggle {
+            if mode_info.mode == InputMode::Locked && previous_mode != InputMode::Locked {
+                // Entering lock mode: save current state and hide pane frames
+                self.draw_pane_frames_before_lock = Some(self.draw_pane_frames);
+                self.draw_pane_frames = false;
+                for tab in self.tabs.values_mut() {
+                    tab.set_pane_frames(false);
+                    tab.hide_non_selectable_panes(); // Hide non-selectable panes like tab bar
+                }
+            } else if previous_mode == InputMode::Locked && mode_info.mode != InputMode::Locked {
+                // Exiting lock mode: restore previous state
+                if let Some(previous_draw_pane_frames) = self.draw_pane_frames_before_lock.take() {
+                    self.draw_pane_frames = previous_draw_pane_frames;
+                    for tab in self.tabs.values_mut() {
+                        tab.set_pane_frames(previous_draw_pane_frames);
+                        tab.show_non_selectable_panes(); // Show non-selectable panes like tab bar
+                    }
+                }
+            }
+        }
+        
         self.mode_info.insert(client_id, mode_info.clone());
         for tab in self.tabs.values_mut() {
             tab.change_mode_info(mode_info.clone(), client_id);
@@ -4990,6 +5018,7 @@ pub(crate) fn screen_thread_main(
     let visual_bell = config_options.visual_bell.unwrap_or(true);
     let focus_follows_mouse = config_options.focus_follows_mouse.unwrap_or(false);
     let mouse_click_through = config_options.mouse_click_through.unwrap_or(false);
+    let lock_hide_toggle = config_options.lock_hide_toggle.unwrap_or(true); // Default to true, i.e., hide UI in lock mode
 
     let thread_senders = bus.senders.clone();
     let mut screen = Screen::new(
@@ -5033,6 +5062,7 @@ pub(crate) fn screen_thread_main(
         mouse_click_through,
         web_server_ip,
         web_server_port,
+        lock_hide_toggle,
     );
 
     let mut pending_tab_ids: HashSet<usize> = HashSet::new();

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -4790,6 +4790,40 @@ impl Tab {
         self.set_should_clear_display_before_rendering();
         self.set_force_render();
     }
+    pub fn hide_non_selectable_panes(&mut self) {
+        let non_selectable_pane_ids = self.tiled_panes.non_selectable_pane_ids();
+        for pane_id in non_selectable_pane_ids {
+            self.tiled_panes.add_to_hidden_panels(pane_id);
+        }
+        // Re-layout panes to allow other panes to expand into the hidden space
+        let display_area = *self.display_area.borrow();
+        self.tiled_panes.resize(display_area);
+        // Reset viewport to the entire display_area since non-selectable panes are hidden
+        {
+            let mut viewport = self.viewport.borrow_mut();
+            *viewport = display_area.into();
+        }
+        self.set_should_clear_display_before_rendering();
+        self.set_force_render();
+    }
+    pub fn show_non_selectable_panes(&mut self) {
+        let non_selectable_pane_ids = self.tiled_panes.non_selectable_pane_ids();
+        for pane_id in non_selectable_pane_ids {
+            self.tiled_panes.remove_from_hidden_panels(pane_id);
+        }
+        // Re-layout panes
+        let display_area = *self.display_area.borrow();
+        self.tiled_panes.resize(display_area);
+        // Recalculate viewport, considering non-selectable panes
+        LayoutApplier::offset_viewport(
+            self.viewport.clone(),
+            self.display_area.clone(),
+            &mut self.tiled_panes,
+            self.draw_pane_frames,
+        );
+        self.set_should_clear_display_before_rendering();
+        self.set_force_render();
+    }
     pub fn panes_to_hide_count(&self) -> usize {
         self.tiled_panes.panes_to_hide_count()
     }

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -327,6 +327,7 @@ fn create_new_screen(
         false, // mouse_click_through
         web_server_ip,
         web_server_port,
+        true, // lock_hide_toggle
     );
     screen
 }
@@ -5295,6 +5296,7 @@ fn create_new_screen_with_message_capture(
         false, // mouse_click_through
         web_server_ip,
         web_server_port,
+        true, // lock_hide_toggle
     );
     (screen, messages)
 }

--- a/zellij-utils/assets/prost_ipc/client_server_contract.rs
+++ b/zellij-utils/assets/prost_ipc/client_server_contract.rs
@@ -1927,6 +1927,9 @@ pub struct Options {
     pub focus_follows_mouse: ::core::option::Option<bool>,
     #[prost(bool, optional, tag="45")]
     pub mouse_click_through: ::core::option::Option<bool>,
+    /// Hide UI elements in lock mode
+    #[prost(bool, optional, tag="46")]
+    pub lock_hide_toggle: ::core::option::Option<bool>,
 }
 /// Pane-targeting action messages
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/zellij-utils/src/client_server_contract/common_types.proto
+++ b/zellij-utils/src/client_server_contract/common_types.proto
@@ -1166,6 +1166,7 @@ message Options {
   optional bool visual_bell = 43;
   optional bool focus_follows_mouse = 44;
   optional bool mouse_click_through = 45;
+  optional bool lock_hide_toggle = 46; // Hide UI elements in lock mode
 }
 
 enum OnForceClose {

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -81,6 +81,11 @@ pub struct Options {
     #[serde(default)]
     /// Mirror session when multiple users are connected (true or false)
     pub mirror_session: Option<bool>,
+    #[clap(long, value_parser)]
+    #[serde(default)]
+    /// Hide pane frames, tab bar and status bar when entering lock mode (true or false)
+    /// Default: true (hide UI elements in lock mode)
+    pub lock_hide_toggle: Option<bool>,
     /// Set behaviour on force close (quit or detach)
     #[clap(long, arg_enum, hide_possible_values = true, value_parser)]
     pub on_force_close: Option<OnForceClose>,
@@ -311,6 +316,7 @@ impl Options {
         let pane_frames = other.pane_frames.or(self.pane_frames);
         let auto_layout = other.auto_layout.or(self.auto_layout);
         let mirror_session = other.mirror_session.or(self.mirror_session);
+        let lock_hide_toggle = other.lock_hide_toggle.or(self.lock_hide_toggle);
         let simplified_ui = other.simplified_ui.or(self.simplified_ui);
         let default_mode = other.default_mode.or(self.default_mode);
         let default_shell = other.default_shell.or_else(|| self.default_shell.clone());
@@ -385,6 +391,7 @@ impl Options {
             mouse_mode,
             pane_frames,
             mirror_session,
+            lock_hide_toggle,
             on_force_close,
             scroll_buffer_size,
             copy_command,
@@ -442,6 +449,7 @@ impl Options {
         let pane_frames = merge_bool(other.pane_frames, self.pane_frames);
         let auto_layout = merge_bool(other.auto_layout, self.auto_layout);
         let mirror_session = merge_bool(other.mirror_session, self.mirror_session);
+        let lock_hide_toggle = merge_bool(other.lock_hide_toggle, self.lock_hide_toggle);
         let session_serialization =
             merge_bool(other.session_serialization, self.session_serialization);
         let serialize_pane_viewport =
@@ -516,6 +524,7 @@ impl Options {
             mouse_mode,
             pane_frames,
             mirror_session,
+            lock_hide_toggle,
             on_force_close,
             scroll_buffer_size,
             copy_command,

--- a/zellij-utils/src/ipc/protobuf_conversion.rs
+++ b/zellij-utils/src/ipc/protobuf_conversion.rs
@@ -638,6 +638,7 @@ impl From<crate::input::options::Options>
             mouse_mode: options.mouse_mode,
             pane_frames: options.pane_frames,
             mirror_session: options.mirror_session,
+            lock_hide_toggle: options.lock_hide_toggle,
             on_force_close: options.on_force_close.map(|o| match o {
                 crate::input::options::OnForceClose::Quit => ProtoOnForceClose::Quit as i32,
                 crate::input::options::OnForceClose::Detach => ProtoOnForceClose::Detach as i32,
@@ -719,6 +720,7 @@ impl TryFrom<crate::client_server_contract::client_server_contract::Options>
             mouse_mode: options.mouse_mode,
             pane_frames: options.pane_frames,
             mirror_session: options.mirror_session,
+            lock_hide_toggle: options.lock_hide_toggle,
             on_force_close: options
                 .on_force_close
                 .map(|o| match ProtoOnForceClose::from_i32(o) {

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -2715,6 +2715,8 @@ impl Options {
                 .map(|(string, _entry)| PathBuf::from(string));
         let mirror_session =
             kdl_property_first_arg_as_bool_or_error!(kdl_options, "mirror_session").map(|(v, _)| v);
+        let lock_hide_toggle =
+            kdl_property_first_arg_as_bool_or_error!(kdl_options, "lock_hide_toggle").map(|(v, _)| v);
         let session_name = kdl_property_first_arg_as_string_or_error!(kdl_options, "session_name")
             .map(|(session_name, _entry)| session_name.to_string());
         let attach_to_session =
@@ -2830,6 +2832,7 @@ impl Options {
             mouse_mode,
             pane_frames,
             mirror_session,
+            lock_hide_toggle,
             on_force_close,
             scroll_buffer_size,
             copy_command,
@@ -3203,6 +3206,37 @@ impl Options {
         };
         if let Some(mirror_session) = self.mirror_session {
             let mut node = create_node(mirror_session);
+            if add_comments {
+                node.set_leading(format!("{}\n", comment_text));
+            }
+            Some(node)
+        } else if add_comments {
+            let mut node = create_node(true);
+            node.set_leading(format!("{}\n// ", comment_text));
+            Some(node)
+        } else {
+            None
+        }
+    }
+    fn lock_hide_toggle_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
+        let comment_text = format!(
+            "{}\n{}\n{}\n{}\n{}\n{}\n{}",
+            " ",
+            "// Hide pane frames, tab bar and status bar when entering lock mode",
+            "// Set to true to hide UI elements in lock mode (Ctrl+g)",
+            "// Set to false to keep UI elements visible in lock mode",
+            "// (Requires restart)",
+            "// Default: true",
+            "// ",
+        );
+
+        let create_node = |node_value: bool| -> KdlNode {
+            let mut node = KdlNode::new("lock_hide_toggle");
+            node.push(KdlValue::Bool(node_value));
+            node
+        };
+        if let Some(lock_hide_toggle) = self.lock_hide_toggle {
+            let mut node = create_node(lock_hide_toggle);
             if add_comments {
                 node.set_leading(format!("{}\n", comment_text));
             }
@@ -4216,6 +4250,9 @@ impl Options {
         }
         if let Some(mirror_session) = self.mirror_session_to_kdl(add_comments) {
             nodes.push(mirror_session);
+        }
+        if let Some(lock_hide_toggle) = self.lock_hide_toggle_to_kdl(add_comments) {
+            nodes.push(lock_hide_toggle);
         }
         if let Some(on_force_close) = self.on_force_close_to_kdl(add_comments) {
             nodes.push(on_force_close);


### PR DESCRIPTION
In issue #694, many people need the ability to dynamically hide unnecessary UI to expand usable screen space. I have this need too, so I modified the main code.

My modifications might not be perfect, but I still hope this feature can be merged into the main branch soon. 

Currently, I added a configuration parameter `lock_hide_toggle`, which is enabled by default. When enabled, entering lock mode with `ctrl+g` hides UI elements like panes, tabs, etc., and the freed space can be used by the user.
When the user exits lock mode (again with `ctrl+g`), the previous UI is restored.

FIX https://github.com/zellij-org/zellij/issues/694