### PR TITLE
fix(attach): preserve options for --create-background

### DIFF
--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -397,6 +397,45 @@ impl ClientInfo {
     }
 }
 
+fn new_session_cli_assets(
+    cli_args: &CliArgs,
+    config_options: &Options,
+    layout_info: Option<LayoutInfo>,
+    layout_cwd: Option<PathBuf>,
+    terminal_window_size: Size,
+) -> CliAssets {
+    CliAssets {
+        config_file_path: Config::config_file_path(cli_args),
+        config_dir: cli_args.config_dir.clone(),
+        should_ignore_config: cli_args.is_setup_clean(),
+        configuration_options: Some(config_options.clone()),
+        layout: layout_info.or_else(|| {
+            cli_args
+                .layout
+                .as_ref()
+                .and_then(|layout| {
+                    LayoutInfo::from_cli(
+                        &config_options.layout_dir,
+                        &Some(layout.clone()),
+                        std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+                    )
+                })
+                .or_else(|| {
+                    LayoutInfo::from_config(
+                        &config_options.layout_dir,
+                        &config_options.default_layout,
+                    )
+                })
+        }),
+        terminal_window_size,
+        data_dir: cli_args.data_dir.clone(),
+        is_debug: cli_args.debug,
+        max_panes: cli_args.max_panes,
+        force_run_layout_commands: false,
+        cwd: layout_cwd,
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) enum InputInstruction {
     KeyEvent(InputEvent, Vec<u8>),
@@ -885,37 +924,13 @@ pub fn start_client(
         },
         ClientInfo::New(name, layout_info, layout_cwd) => {
             envs::set_session_name(name.clone());
-
-            let cli_assets = CliAssets {
-                config_file_path: Config::config_file_path(&cli_args),
-                config_dir: cli_args.config_dir.clone(),
-                should_ignore_config: cli_args.is_setup_clean(),
-                configuration_options: Some(config_options.clone()),
-                layout: layout_info.or_else(|| {
-                    cli_args
-                        .layout
-                        .as_ref()
-                        .and_then(|l| {
-                            LayoutInfo::from_cli(
-                                &config_options.layout_dir,
-                                &Some(l.clone()),
-                                std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-                            )
-                        })
-                        .or_else(|| {
-                            LayoutInfo::from_config(
-                                &config_options.layout_dir,
-                                &config_options.default_layout,
-                            )
-                        })
-                }),
-                terminal_window_size: full_screen_ws,
-                data_dir: cli_args.data_dir.clone(),
-                is_debug: cli_args.debug,
-                max_panes: cli_args.max_panes,
-                force_run_layout_commands: false,
-                cwd: layout_cwd,
-            };
+            let cli_assets = new_session_cli_assets(
+                &cli_args,
+                &config_options,
+                layout_info,
+                layout_cwd,
+                full_screen_ws,
+            );
 
             os_input.update_session_name(name);
             let ipc_pipe = create_ipc_pipe();
@@ -1359,38 +1374,13 @@ pub fn start_server_detached(
         },
         ClientInfo::New(name, layout_info, layout_cwd) => {
             envs::set_session_name(name.clone());
-
-            let cli_assets = CliAssets {
-                config_file_path: Config::config_file_path(&cli_args),
-                config_dir: cli_args.config_dir.clone(),
-                should_ignore_config: cli_args.is_setup_clean(),
-                configuration_options: cli_args.options(),
-                layout: layout_info.or_else(|| {
-                    cli_args
-                        .layout
-                        .as_ref()
-                        .and_then(|l| {
-                            LayoutInfo::from_cli(
-                                &config_options.layout_dir,
-                                &Some(l.clone()),
-                                std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-                            )
-                        })
-                        .or_else(|| {
-                            LayoutInfo::from_config(
-                                &config_options.layout_dir,
-                                &config_options.default_layout,
-                            )
-                        })
-                }),
-                terminal_window_size: Size { cols: 50, rows: 50 }, // static number until a
-                // client connects
-                data_dir: cli_args.data_dir.clone(),
-                is_debug: cli_args.debug,
-                max_panes: cli_args.max_panes,
-                force_run_layout_commands: false,
-                cwd: layout_cwd,
-            };
+            let cli_assets = new_session_cli_assets(
+                &cli_args,
+                &config_options,
+                layout_info,
+                layout_cwd,
+                Size { cols: 50, rows: 50 },
+            );
 
             os_input.update_session_name(name);
             let ipc_pipe = create_ipc_pipe();

--- a/zellij-client/src/unit/mod.rs
+++ b/zellij-client/src/unit/mod.rs
@@ -1,3 +1,5 @@
 #[cfg(test)]
+mod startup_tests;
+#[cfg(test)]
 #[cfg(feature = "web_server_capability")]
 mod terminal_loop_tests;

--- a/zellij-client/src/unit/startup_tests.rs
+++ b/zellij-client/src/unit/startup_tests.rs
@@ -1,0 +1,56 @@
+use std::path::PathBuf;
+
+use crate::new_session_cli_assets;
+use zellij_utils::{
+    cli::{CliArgs, Command, SessionCommand, Sessions},
+    input::options::Options,
+    pane_size::Size,
+};
+
+#[test]
+fn detached_new_sessions_keep_merged_attach_options() {
+    let merged_options = Options {
+        default_cwd: Some(PathBuf::from("/tmp/expected-cwd")),
+        theme: Some("dayfox".to_owned()),
+        ..Default::default()
+    };
+    let cli_args = CliArgs {
+        command: Some(Command::Sessions(Sessions::Attach {
+            session_name: Some("detached-session".to_owned()),
+            create: false,
+            create_background: true,
+            index: None,
+            options: Some(Box::new(SessionCommand::Options(merged_options.clone()))),
+            force_run_commands: false,
+            token: None,
+            remember: false,
+            forget: false,
+            ca_cert: None,
+            insecure: false,
+        })),
+        ..Default::default()
+    };
+
+    assert_eq!(cli_args.options(), None);
+
+    let cli_assets = new_session_cli_assets(
+        &cli_args,
+        &merged_options,
+        None,
+        None,
+        Size { cols: 50, rows: 50 },
+    );
+
+    assert_eq!(cli_assets.configuration_options, Some(merged_options));
+
+    let (config, _layout) = cli_assets.load_config_and_layout();
+    let runtime_config_options = match cli_assets.configuration_options.clone() {
+        Some(configuration_options) => config.options.merge(configuration_options),
+        None => config.options,
+    };
+    assert_eq!(
+        runtime_config_options.default_cwd,
+        Some(PathBuf::from("/tmp/expected-cwd"))
+    );
+    assert_eq!(runtime_config_options.theme.as_deref(), Some("dayfox"));
+}


### PR DESCRIPTION
Closes #5023

When `zellij attach --create-background ... options ...` creates a new detached session, the detached startup path builds `CliAssets` from `cli_args.options()`. That only includes top-level `zellij options ...` flags, so nested attach options like `--default-cwd` and `--theme` are dropped.

This reuses the same new-session `CliAssets` builder for both attached and detached startup paths so detached sessions keep the merged attach options just like `--create` does.

Validation:
- `cargo test -p zellij-client detached_new_sessions_keep_merged_attach_options`
- `cargo test -p zellij-client`
- `cargo fmt --all --check`
