### PR TITLE
fix(server): remember focused pane when switching tabs

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1642,6 +1642,14 @@ impl Screen {
 
                     let current_tab_index = current_tab.id;
                     let new_tab_index = new_tab.id;
+                    // If the client already has a valid focused pane in the
+                    // destination tab (from a previous visit), don't override
+                    // it with focus_pane_on_edge.
+                    let dest_has_prior_focus = self
+                        .tabs
+                        .get(&new_tab_index)
+                        .map(|t| t.client_has_valid_pane_focus(client_id))
+                        .unwrap_or(false);
                     if self.session_is_mirrored {
                         self.move_clients_between_tabs(
                             current_tab_index,
@@ -1658,14 +1666,16 @@ impl Screen {
                             .collect();
                         for client_id in all_connected_clients {
                             self.update_client_tab_focus(client_id, new_tab_index);
-                            match (
-                                should_change_pane_focus,
-                                self.get_indexed_tab_mut(new_tab_index),
-                            ) {
-                                (Some(direction), Some(new_tab)) => {
-                                    new_tab.focus_pane_on_edge(direction, client_id);
-                                },
-                                _ => {},
+                            if !dest_has_prior_focus {
+                                match (
+                                    should_change_pane_focus,
+                                    self.get_indexed_tab_mut(new_tab_index),
+                                ) {
+                                    (Some(direction), Some(new_tab)) => {
+                                        new_tab.focus_pane_on_edge(direction, client_id);
+                                    },
+                                    _ => {},
+                                }
                             }
                         }
                     } else {
@@ -1676,14 +1686,16 @@ impl Screen {
                             Some(vec![client_id]),
                         )
                         .with_context(err_context)?;
-                        match (
-                            should_change_pane_focus,
-                            self.get_indexed_tab_mut(new_tab_index),
-                        ) {
-                            (Some(direction), Some(new_tab)) => {
-                                new_tab.focus_pane_on_edge(direction, client_id);
-                            },
-                            _ => {},
+                        if !dest_has_prior_focus {
+                            match (
+                                should_change_pane_focus,
+                                self.get_indexed_tab_mut(new_tab_index),
+                            ) {
+                                (Some(direction), Some(new_tab)) => {
+                                    new_tab.focus_pane_on_edge(direction, client_id);
+                                },
+                                _ => {},
+                            }
                         }
                         self.update_client_tab_focus(client_id, new_tab_index);
                     }

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1643,6 +1643,28 @@ impl Screen {
                     let current_tab_index = current_tab.id;
                     let new_tab_index = new_tab.id;
                     if self.session_is_mirrored {
+                        let all_connected_clients: Vec<ClientId> = self
+                            .connected_clients
+                            .borrow()
+                            .iter()
+                            .map(|(c, _i)| *c)
+                            .collect();
+                        let clients_needing_edge_focus: Vec<ClientId> =
+                            if should_change_pane_focus.is_some() {
+                                all_connected_clients
+                                    .iter()
+                                    .filter(|&&cid| {
+                                        !self
+                                            .get_indexed_tab_mut(new_tab_index)
+                                            .map_or(false, |tab| {
+                                                tab.client_has_valid_pane_focus(cid)
+                                            })
+                                    })
+                                    .copied()
+                                    .collect()
+                            } else {
+                                vec![]
+                            };
                         self.move_clients_between_tabs(
                             current_tab_index,
                             new_tab_index,
@@ -1650,25 +1672,22 @@ impl Screen {
                             None,
                         )
                         .with_context(err_context)?;
-                        let all_connected_clients: Vec<ClientId> = self
-                            .connected_clients
-                            .borrow()
-                            .iter()
-                            .map(|(c, _i)| *c)
-                            .collect();
                         for client_id in all_connected_clients {
                             self.update_client_tab_focus(client_id, new_tab_index);
-                            match (
-                                should_change_pane_focus,
-                                self.get_indexed_tab_mut(new_tab_index),
-                            ) {
-                                (Some(direction), Some(new_tab)) => {
-                                    new_tab.focus_pane_on_edge(direction, client_id);
-                                },
-                                _ => {},
+                        }
+                        if let Some(direction) = should_change_pane_focus {
+                            for cid in clients_needing_edge_focus {
+                                if let Some(new_tab) = self.get_indexed_tab_mut(new_tab_index) {
+                                    new_tab.focus_pane_on_edge(direction, cid);
+                                }
                             }
                         }
                     } else {
+                        let has_prior_focus = self
+                            .get_indexed_tab_mut(new_tab_index)
+                            .map_or(false, |tab| {
+                                tab.client_has_valid_pane_focus(client_id)
+                            });
                         self.move_clients_between_tabs(
                             current_tab_index,
                             new_tab_index,
@@ -1676,14 +1695,12 @@ impl Screen {
                             Some(vec![client_id]),
                         )
                         .with_context(err_context)?;
-                        match (
-                            should_change_pane_focus,
-                            self.get_indexed_tab_mut(new_tab_index),
-                        ) {
-                            (Some(direction), Some(new_tab)) => {
-                                new_tab.focus_pane_on_edge(direction, client_id);
-                            },
-                            _ => {},
+                        if !has_prior_focus {
+                            if let Some(direction) = should_change_pane_focus {
+                                if let Some(new_tab) = self.get_indexed_tab_mut(new_tab_index) {
+                                    new_tab.focus_pane_on_edge(direction, client_id);
+                                }
+                            }
                         }
                         self.update_client_tab_focus(client_id, new_tab_index);
                     }

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -2080,6 +2080,28 @@ impl Screen {
                         .map(|c| (*c, self.get_active_pane_id(c)))
                         .collect();
                     if self.session_is_mirrored {
+                        let all_connected_clients: Vec<ClientId> = self
+                            .connected_clients
+                            .borrow()
+                            .iter()
+                            .map(|(c, _i)| *c)
+                            .collect();
+                        let clients_needing_edge_focus: Vec<ClientId> =
+                            if should_change_pane_focus.is_some() {
+                                all_connected_clients
+                                    .iter()
+                                    .filter(|&&cid| {
+                                        !self
+                                            .get_indexed_tab_mut(new_tab_index)
+                                            .map_or(false, |tab| {
+                                                tab.client_has_valid_pane_focus(cid)
+                                            })
+                                    })
+                                    .copied()
+                                    .collect()
+                            } else {
+                                vec![]
+                            };
                         self.move_clients_between_tabs(
                             current_tab_index,
                             new_tab_index,
@@ -2087,25 +2109,22 @@ impl Screen {
                             None,
                         )
                         .with_context(err_context)?;
-                        let all_connected_clients: Vec<ClientId> = self
-                            .connected_clients
-                            .borrow()
-                            .iter()
-                            .map(|(c, _i)| *c)
-                            .collect();
                         for client_id in all_connected_clients {
                             self.update_client_tab_focus(client_id, new_tab_index);
-                            match (
-                                should_change_pane_focus,
-                                self.get_indexed_tab_mut(new_tab_index),
-                            ) {
-                                (Some(direction), Some(new_tab)) => {
-                                    new_tab.focus_pane_on_edge(direction, client_id);
-                                },
-                                _ => {},
+                        }
+                        if let Some(direction) = should_change_pane_focus {
+                            for cid in clients_needing_edge_focus {
+                                if let Some(new_tab) = self.get_indexed_tab_mut(new_tab_index) {
+                                    new_tab.focus_pane_on_edge(direction, cid);
+                                }
                             }
                         }
                     } else {
+                        let has_prior_focus = self
+                            .get_indexed_tab_mut(new_tab_index)
+                            .map_or(false, |tab| {
+                                tab.client_has_valid_pane_focus(client_id)
+                            });
                         self.move_clients_between_tabs(
                             current_tab_index,
                             new_tab_index,
@@ -2113,14 +2132,12 @@ impl Screen {
                             Some(vec![client_id]),
                         )
                         .with_context(err_context)?;
-                        match (
-                            should_change_pane_focus,
-                            self.get_indexed_tab_mut(new_tab_index),
-                        ) {
-                            (Some(direction), Some(new_tab)) => {
-                                new_tab.focus_pane_on_edge(direction, client_id);
-                            },
-                            _ => {},
+                        if !has_prior_focus {
+                            if let Some(direction) = should_change_pane_focus {
+                                if let Some(new_tab) = self.get_indexed_tab_mut(new_tab_index) {
+                                    new_tab.focus_pane_on_edge(direction, client_id);
+                                }
+                            }
                         }
                         self.update_client_tab_focus(client_id, new_tab_index);
                     }

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1294,6 +1294,14 @@ impl Tab {
         self.connected_clients.borrow_mut().remove(&client_id);
         (client_id, client_mode_info)
     }
+    pub fn client_has_valid_pane_focus(&self, client_id: ClientId) -> bool {
+        self.tiled_panes
+            .focused_pane_id(client_id)
+            .map_or(false, |id| self.tiled_panes.panes_contain(&id))
+            || self.floating_panes
+                .active_pane_id(client_id)
+                .map_or(false, |id| self.floating_panes.panes_contain(&id))
+    }
     pub fn has_no_connected_clients(&self) -> bool {
         self.connected_clients.borrow().is_empty()
     }

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1294,6 +1294,15 @@ impl Tab {
         self.connected_clients.borrow_mut().remove(&client_id);
         (client_id, client_mode_info)
     }
+    pub fn client_has_valid_pane_focus(&self, client_id: ClientId) -> bool {
+        self.tiled_panes
+            .focused_pane_id(client_id)
+            .is_some_and(|id| self.tiled_panes.panes_contain(&id))
+            || self
+                .floating_panes
+                .active_pane_id(client_id)
+                .is_some_and(|id| self.floating_panes.panes_contain(&id))
+    }
     pub fn has_no_connected_clients(&self) -> bool {
         self.connected_clients.borrow().is_empty()
     }

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -2314,6 +2314,15 @@ impl Tab {
         self.connected_clients.borrow_mut().remove(&client_id);
         (client_id, client_mode_info)
     }
+    pub fn client_has_valid_pane_focus(&self, client_id: ClientId) -> bool {
+        self.tiled_panes
+            .focused_pane_id(client_id)
+            .is_some_and(|id| self.tiled_panes.panes_contain(&id))
+            || self
+                .floating_panes
+                .active_pane_id(client_id)
+                .is_some_and(|id| self.floating_panes.panes_contain(&id))
+    }
     pub fn has_no_connected_clients(&self) -> bool {
         self.connected_clients.borrow().is_empty()
     }


### PR DESCRIPTION
Save per-client tiled/floating pane focus on tab leave and restore it on return, instead of defaulting to another client's focus or the last-created pane.

Closes #1676