### PR TITLE
fix: lost web characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 * fix: idle CPU + disk i/o, CommandChanged plugin Event, GetSessionList plugin command (https://github.com/zellij-org/zellij/pull/5063)
+* fix: occasional dropped characters in web client (https://github.com/zellij-org/zellij/pull/5080)
 
 ## [0.44.1] - 2026-04-07
 * fix: don't display default ports as offline in `share` plugin (https://github.com/zellij-org/zellij/pull/4908)

--- a/zellij-client/assets/input.js
+++ b/zellij-client/assets/input.js
@@ -15,6 +15,22 @@ export function setupInputHandlers(term, sendFunction) {
     let prev_col = 0;
     let prev_row = 0;
 
+    // Work around xterm.js's composition-based character drop under active IMEs
+    // (ibus/fcitx on Linux, etc.). When an IME is attached, every keystroke comes
+    // through with ev.key === "Process" and a phantom compositionstart/end wraps
+    // the keystroke. xterm.js sometimes fails to forward the character through
+    // its composition path under fast typing. We bypass that path only for this
+    // case: use the textarea's standardized `input` event as the authoritative
+    // source of the character, and clear the textarea so xterm.js's composition
+    // handler sees no diff and cannot double-emit.
+    //
+    // - Non-IME typing (ev.key !== "Process") is untouched: xterm.js's keyboard
+    //   handler still emits onData directly, our listener does not trigger.
+    // - Real IME composition (Japanese/Chinese) emits `insertCompositionText`,
+    //   not `insertText` — our filter ignores it; xterm.js handles it as today.
+    // - Paste fires `insertFromPaste` — also ignored here.
+    installImeBypass(term, sendFunction);
+
     // Custom key event handler
     term.attachCustomKeyEventHandler((ev) => {
         if (ev.type === "keydown") {
@@ -165,6 +181,71 @@ export function setupInputHandlers(term, sendFunction) {
         }
         sendFunction(buffer);
     });
+}
+
+/**
+ * Install the IME-bypass input listener exactly once per page load.
+ * The send-function reference is refreshed on every call so the real
+ * WebSocket sender (installed after initWebSockets) replaces the initial
+ * placeholder — see index.js where setupInputHandlers is called twice.
+ */
+function installImeBypass(term, sendFunction) {
+    if (typeof window.__zjImeBypass === "undefined") {
+        window.__zjImeBypass = {
+            installed: false,
+            sendFn: sendFunction,
+            lastKeyWasProcess: false,
+        };
+    }
+    // Always point at the most-recently-provided sender.
+    window.__zjImeBypass.sendFn = sendFunction;
+
+    if (window.__zjImeBypass.installed) {
+        return;
+    }
+    window.__zjImeBypass.installed = true;
+    const state = window.__zjImeBypass;
+
+    // Track whether the most recent keydown was IME-intercepted. Non-IME keys
+    // report their actual key value ("a", "Enter", "ArrowLeft", ...) and go
+    // through xterm.js's normal keyboard path; we do not want to interfere.
+    document.addEventListener(
+        "keydown",
+        (ev) => {
+            state.lastKeyWasProcess = ev.key === "Process";
+        },
+        true
+    );
+
+    // The xterm.js textarea is created asynchronously by term.open(). Poll
+    // briefly until it's available, then attach our capture-phase input
+    // listener.
+    const attach = () => {
+        const ta = term && term._core && term._core.textarea;
+        if (!ta) {
+            setTimeout(attach, 50);
+            return;
+        }
+        ta.addEventListener(
+            "input",
+            (ev) => {
+                if (
+                    state.lastKeyWasProcess &&
+                    ev.inputType === "insertText" &&
+                    !ev.isComposing &&
+                    ev.data
+                ) {
+                    state.sendFn(ev.data);
+                    // Clear so xterm.js's composition diff at compositionend
+                    // finds no text to emit — prevents double-send.
+                    ev.target.value = "";
+                    state.lastKeyWasProcess = false;
+                }
+            },
+            true
+        );
+    };
+    attach();
 }
 
 /**


### PR DESCRIPTION
When typing fast in the web client, on platforms that support IME, we would occasionally lose characters. This is because xterm.js doesn't seem to handle (unless I missed something) IME composition of normal characters (the "I didn't actually need IME" path).

To bypass this, we're sending the character directly if we detect that this is the case - bypassing xterm.js.