### PR TITLE
fix(windows): resolve named pipe path from marker file after session rename

### DIFF
--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -182,10 +182,30 @@ pub fn ipc_connect(path: &std::path::Path) -> std::io::Result<interprocess::loca
     LocalSocketStream::connect(fs_name)
 }
 
+/// Read the pipe source path from a Windows marker file.
+///
+/// The marker file format is `PID\n<pipe_source_path>`. If the second line
+/// is present, returns that path (the original path used when the pipe was
+/// created). Otherwise falls back to the marker file path itself. This
+/// allows session rename to work: the marker file moves but its content
+/// still points to the original pipe name.
+#[cfg(windows)]
+fn read_pipe_path(marker_path: &std::path::Path) -> std::path::PathBuf {
+    if let Ok(contents) = std::fs::read_to_string(marker_path) {
+        if let Some(pipe_path) = contents.lines().nth(1) {
+            if !pipe_path.is_empty() {
+                return std::path::PathBuf::from(pipe_path);
+            }
+        }
+    }
+    marker_path.to_path_buf()
+}
+
 #[cfg(windows)]
 pub fn ipc_connect(path: &std::path::Path) -> std::io::Result<interprocess::local_socket::Stream> {
     use interprocess::local_socket::{prelude::*, GenericNamespaced, Stream as LocalSocketStream};
-    let name = path.to_string_lossy().to_string();
+    let pipe_path = read_pipe_path(path);
+    let name = pipe_path.to_string_lossy().to_string();
     let ns_name = name.to_ns_name::<GenericNamespaced>()?;
     LocalSocketStream::connect(ns_name)
 }
@@ -208,7 +228,8 @@ pub fn ipc_bind(path: &std::path::Path) -> std::io::Result<interprocess::local_s
     let name = path.to_string_lossy().to_string();
     let ns_name = name.to_ns_name::<GenericNamespaced>()?;
     let listener = ListenerOptions::new().name(ns_name).create_sync()?;
-    std::fs::write(path, std::process::id().to_string())?;
+    let marker = format!("{}\n{}", std::process::id(), path.to_string_lossy());
+    std::fs::write(path, marker)?;
     Ok(listener)
 }
 
@@ -234,7 +255,8 @@ pub fn ipc_bind_async(
     let name = path.to_string_lossy().to_string();
     let ns_name = name.to_ns_name::<GenericNamespaced>()?;
     let listener = ListenerOptions::new().name(ns_name).create_tokio()?;
-    std::fs::write(path, std::process::id().to_string())?;
+    let marker = format!("{}\n{}", std::process::id(), path.to_string_lossy());
+    std::fs::write(path, marker)?;
     Ok(listener)
 }
 
@@ -246,7 +268,8 @@ pub fn ipc_connect_reply(
     path: &std::path::Path,
 ) -> std::io::Result<interprocess::local_socket::Stream> {
     use interprocess::local_socket::{prelude::*, GenericNamespaced, Stream as LocalSocketStream};
-    let name = format!("{}-reply", path.to_string_lossy());
+    let pipe_path = read_pipe_path(path);
+    let name = format!("{}-reply", pipe_path.to_string_lossy());
     let ns_name = name.to_ns_name::<GenericNamespaced>()?;
     LocalSocketStream::connect(ns_name)
 }

--- a/zellij-utils/src/sessions.rs
+++ b/zellij-utils/src/sessions.rs
@@ -173,13 +173,15 @@ fn assert_socket(name: &str) -> bool {
     use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
 
     let path = &*ZELLIJ_SOCK_DIR.join(name);
-    let pid_str = match fs::read_to_string(path) {
+    let contents = match fs::read_to_string(path) {
         Ok(s) => s,
         Err(_) => {
             drop(fs::remove_file(path));
             return false;
         },
     };
+    // First line is the PID; second line (if present) is the original pipe path.
+    let pid_str = contents.lines().next().unwrap_or("");
     let pid: u32 = match pid_str.trim().parse() {
         Ok(p) => p,
         Err(_) => {


### PR DESCRIPTION
On Windows, session rename only moves the marker file. The named pipes are kernel objects that cannot be renamed. Store the original pipe source path in the marker file (PID\n<path>) so clients can connect to the correct pipe even after the session has been renamed.

Fixes https://github.com/zellij-org/zellij/issues/4998