### PR TITLE
fix: ignore unbound Super (Cmd) modifier keys instead of writing bare…

### DIFF
--- a/zellij-utils/src/input/keybinds.rs
+++ b/zellij-utils/src/input/keybinds.rs
@@ -75,12 +75,17 @@ impl Keybinds {
         default_input_mode: InputMode,
         key_is_kitty_protocol: bool,
     ) -> Action {
-        // Keys with the Super (Cmd on macOS) modifier that aren't explicitly bound
-        // should be ignored. These are OS-level shortcuts (e.g. Cmd+C for copy)
-        // that should be handled by the terminal emulator, not by Zellij.
-        if let Some(kwm) = key_with_modifier {
-            if kwm.key_modifiers.contains(&KeyModifier::Super) {
-                return Action::NoOp;
+        // When the event arrives via the Kitty keyboard protocol, keys with the Super
+        // (Cmd on macOS) modifier that aren't explicitly bound should be ignored.
+        // These are OS-level shortcuts (e.g. Cmd+C for copy) that should be handled
+        // by the terminal emulator, not by Zellij.
+        // Non-Kitty inputs with a Super modifier are not guarded here because the
+        // modifier may carry different semantics in other input backends.
+        if key_is_kitty_protocol {
+            if let Some(kwm) = key_with_modifier {
+                if kwm.key_modifiers.contains(&KeyModifier::Super) {
+                    return Action::NoOp;
+                }
             }
         }
 

--- a/zellij-utils/src/input/keybinds.rs
+++ b/zellij-utils/src/input/keybinds.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 
 use super::actions::Action;
-use crate::data::{BareKey, InputMode, KeyWithModifier, KeybindsVec};
+use crate::data::{BareKey, InputMode, KeyModifier, KeyWithModifier, KeybindsVec};
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -75,6 +75,15 @@ impl Keybinds {
         default_input_mode: InputMode,
         key_is_kitty_protocol: bool,
     ) -> Action {
+        // Keys with the Super (Cmd on macOS) modifier that aren't explicitly bound
+        // should be ignored. These are OS-level shortcuts (e.g. Cmd+C for copy)
+        // that should be handled by the terminal emulator, not by Zellij.
+        if let Some(kwm) = key_with_modifier {
+            if kwm.key_modifiers.contains(&KeyModifier::Super) {
+                return Action::NoOp;
+            }
+        }
+
         match *mode {
             InputMode::Locked => Action::Write {
                 key_with_modifier: key_with_modifier.cloned(),

--- a/zellij-utils/src/input/unit/keybinds_test.rs
+++ b/zellij-utils/src/input/unit/keybinds_test.rs
@@ -655,7 +655,7 @@ fn super_modifier_with_explicit_binding_works() {
 
 #[test]
 fn super_modifier_returns_noop_in_locked_mode() {
-    // Super modifier keys should be NoOp even in locked mode
+    // Super modifier keys should be NoOp even in locked mode when using Kitty protocol
     let config = Config::from_kdl("keybinds {}", None).unwrap();
     let super_c = KeyWithModifier::new(BareKey::Char('c')).with_super_modifier();
     let actions = config
@@ -670,6 +670,34 @@ fn super_modifier_returns_noop_in_locked_mode() {
     assert_eq!(
         actions,
         vec![Action::NoOp],
-        "Super+C should be NoOp even in locked mode"
+        "Super+C should be NoOp even in locked mode (Kitty protocol)"
+    );
+}
+
+#[test]
+fn super_modifier_non_kitty_falls_through_to_write() {
+    // When the event does NOT come via the Kitty keyboard protocol the Super-modifier
+    // guard must not fire; the key should fall through to the normal Write action so
+    // that non-Kitty input backends are unaffected.
+    let config = Config::from_kdl("keybinds {}", None).unwrap();
+    let super_c = KeyWithModifier::new(BareKey::Char('c')).with_super_modifier();
+    let raw = vec![0x63u8]; // 'c'
+    let actions = config
+        .keybinds
+        .get_actions_for_key_in_mode_or_default_action(
+            &InputMode::Locked,
+            &super_c,
+            raw.clone(),
+            InputMode::Normal,
+            false, // not Kitty protocol
+        );
+    assert_eq!(
+        actions,
+        vec![Action::Write {
+            key_with_modifier: Some(super_c),
+            bytes: raw,
+            is_kitty_keyboard_protocol: false,
+        }],
+        "Super+C without Kitty protocol should fall through to Write, not NoOp"
     );
 }

--- a/zellij-utils/src/input/unit/keybinds_test.rs
+++ b/zellij-utils/src/input/unit/keybinds_test.rs
@@ -1,6 +1,6 @@
 use super::super::actions::*;
 use super::super::keybinds::*;
-use crate::data::{BareKey, Direction, KeyWithModifier};
+use crate::data::{BareKey, Direction, InputMode, KeyWithModifier};
 use crate::input::config::Config;
 use insta::assert_snapshot;
 use strum::IntoEnumIterator;
@@ -593,4 +593,83 @@ fn error_received_on_unknown_key_instruction() {
     "#;
     let config_error = Config::from_kdl(config_contents, None).unwrap_err();
     assert_snapshot!(format!("{:?}", config_error));
+}
+
+#[test]
+fn super_modifier_without_binding_returns_noop() {
+    // When a key with the Super (Cmd on macOS) modifier is pressed and there is no
+    // explicit keybinding for it, the default action should be NoOp rather than Write.
+    // This prevents Zellij from intercepting OS-level shortcuts like Cmd+C (copy).
+    let config_contents = r#"
+        keybinds {
+            normal {
+                bind "Ctrl g" { SwitchToMode "Locked"; }
+            }
+        }
+    "#;
+    let config = Config::from_kdl(config_contents, None).unwrap();
+    let super_c = KeyWithModifier::new(BareKey::Char('c')).with_super_modifier();
+    let actions = config
+        .keybinds
+        .get_actions_for_key_in_mode_or_default_action(
+            &InputMode::Normal,
+            &super_c,
+            vec![0x1b, 0x5b, 0x39, 0x39, 0x3b, 0x39, 0x75], // CSI 99;9u
+            InputMode::Normal,
+            true,
+        );
+    assert_eq!(
+        actions,
+        vec![Action::NoOp],
+        "Super+C without explicit binding should be NoOp, not Write"
+    );
+}
+
+#[test]
+fn super_modifier_with_explicit_binding_works() {
+    // When a key with the Super modifier IS explicitly bound, the binding should work.
+    let config_contents = r#"
+        keybinds {
+            normal {
+                bind "Super c" { Copy; }
+            }
+        }
+    "#;
+    let config = Config::from_kdl(config_contents, None).unwrap();
+    let super_c = KeyWithModifier::new(BareKey::Char('c')).with_super_modifier();
+    let actions = config
+        .keybinds
+        .get_actions_for_key_in_mode_or_default_action(
+            &InputMode::Normal,
+            &super_c,
+            vec![0x1b, 0x5b, 0x39, 0x39, 0x3b, 0x39, 0x75], // CSI 99;9u
+            InputMode::Normal,
+            true,
+        );
+    assert_eq!(
+        actions,
+        vec![Action::Copy],
+        "Super+C with explicit binding should use the configured action"
+    );
+}
+
+#[test]
+fn super_modifier_returns_noop_in_locked_mode() {
+    // Super modifier keys should be NoOp even in locked mode
+    let config = Config::from_kdl("keybinds {}", None).unwrap();
+    let super_c = KeyWithModifier::new(BareKey::Char('c')).with_super_modifier();
+    let actions = config
+        .keybinds
+        .get_actions_for_key_in_mode_or_default_action(
+            &InputMode::Locked,
+            &super_c,
+            vec![0x1b, 0x5b, 0x39, 0x39, 0x3b, 0x39, 0x75],
+            InputMode::Normal,
+            true,
+        );
+    assert_eq!(
+        actions,
+        vec![Action::NoOp],
+        "Super+C should be NoOp even in locked mode"
+    );
 }


### PR DESCRIPTION
… character

When a key with the Super (Cmd on macOS) modifier is received via the Kitty keyboard protocol and has no explicit keybinding, Zellij was falling back to writing the bare character to the terminal. This caused Cmd+C to type 'c' instead of allowing the terminal emulator to handle the native copy action.

Now, unbound Super-modified keys return NoOp, letting the terminal emulator handle OS-level shortcuts like Cmd+C natively.

Fixes #4703

Agent-Logs-Url: https://github.com/cossio/zellij/sessions/39a1d924-189b-4445-b4e5-924a843d5d68