### PR TITLE
feat(link): make floating pane size configurable via plugin config

### DIFF
--- a/default-plugins/link/src/main.rs
+++ b/default-plugins/link/src/main.rs
@@ -17,12 +17,15 @@ struct State {
     /// Session environment variables, fetched once on load.
     /// Used for `~` and `$VAR` expansion in clicked paths.
     env_vars: BTreeMap<String, String>,
+    /// Optional floating pane coordinates parsed from plugin configuration.
+    /// When `None`, zellij uses its default floating pane size.
+    floating_pane_coordinates: Option<FloatingPaneCoordinates>,
 }
 
 register_plugin!(State);
 
 impl ZellijPlugin for State {
-    fn load(&mut self, _configuration: BTreeMap<String, String>) {
+    fn load(&mut self, configuration: BTreeMap<String, String>) {
         subscribe(&[
             EventType::PaneUpdate,
             EventType::HighlightClicked,
@@ -32,6 +35,14 @@ impl ZellijPlugin for State {
         // allowing std::fs operations on /host/<absolute_path>.
         change_host_folder(PathBuf::from("/"));
         self.env_vars = get_session_environment_variables();
+        self.floating_pane_coordinates = FloatingPaneCoordinates::new(
+            configuration.get("x").cloned(),
+            configuration.get("y").cloned(),
+            configuration.get("width").cloned(),
+            configuration.get("height").cloned(),
+            configuration.get("pinned").map(|v| v == "true"),
+            configuration.get("borderless").map(|v| v == "true"),
+        );
     }
 
     fn update(&mut self, event: Event) -> bool {
@@ -159,7 +170,7 @@ impl State {
             if let Some(line) = line_number {
                 file_to_open = file_to_open.with_line_number(line);
             }
-            open_file_floating(file_to_open, None, BTreeMap::new());
+            open_file_floating(file_to_open, self.floating_pane_coordinates.clone(), BTreeMap::new());
         }
     }
 


### PR DESCRIPTION
## Summary

The link plugin opens files in a floating pane on alt+click, but hardcodes `None` for `FloatingPaneCoordinates`, making the pane size uncontrollable by users.

This PR wires the existing (but ignored) `configuration: BTreeMap<String, String>` in `load()` into `FloatingPaneCoordinates::new()` and passes the result to `open_file_floating()`. When no config keys are provided, `new()` returns `None` and behaviour is completely unchanged.

## Usage

```kdl
load_plugins {
    zellij:link {
        x "10%"
        y "10%"
        width "80%"
        height "80%"
    }
}
```

All four dimensions accept either a percentage (`"80%"`) or a fixed character count (`"40"`). `pinned` and `borderless` are also supported (`"true"`/`"false"`). Any omitted key falls back to zellij's default.

## Changes

- `State` struct: add `floating_pane_coordinates: Option<FloatingPaneCoordinates>` field
- `load()`: parse `x`/`y`/`width`/`height`/`pinned`/`borderless` from config map
- `handle_highlight_clicked()`: pass `self.floating_pane_coordinates.clone()` instead of `None`

Closes #5038