### PR TITLE
fix(ci): pin WiX CLI to v6.0.2 to avoid v7 OSMF EULA gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,7 @@ jobs:
       # ===== Windows MSI installer =====
       - name: Install WiX v6
         if: runner.os == 'Windows'
-        run: dotnet tool install --global wix
+        run: dotnet tool install --global wix --version 6.0.2
 
       - name: Add WiX UI extension
         if: runner.os == 'Windows'
@@ -364,7 +364,7 @@ jobs:
       # ===== Windows MSI installer (no-web) =====
       - name: Install WiX v6
         if: runner.os == 'Windows'
-        run: dotnet tool install --global wix
+        run: dotnet tool install --global wix --version 6.0.2
 
       - name: Add WiX UI extension
         if: runner.os == 'Windows'


### PR DESCRIPTION
WiX v7 introduced a mandatory EULA acceptance that breaks unattended CI builds. Pin the dotnet tool install to 6.0.2 to match the extension.