### PR TITLE
fix(server): faster + clearer disconnect on protocol desync

### DIFF
--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -2647,16 +2647,45 @@ pub(crate) fn route_thread_main(
                 }
             },
             None => {
+                // Tiered protection against protocol desync (e.g. a client
+                // running an incompatible binary version). The old behavior
+                // waited for 1000 unknown messages before disconnecting,
+                // which could keep one CPU core pinned for several seconds
+                // while logs were flooded.
+                //
+                // New thresholds:
+                //   1 message  → log a warning once, letting the client
+                //                recover if this was transient.
+                //   100 messages → disconnect and tell the client the
+                //                  protocol is out of sync so it can surface
+                //                  a clear error to the user (usually:
+                //                  "upgrade your client, or restart zellij
+                //                  so the server is rebuilt").
+                const DESYNC_DISCONNECT_THRESHOLD: usize = 100;
                 consecutive_unknown_messages_received += 1;
                 if consecutive_unknown_messages_received == 1 {
-                    log::error!("Received unknown message from client.");
+                    log::warn!(
+                        "Received unknown message from client {}. \
+                         This usually indicates a protocol version mismatch \
+                         between client and server.",
+                        client_id
+                    );
                 }
-                if consecutive_unknown_messages_received >= 1000 {
-                    log::error!("Client sent over 1000 consecutive unknown messages, this is probably an infinite loop, logging client out");
+                if consecutive_unknown_messages_received >= DESYNC_DISCONNECT_THRESHOLD {
+                    log::error!(
+                        "Client {} sent {} consecutive unknown messages — \
+                         disconnecting due to protocol desync.",
+                        client_id, DESYNC_DISCONNECT_THRESHOLD
+                    );
                     let _ = os_input.send_to_client(
                         client_id,
                         ServerToClientMsg::Exit {
-                            exit_reason: ExitReason::Error("Received empty message".to_string()),
+                            exit_reason: ExitReason::Error(
+                                "Protocol version mismatch between client and server. \
+                                 Please ensure both are the same zellij version, \
+                                 then restart."
+                                    .to_string(),
+                            ),
                         },
                     );
                     let _ = to_server.send(ServerInstruction::RemoveClient(client_id));


### PR DESCRIPTION
## Problem

When a client speaks an incompatible protocol version (e.g. after a zellij upgrade where the binary was replaced but some session servers kept running the old version), the router waits for **1000** consecutive unknown messages before disconnecting.

At typical message rates this pins one CPU core for several seconds and floods logs with identical errors. Users experience it as **\"zellij web hangs\"** followed by a cryptic **\"Received empty message\"** disconnect.

## Changes

**\`zellij-server/src/route.rs\`** — 1 file, +33/-4 lines

### 1. Lower threshold: 1000 → 100

10x reduction in wasted CPU time and log noise, while still tolerating transient protocol hiccups. The counter resets on every successfully handled message, so well-behaved clients are unaffected.

### 2. Clearer first-message log

\`log::error!(\"Received unknown message from client.\")\` — downgraded to \`warn\` and augmented:

\`\`\`
WARN: Received unknown message from client 1. This usually indicates
a protocol version mismatch between client and server.
\`\`\`

### 3. Actionable disconnect message

\`\"Received empty message\"\` — replaced with:

\`\`\`
Protocol version mismatch between client and server.
Please ensure both are the same zellij version, then restart.
\`\`\`

This guides users to the actual fix (match versions + restart) rather than leaving them to infer it from \"empty message\".

## No behavioral changes for well-behaved clients

The unknown-message counter resets on every successfully routed message (unchanged). This patch only tightens the failure path.

🤖 Generated with [Claude Code](https://claude.ai/code)