### PR TITLE
fix: keep IME anchor aligned when terminal cursor is hidden

### DIFF
--- a/zellij-server/src/output/mod.rs
+++ b/zellij-server/src/output/mod.rs
@@ -663,6 +663,19 @@ impl Output {
             .map(|s| s.cursor_is_visible(cursor_x, cursor_y, z_index))
             .unwrap_or(true)
     }
+    /// Check whether a cursor position is occluded by floating panes without
+    /// mutating the tracked cursor coordinates used elsewhere during render.
+    pub fn is_cursor_not_occluded(
+        &self,
+        cursor_x: usize,
+        cursor_y: usize,
+        z_index: Option<usize>,
+    ) -> bool {
+        self.floating_panes_stack
+            .as_ref()
+            .map(|s| s.cursor_is_visible(cursor_x, cursor_y, z_index))
+            .unwrap_or(true)
+    }
     pub fn add_pane_contents(
         &mut self,
         client_ids: &[ClientId],

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1581,6 +1581,13 @@ impl Grid {
             Some((self.cursor.x, self.cursor.y))
         }
     }
+    pub fn cursor_position_for_ime(&self) -> Option<(usize, usize)> {
+        if self.cursor.x >= self.width || self.cursor.y >= self.height {
+            None
+        } else {
+            Some((self.cursor.x, self.cursor.y))
+        }
+    }
     pub fn is_mid_frame(&self) -> bool {
         self.lock_renders
     }

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -218,6 +218,15 @@ impl Pane for TerminalPane {
             .cursor_coordinates()
             .map(|(x, y)| (x + left, y + top))
     }
