### PR TITLE
fix(web): clean up stale IPC sockets on web server startup

### DIFF
--- a/zellij-client/src/web_client/mod.rs
+++ b/zellij-client/src/web_client/mod.rs
@@ -88,6 +88,17 @@ pub fn start_web_client(
             std::process::exit(2);
         })
     });
+    // Clean up any stale IPC sockets from a previous ungraceful exit before
+    // we bind new ones. This prevents routing confusion when a previous
+    // web server or session server crashed without removing its socket.
+    match zellij_utils::consts::cleanup_stale_sockets(
+        &zellij_utils::consts::WEBSERVER_SOCKET_PATH,
+    ) {
+        Ok(0) => {},
+        Ok(n) => log::info!("Cleaned {} stale IPC socket(s) before startup", n),
+        Err(e) => log::warn!("Failed to clean stale IPC sockets: {}", e),
+    }
+
     let web_server_ip = custom_ip.unwrap_or_else(|| {
         config_options
             .web_server_ip

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -226,6 +226,85 @@ pub fn ipc_bind_async(
     ListenerOptions::new().name(fs_name).create_tokio()
 }
 
+/// Remove IPC socket files in `ipc_dir` that no longer have a listening process.
+///
+/// On Unix: attempts a short `connect()` to each socket. Failures indicate the
+/// socket is orphaned (the process that owned it has died without cleanup).
+///
+/// On Windows: each entry is a named-pipe marker file containing the owner's
+/// PID. If the PID is no longer running, the marker is removed.
+///
+/// Returns the number of stale entries cleaned.
+///
+/// This is typically called at web server or session server startup to avoid
+/// confusion between connections and dead processes after an ungraceful exit
+/// or a binary upgrade that left orphaned sockets behind.
+pub fn cleanup_stale_sockets(ipc_dir: &std::path::Path) -> std::io::Result<usize> {
+    if !ipc_dir.exists() {
+        return Ok(0);
+    }
+    let mut cleaned = 0;
+    for entry in std::fs::read_dir(ipc_dir)? {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let path = entry.path();
+        // Skip subdirectories (e.g. per-session folders); only clean top-level
+        // socket files in the ipc dir.
+        if path.is_dir() {
+            continue;
+        }
+        if is_socket_stale(&path) {
+            if std::fs::remove_file(&path).is_ok() {
+                cleaned += 1;
+            }
+        }
+    }
+    Ok(cleaned)
+}
+
+#[cfg(unix)]
+fn is_socket_stale(path: &std::path::Path) -> bool {
+    use interprocess::local_socket::{prelude::*, GenericFilePath, Stream};
+    let fs_name = match path.to_fs_name::<GenericFilePath>() {
+        Ok(n) => n,
+        Err(_) => return false,
+    };
+    // If we can't connect, the socket has no listener — it's orphaned.
+    Stream::connect(fs_name).is_err()
+}
+
+#[cfg(windows)]
+fn is_socket_stale(path: &std::path::Path) -> bool {
+    // On Windows, the "socket" file stores the owning process's PID.
+    let pid_str = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    let pid: u32 = match pid_str.trim().parse() {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+    !process_is_alive(pid)
+}
+
+#[cfg(windows)]
+fn process_is_alive(pid: u32) -> bool {
+    use std::process::Command;
+    // `tasklist` is available on all Windows installations.
+    match Command::new("tasklist")
+        .args(&["/FI", &format!("PID eq {}", pid), "/NH", "/FO", "CSV"])
+        .output()
+    {
+        Ok(out) => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            stdout.contains(&format!(",\"{}\",", pid))
+        },
+        Err(_) => true, // If we can't check, err on the side of keeping the socket
+    }
+}
+
 #[cfg(windows)]
 pub fn ipc_bind_async(
     path: &std::path::Path,

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -239,6 +239,7 @@ pub fn ipc_bind_async(
 /// This is typically called at web server or session server startup to avoid
 /// confusion between connections and dead processes after an ungraceful exit
 /// or a binary upgrade that left orphaned sockets behind.
+#[cfg(any(unix, windows))]
 pub fn cleanup_stale_sockets(ipc_dir: &std::path::Path) -> std::io::Result<usize> {
     if !ipc_dir.exists() {
         return Ok(0);
@@ -262,6 +263,12 @@ pub fn cleanup_stale_sockets(ipc_dir: &std::path::Path) -> std::io::Result<usize
         }
     }
     Ok(cleaned)
+}
+
+/// Stub for non-Unix/non-Windows targets (e.g. WASM plugins).
+#[cfg(not(any(unix, windows)))]
+pub fn cleanup_stale_sockets(_ipc_dir: &std::path::Path) -> std::io::Result<usize> {
+    Ok(0)
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

When a web server or session server exits ungracefully (crash, SIGKILL, binary upgrade without cleanup), its IPC socket file remains in `WEBSERVER_SOCKET_PATH`. On next startup, the new web server can route connections to these orphaned sockets, triggering protocol desync symptoms such as:

```
ERROR route: Received unknown message from client.
ERROR route: Client sent over 1000 consecutive unknown messages...
```

This wedges the new web server in a CPU-bound loop for several seconds before the existing 1000-message protection triggers.

## Fix

Add `cleanup_stale_sockets()` in `zellij-utils/src/consts.rs` and call it at the start of `start_web_client()` before binding sockets.

**Detection strategy:**

- **Unix**: Attempt a local-socket `connect()`. If no listener accepts, the socket is orphaned and removed.
- **Windows**: Each pipe marker file stores the owner's PID (existing convention). Use `tasklist /FI "PID eq N"` to check liveness; remove the marker if the PID is gone.

Only top-level files in `WEBSERVER_SOCKET_PATH` are probed — per-session subdirectories are left alone.

## Changes

- **2 files changed, 90 insertions**
- `zellij-utils/src/consts.rs` — adds `cleanup_stale_sockets()` + platform-specific helpers
- `zellij-client/src/web_client/mod.rs` — calls cleanup early in `start_web_client()`

## Testing

Reproduction steps for the original issue:

1. Start `zellij web -d`
2. `kill -9` the web server process (simulating a crash)
3. Start `zellij web -d` again
4. Connect a client — observe "unknown message" errors in logs

With this patch, stale sockets are removed at step 3, and step 4 works cleanly.

🤖 Generated with [Claude Code](https://claude.ai/code)