### PR TITLE
feat(web): add /healthz endpoint for external monitoring

### DIFF
--- a/zellij-client/src/web_client/http_handlers.rs
+++ b/zellij-client/src/web_client/http_handlers.rs
@@ -161,3 +161,38 @@ pub async fn get_static_asset(AxumPath(path): AxumPath<String>) -> impl IntoResp
 pub async fn version_handler() -> &'static str {
     VERSION
 }
+
+/// Health check endpoint for external monitoring (liveness/readiness probes).
+///
+/// Returns a JSON object describing the web server's current state. Always
+/// returns HTTP 200 when the server is able to respond — a non-200 or no
+/// response at all should be treated as "unhealthy" by the caller.
+///
+/// Unlike `/info/version`, this endpoint also exposes:
+///   - `uptime_seconds`: seconds since the web server started
+///   - `active_connections`: number of active web client connections
+///   - `protocol_version`: the IPC contract version (useful for upgrade
+///     detection from orchestration tooling)
+///
+/// The endpoint is unauthenticated by design so that health probes do not
+/// require credentials. It does not leak session content or tokens.
+pub async fn healthz_handler(State(state): State<AppState>) -> impl IntoResponse {
+    let uptime_seconds = SERVER_START_TIME.elapsed().as_secs();
+    let active_connections = state
+        .connection_table
+        .lock()
+        .map(|t| t.client_id_to_channels.len())
+        .unwrap_or(0);
+    Json(serde_json::json!({
+        "status": "ok",
+        "version": VERSION,
+        "protocol_version": zellij_utils::consts::CLIENT_SERVER_CONTRACT_VERSION,
+        "uptime_seconds": uptime_seconds,
+        "active_connections": active_connections,
+    }))
+}
+
+/// Tracks when the web server started, for the `uptime_seconds` field of
+/// `/healthz`. Initialized on first access.
+static SERVER_START_TIME: std::sync::LazyLock<std::time::Instant> =
+    std::sync::LazyLock::new(std::time::Instant::now);

--- a/zellij-client/src/web_client/mod.rs
+++ b/zellij-client/src/web_client/mod.rs
@@ -43,7 +43,8 @@ use zellij_utils::input::{config::Config, options::Options};
 
 use authentication::auth_middleware;
 use http_handlers::{
-    create_new_client, get_static_asset, login_handler, serve_html, version_handler,
+    create_new_client, get_static_asset, healthz_handler, login_handler, serve_html,
+    version_handler,
 };
 use ipc_listener::listen_to_web_server_instructions;
 
@@ -242,6 +243,7 @@ pub async fn serve_web_client(
         .route("/assets/{*path}", get(get_static_asset))
         .route("/command/login", post(login_handler))
         .route("/info/version", get(version_handler))
+        .route("/healthz", get(healthz_handler))
         .with_state(state)
         .layer(axum::middleware::from_fn(move |request, next: axum::middleware::Next| {
             async move {


### PR DESCRIPTION
## Summary

Adds a lightweight unauthenticated `/healthz` endpoint that returns a JSON object describing the web server's state.

## Motivation

- **Orchestration**: Kubernetes liveness/readiness probes, launchd `KeepAlive` health checks, systemd `WatchdogSec`, container orchestrators — all expect a standard HTTP endpoint.
- **External monitoring**: Prometheus, Datadog, Uptime Kuma, and similar tools need a parseable status endpoint.
- **Upgrade coordination**: Operators can read \`protocol_version\` to detect incompatible deployments before rolling traffic.

The existing \`/info/version\` returns only a plain-text version string, which is insufficient for these use cases.

## Response

\`\`\`
GET /healthz

{
  \"status\": \"ok\",
  \"version\": \"0.45.0\",
  \"protocol_version\": 1,
  \"uptime_seconds\": 3600,
  \"active_connections\": 2
}
\`\`\`

## Security

The endpoint is intentionally unauthenticated — probes typically cannot carry credentials. It exposes **aggregate counters only**:

- No session content
- No token values
- No user identifiers

## Performance

Cost per request: a single \`Mutex::lock()\` on the connection table and a \`LazyLock\` read for the start time. Negligible.

## Changes

- **2 files changed, 38 insertions, 1 deletion**
- \`zellij-client/src/web_client/http_handlers.rs\` — adds \`healthz_handler\` + \`SERVER_START_TIME\`
- \`zellij-client/src/web_client/mod.rs\` — registers the route

🤖 Generated with [Claude Code](https://claude.ai/code)