### PR TITLE
show OSC 9;4 progress badge in the tab

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -27,6 +27,12 @@ use zellij_utils::{
 const TABSTOP_WIDTH: usize = 8; // TODO: is this always right?
 pub const MAX_TITLE_STACK_SIZE: usize = 1000;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PaneProgress {
+    Determinate(u8),
+    Indeterminate,
+}
+
 /// Rewrites OSC 99 metadata for multiplexer forwarding:
 ///
 /// 1. Namespaces the `i=` value with a pane ID prefix and flags so responses
@@ -623,6 +629,7 @@ pub struct Grid {
     pub pending_messages_to_pty: Vec<Vec<u8>>,
     pub selection: Selection,
     pub title: Option<String>,
+    pane_progress: Option<PaneProgress>,
     pub is_scrolled: bool,
     pub link_handler: Rc<RefCell<LinkHandler>>,
     pub ring_bell: bool,
@@ -666,6 +673,13 @@ impl Grid {
             self.pane_default_fg.and_then(ansi_code_to_color_string),
             self.pane_default_bg.and_then(ansi_code_to_color_string),
         )
+    }
+    pub fn progress_badge(&self) -> Option<String> {
+        match self.pane_progress {
+            Some(PaneProgress::Determinate(progress)) => Some(format!("[{}%]", progress)),
+            Some(PaneProgress::Indeterminate) => Some("[~]".to_owned()),
+            None => None,
+        }
     }
 }
 