+    fn cursor_position_for_ime(&self, _client_id: Option<ClientId>) -> Option<(usize, usize)> {
+        if self.get_content_rows() < 1 || self.get_content_columns() < 1 {
+            return None;
+        }
+        let Offset { top, left, .. } = self.content_offset;
+        self.grid
+            .cursor_position_for_ime()
+            .map(|(x, y)| (x + left, y + top))
+    }
     fn is_mid_frame(&self) -> bool {
         self.grid.is_mid_frame()
     }

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -191,6 +191,7 @@ pub(crate) struct Tab {
     cursor_positions_and_shape: HashMap<ClientId, (usize, usize, String)>, // (x_position,
     // y_position,
     // cursor_shape_csi)
+    ime_cursor_positions: HashMap<ClientId, (usize, usize)>,
     is_pending: bool, // a pending tab is one that is still being loaded or otherwise waiting
     pending_instructions: Vec<BufferedTabInstruction>, // instructions that came while the tab was
     // pending and need to be re-applied
@@ -241,6 +242,9 @@ pub trait Pane {
     fn handle_plugin_bytes(&mut self, _client_id: ClientId, _bytes: VteBytes) {}
     fn show_cursor(&mut self, _client_id: ClientId, _cursor_position: Option<(usize, usize)>) {}
     fn cursor_coordinates(&self, _client_id: Option<ClientId>) -> Option<(usize, usize)>;
+    fn cursor_position_for_ime(&self, client_id: Option<ClientId>) -> Option<(usize, usize)> {
+        self.cursor_coordinates(client_id)
+    }
     fn is_mid_frame(&self) -> bool {
         false
     }
@@ -803,6 +807,7 @@ impl Tab {
             terminal_emulator_color_codes,
             pids_waiting_resize: HashSet::new(),
             cursor_positions_and_shape: HashMap::new(),
+            ime_cursor_positions: HashMap::new(),
             is_pending: true, // will be switched to false once the layout is applied
             pending_instructions: vec![],
             swap_layouts,
@@ -3058,6 +3063,29 @@ impl Tab {
                 (x, y)
             })
     }
+    pub fn get_active_terminal_ime_cursor_position(
+        &self,
+        client_id: ClientId,
+    ) -> Option<(usize, usize)> {
+        let active_pane_id = if self.floating_panes.panes_are_visible() {
+            self.floating_panes
+                .get_active_pane_id(client_id)
+                .or_else(|| self.tiled_panes.get_active_pane_id(client_id))?
+        } else {
+            self.tiled_panes.get_active_pane_id(client_id)?
+        };
+        let active_terminal = &self
+            .floating_panes
+            .get(&active_pane_id)
+            .or_else(|| self.tiled_panes.get_pane(active_pane_id))?;
+        active_terminal
+            .cursor_position_for_ime(Some(client_id))
+            .map(|(x_in_terminal, y_in_terminal)| {
+                let x = active_terminal.x() + x_in_terminal;
+                let y = active_terminal.y() + y_in_terminal;
+                (x, y)
+            })
+    }
     pub fn toggle_active_pane_fullscreen(&mut self, client_id: ClientId) {
         if self.floating_panes.panes_are_visible() {
             return;
@@ -3295,6 +3323,35 @@ impl Tab {
                 None => {
                     let hide_cursor = "\u{1b}[?25l";
                     output.add_post_vte_instruction_to_client(client_id, hide_cursor);
+
+                    let active_terminal_is_mid_frame = self
+                        .active_terminal_is_mid_frame(client_id)
+                        .unwrap_or(false);
+                    if !active_terminal_is_mid_frame {
+                        if let Some((ime_x, ime_y)) =
+                            self.get_active_terminal_ime_cursor_position(client_id)
+                        {
+                            let active_pane_z_index = self
+                                .get_active_pane_id(client_id)
+                                .and_then(|pane_id| self.floating_panes.get_pane_z_index(pane_id));
+                            let ime_position_changed = self
+                                .ime_cursor_positions
+                                .get(&client_id)
+                                .map(|(prev_x, prev_y)| prev_x != &ime_x || prev_y != &ime_y)
+                                .unwrap_or(true);
+                            if (output.is_dirty() || ime_position_changed)
+                                && output.is_cursor_not_occluded(ime_x, ime_y, active_pane_z_index)
+                            {
+                                let goto_cursor_position =
+                                    &format!("\u{1b}[{};{}H", ime_y + 1, ime_x + 1);
+                                output.add_post_vte_instruction_to_client(
+                                    client_id,
+                                    goto_cursor_position,
+                                );
+                                self.ime_cursor_positions.insert(client_id, (ime_x, ime_y));
+                            }
+                        }
+                    }
                 },
             }
         }


### PR DESCRIPTION
## Summary

Fix IME candidate/composition window drift when terminal applications hide the cursor during their render cycle.

This was reproduced with Claude Code on macOS, where the logical text cursor was correct but the host terminal cursor stayed at an old position, causing the OS IME candidate window to appear in the wrong place.

## Root cause

Some TUIs hide the cursor with `CSI ? 25 l` while rendering and only restore it later. In Zellij, the hidden-cursor path treated this as effectively "no cursor position", so it hid the host cursor but did not keep the host cursor position aligned with the active pane's logical cursor.

The host terminal's IME uses the host cursor position, even when the cursor is hidden, to anchor the composition/candidate UI.

## Changes

- add `cursor_position_for_ime()` to `Grid`
- expose `cursor_position_for_ime()` through the `Pane` trait and `TerminalPane`
- add `is_cursor_not_occluded()` to `Output` so IME visibility checks do not mutate tracked render cursor state
- add `ime_cursor_positions` caching in `Tab`
- when the real cursor is hidden, still send a CUP sequence to keep the host cursor aligned for IME anchoring

## Testing

Manual:
- reproduced with Claude Code and CJK IME inside Zellij
- verified that a locally built binary fixes the issue on macOS
- deployed the same branch to a Linux machine and verified the rebuilt binary works there as well

Automated:
- `cargo test -p zellij-server cursor_hidden_when_floating_pane_is_under_pinned_pane --lib --quiet`
- `cargo test -p zellij-server cursor_visible_when_pinned_pane_is_focused --lib --quiet`

## Notes

This likely overlaps with or is adjacent to:
- #4951
- #4943

Opening this branch anyway because it was independently validated from a local working tree that reliably fixed the issue in real use.