### PR TITLE
fix: preserve wrapped content when copying a selection from the scrollback

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1873,36 +1873,56 @@ impl Grid {
             let empty_row =
                 Row::from_columns(VecDeque::from(vec![EMPTY_TERMINAL_CHARACTER; self.width]));
 
-            // get the row from lines_above, viewport, or lines below depending on index
-            let row = if l < 0 && self.lines_above.len() > l.abs() as usize {
-                let offset_from_end = l.abs();
-                &self.lines_above[self
-                    .lines_above
-                    .len()
-                    .saturating_sub(offset_from_end as usize)]
-            } else if l >= 0 && (l as usize) < self.viewport.len() {
-                &self.viewport[l as usize]
+            // Rows stored in `lines_above` can be joined (width > self.width) because
+            // `transfer_rows_from_viewport_to_lines_above` merges wrapped continuations
+            // into the preceding canonical row. Walk newest-to-oldest, summing each
+            // row's display height, to find which stored row visual offset |l| maps
+            // to and at what column offset inside it.
+            let (row, col_offset) = if l < 0 {
+                let mut remaining = l.unsigned_abs() as usize;
+                let mut found = None;
+                for r in self.lines_above.iter().rev() {
+                    let vh = if r.columns.len() <= self.width {
+                        1
+                    } else {
+                        calculate_row_display_height(r.width(), self.width)
+                    };
+                    if remaining <= vh {
+                        found = Some((r, (vh - remaining) * self.width));
+                        break;
+                    }
+                    remaining -= vh;
+                }
+                match found {
+                    Some(t) => t,
+                    None => continue,
+                }
+            } else if (l as usize) < self.viewport.len() {
+                (&self.viewport[l as usize], 0)
             } else if (l as usize) < self.height {
                 // index is in viewport but there is no line
-                &empty_row
+                (&empty_row, 0)
             } else if self.lines_below.len() > (l as usize).saturating_sub(self.viewport.len()) {
-                &self.lines_below[(l as usize) - self.viewport.len()]
+                (&self.lines_below[(l as usize) - self.viewport.len()], 0)
             } else {
                 // can't find the line, this probably it's on the pane border
-                // is on the pane border
                 continue;
             };
 
             let mut terminal_col = 0;
+            let lower = col_offset + start_column;
+            let upper = col_offset + end_column;
             for terminal_character in &row.columns {
-                if (start_column..end_column).contains(&terminal_col) {
+                if (lower..upper).contains(&terminal_col) {
                     line_selection.push(terminal_character.character);
                 }
 
                 terminal_col += terminal_character.width();
             }
 
-            if row.is_canonical {
+            // A non-top chunk of a joined lines_above row must be merged with the
+            // previous entry just like a non-canonical viewport row.
+            if row.is_canonical && col_offset == 0 {
                 selection.push(line_selection);
             } else {
                 // rejoin wrapped lines if possible

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -1672,6 +1672,63 @@ fn copy_selected_text_from_lines_below() {
     );
 }
 
+#[test]
+fn copy_wrapped_selection_after_scroll_off() {
+    // User's scenario: a wrapped long line is in the viewport, user starts a
+    // selection covering it, then more content is printed which scrolls the
+    // selection off into lines_above. The expected clipboard should still be
+    // the full wrapped line.
+    let mut vte_parser = vte::Parser::new();
+    let sixel_image_store = Rc::new(RefCell::new(SixelImageStore::default()));
+    let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
+    let debug = false;
+    let arrow_fonts = true;
+    let styled_underlines = true;
+    let explicitly_disable_kitty_keyboard_protocol = false;
+    let width: usize = 20;
+    let height: usize = 5;
+    let mut grid = Grid::new(
+        height,
+        width,
+        Rc::new(RefCell::new(Palette::default())),
+        terminal_emulator_color_codes,
+        Rc::new(RefCell::new(LinkHandler::new())),
+        Rc::new(RefCell::new(None)),
+        sixel_image_store,
+        Style::default(),
+        debug,
+        arrow_fonts,
+        styled_underlines,
+        explicitly_disable_kitty_keyboard_protocol,
+    );
+
+    // Write a long line (60 chars → 3 rows at width 20), then "pad1".
+    // At this point viewport = [AAA, BBB, CCC, pad1, empty], cursor at row 4.
+    let long_line = "AAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCC";
+    for byte in format!("{}\r\npad1\r\n", long_line).bytes() {
+        vte_parser.advance(&mut grid, byte);
+    }
+
+    // User starts a selection covering the full wrapped line while it's still
+    // visible in the viewport.
+    grid.start_selection(&Position::new(0, 0));
+    grid.end_selection(&Position::new(2, width as u16));
+    // Sanity-check: it works while still in viewport.
+    assert_eq!(grid.get_selected_text().unwrap(), long_line);
+
+    // Now print more content that scrolls the viewport. Each newline at the
+    // bottom of the scroll region drains one viewport row into lines_above
+    // (and moves the selection up by one). After 3 additional newlines, the
+    // wrapped line has been joined into a single row in lines_above and the
+    // selection's line indices all point into lines_above.
+    for byte in "pad2\r\npad3\r\npad4\r\n".bytes() {
+        vte_parser.advance(&mut grid, byte);
+    }
+
+    let text = grid.get_selected_text();
+    assert_eq!(text.unwrap(), long_line);
+}
+
 /*
  * These tests below are general compatibility tests for non-trivial scenarios running in the terminal.
  * They use fake TTY input replicated from these scenarios.


### PR DESCRIPTION
`get_selected_text` truncates wrapped lines when the selection spans rows that have scrolled off the viewport into `lines_above`. `transfer_rows_from_viewport_to_lines_above` merges wrapped continuations into the preceding canonical row, so one entry in `lines_above` can store a row whose columns.len() exceeds self.width (a "joined" row). `get_selected_text` assumed one stored row equals one visual row: it indexed `lines_above` by |l| and capped end_column at self.width, which dropped every character past the wrap point.

Resolve |l| to (row, col_offset) by walking `lines_above` newest-to-oldest and summing each row's display height. Extraction shifts the column window by col_offset. A new selection entry is only started when col_offset == 0, so middle/bottom chunks of a joined row append to the previous entry like non-canonical viewport rows. Viewport and `lines_below` paths are unchanged (col_offset stays 0). 

Adds `copy_wrapped_selection_after_scroll_off` as a test: select a wrapped line while in the viewport, print enough lines to drain it into `lines_above`, and assert the clipboard still contains the full line. 