@@ -908,6 +922,7 @@ impl Grid {
             selection: Default::default(),
             title_stack: vec![],
             title: None,
+            pane_progress: None,
             changed_colors: None,
             is_scrolled: false,
             link_handler,
@@ -2220,6 +2235,7 @@ impl Grid {
         self.focus_event_tracking = false;
         self.cursor_is_hidden = false;
         self.supports_kitty_keyboard_protocol = false;
+        self.pane_progress = None;
         self.set_scroll_region_to_viewport_size();
         self.pane_default_fg = None;
         self.pane_default_bg = None;
@@ -3472,6 +3488,28 @@ impl Perform for Grid {
                 if let Some(raw) = params.get(1) {
                     if let Some(path) = parse_osc7_path(raw) {
                         self.pending_osc7_cwd = Some(path);
+                    }
+                }
+            },
+
+            b"9" => {
+                if params.len() >= 3 && params[1] == b"4" {
+                    match params.get(2).and_then(|state| parse_number(state)) {
+                        Some(0) => {
+                            self.pane_progress = None;
+                        },
+                        Some(1) => {
+                            self.pane_progress = params
+                                .get(3)
+                                .and_then(|progress| parse_number(progress))
+                                .map(PaneProgress::Determinate);
+                        },
+                        Some(3) => {
+                            self.pane_progress = Some(PaneProgress::Indeterminate);
+                        },
+                        _ => {
+                            self.pane_progress = None;
+                        },
                     }
                 }
             },

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -399,10 +399,21 @@ impl Pane for TerminalPane {
             .and_then(|(_color, text)| text.as_ref())
         {
             text_color_override.into()
-        } else if self.has_bell_notification {
-            format!("{} [!]", normal_title)
         } else {
-            normal_title
+            let mut pane_title = normal_title;
+            if self.has_bell_notification {
+                if !pane_title.is_empty() {
+                    pane_title.push(' ');
+                }
+                pane_title.push_str("[!]");
+            }
+            if let Some(progress_badge) = self.grid.progress_badge() {
+                if !pane_title.is_empty() {
+                    pane_title.push(' ');
+                }
+                pane_title.push_str(&progress_badge);
+            }
+            pane_title
         };
 
         let frame_geom = self.current_geom();

--- a/zellij-server/src/panes/unit/terminal_pane_tests.rs
+++ b/zellij-server/src/panes/unit/terminal_pane_tests.rs
@@ -2,12 +2,13 @@ use super::super::TerminalPane;
 use crate::panes::sixel::SixelImageStore;
 use crate::panes::LinkHandler;
 use crate::tab::Pane;
+use crate::ui::pane_boundaries_frame::FrameParams;
 use insta::assert_snapshot;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 use zellij_utils::{
-    data::{Palette, Style},
+    data::{InputMode, Palette, Style},
     pane_size::{Offset, PaneGeom, SizeInPixels},
     position::Position,
 };
@@ -733,6 +734,42 @@ fn make_terminal_pane_for_bell() -> TerminalPane {
     )
 }
 
+fn frame_params() -> FrameParams {
+    FrameParams {
+        focused_client: Some(1),
+        is_main_client: true,
+        other_focused_clients: vec![],
+        style: Style::default(),
+        color: None,
+        other_cursors_exist_in_session: false,
+        pane_is_stacked_under: false,
+        pane_is_stacked_over: false,
+        should_draw_pane_frames: true,
+        pane_is_floating: false,
+        content_offset: Offset::default(),
+        mouse_is_hovering_over_pane: false,
+        pane_is_selectable: true,
+        show_help_text: false,
+        highlight_tooltip: None,
+    }
+}
+
+fn frame_text(terminal_pane: &mut TerminalPane) -> String {
+    let (chunks, _raw_vte) = terminal_pane
+        .render_frame(1, frame_params(), InputMode::Normal)
+        .unwrap()
+        .unwrap();
+    chunks
+        .iter()
+        .flat_map(|chunk| {
+            chunk
+                .terminal_characters
+                .iter()
+                .map(|character| character.character)
+        })
+        .collect()
+}
+
 #[test]
 pub fn bell_notification_state_set_and_cleared() {
     let mut terminal_pane = make_terminal_pane_for_bell();
@@ -774,6 +811,49 @@ pub fn has_bell_reflects_grid_ring_bell() {
     assert!(
         !terminal_pane.has_bell(),
         "has_bell should be false after consume_bell"
+    );
+}
+
+#[test]
+pub fn render_frame_shows_determinate_progress_badge() {
+    let mut terminal_pane = make_terminal_pane_for_bell();
+
+    terminal_pane.handle_pty_bytes(b"\x1b]9;4;1;42\x07".to_vec());
+
+    let frame_text = frame_text(&mut terminal_pane);
+    assert!(
+        frame_text.contains("[42%]"),
+        "Expected determinate progress badge in pane title, got: {:?}",
+        frame_text
+    );
+}
+
+#[test]
+pub fn render_frame_shows_indeterminate_progress_badge() {
+    let mut terminal_pane = make_terminal_pane_for_bell();
+
+    terminal_pane.handle_pty_bytes(b"\x1b]9;4;3\x07".to_vec());
+
+    let frame_text = frame_text(&mut terminal_pane);
+    assert!(
+        frame_text.contains("[~]"),
+        "Expected indeterminate progress badge in pane title, got: {:?}",
+        frame_text
+    );
+}
+
+#[test]
+pub fn render_frame_clears_progress_badge() {
+    let mut terminal_pane = make_terminal_pane_for_bell();
+
+    terminal_pane.handle_pty_bytes(b"\x1b]9;4;1;42\x07".to_vec());
+    terminal_pane.handle_pty_bytes(b"\x1b]9;4;0\x07".to_vec());
+
+    let frame_text = frame_text(&mut terminal_pane);
+    assert!(
+        !frame_text.contains("[42%]"),
+        "Expected progress badge to be cleared from pane title, got: {:?}",
+        frame_text
     );
 }
 


### PR DESCRIPTION
I know this is not likely to be added in, but wanted to submit in case other people are interested in the feature as well. 

I  personally I have workflows where I have lots of tabs open, each with an agent and I'm hopping around between them. Being able to see more info about what is going on from the tab level is really handy to me, so this adds in support for the progress states. 

This is similar to the existing pane badge for the bell `[!]` but also adds in 

   - determinate progress: `[42%]`
   - indeterminate progress: `[~]`

   ## Related issues

   Partially addresses #4531 by surfacing `OSC 9;4` progress state in pane titles.

   This is also similar in spirit to prior pane/pane-title UI state work such as:
   - #4581
   - #3245

   Supported mappings:

   - `OSC 9;4;1;<n>` → append `[<n>%]` to the pane title
   - `OSC 9;4;3` → append `[~]` to the pane title
   - `OSC 9;4;0` → clear the progress badge

   Other / unsupported `OSC 9;4` states currently clear the badge.

   The badge composes with the existing bell badge, eg:

   ```text
   my pane [!] [42%]
   my pane [~]
 ```

 Implementation

 ### zellij-server/src/panes/grid.rs

 - add pane-local progress state storage
 - parse OSC 9;4
 - expose a progress_badge() helper for title rendering
 - clear progress state on terminal reset

 ### zellij-server/src/panes/terminal_pane.rs

 - append the progress badge to the pane frame title
 - preserve existing bell badge behavior

 ### zellij-server/src/panes/unit/terminal_pane_tests.rs

 - add tests for:
     - determinate progress badge
     - indeterminate progress badge
     - clearing the badge

 Ran locally:

 ```sh
   cargo test -p zellij-server progress_badge -- --nocapture
   cargo xtask test
 ```

 Added coverage for:
 - showing [42%] for determinate progress
 - showing [~] for indeterminate progress
 - clearing progress when OSC 9;4;0 is received

I think it would be even cooler if the indeterminate one was animated, but left that for the future. 