### PR TITLE
fix(windows): reuse of terminal pane ids breaks new panes from opening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 * fix: idle CPU + disk i/o, CommandChanged plugin Event, GetSessionList plugin command (https://github.com/zellij-org/zellij/pull/5063)
 * fix: restore kitty keyboard mode on error, handle DECRPM 2026 state 3, clean up client terminal teardown sequences (https://github.com/zellij-org/zellij/pull/5058)
+* fix: stop reusing terminal pane ids on windows so reopened panes are not closed by stale events (https://github.com/zellij-org/zellij/pull/5082)
 
 ## [0.44.1] - 2026-04-07
 * fix: don't display default ports as offline in `share` plugin (https://github.com/zellij-org/zellij/pull/4908)

--- a/zellij-server/src/os_input_output_windows.rs
+++ b/zellij-server/src/os_input_output_windows.rs
@@ -2,13 +2,13 @@ use crate::os_input_output::{resolve_command, AsyncReader};
 use crate::panes::PaneId;
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeMap,
     ffi::OsStr,
     io,
     os::windows::ffi::OsStrExt,
     os::windows::io::{FromRawHandle, IntoRawHandle, OwnedHandle},
     sync::{
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicU32, AtomicU64, Ordering},
         Arc, Mutex,
     },
 };
@@ -370,12 +370,14 @@ fn terminate_process(pid: u32) -> std::result::Result<(), std::io::Error> {
 #[derive(Clone)]
 pub(crate) struct WindowsPtyBackend {
     terminals: Arc<Mutex<BTreeMap<u32, Option<ConPtyTerminal>>>>,
+    next_terminal_id_counter: Arc<AtomicU32>,
 }
 
 impl WindowsPtyBackend {
     pub fn new() -> Result<Self, io::Error> {
         Ok(Self {
             terminals: Arc::new(Mutex::new(BTreeMap::new())),
+            next_terminal_id_counter: Arc::new(AtomicU32::new(0)),
         })
     }
 
@@ -634,14 +636,9 @@ impl WindowsPtyBackend {
     }
 
     pub fn next_terminal_id(&self) -> Option<u32> {
-        self.terminals
-            .lock()
-            .unwrap()
-            .keys()
-            .copied()
-            .collect::<BTreeSet<u32>>()
-            .last()
-            .map(|l| l + 1)
-            .or(Some(0))
+        Some(
+            self.next_terminal_id_counter
+                .fetch_add(1, Ordering::Relaxed),
+        )
     }
 }


### PR DESCRIPTION
Hello,

I have no idea how this code works so I used AI to fix a critical issue I was having (described below). to be clear this code change does fix my issue, but this is **not necessarily intended to be accepted** verbatim. It is to provide insight to a real dev who knows what they're doing to make a real fix.

below is mostly AI generated but I read it all multiple times and it seems okay. my intention here is to help not be annoying with AI stuff. I'm sorry if I've offended anyone.

## Summary
Fix a Windows-specific pane reopen bug caused by terminal pane ids being reused after a pane is closed.

## Reproduction
using version 0.44.1 on windows. either cmd or powershell.
1. Open a new pane with `Alt+n`
2. Close that pane with `Ctrl+p`, then `x`
3. Open a new pane again

## Expected
A new pane opens normally.

## Actual
On Windows, the reopened pane is immediately closed / fails to stay open.

## Fix
Use a monotonic terminal id allocator on Windows so a stale deferred close event cannot target a newly created pane.

## Reasoning
On Windows, pane ids could be reused after a pane was closed. A late `ClosePane` event from the old pane could then be delivered after a new pane had already been created with the same id, causing the new pane to be closed immediately. The fix is to stop reusing terminal ids on Windows and allocate them monotonically instead, matching the Unix implementation.

## Validation
- Verified manually on Windows that pane reopen now works correctly after the fix
- `cargo xtask build` passed locally
- `cargo xtask format --check` passed locally
- `cargo xtask test` did not complete locally due to unrelated pre-existing Windows plugin-test linker failures (`host_run_plugin_command` unresolved in multiple plugin test targets)
