### PR TITLE
Feat/cli new tab no focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+* feat: add `--no-focus`/`-d` flag to `zellij action new-tab` to create a tab without switching focus to it (closes https://github.com/zellij-org/zellij/issues/1988)
 * fix: idle CPU + disk i/o, CommandChanged plugin Event, GetSessionList plugin command (https://github.com/zellij-org/zellij/pull/5063)
 * fix: occasional dropped characters in web client (https://github.com/zellij-org/zellij/pull/5080)
 * fix: restore kitty keyboard mode on error, handle DECRPM 2026 state 3, clean up client terminal teardown sequences (https://github.com/zellij-org/zellij/pull/5058)

--- a/src/main.rs
+++ b/src/main.rs
@@ -284,6 +284,7 @@ fn main() {
                 block_until_exit_success: false,
                 block_until_exit_failure: false,
                 block_until_exit: false,
+                no_focus: false,
             };
             commands::send_action_to_session(new_layout_cli_action, Some(session_name), config);
         } else {

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -3668,6 +3668,7 @@ pub fn send_cli_new_tab_action_default_params() {
         block_until_exit: false,
         block_until_exit_success: false,
         block_until_exit_failure: false,
+        no_focus: false,
     };
     send_cli_action_to_server(&session_metadata, new_tab_action, client_id);
     std::thread::sleep(std::time::Duration::from_millis(100));
@@ -3716,6 +3717,7 @@ pub fn send_cli_new_tab_action_with_name_and_layout() {
         block_until_exit: false,
         block_until_exit_success: false,
         block_until_exit_failure: false,
+        no_focus: false,
     };
     send_cli_action_to_server(&session_metadata, new_tab_action, client_id);
     std::thread::sleep(std::time::Duration::from_millis(100));
@@ -7781,6 +7783,7 @@ pub fn send_cli_new_tab_action_with_layout_string() {
         block_until_exit: false,
         block_until_exit_success: false,
         block_until_exit_failure: false,
+        no_focus: false,
     };
     send_cli_action_to_server(&session_metadata, new_tab_action, client_id);
     std::thread::sleep(std::time::Duration::from_millis(100));
@@ -7835,6 +7838,7 @@ pub fn send_cli_new_tab_action_with_layout_string_and_name() {
         block_until_exit: false,
         block_until_exit_success: false,
         block_until_exit_failure: false,
+        no_focus: false,
     };
     send_cli_action_to_server(&session_metadata, new_tab_action, client_id);
     std::thread::sleep(std::time::Duration::from_millis(100));

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -3685,6 +3685,58 @@ pub fn send_cli_new_tab_action_default_params() {
 }
 
 #[test]
+pub fn send_cli_new_tab_action_with_no_focus() {
+    let size = Size { cols: 80, rows: 10 };
+    let client_id = 10; // fake client id should not appear in the screen's state
+    let mut initial_layout = TiledPaneLayout::default();
+    initial_layout.children_split_direction = SplitDirection::Vertical;
+    initial_layout.children = vec![TiledPaneLayout::default(), TiledPaneLayout::default()];
+    let mut mock_screen = MockScreen::new(size);
+    let session_metadata = mock_screen.clone_session_metadata();
+    let screen_thread = mock_screen.run(Some(initial_layout), vec![]);
+    let received_plugin_instructions = Arc::new(Mutex::new(vec![]));
+    let plugin_receiver = mock_screen.plugin_receiver.take().unwrap();
+    let plugin_thread = log_actions_in_thread!(
+        received_plugin_instructions,
+        PluginInstruction::Exit,
+        plugin_receiver
+    );
+    let new_tab_action = CliAction::NewTab {
+        name: Some("bg".into()),
+        layout: None,
+        layout_string: None,
+        layout_dir: None,
+        cwd: None,
+        initial_command: vec![],
+        initial_plugin: None,
+        close_on_exit: Default::default(),
+        start_suspended: Default::default(),
+        block_until_exit: false,
+        block_until_exit_success: false,
+        block_until_exit_failure: false,
+        no_focus: true,
+    };
+    send_cli_action_to_server(&session_metadata, new_tab_action, client_id);
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    mock_screen.teardown(vec![plugin_thread, screen_thread]);
+    let new_tab_instruction = received_plugin_instructions
+        .lock()
+        .unwrap()
+        .iter()
+        .rev()
+        .find(|i| {
+            if let PluginInstruction::NewTab(..) = i {
+                return true;
+            } else {
+                return false;
+            }
+        })
+        .unwrap()
+        .clone();
+    assert_snapshot!(format!("{:#?}", new_tab_instruction));
+}
+
+#[test]
 pub fn send_cli_new_tab_action_with_name_and_layout() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10; // fake client id should not appear in the screen's state

--- a/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_tab_action_with_no_focus.snap
+++ b/zellij-server/src/unit/snapshots/zellij_server__screen__screen_tests__send_cli_new_tab_action_with_no_focus.snap
@@ -1,0 +1,32 @@
+---
+source: zellij-server/src/./unit/screen_tests.rs
+assertion_line: 3736
+expression: "format!(\"{:#?}\", new_tab_instruction)"
+---
+NewTab(
+    Some(
+        ".",
+    ),
+    None,
+    None,
+    [],
+    1,
+    None,
+    false,
+    false,
+    (
+        10,
+        false,
+    ),
+    Some(
+        NotificationEnd {
+            channel: None,
+            exit_status: None,
+            unblock_condition: None,
+            affected_pane_id: None,
+            affected_tab_id: None,
+            error_message: None,
+            stdout_message: None,
+        },
+    ),
+)

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -1316,6 +1316,16 @@ pub enum CliAction {
             conflicts_with("block-until-exit-failure")
         )]
         block_until_exit: bool,
+
+        /// Create the tab without switching focus to it (similar to tmux `new-window -d`)
+        #[clap(
+            short = 'd',
+            long,
+            value_parser,
+            default_value("false"),
+            takes_value(false)
+        )]
+        no_focus: bool,
     },
     /// Move the focused tab in the specified direction. [right|left]
     MoveTab {

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -3454,6 +3454,114 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[test]
+    fn test_new_tab_no_focus_bare() {
+        let cli_action = CliAction::NewTab {
+            name: Some("bg".into()),
+            layout: None,
+            layout_string: None,
+            layout_dir: None,
+            cwd: None,
+            initial_command: vec![],
+            initial_plugin: None,
+            close_on_exit: Default::default(),
+            start_suspended: Default::default(),
+            block_until_exit: false,
+            block_until_exit_success: false,
+            block_until_exit_failure: false,
+            no_focus: true,
+        };
+        let result = Action::actions_from_cli(cli_action, Box::new(|| PathBuf::from("/tmp")), None);
+        assert!(result.is_ok());
+        let actions = result.unwrap();
+        assert_eq!(actions.len(), 1);
+        match &actions[0] {
+            Action::NewTab {
+                should_change_focus_to_new_tab,
+                tab_name,
+                ..
+            } => {
+                assert_eq!(
+                    *should_change_focus_to_new_tab, false,
+                    "--no-focus must set should_change_focus_to_new_tab to false"
+                );
+                assert_eq!(tab_name.as_deref(), Some("bg"));
+            },
+            _ => panic!("Expected NewTab action"),
+        }
+    }
+
+    #[test]
+    fn test_new_tab_no_focus_with_layout_string() {
+        let cli_action = CliAction::NewTab {
+            name: None,
+            layout: None,
+            layout_string: Some("layout {\n    pane\n}\n".into()),
+            layout_dir: None,
+            cwd: None,
+            initial_command: vec![],
+            initial_plugin: None,
+            close_on_exit: Default::default(),
+            start_suspended: Default::default(),
+            block_until_exit: false,
+            block_until_exit_success: false,
+            block_until_exit_failure: false,
+            no_focus: true,
+        };
+        let result = Action::actions_from_cli(cli_action, Box::new(|| PathBuf::from("/tmp")), None);
+        assert!(result.is_ok());
+        let actions = result.unwrap();
+        assert!(!actions.is_empty());
+        for action in &actions {
+            match action {
+                Action::NewTab {
+                    should_change_focus_to_new_tab,
+                    ..
+                } => {
+                    assert_eq!(
+                        *should_change_focus_to_new_tab, false,
+                        "--no-focus must set should_change_focus_to_new_tab to false for every emitted NewTab"
+                    );
+                },
+                _ => panic!("Expected NewTab action"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_new_tab_default_focuses() {
+        let cli_action = CliAction::NewTab {
+            name: None,
+            layout: None,
+            layout_string: None,
+            layout_dir: None,
+            cwd: None,
+            initial_command: vec![],
+            initial_plugin: None,
+            close_on_exit: Default::default(),
+            start_suspended: Default::default(),
+            block_until_exit: false,
+            block_until_exit_success: false,
+            block_until_exit_failure: false,
+            no_focus: false,
+        };
+        let result = Action::actions_from_cli(cli_action, Box::new(|| PathBuf::from("/tmp")), None);
+        assert!(result.is_ok());
+        let actions = result.unwrap();
+        assert_eq!(actions.len(), 1);
+        match &actions[0] {
+            Action::NewTab {
+                should_change_focus_to_new_tab,
+                ..
+            } => {
+                assert_eq!(
+                    *should_change_focus_to_new_tab, true,
+                    "default (no --no-focus) must set should_change_focus_to_new_tab to true"
+                );
+            },
+            _ => panic!("Expected NewTab action"),
+        }
+    }
 
     #[test]
     fn test_override_layout_with_layout_string() {

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -1389,6 +1389,7 @@ impl Action {
                 block_until_exit_success,
                 block_until_exit_failure,
                 block_until_exit,
+                no_focus,
             } => {
                 let current_dir = get_current_dir();
                 let cwd = cwd
@@ -1497,7 +1498,7 @@ impl Action {
                             let name = tab_name.or_else(|| name.clone());
                             let should_change_focus_to_new_tab =
                                 layout.focus.unwrap_or_else(|| {
-                                    if !has_focused_tab {
+                                    if !has_focused_tab && !no_focus {
                                         has_focused_tab = true;
                                         true
                                     } else {
@@ -1521,7 +1522,7 @@ impl Action {
                         let swap_tiled_layouts = Some(layout.swap_tiled_layouts.clone());
                         let swap_floating_layouts = Some(layout.swap_floating_layouts.clone());
                         let (layout, floating_panes_layout) = layout.new_tab();
-                        let should_change_focus_to_new_tab = true;
+                        let should_change_focus_to_new_tab = !no_focus;
                         Ok(vec![Action::NewTab {
                             tiled_layout: Some(layout),
                             floating_layouts: floating_panes_layout,
@@ -1613,7 +1614,7 @@ impl Action {
                             let name = tab_name.or_else(|| name.clone());
                             let should_change_focus_to_new_tab =
                                 layout.focus.unwrap_or_else(|| {
-                                    if !has_focused_tab {
+                                    if !has_focused_tab && !no_focus {
                                         has_focused_tab = true;
                                         true
                                     } else {
@@ -1637,7 +1638,7 @@ impl Action {
                         let swap_tiled_layouts = Some(layout.swap_tiled_layouts.clone());
                         let swap_floating_layouts = Some(layout.swap_floating_layouts.clone());
                         let (layout, floating_panes_layout) = layout.new_tab();
-                        let should_change_focus_to_new_tab = true;
+                        let should_change_focus_to_new_tab = !no_focus;
                         Ok(vec![Action::NewTab {
                             tiled_layout: Some(layout),
                             floating_layouts: floating_panes_layout,
@@ -1651,7 +1652,7 @@ impl Action {
                         }])
                     }
                 } else {
-                    let should_change_focus_to_new_tab = true;
+                    let should_change_focus_to_new_tab = !no_focus;
                     Ok(vec![Action::NewTab {
                         tiled_layout: None,
                         floating_layouts: vec![],
@@ -3410,6 +3411,7 @@ mod tests {
             block_until_exit: false,
             block_until_exit_success: false,
             block_until_exit_failure: false,
+            no_focus: false,
         };
         let result = Action::actions_from_cli(cli_action, Box::new(|| PathBuf::from("/tmp")), None);
         assert!(result.is_ok());
@@ -3446,10 +3448,12 @@ mod tests {
             block_until_exit: false,
             block_until_exit_success: false,
             block_until_exit_failure: false,
+            no_focus: false,
         };
         let result = Action::actions_from_cli(cli_action, Box::new(|| PathBuf::from("/tmp")), None);
         assert!(result.is_err());
     }
+
 
     #[test]
     fn test_override_layout_with_layout_string() {


### PR DESCRIPTION
I created a `--no-focus` flag when creating new tabs that won't change the focus when using the cli. This is related to issue #1988. It looks like the hooks were already there in the server, so I just plugged into the existing functionality and exposed it. 

Thanks for reviewing!