### PR TITLE
fix: fall back to modified time when creation time is unavailable on Linux

### DIFF
--- a/zellij-server/src/background_jobs.rs
+++ b/zellij-server/src/background_jobs.rs
@@ -755,23 +755,25 @@ fn find_resurrectable_sessions(
                         return None;
                     }
                     let layout_file_name = session_layout_cache_file_name(&session_name);
-                    let ctime = match std::fs::metadata(&layout_file_name)
-                        .and_then(|metadata| metadata.created())
-                    {
-                        Ok(created) => Some(created),
+                    let metadata = match std::fs::metadata(&layout_file_name) {
+                        Ok(m) => m,
                         Err(e) => {
                             if e.kind() == std::io::ErrorKind::NotFound {
-                                return None; // no layout file, cannot resurrect session, let's not
-                                             // list it
-                            } else {
-                                log::error!(
-                                    "Failed to read created stamp of resurrection file: {:?}",
-                                    e
-                                );
+                                return None; // no layout file, cannot resurrect session
                             }
-                            None
+                            log::error!(
+                                "Failed to read metadata of resurrection file: {:?}",
+                                e
+                            );
+                            return None;
                         },
                     };
+                    // metadata.created() is not available on some Linux
+                    // filesystems (e.g. ext4), fall back to modified time
+                    let ctime = metadata
+                        .created()
+                        .or_else(|_| metadata.modified())
+                        .ok();
                     let elapsed_duration = ctime
                         .map(|ctime| {
                             Duration::from_secs(ctime.elapsed().ok().unwrap_or_default().as_secs())


### PR DESCRIPTION
## Problem

On Linux with ext4 filesystem, `std::fs::Metadata::created()` returns `ErrorKind::Unsupported` because creation time (btime) is not exposed through the standard Rust API on this platform.

In `background_jobs.rs`, the resurrection file listing function calls `metadata.created()` in a loop. When it fails, the error is logged but the function continues normally — however, **the caller re-invokes this function repeatedly (~1s interval)**, causing the error to be logged indefinitely.

In a long-running session (17 days, 11 tabs, 13 panes), this contributed to severe degradation:

- **193% CPU** (2 cores saturated — `screen` and `plugin-exec-1` threads stuck in Running state)
- **1.4 GB RSS** (vs ~50 MB for healthy sessions), peak 3.9 GB
- 17,307 "Broken pipe" errors in 25 minutes
- `MouseEvent` action timeouts every second
- UI completely frozen, required SIGKILL

Log excerpt (repeated ~14,000 times over ~4 hours before rotation):
```
ERROR | zellij_server::background | background_jobs.rs:767:
  Failed to read created stamp of resurrection file:
  Error { kind: Unsupported, message: "creation time is not available on this platform currently" }
```

## Fix

- Fall back to `metadata.modified()` when `metadata.created()` is unavailable, instead of logging an error and returning `None`
- This provides a reasonable approximation of session age on platforms where creation time is not supported
- Also separates the `metadata()` call from `created()` to properly handle metadata read failures

## Environment where the bug was observed

- **Zellij:** 0.44.0 (verified same code in 0.44.1)
- **OS:** Ubuntu 22.04.5 LTS, kernel 5.15.0-173-generic
- **Filesystem:** ext4