### PR TITLE
Feat sessions registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4938,6 +4938,7 @@ dependencies = [
  "anyhow",
  "backtrace",
  "bitflags 2.11.0",
+ "chrono",
  "clap",
  "clap_complete",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ rust-version = "1.92"
 ansi_term = { version = "0.12.1", default-features = false }
 anyhow = { version = "1.0.70", default-features = false, features = ["backtrace", "std"] }
 async-trait = { version = "0.1", default-features = false }
+chrono = { version = "0.4.19", default-features = false, features = ["std", "clock"] }
 clap = { version = "3.2.2", default-features = false, features = ["env", "derive", "color", "std", "suggestions"] }
 crossterm = { version = "0.28", default-features = false, features = ["windows"] }
 daemonize = { version = "0.5", default-features = false }

--- a/zellij-client/src/cli_client.rs
+++ b/zellij-client/src/cli_client.rs
@@ -2,9 +2,9 @@
 //! and dispatch actions, that are specified through the command line.
 use std::collections::{BTreeMap, HashSet};
 use std::io::{self, BufRead, Write};
+use std::path::PathBuf;
 use std::process;
 use std::str::FromStr;
-use std::{fs, path::PathBuf};
 
 use crate::os_input_output::ClientOsApi;
 use uuid::Uuid;
@@ -21,14 +21,7 @@ pub fn start_cli_client(
     session_name: &str,
     actions: Vec<Action>,
 ) {
-    let zellij_ipc_pipe: PathBuf = {
-        let mut sock_dir = zellij_utils::consts::ZELLIJ_SOCK_DIR.clone();
-        fs::create_dir_all(&sock_dir).unwrap();
-        zellij_utils::shared::set_permissions(&sock_dir, 0o700).unwrap();
-        sock_dir.push(session_name);
-        sock_dir
-    };
-    crate::check_ipc_pipe_length(&zellij_ipc_pipe);
+    let zellij_ipc_pipe: PathBuf = crate::resolve_session_ipc_pipe(session_name);
     os_input.connect_to_server(&*zellij_ipc_pipe);
     let pane_id = os_input
         .env_variable("ZELLIJ_PANE_ID")
@@ -258,14 +251,7 @@ pub fn start_subscribe_client(
     session_name: &str,
     subscribe_cli: SubscribeCli,
 ) {
-    let zellij_ipc_pipe: PathBuf = {
-        let mut sock_dir = zellij_utils::consts::ZELLIJ_SOCK_DIR.clone();
-        fs::create_dir_all(&sock_dir).unwrap();
-        zellij_utils::shared::set_permissions(&sock_dir, 0o700).unwrap();
-        sock_dir.push(session_name);
-        sock_dir
-    };
-    crate::check_ipc_pipe_length(&zellij_ipc_pipe);
+    let zellij_ipc_pipe: PathBuf = crate::resolve_session_ipc_pipe(session_name);
     os_input.connect_to_server(&*zellij_ipc_pipe);
 
     // Parse pane IDs

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -138,6 +138,7 @@ use zellij_utils::{
     input::{cli_assets::CliAssets, config::Config, options::Options},
     ipc::{ClientToServerMsg, ExitReason, ServerToClientMsg},
     pane_size::Size,
+    sessions::{register_session, resolve_session_socket_path},
     vendored::termwiz::input::InputEvent,
 };
 
@@ -302,21 +303,33 @@ fn spawn_web_server(_cli_args: &CliArgs) -> Result<String, String> {
     Ok("".to_owned())
 }
 
-fn check_ipc_pipe_length(ipc_pipe: &Path) {
-    use zellij_utils::consts::ZELLIJ_SOCK_MAX_LENGTH;
-    let path_len = ipc_pipe.as_os_str().len();
-    if path_len >= ZELLIJ_SOCK_MAX_LENGTH {
-        eprintln!(
-            "Error: the IPC socket path is too long ({} bytes, max {}):\n  {}\n\n\
-             This is usually caused by a long $TMPDIR path.\n\
-             To fix this, set a shorter socket directory, eg.:\n  \
-             ZELLIJ_SOCKET_DIR=/tmp/zellij zellij",
-            path_len,
-            ZELLIJ_SOCK_MAX_LENGTH - 1,
-            ipc_pipe.display()
-        );
+fn ensure_sock_dir() {
+    zellij_utils::consts::check_sock_dir_length();
+    let sock_dir = ZELLIJ_SOCK_DIR.clone();
+    std::fs::create_dir_all(&sock_dir).unwrap();
+    set_permissions(&sock_dir, 0o700).unwrap();
+}
+
+/// Create a new IPC pipe path for a brand-new session.
+///
+/// Generates a UUID, registers the session in `sessions.kdl`, and returns
+/// `ZELLIJ_SOCK_DIR/<uuid>`.
+fn new_session_ipc_pipe(session_name: &str) -> PathBuf {
+    ensure_sock_dir();
+    let session_id = register_session(session_name).unwrap_or_else(|e| {
+        eprintln!("Failed to register session: {}", e);
         std::process::exit(1);
-    }
+    });
+    ZELLIJ_SOCK_DIR.join(&session_id)
+}
+
+/// Resolve an existing session name to its IPC pipe path.
+///
+/// Looks up the session in `sessions.kdl`. Falls back to the legacy
+/// `ZELLIJ_SOCK_DIR/<name>` path for sessions created before the registry.
+fn resolve_session_ipc_pipe(session_name: &str) -> PathBuf {
+    ensure_sock_dir();
+    resolve_session_socket_path(session_name).unwrap_or_else(|| ZELLIJ_SOCK_DIR.join(session_name))
 }
 
 /// Spawn the Zellij server process.
@@ -769,20 +782,11 @@ pub fn start_client(
         config_options.web_server_cert.is_some() && config_options.web_server_key.is_some();
     let enforce_https_for_localhost = config_options.enforce_https_for_localhost.unwrap_or(false);
 
-    let create_ipc_pipe = || -> std::path::PathBuf {
-        let mut sock_dir = ZELLIJ_SOCK_DIR.clone();
-        std::fs::create_dir_all(&sock_dir).unwrap();
-        set_permissions(&sock_dir, 0o700).unwrap();
-        sock_dir.push(envs::get_session_name().unwrap());
-        check_ipc_pipe_length(&sock_dir);
-        sock_dir
-    };
-
     let (first_msg, ipc_pipe) = match info {
         ClientInfo::Attach(name, config_options) => {
             envs::set_session_name(name.clone());
-            os_input.update_session_name(name);
-            let ipc_pipe = create_ipc_pipe();
+            os_input.update_session_name(name.clone());
+            let ipc_pipe = resolve_session_ipc_pipe(&name);
             let is_web_client = false;
 
             let cli_assets = CliAssets {
@@ -831,8 +835,8 @@ pub fn start_client(
         },
         ClientInfo::Watch(name, _config_options) => {
             envs::set_session_name(name.clone());
-            os_input.update_session_name(name);
-            let ipc_pipe = create_ipc_pipe();
+            os_input.update_session_name(name.clone());
+            let ipc_pipe = resolve_session_ipc_pipe(&name);
             let is_web_client = false;
 
             (
@@ -863,8 +867,8 @@ pub fn start_client(
                 cwd,
             };
 
-            os_input.update_session_name(name);
-            let ipc_pipe = create_ipc_pipe();
+            os_input.update_session_name(name.clone());
+            let ipc_pipe = new_session_ipc_pipe(&name);
 
             spawn_server(&*ipc_pipe, cli_args.debug).unwrap();
             if should_start_web_server {
@@ -917,8 +921,8 @@ pub fn start_client(
                 cwd: layout_cwd,
             };
 
-            os_input.update_session_name(name);
-            let ipc_pipe = create_ipc_pipe();
+            os_input.update_session_name(name.clone());
+            let ipc_pipe = new_session_ipc_pipe(&name);
 
             spawn_server(&*ipc_pipe, cli_args.debug).unwrap();
             if should_start_web_server {
@@ -1306,15 +1310,6 @@ pub fn start_server_detached(
 
     let should_start_web_server = config_options.web_server.map(|w| w).unwrap_or(false);
 
-    let create_ipc_pipe = || -> std::path::PathBuf {
-        let mut sock_dir = ZELLIJ_SOCK_DIR.clone();
-        std::fs::create_dir_all(&sock_dir).unwrap();
-        set_permissions(&sock_dir, 0o700).unwrap();
-        sock_dir.push(envs::get_session_name().unwrap());
-        check_ipc_pipe_length(&sock_dir);
-        sock_dir
-    };
-
     let (first_msg, ipc_pipe) = match info {
         ClientInfo::Resurrect(name, path_to_layout, force_run_commands, cwd) => {
             envs::set_session_name(name.clone());
@@ -1337,8 +1332,8 @@ pub fn start_server_detached(
                 cwd,
             };
 
-            os_input.update_session_name(name);
-            let ipc_pipe = create_ipc_pipe();
+            os_input.update_session_name(name.clone());
+            let ipc_pipe = new_session_ipc_pipe(&name);
 
             spawn_server(&*ipc_pipe, cli_args.debug).unwrap();
             if should_start_web_server {
@@ -1392,8 +1387,8 @@ pub fn start_server_detached(
                 cwd: layout_cwd,
             };
 
-            os_input.update_session_name(name);
-            let ipc_pipe = create_ipc_pipe();
+            os_input.update_session_name(name.clone());
+            let ipc_pipe = new_session_ipc_pipe(&name);
 
             spawn_server(&*ipc_pipe, cli_args.debug).unwrap();
             if should_start_web_server {

--- a/zellij-client/src/web_client/server_listener.rs
+++ b/zellij-client/src/web_client/server_listener.rs
@@ -6,10 +6,8 @@ use crate::web_client::session_management::{
 use crate::web_client::types::{ClientConnectionBus, ConnectionTable, SessionManager};
 use crate::web_client::utils::terminal_init_messages;
 
-use std::{
-    path::PathBuf,
-    sync::{Arc, Mutex},
-};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 use zellij_utils::{
     cli::CliArgs,
     data::Style,
@@ -48,8 +46,8 @@ pub fn zellij_server_listener(
                 'reconnect_loop: loop {
                     let reconnect_info = reconnect_to_session.take();
                     let initial_layout = reconnect_info.as_ref().and_then(|r| r.layout.clone());
-                    let path = {
-                        let Some(session_name) = reconnect_info
+                    let session_name = {
+                        let Some(name) = reconnect_info
                             .as_ref()
                             .and_then(|r| r.name.clone())
                             .or_else(generate_unique_session_name)
@@ -58,14 +56,12 @@ pub fn zellij_server_listener(
                             client_connection_bus.close_connection();
                             return;
                         };
-                        let mut sock_dir = zellij_utils::consts::ZELLIJ_SOCK_DIR.clone();
-                        if let Err(e) = zellij_utils::sessions::validate_session_name(&session_name) {
+                        if let Err(e) = zellij_utils::sessions::validate_session_name(&name) {
                             log::error!("Invalid session name: {}", e);
                             client_connection_bus.close_connection();
                             return;
                         }
-                        sock_dir.push(session_name.clone());
-                        sock_dir.to_str().unwrap().to_owned()
+                        name
                     };
 
                     reload_config_from_disk(&mut config, &mut config_options, &config_file_path);
@@ -85,13 +81,6 @@ pub fn zellij_server_listener(
                         },
                     };
 
-                    let session_name = PathBuf::from(path.clone())
-                        .file_name()
-                        .unwrap()
-                        .to_str()
-                        .unwrap()
-                        .to_owned();
-
                     // Look up read-only status from connection table
                     let is_read_only = connection_table
                         .lock()
@@ -109,7 +98,7 @@ pub fn zellij_server_listener(
 
                     let should_create_new_session = !session_exists;
                     let first_message = create_first_message(is_read_only, config_file_path.clone(), client_attributes.clone(), config_options.clone(), should_create_new_session, &session_name, initial_layout);
-                    let zellij_ipc_pipe = create_ipc_pipe(&session_name);
+                    let zellij_ipc_pipe = create_ipc_pipe(&session_name, session_exists);
 
                     session_manager.spawn_session_if_needed(
                         &session_name,

--- a/zellij-client/src/web_client/session_management.rs
+++ b/zellij-client/src/web_client/session_management.rs
@@ -1,7 +1,7 @@
 use crate::os_input_output::ClientOsApi;
 use crate::spawn_server;
 
-use std::{fs, path::PathBuf};
+use std::path::PathBuf;
 use zellij_utils::{
     consts::session_layout_cache_file_name,
     data::{ConnectToSession, LayoutInfo, LayoutMetadata, WebSharing},
@@ -133,18 +133,14 @@ pub fn create_first_message(
     }
 }
 
-pub fn create_ipc_pipe(session_name: &str) -> PathBuf {
+pub fn create_ipc_pipe(session_name: &str, session_exists: bool) -> PathBuf {
     if let Err(e) = zellij_utils::sessions::validate_session_name(session_name) {
         log::error!("Invalid session name: {}", e);
         panic!("Invalid session name: {}", e);
     }
-    let zellij_ipc_pipe: PathBuf = {
-        let mut sock_dir = zellij_utils::consts::ZELLIJ_SOCK_DIR.clone();
-        fs::create_dir_all(&sock_dir).unwrap();
-        zellij_utils::shared::set_permissions(&sock_dir, 0o700).unwrap();
-        sock_dir.push(session_name);
-        sock_dir
-    };
-    crate::check_ipc_pipe_length(&zellij_ipc_pipe);
-    zellij_ipc_pipe
+    if session_exists {
+        crate::resolve_session_ipc_pipe(session_name)
+    } else {
+        crate::new_session_ipc_pipe(session_name)
+    }
 }

--- a/zellij-server/Cargo.toml
+++ b/zellij-server/Cargo.toml
@@ -17,7 +17,7 @@ base64 = { version = "0.13.0", default-features = false, features = ["std"] }
 byteorder = { version = "1.4.3", default-features = false, features = ["std"] }
 bytes = { version = "1.6.0", default-features = false, features = ["std"] }
 cassowary = { version = "0.3.0", default-features = false }
-chrono = { version = "0.4.19", default-features = false, features = ["std", "clock"] }
+chrono = { workspace = true }
 crossbeam = { version = "0.8", default-features = false, features = ["crossbeam-channel", "std"] }
 highway = { version = "0.6.4", default-features = false, features = ["std"] }
 interprocess = { workspace = true }

--- a/zellij-server/src/background_jobs.rs
+++ b/zellij-server/src/background_jobs.rs
@@ -20,6 +20,12 @@ use isahc::prelude::*;
 use isahc::AsyncReadResponseExt;
 use isahc::{config::RedirectPolicy, HttpClient, Request};
 
+use crate::panes::PaneId;
+use crate::plugins::{PluginId, PluginInstruction};
+use crate::pty::PtyInstruction;
+use crate::screen::ScreenInstruction;
+use crate::thread_bus::Bus;
+use crate::{ClientId, ServerInstruction};
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::io::Write;
@@ -29,14 +35,6 @@ use std::sync::{
     Arc, Mutex,
 };
 use std::time::{Duration, Instant};
-use zellij_utils::consts::is_ipc_socket;
-
-use crate::panes::PaneId;
-use crate::plugins::{PluginId, PluginInstruction};
-use crate::pty::PtyInstruction;
-use crate::screen::ScreenInstruction;
-use crate::thread_bus::Bus;
-use crate::{ClientId, ServerInstruction};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum BackgroundJob {
@@ -742,37 +740,26 @@ fn read_other_live_session_states(
     sock_dir: &Path,
     session_info_cache_dir: &Path,
 ) -> BTreeMap<String, SessionInfo> {
-    let mut other_session_names: Vec<(String, Duration)> = vec![];
     let mut session_infos_on_machine = BTreeMap::new();
-    // we do this so that the session infos will be actual and we're
-    // reasonably sure their session is running
-    if let Ok(files) = fs::read_dir(sock_dir) {
-        files.for_each(|file| {
-            if let Ok(file) = file {
-                if let Ok(file_name) = file.file_name().into_string() {
-                    if is_ipc_socket(&file.file_type().unwrap()) {
-                        let creation_time = std::fs::metadata(&file.path())
-                            .ok()
-                            .and_then(|f| f.created().ok().or_else(|| f.modified().ok()))
-                            .and_then(|d| d.elapsed().ok())
-                            .unwrap_or_default();
-                        other_session_names.push((file_name, creation_time));
-                    }
-                }
-            }
-        });
-    }
+    let registry = zellij_utils::sessions::ensure_registry();
 
-    for (session_name, creation_time) in other_session_names {
+    for entry in registry.running_sessions() {
+        let session_name = &entry.display_name;
+        let creation_time = std::fs::metadata(sock_dir.join(&entry.id))
+            .ok()
+            .and_then(|f| f.created().ok().or_else(|| f.modified().ok()))
+            .and_then(|d| d.elapsed().ok())
+            .map(|d| Duration::from_secs(d.as_secs()))
+            .unwrap_or_default();
         let session_cache_file_name = session_info_cache_dir
-            .join(&session_name)
+            .join(session_name)
             .join("session-metadata.kdl");
         if let Ok(raw_session_info) = fs::read_to_string(&session_cache_file_name) {
             if let Ok(mut session_info) =
                 SessionInfo::from_string(&raw_session_info, &current_session_name)
             {
                 session_info.creation_time = creation_time;
-                session_infos_on_machine.insert(session_name, session_info);
+                session_infos_on_machine.insert(session_name.clone(), session_info);
             }
         }
     }

--- a/zellij-server/src/background_jobs.rs
+++ b/zellij-server/src/background_jobs.rs
@@ -624,8 +624,19 @@ pub(crate) fn background_jobs_main(
                     loading_plugin.store(false, Ordering::SeqCst);
                 }
 
-                let cache_file_name =
-                    session_info_cache_file_name(&current_session_name.lock().unwrap().to_owned());
+                // Flush the current layout to disk before shutting down so the
+                // session is resurrectable even if it exited before the
+                // periodic SESSION_METADATA_WRITE_INTERVAL_MS ticker fired.
+                // Writes session-layout.kdl which list-sessions uses to mark
+                // the session as resurrectable.
+                let name = current_session_name.lock().unwrap().clone();
+                if !name.is_empty() {
+                    let info = current_session_info.lock().unwrap().clone();
+                    let layout = current_session_layout.lock().unwrap().clone();
+                    write_session_state_to_disk(name.clone(), info, layout);
+                }
+
+                let cache_file_name = session_info_cache_file_name(&name);
                 let _ = std::fs::remove_file(cache_file_name);
                 return Ok(());
             },

--- a/zellij-server/src/background_jobs.rs
+++ b/zellij-server/src/background_jobs.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)] // some imports used only with web_server_capability feature
 use zellij_utils::consts::{
-    session_info_cache_file_name, session_info_folder_for_session, session_layout_cache_file_name,
-    VERSION, ZELLIJ_SESSION_INFO_CACHE_DIR, ZELLIJ_SOCK_DIR,
+    is_ipc_socket, session_info_cache_file_name, session_info_folder_for_session,
+    session_layout_cache_file_name, VERSION, ZELLIJ_SESSION_INFO_CACHE_DIR, ZELLIJ_SOCK_DIR,
 };
 #[allow(unused_imports)]
 use zellij_utils::data::{Event, HttpVerb, LayoutInfo, SessionInfo, WebServerStatus};
@@ -752,25 +752,51 @@ fn read_other_live_session_states(
     session_info_cache_dir: &Path,
 ) -> BTreeMap<String, SessionInfo> {
     let mut session_infos_on_machine = BTreeMap::new();
+    // The registry maps UUID-named sockets to their user-visible display names.
+    // For legacy or test sockets named directly after the session, the registry
+    // lookup misses and we fall back to the filename.
     let registry = zellij_utils::sessions::ensure_registry();
 
-    for entry in registry.running_sessions() {
-        let session_name = &entry.display_name;
-        let creation_time = std::fs::metadata(sock_dir.join(&entry.id))
+    let entries = match fs::read_dir(sock_dir) {
+        Ok(entries) => entries,
+        Err(_) => return session_infos_on_machine,
+    };
+
+    for entry in entries.flatten() {
+        let file_name = match entry.file_name().into_string() {
+            Ok(n) => n,
+            Err(_) => continue,
+        };
+        if file_name == "sessions.kdl" || file_name == "sessions.kdl.lock" {
+            continue;
+        }
+        let file_type = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(_) => continue,
+        };
+        if !is_ipc_socket(&file_type) {
+            continue;
+        }
+
+        let session_name = registry
+            .find_by_id(&file_name)
+            .map(|e| e.display_name.clone())
+            .unwrap_or(file_name);
+        let creation_time = std::fs::metadata(entry.path())
             .ok()
             .and_then(|f| f.created().ok().or_else(|| f.modified().ok()))
             .and_then(|d| d.elapsed().ok())
             .map(|d| Duration::from_secs(d.as_secs()))
             .unwrap_or_default();
         let session_cache_file_name = session_info_cache_dir
-            .join(session_name)
+            .join(&session_name)
             .join("session-metadata.kdl");
         if let Ok(raw_session_info) = fs::read_to_string(&session_cache_file_name) {
             if let Ok(mut session_info) =
-                SessionInfo::from_string(&raw_session_info, &current_session_name)
+                SessionInfo::from_string(&raw_session_info, current_session_name)
             {
                 session_info.creation_time = creation_time;
-                session_infos_on_machine.insert(session_name.clone(), session_info);
+                session_infos_on_machine.insert(session_name, session_info);
             }
         }
     }

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -2256,5 +2256,5 @@ fn get_available_layouts(config_options: &Options) -> (Vec<LayoutInfo>, Vec<Layo
 }
 
 #[cfg(test)]
-#[path = "./unit/session_harness_tests.rs"]
-mod session_harness_tests;
+#[path = "./unit/session_registry_tests.rs"]
+mod session_registry_tests;

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -441,23 +441,32 @@ impl SessionMetaData {
 
 impl Drop for SessionMetaData {
     fn drop(&mut self) {
-        let _ = self.senders.send_to_pty(PtyInstruction::Exit);
+        // Force a final serialization so the session shows up in list-sessions
+        // even if it exited before the periodic serialization interval fired.
+        // The flow Screen -> Plugin -> PTY must drain fully before any thread
+        // sees its Exit message, otherwise the disk write is lost. So we exit
+        // the threads in pipeline order (screen first, then plugin, then pty),
+        // joining each one before queuing Exit on the next.
+        let _ = self
+            .senders
+            .send_to_screen(ScreenInstruction::SerializeLayoutForResurrection);
         let _ = self.senders.send_to_screen(ScreenInstruction::Exit);
-        let _ = self.senders.send_to_plugin(PluginInstruction::Exit);
-        let _ = self.senders.send_to_pty_writer(PtyWriteInstruction::Exit);
-        let _ = self.senders.send_to_background_jobs(BackgroundJob::Exit);
         if let Some(screen_thread) = self.screen_thread.take() {
             let _ = screen_thread.join();
         }
-        if let Some(pty_thread) = self.pty_thread.take() {
-            let _ = pty_thread.join();
-        }
+        let _ = self.senders.send_to_plugin(PluginInstruction::Exit);
         if let Some(plugin_thread) = self.plugin_thread.take() {
             let _ = plugin_thread.join();
         }
+        let _ = self.senders.send_to_pty(PtyInstruction::Exit);
+        if let Some(pty_thread) = self.pty_thread.take() {
+            let _ = pty_thread.join();
+        }
+        let _ = self.senders.send_to_pty_writer(PtyWriteInstruction::Exit);
         if let Some(pty_writer_thread) = self.pty_writer_thread.take() {
             let _ = pty_writer_thread.join();
         }
+        let _ = self.senders.send_to_background_jobs(BackgroundJob::Exit);
         if let Some(background_jobs_thread) = self.background_jobs_thread.take() {
             let _ = background_jobs_thread.join();
         }

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -664,11 +664,13 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
         // preserve the current umask: read current value by setting to another mode, and then restoring it
         let current_umask = umask(Mode::all());
         umask(current_umask);
-        daemonize::Daemonize::new()
-            .working_directory(std::env::current_dir().unwrap())
-            .umask(current_umask.bits() as u32)
-            .start()
-            .expect("could not daemonize the server process");
+        if std::env::var("ZELLIJ_NO_DAEMONIZE").is_err() {
+            daemonize::Daemonize::new()
+                .working_directory(std::env::current_dir().unwrap())
+                .umask(current_umask.bits() as u32)
+                .start()
+                .expect("could not daemonize the server process");
+        }
     }
 
     #[cfg(windows)]
@@ -2252,3 +2254,7 @@ fn get_available_layouts(config_options: &Options) -> (Vec<LayoutInfo>, Vec<Layo
         .map(|l| format!("{}", l.display()));
     Layout::list_available_layouts(layout_dir, &default_layout_name)
 }
+
+#[cfg(test)]
+#[path = "./unit/session_harness_tests.rs"]
+mod session_harness_tests;

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -653,6 +653,11 @@ impl SessionState {
 pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
     info!("Starting Zellij server!");
 
+    let session_id = socket_path
+        .file_name()
+        .map(|f| f.to_string_lossy().to_string())
+        .unwrap_or_default();
+
     #[cfg(unix)]
     {
         use nix::sys::stat::{umask, Mode};
@@ -681,6 +686,15 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
     }
 
     envs::set_zellij("0".to_string());
+
+    // Update PID in session registry (post-daemonize on Unix, so this is the real PID).
+    if let Err(e) = zellij_utils::sessions::with_registry(|reg| {
+        if let Some(entry) = reg.find_by_id_mut(&session_id) {
+            entry.pid = Some(std::process::id());
+        }
+    }) {
+        log::error!("Failed to update PID in session registry: {:?}", e);
+    }
 
     let (to_server, server_receiver): ChannelWithContext<ServerInstruction> = channels::bounded(50);
     let to_server = SenderWithContext::new(to_server);
@@ -818,6 +832,7 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                     config.clone(),
                     config.plugins.clone(),
                     client_id,
+                    session_id.clone(),
                 );
                 info!("FirstClientConnected: session initialized, spawning tabs");
                 let mut runtime_configuration = config.clone();
@@ -1713,6 +1728,17 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
     // Drop cached session data before exit.
     *session_data.write().unwrap() = None;
 
+    // Update session registry: mark as exited, clear PID.
+    if let Err(e) = zellij_utils::sessions::with_registry(|reg| {
+        if let Some(entry) = reg.find_by_id_mut(&session_id) {
+            entry.state = zellij_utils::sessions::SessionState::Exited;
+            entry.pid = None;
+            entry.exited_at = Some(chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string());
+        }
+    }) {
+        log::error!("Failed to update session registry on exit: {:?}", e);
+    }
+
     drop(std::fs::remove_file(&socket_path));
 }
 
@@ -1726,6 +1752,7 @@ fn init_session(
     mut config: Config,
     plugin_aliases: PluginAliases,
     client_id: ClientId,
+    session_id: String,
 ) -> SessionMetaData {
     config.options = config.options.merge(*config_options.clone());
 
@@ -1831,6 +1858,7 @@ fn init_session(
             let debug = cli_assets.is_debug;
             let layout = layout.clone();
             let config = config.clone();
+            let session_id = session_id.clone();
             move || {
                 screen_thread_main(
                     screen_bus,
@@ -1839,6 +1867,7 @@ fn init_session(
                     config,
                     debug,
                     layout,
+                    session_id,
                 )
                 .fatal();
             }

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -2924,19 +2924,13 @@ fn delete_dead_session(session_name: String) -> Result<()> {
 }
 
 fn delete_all_dead_sessions() -> Result<()> {
-    use zellij_utils::consts::is_ipc_socket;
-    let mut live_sessions = vec![];
-    if let Ok(files) = std::fs::read_dir(&*ZELLIJ_SOCK_DIR) {
-        files.for_each(|file| {
-            if let Ok(file) = file {
-                if let Ok(file_name) = file.file_name().into_string() {
-                    if is_ipc_socket(&file.file_type().unwrap()) {
-                        live_sessions.push(file_name);
-                    }
-                }
-            }
-        });
-    }
+    let registry = zellij_utils::sessions::ensure_registry();
+    let live_sessions: Vec<String> = registry
+        .running_sessions()
+        .iter()
+        .map(|e| e.display_name.clone())
+        .collect();
+
     let dead_sessions: Vec<String> = match std::fs::read_dir(&*ZELLIJ_SESSION_INFO_CACHE_DIR) {
         Ok(files_in_session_info_folder) => {
             let files_that_are_folders = files_in_session_info_folder
@@ -2946,7 +2940,6 @@ fn delete_all_dead_sessions() -> Result<()> {
                 .filter_map(|folder_name| {
                     let session_name = folder_name.file_name()?.to_str()?.to_owned();
                     if live_sessions.contains(&session_name) {
-                        // this is not a dead session...
                         return None;
                     }
                     Some(session_name)
@@ -3275,7 +3268,9 @@ fn disconnect_other_clients(env: &PluginEnv) {
 
 fn kill_sessions(session_names: Vec<String>) {
     for session_name in session_names {
-        let path = &*ZELLIJ_SOCK_DIR.join(&session_name);
+        let resolved = zellij_utils::sessions::resolve_session_socket_path(&session_name)
+            .unwrap_or_else(|| ZELLIJ_SOCK_DIR.join(&session_name));
+        let path = &*resolved;
         match ipc_connect(path) {
             Ok(stream) => {
                 #[cfg(windows)]

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1320,6 +1320,7 @@ pub(crate) struct Screen {
     copy_options: CopyOptions,
     debug: bool,
     session_name: String,
+    session_id: String,
     peer_sessions_cache: BTreeMap<String, SessionInfo>, // String is the session name, can
     // also be this session
     resurrectable_sessions_cache: BTreeMap<String, Duration>, // String is the session name,
@@ -1392,6 +1393,7 @@ impl Screen {
         mouse_click_through: bool,
         web_server_ip: IpAddr,
         web_server_port: u16,
+        session_id: String,
     ) -> Self {
         let session_name = mode_info.session_name.clone().unwrap_or_default();
         let session_info = SessionInfo::new(session_name.clone());
@@ -1424,6 +1426,7 @@ impl Screen {
             copy_options,
             debug,
             session_name,
+            session_id,
             peer_sessions_cache,
             default_layout,
             default_layout_name,
@@ -2904,7 +2907,7 @@ impl Screen {
         }
         let available_layouts = self.cached_layouts.clone();
         let creation_time = {
-            let sock_path = ZELLIJ_SOCK_DIR.join(&self.session_name);
+            let sock_path = ZELLIJ_SOCK_DIR.join(&self.session_id);
             std::fs::metadata(&sock_path)
                 .ok()
                 .and_then(|f| f.created().ok().or_else(|| f.modified().ok()))
@@ -4959,6 +4962,7 @@ pub(crate) fn screen_thread_main(
     config: Config,
     debug: bool,
     default_layout: Box<Layout>,
+    session_id: String,
 ) -> Result<()> {
     let config_options = config.options;
     let arrow_fonts = !config_options.simplified_ui.unwrap_or_default();
@@ -5058,6 +5062,7 @@ pub(crate) fn screen_thread_main(
         mouse_click_through,
         web_server_ip,
         web_server_port,
+        session_id,
     );
 
     let mut pending_tab_ids: HashSet<usize> = HashSet::new();
@@ -7983,16 +7988,17 @@ pub(crate) fn screen_thread_main(
                         tab.rename_session(name.clone()).with_context(err_context)?;
                     }
 
-                    // rename socket file
-                    let old_socket_file_path = ZELLIJ_SOCK_DIR.join(&old_session_name);
-                    let new_socket_file_path = ZELLIJ_SOCK_DIR.join(&name);
-                    if let Err(e) = std::fs::rename(old_socket_file_path, new_socket_file_path) {
-                        log::error!("Failed to rename ipc socket: {:?}", e);
+                    // update session name in registry (socket file is never renamed)
+                    let session_id = screen.session_id.clone();
+                    if let Err(e) = zellij_utils::sessions::with_registry(|reg| {
+                        if let Some(entry) = reg.find_by_id_mut(&session_id) {
+                            entry.display_name = name.clone();
+                        }
+                    }) {
+                        log::error!("Failed to update session registry: {:?}", e);
                     }
 
-                    // rename session_info folder (TODO: make this atomic, right now there is a
-                    // chance background_jobs will re-create this folder before it knows the
-                    // session was renamed)
+                    // rename session_info folder
                     let old_session_info_folder =
                         session_info_folder_for_session(&old_session_name);
                     let new_session_info_folder = session_info_folder_for_session(&name);

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -330,6 +330,7 @@ fn create_new_screen(
         false, // mouse_click_through
         web_server_ip,
         web_server_port,
+        "a3f7b9c1-e29b-41d4-a716-446655440000".to_string(),
     );
     screen
 }
@@ -392,6 +393,7 @@ impl MockScreen {
                     config,
                     debug,
                     Box::new(Layout::default()),
+                    "a3f7b9c1-e29b-41d4-a716-446655440000".to_string(),
                 )
                 .expect("TEST")
             })
@@ -478,6 +480,7 @@ impl MockScreen {
                     config,
                     debug,
                     Box::new(Layout::default()),
+                    "a3f7b9c1-e29b-41d4-a716-446655440000".to_string(),
                 )
                 .expect("TEST")
             })
@@ -5366,6 +5369,7 @@ fn create_new_screen_with_message_capture(
         false, // mouse_click_through
         web_server_ip,
         web_server_port,
+        "a3f7b9c1-e29b-41d4-a716-446655440000".to_string(),
     );
     (screen, messages)
 }

--- a/zellij-server/src/unit/session_harness_tests.rs
+++ b/zellij-server/src/unit/session_harness_tests.rs
@@ -1,0 +1,132 @@
+//! Integration test harness prototype.
+//!
+//! Demonstrates the session registry (sessions.kdl) lifecycle through direct
+//! registry API calls — register, rename, exit, migration.
+//!
+//! ## Concurrency note
+//!
+//! These tests share a single `sessions.kdl` file (determined by the
+//! `ZELLIJ_SOCK_DIR` lazy_static). Each test performs its full workflow
+//! inside a single `with_registry` call to avoid races with parallel tests.
+//!
+//! ## Future direction
+//!
+//! A full `TestSession` harness that spawns a real server thread (with
+//! `ZELLIJ_NO_DAEMONIZE=1` on Unix) and communicates via IPC sockets
+//! requires:
+//! - Per-test `ZELLIJ_SOCKET_DIR` isolation (before lazy_static init)
+//! - A `ServerOsApi` mock that implements `new_client` with real sockets
+//! - Thread lifecycle management (spawn, connect, kill, join)
+
+use zellij_utils::sessions::{
+    ensure_registry, generate_session_id, with_registry, SessionEntry, SessionState,
+};
+
+/// Verify that registering and reading back a session works atomically.
+#[test]
+fn registry_register_and_read_back() {
+    let id = generate_session_id();
+    let display_name = format!("harness-test-{}", &id[..8]);
+
+    with_registry(|reg| {
+        reg.sessions.push(SessionEntry {
+            id: id.clone(),
+            display_name: display_name.clone(),
+            pid: Some(99999),
+            state: SessionState::Running,
+            created_at: "2024-01-15T10:00:00Z".to_string(),
+            exited_at: None,
+        });
+
+        let entry = reg.find_by_id(&id).expect("session not found after insert");
+        assert_eq!(entry.display_name, display_name);
+        assert_eq!(entry.state, SessionState::Running);
+        assert_eq!(entry.pid, Some(99999));
+
+        // Clean up within the same transaction.
+        reg.remove_by_id(&id);
+    })
+    .expect("with_registry failed");
+}
+
+/// Verify that renaming a session updates display_name but not the id.
+#[test]
+fn registry_rename_session() {
+    let id = generate_session_id();
+    let original_name = format!("rename-orig-{}", &id[..8]);
+    let new_name = format!("rename-new-{}", &id[..8]);
+
+    with_registry(|reg| {
+        reg.sessions.push(SessionEntry {
+            id: id.clone(),
+            display_name: original_name.clone(),
+            pid: Some(99999),
+            state: SessionState::Running,
+            created_at: "2024-01-15T10:00:00Z".to_string(),
+            exited_at: None,
+        });
+
+        // Rename.
+        let entry = reg.find_by_id_mut(&id).expect("session not found");
+        entry.display_name = new_name.clone();
+
+        // Verify.
+        assert!(reg.find_running_by_name(&original_name).is_none());
+        let entry = reg
+            .find_running_by_name(&new_name)
+            .expect("renamed session not found");
+        assert_eq!(entry.id, id, "id must not change on rename");
+
+        reg.remove_by_id(&id);
+    })
+    .expect("with_registry failed");
+}
+
+/// Verify that marking a session as exited clears PID and removes it from
+/// running lookups.
+#[test]
+fn registry_mark_session_exited() {
+    let id = generate_session_id();
+    let name = format!("exit-test-{}", &id[..8]);
+
+    with_registry(|reg| {
+        reg.sessions.push(SessionEntry {
+            id: id.clone(),
+            display_name: name.clone(),
+            pid: Some(99999),
+            state: SessionState::Running,
+            created_at: "2024-01-15T10:00:00Z".to_string(),
+            exited_at: None,
+        });
+
+        // Simulate server exit.
+        let entry = reg.find_by_id_mut(&id).expect("session not found");
+        entry.state = SessionState::Exited;
+        entry.pid = None;
+        entry.exited_at = Some("2024-01-15T18:00:00Z".to_string());
+
+        // Verify.
+        let entry = reg.find_by_id(&id).expect("session not found after exit");
+        assert_eq!(entry.state, SessionState::Exited);
+        assert!(entry.pid.is_none());
+        assert!(entry.exited_at.is_some());
+        assert!(
+            reg.find_running_by_name(&name).is_none(),
+            "exited session should not appear in running lookups"
+        );
+
+        reg.remove_by_id(&id);
+    })
+    .expect("with_registry failed");
+}
+
+/// Verify that ensure_registry creates the file if missing.
+#[test]
+fn ensure_registry_creates_file() {
+    let registry = ensure_registry();
+    assert!(
+        zellij_utils::consts::ZELLIJ_SESSIONS_KDL.exists(),
+        "sessions.kdl should exist after ensure_registry"
+    );
+    let _ = registry.running_sessions();
+}

--- a/zellij-server/src/unit/session_registry_tests.rs
+++ b/zellij-server/src/unit/session_registry_tests.rs
@@ -1,22 +1,14 @@
-//! Integration test harness prototype.
+//! Session registry lifecycle tests.
 //!
-//! Demonstrates the session registry (sessions.kdl) lifecycle through direct
-//! registry API calls — register, rename, exit, migration.
+//! Exercises `sessions.kdl` through direct registry API calls — register,
+//! rename, exit, migration. No server threads or IPC involved; for that,
+//! see `zellij-server/tests/session_integration.rs`.
 //!
 //! ## Concurrency note
 //!
 //! These tests share a single `sessions.kdl` file (determined by the
 //! `ZELLIJ_SOCK_DIR` lazy_static). Each test performs its full workflow
 //! inside a single `with_registry` call to avoid races with parallel tests.
-//!
-//! ## Future direction
-//!
-//! A full `TestSession` harness that spawns a real server thread (with
-//! `ZELLIJ_NO_DAEMONIZE=1` on Unix) and communicates via IPC sockets
-//! requires:
-//! - Per-test `ZELLIJ_SOCKET_DIR` isolation (before lazy_static init)
-//! - A `ServerOsApi` mock that implements `new_client` with real sockets
-//! - Thread lifecycle management (spawn, connect, kill, join)
 
 use zellij_utils::sessions::{
     ensure_registry, generate_session_id, with_registry, SessionEntry, SessionState,

--- a/zellij-server/tests/session_integration.rs
+++ b/zellij-server/tests/session_integration.rs
@@ -1,0 +1,442 @@
+//! Integration test: real client-server communication via IPC sockets.
+//!
+//! This test binary gets its own process, so we can set `ZELLIJ_SOCKET_DIR`
+//! before any lazy_static is initialized, giving us full test isolation.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use zellij_server::os_input_output::{AsyncReader, ServerOsApi};
+use zellij_server::panes::PaneId;
+use zellij_utils::channels;
+use zellij_utils::consts::{ipc_connect, ZELLIJ_SOCK_DIR};
+use zellij_utils::data::Palette;
+use zellij_utils::errors::prelude::*;
+use zellij_utils::input::cli_assets::CliAssets;
+use zellij_utils::input::command::RunCommand;
+use zellij_utils::ipc::{
+    ClientToServerMsg, IpcReceiverWithContext, IpcSenderWithContext, ServerToClientMsg,
+};
+use zellij_utils::pane_size::Size;
+use zellij_utils::sessions::register_session;
+
+use interprocess::local_socket::Stream as LocalSocketStream;
+
+type ClientId = u16;
+
+/// Shared test directory — initialized once per process.
+static TEST_DIR: std::sync::OnceLock<tempfile::TempDir> = std::sync::OnceLock::new();
+
+fn init_test_env() {
+    TEST_DIR.get_or_init(|| {
+        let tmpdir = tempfile::tempdir().expect("failed to create tmpdir");
+        std::env::set_var("ZELLIJ_SOCKET_DIR", tmpdir.path());
+        std::env::set_var("ZELLIJ_NO_DAEMONIZE", "1");
+        let sock_dir = tmpdir.path().join(format!(
+            "contract_version_{}",
+            zellij_utils::consts::CLIENT_SERVER_CONTRACT_VERSION,
+        ));
+        std::fs::create_dir_all(&sock_dir).unwrap();
+        tmpdir
+    });
+}
+
+/// Channel-driven mock PTY reader. The test pushes output bytes via
+/// `PaneOutputSender`, and the server's terminal_bytes thread reads them
+/// through this reader as if a real PTY produced them.
+struct MockAsyncReader {
+    receiver: tokio::sync::mpsc::Receiver<Vec<u8>>,
+    buf: Vec<u8>,
+}
+
+impl MockAsyncReader {
+    fn new(receiver: tokio::sync::mpsc::Receiver<Vec<u8>>) -> Self {
+        Self {
+            receiver,
+            buf: Vec::new(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl AsyncReader for MockAsyncReader {
+    async fn read(&mut self, buf: &mut [u8]) -> std::result::Result<usize, std::io::Error> {
+        // If we have leftover data from a previous chunk, serve it first.
+        if !self.buf.is_empty() {
+            let n = std::cmp::min(buf.len(), self.buf.len());
+            buf[..n].copy_from_slice(&self.buf[..n]);
+            self.buf.drain(..n);
+            return Ok(n);
+        }
+        // Wait for the next chunk from the test.
+        match self.receiver.recv().await {
+            Some(data) => {
+                let n = std::cmp::min(buf.len(), data.len());
+                buf[..n].copy_from_slice(&data[..n]);
+                if data.len() > n {
+                    self.buf.extend_from_slice(&data[n..]);
+                }
+                Ok(n)
+            },
+            None => {
+                // Channel closed — sleep forever (pane stays idle).
+                loop {
+                    tokio::time::sleep(Duration::from_secs(3600)).await;
+                }
+            },
+        }
+    }
+}
+
+/// Handle for pushing output to a specific pane's mock PTY.
+type PaneOutputSender = tokio::sync::mpsc::Sender<Vec<u8>>;
+
+/// Minimal ServerOsApi for integration tests.
+///
+/// Real IPC client handling. Mock PTY with channel-driven output.
+#[derive(Clone, Default)]
+struct HarnessOsInput {
+    client_senders: Arc<Mutex<HashMap<ClientId, channels::Sender<ServerToClientMsg>>>>,
+    pane_senders: Arc<Mutex<HashMap<u32, PaneOutputSender>>>,
+}
+
+impl HarnessOsInput {
+    /// Get a sender for pushing output to a pane by terminal_id.
+    fn pane_output_sender(&self, terminal_id: u32) -> Option<PaneOutputSender> {
+        self.pane_senders.lock().unwrap().get(&terminal_id).cloned()
+    }
+
+    /// Return all terminal IDs that have been allocated by this harness.
+    fn terminal_ids(&self) -> Vec<u32> {
+        self.pane_senders.lock().unwrap().keys().copied().collect()
+    }
+}
+
+impl ServerOsApi for HarnessOsInput {
+    fn set_terminal_size_using_terminal_id(
+        &self,
+        _id: u32,
+        _cols: u16,
+        _rows: u16,
+        _w: Option<u16>,
+        _h: Option<u16>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn spawn_terminal(
+        &self,
+        _action: zellij_utils::input::command::TerminalAction,
+        _quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>,
+        _default_editor: Option<PathBuf>,
+    ) -> Result<(u32, Box<dyn AsyncReader>, Option<u32>)> {
+        static NEXT_ID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(1);
+        let id = NEXT_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let (tx, rx) = tokio::sync::mpsc::channel(256);
+        self.pane_senders.lock().unwrap().insert(id, tx);
+        Ok((id, Box::new(MockAsyncReader::new(rx)), None))
+    }
+
+    fn reserve_terminal_id(&self) -> Result<u32> {
+        static NEXT_ID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(1000);
+        Ok(NEXT_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst))
+    }
+
+    fn write_to_tty_stdin(&self, _id: u32, _buf: &[u8]) -> Result<usize> {
+        Ok(0)
+    }
+    fn tcdrain(&self, _id: u32) -> Result<()> {
+        Ok(())
+    }
+    fn kill(&self, _pid: u32) -> Result<()> {
+        Ok(())
+    }
+    fn force_kill(&self, _pid: u32) -> Result<()> {
+        Ok(())
+    }
+    fn send_sigint(&self, _pid: u32) -> Result<()> {
+        Ok(())
+    }
+
+    fn box_clone(&self) -> Box<dyn ServerOsApi> {
+        Box::new((*self).clone())
+    }
+
+    fn send_to_client(&self, client_id: ClientId, msg: ServerToClientMsg) -> Result<()> {
+        if let Some(sender) = self.client_senders.lock().unwrap().get(&client_id) {
+            let _ = sender.send(msg);
+        }
+        Ok(())
+    }
+
+    fn new_client(
+        &mut self,
+        client_id: ClientId,
+        stream: LocalSocketStream,
+    ) -> Result<IpcReceiverWithContext<ClientToServerMsg>> {
+        let receiver = IpcReceiverWithContext::new(stream);
+        let ipc_sender: IpcSenderWithContext<ServerToClientMsg> = receiver.get_sender();
+        let (tx, rx) = channels::bounded::<ServerToClientMsg>(500);
+        thread::spawn(move || {
+            let mut ipc_sender = ipc_sender;
+            for msg in rx.iter() {
+                let _ = ipc_sender.send_server_msg(msg);
+            }
+        });
+        self.client_senders.lock().unwrap().insert(client_id, tx);
+        Ok(receiver)
+    }
+
+    fn new_client_with_reply(
+        &mut self,
+        client_id: ClientId,
+        stream: LocalSocketStream,
+        reply_stream: LocalSocketStream,
+    ) -> Result<IpcReceiverWithContext<ClientToServerMsg>> {
+        let receiver = IpcReceiverWithContext::new(stream);
+        let ipc_sender: IpcSenderWithContext<ServerToClientMsg> =
+            IpcSenderWithContext::new(reply_stream);
+        let (tx, rx) = channels::bounded::<ServerToClientMsg>(500);
+        thread::spawn(move || {
+            let mut ipc_sender = ipc_sender;
+            for msg in rx.iter() {
+                let _ = ipc_sender.send_server_msg(msg);
+            }
+        });
+        self.client_senders.lock().unwrap().insert(client_id, tx);
+        Ok(receiver)
+    }
+
+    fn remove_client(&mut self, client_id: ClientId) -> Result<()> {
+        self.client_senders.lock().unwrap().remove(&client_id);
+        Ok(())
+    }
+    fn load_palette(&self) -> Palette {
+        Palette::default()
+    }
+    fn get_cwd(&self, _pid: u32) -> Option<PathBuf> {
+        None
+    }
+    fn write_to_file(&mut self, _buf: String, _file: Option<String>) -> Result<()> {
+        Ok(())
+    }
+    fn re_run_command_in_terminal(
+        &self,
+        _id: u32,
+        _cmd: RunCommand,
+        _quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send>,
+    ) -> Result<(Box<dyn AsyncReader>, Option<u32>)> {
+        let (tx, rx) = tokio::sync::mpsc::channel(256);
+        // We don't track re-run terminals in pane_senders for now.
+        drop(tx);
+        Ok((Box::new(MockAsyncReader::new(rx)), None))
+    }
+    fn clear_terminal_id(&self, _id: u32) -> Result<()> {
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// Try to connect to the server (main pipe + reply pipe on Windows).
+fn try_connect(
+    socket_path: &std::path::Path,
+) -> Option<(
+    IpcSenderWithContext<ClientToServerMsg>,
+    IpcReceiverWithContext<ServerToClientMsg>,
+)> {
+    let stream = ipc_connect(socket_path).ok()?;
+    #[cfg(windows)]
+    {
+        let reply_stream = zellij_utils::consts::ipc_connect_reply(socket_path).ok()?;
+        Some((
+            IpcSenderWithContext::new(stream),
+            IpcReceiverWithContext::new(reply_stream),
+        ))
+    }
+    #[cfg(not(windows))]
+    {
+        let sender = IpcSenderWithContext::new(stream);
+        let receiver = sender.get_receiver();
+        Some((sender, receiver))
+    }
+}
+
+fn minimal_cli_assets() -> CliAssets {
+    CliAssets {
+        config_file_path: None,
+        config_dir: None,
+        should_ignore_config: true,
+        configuration_options: None,
+        layout: None,
+        terminal_window_size: Size { rows: 24, cols: 80 },
+        data_dir: None,
+        is_debug: false,
+        max_panes: None,
+        force_run_layout_commands: false,
+        cwd: None,
+    }
+}
+
+/// A running test session with mock PTY output.
+struct TestSession {
+    pub sender: IpcSenderWithContext<ClientToServerMsg>,
+    pub receiver: IpcReceiverWithContext<ServerToClientMsg>,
+    os_input: HarnessOsInput,
+}
+
+impl TestSession {
+    /// Spawn a server, connect, initialize a session, wait for Render.
+    fn new(session_name: &str) -> Self {
+        init_test_env();
+        let session_id = register_session(session_name).expect("failed to register session");
+        let socket_path = ZELLIJ_SOCK_DIR.join(&session_id);
+
+        let os_input = HarnessOsInput::default();
+        let os_input_clone = os_input.clone();
+        let server_socket_path = socket_path.clone();
+        thread::spawn(move || {
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                zellij_server::start_server(Box::new(os_input_clone), server_socket_path);
+            }));
+        });
+
+        // Poll until connected.
+        let (mut sender, receiver) = {
+            let mut conn = None;
+            for _ in 0..200 {
+                if let Some(c) = try_connect(&socket_path) {
+                    conn = Some(c);
+                    break;
+                }
+                thread::sleep(Duration::from_millis(10));
+            }
+            conn.expect("timed out waiting for server to bind")
+        };
+
+        sender
+            .send_client_msg(ClientToServerMsg::FirstClientConnected {
+                cli_assets: minimal_cli_assets(),
+                is_web_client: false,
+            })
+            .expect("failed to send FirstClientConnected");
+
+        let mut session = TestSession {
+            sender,
+            receiver,
+            os_input,
+        };
+        session.wait_for_render();
+        session
+    }
+
+    /// Push output bytes to a pane's mock PTY.
+    fn push_pane_output(&self, terminal_id: u32, data: &[u8]) {
+        if let Some(tx) = self.os_input.pane_output_sender(terminal_id) {
+            tx.blocking_send(data.to_vec())
+                .expect("failed to push pane output");
+        } else {
+            panic!("no pane with terminal_id {}", terminal_id);
+        }
+    }
+
+    /// Send an action to the server.
+    fn send_action(&mut self, action: zellij_utils::input::actions::Action) {
+        self.sender
+            .send_client_msg(ClientToServerMsg::Action {
+                action,
+                terminal_id: None,
+                client_id: None,
+                is_cli_client: false,
+            })
+            .expect("failed to send action");
+    }
+
+    /// Drain messages until we get a Render, return its content.
+    fn wait_for_render(&mut self) -> String {
+        for _ in 0..100 {
+            match self.receiver.recv_server_msg() {
+                Some((ServerToClientMsg::Render { content }, _)) => return content,
+                Some(_) => continue,
+                None => thread::sleep(Duration::from_millis(50)),
+            }
+        }
+        panic!("timed out waiting for Render");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn session_initializes_and_renders() {
+    let session = TestSession::new("init-test");
+    // If we got here, the server initialized, created a pane, and rendered.
+    drop(session);
+}
+
+#[test]
+fn client_can_rename_session_via_action() {
+    let session_name = "rename-action-test";
+    let mut session = TestSession::new(session_name);
+
+    session.send_action(zellij_utils::input::actions::Action::RenameSession {
+        name: "renamed-session".to_string(),
+    });
+
+    let mut got_renamed = false;
+    for _ in 0..50 {
+        match session.receiver.recv_server_msg() {
+            Some((ServerToClientMsg::RenamedSession { name }, _)) => {
+                assert_eq!(name, "renamed-session");
+                got_renamed = true;
+                break;
+            },
+            Some(_) => continue,
+            None => thread::sleep(Duration::from_millis(50)),
+        }
+    }
+    assert!(
+        got_renamed,
+        "client should receive RenamedSession notification"
+    );
+
+    let registry = zellij_utils::sessions::read_registry();
+    assert!(registry.find_running_by_name("renamed-session").is_some());
+    assert!(registry.find_running_by_name(session_name).is_none());
+}
+
+#[test]
+fn pane_displays_mock_pty_output() {
+    let mut session = TestSession::new("pty-output-test");
+
+    // Get the terminal ID of the first pane (allocated by spawn_terminal).
+    let terminal_ids = session.os_input.terminal_ids();
+    assert!(!terminal_ids.is_empty(), "no terminals were spawned");
+    let first_terminal = *terminal_ids.iter().min().unwrap();
+    session.push_pane_output(first_terminal, b"hello from mock pty\r\n");
+
+    // The server only sends Render on certain events (resize, input, etc.),
+    // not immediately when pane content changes. Force a re-render by
+    // sending a terminal resize.
+    session
+        .sender
+        .send_client_msg(ClientToServerMsg::TerminalResize {
+            new_size: Size { rows: 24, cols: 80 },
+        })
+        .expect("failed to send resize");
+
+    let render = session.wait_for_render();
+
+    assert!(
+        render.contains("hello from mock pty"),
+        "Render should contain mock PTY output. Render length: {} bytes",
+        render.len(),
+    );
+}

--- a/zellij-server/tests/session_integration.rs
+++ b/zellij-server/tests/session_integration.rs
@@ -368,6 +368,24 @@ impl TestSession {
         }
         panic!("timed out waiting for Render");
     }
+
+    /// Drain Render messages until one contains `needle`, return its content.
+    /// Avoids races where the first Render arrives before async PTY bytes have
+    /// been parsed into the grid.
+    fn wait_for_render_containing(&mut self, needle: &str) -> String {
+        for _ in 0..200 {
+            match self.receiver.recv_server_msg() {
+                Some((ServerToClientMsg::Render { content }, _)) => {
+                    if content.contains(needle) {
+                        return content;
+                    }
+                },
+                Some(_) => continue,
+                None => thread::sleep(Duration::from_millis(50)),
+            }
+        }
+        panic!("timed out waiting for Render containing {:?}", needle);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -432,11 +450,5 @@ fn pane_displays_mock_pty_output() {
         })
         .expect("failed to send resize");
 
-    let render = session.wait_for_render();
-
-    assert!(
-        render.contains("hello from mock pty"),
-        "Render should contain mock PTY output. Render length: {} bytes",
-        render.len(),
-    );
+    let _render = session.wait_for_render_containing("hello from mock pty");
 }

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -13,6 +13,7 @@ include = ["src/**/*", "assets/"]
 anyhow = { workspace = true }
 backtrace = { version = "0.3.55", default-features = false, features = ["std"] }
 bitflags = { version = "2.5.0", default-features = false }
+chrono = { workspace = true }
 clap = { workspace = true }
 clap_complete = { version = "3.2.1", default-features = false }
 colored = { version = "2.0.0", default-features = false }
@@ -62,6 +63,8 @@ nix = { workspace = true }
 crossterm = { workspace = true, features = ["events"] }
 windows-sys = { workspace = true, features = [
     "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+    "Win32_System_IO",
     "Win32_System_Threading",
 ] }
 winapi = { version = "0.3.9", default-features = false }

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -11,26 +11,9 @@ use std::path::PathBuf;
 use url::Url;
 
 fn validate_session(name: &str) -> Result<String, String> {
-    #[cfg(unix)]
-    {
-        use crate::consts::ZELLIJ_SOCK_MAX_LENGTH;
-
-        let mut socket_path = crate::consts::ZELLIJ_SOCK_DIR.clone();
-        socket_path.push(name);
-
-        if socket_path.as_os_str().len() >= ZELLIJ_SOCK_MAX_LENGTH {
-            // socket path must be less than 108 bytes
-            let available_length = ZELLIJ_SOCK_MAX_LENGTH
-                .saturating_sub(socket_path.as_os_str().len())
-                .saturating_sub(1);
-
-            return Err(format!(
-                "session name must be less than {} characters",
-                available_length
-            ));
-        };
-    };
-
+    // Socket paths now use UUIDs as filenames (not session names), so
+    // path-length constraints no longer apply to session names. Semantic
+    // validation is handled by sessions::validate_session_name().
     Ok(name.to_owned())
 }
 

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -37,6 +37,36 @@ pub fn session_info_folder_for_session(session_name: &str) -> PathBuf {
     ZELLIJ_SESSION_INFO_CACHE_DIR.join(session_name)
 }
 
+/// Length of a hyphenated UUID v4 string (e.g., "a3f7b9c1-e29b-41d4-a716-446655440000").
+pub const SESSION_ID_LENGTH: usize = 36;
+
+/// Validate that `ZELLIJ_SOCK_DIR` is short enough to fit a UUID-based socket
+/// filename within the platform's Unix domain socket path limit.
+///
+/// Should be called once at startup. Exits with an error message if the
+/// directory is too long.
+pub fn check_sock_dir_length() {
+    let dir_len = ZELLIJ_SOCK_DIR.as_os_str().len();
+    // +1 for the path separator between dir and filename.
+    let required = dir_len + 1 + SESSION_ID_LENGTH;
+    if required >= ZELLIJ_SOCK_MAX_LENGTH {
+        let max_dir_len = ZELLIJ_SOCK_MAX_LENGTH.saturating_sub(1 + SESSION_ID_LENGTH + 1);
+        eprintln!(
+            "Error: the socket directory path is too long ({} bytes, max {}):\n  {}\n\n\
+             Session socket paths use UUIDs ({} bytes) as filenames, leaving\n\
+             at most {} bytes for the directory.\n\
+             To fix this, set a shorter socket directory, eg.:\n  \
+             ZELLIJ_SOCKET_DIR=/tmp/zellij zellij",
+            dir_len,
+            max_dir_len,
+            ZELLIJ_SOCK_DIR.display(),
+            SESSION_ID_LENGTH,
+            max_dir_len,
+        );
+        std::process::exit(1);
+    }
+}
+
 pub fn create_config_and_cache_folders() {
     if let Err(e) = std::fs::create_dir_all(&ZELLIJ_CACHE_DIR.as_path()) {
         log::error!("Failed to create cache dir: {:?}", e);
@@ -106,6 +136,8 @@ lazy_static! {
     pub static ref ZELLIJ_SESSION_INFO_CACHE_DIR: PathBuf = ZELLIJ_CACHE_DIR
         .join(CLIENT_SERVER_CONTRACT_DIR.clone())
         .join("session_info");
+    pub static ref ZELLIJ_SESSIONS_KDL: PathBuf = ZELLIJ_SOCK_DIR.join("sessions.kdl");
+    pub static ref ZELLIJ_SESSIONS_LOCK: PathBuf = ZELLIJ_SOCK_DIR.join("sessions.kdl.lock");
     pub static ref ZELLIJ_STDIN_CACHE_FILE: PathBuf =
         ZELLIJ_CACHE_DIR.join(VERSION).join("stdin_cache");
     pub static ref ZELLIJ_PLUGIN_ARTIFACT_DIR: PathBuf = ZELLIJ_CACHE_DIR.join(VERSION);

--- a/zellij-utils/src/sessions.rs
+++ b/zellij-utils/src/sessions.rs
@@ -1204,3 +1204,146 @@ const NOUNS: &[&'static str] = &[
     "yak",
     "zebra",
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const UUID_1: &str = "a3f7b9c1-e29b-41d4-a716-446655440001";
+    const UUID_2: &str = "550e8400-e29b-41d4-a716-446655440002";
+    const UUID_3: &str = "6ba7b810-9dad-41d4-80b4-00c04fd430c3";
+
+    fn make_running_entry(id: &str, name: &str, pid: u32) -> SessionEntry {
+        SessionEntry {
+            id: id.to_string(),
+            display_name: name.to_string(),
+            pid: Some(pid),
+            state: SessionState::Running,
+            created_at: "2024-01-15T10:00:00Z".to_string(),
+            exited_at: None,
+        }
+    }
+
+    fn make_exited_entry(id: &str, name: &str) -> SessionEntry {
+        SessionEntry {
+            id: id.to_string(),
+            display_name: name.to_string(),
+            pid: None,
+            state: SessionState::Exited,
+            created_at: "2024-01-14T09:00:00Z".to_string(),
+            exited_at: Some("2024-01-14T18:00:00Z".to_string()),
+        }
+    }
+
+    #[test]
+    fn kdl_roundtrip() {
+        let registry = SessionRegistry {
+            sessions: vec![
+                make_running_entry(UUID_1, "my-session", 12345),
+                make_exited_entry(UUID_2, "old-session"),
+            ],
+        };
+        let kdl = registry.to_kdl();
+        let parsed = SessionRegistry::from_kdl(&kdl).unwrap();
+        assert_eq!(parsed.sessions.len(), 2);
+
+        let running = &parsed.sessions[0];
+        assert_eq!(running.id, UUID_1);
+        assert_eq!(running.display_name, "my-session");
+        assert_eq!(running.pid, Some(12345));
+        assert_eq!(running.state, SessionState::Running);
+        assert_eq!(running.created_at, "2024-01-15T10:00:00Z");
+        assert!(running.exited_at.is_none());
+
+        let exited = &parsed.sessions[1];
+        assert_eq!(exited.id, UUID_2);
+        assert_eq!(exited.display_name, "old-session");
+        assert!(exited.pid.is_none());
+        assert_eq!(exited.state, SessionState::Exited);
+        assert_eq!(exited.exited_at.as_deref(), Some("2024-01-14T18:00:00Z"));
+    }
+
+    #[test]
+    fn kdl_roundtrip_no_pid_for_exited() {
+        let registry = SessionRegistry {
+            sessions: vec![make_exited_entry(UUID_1, "dead-session")],
+        };
+        let kdl = registry.to_kdl();
+        assert!(
+            !kdl.contains("pid"),
+            "exited session should not have pid node"
+        );
+        let parsed = SessionRegistry::from_kdl(&kdl).unwrap();
+        assert!(parsed.sessions[0].pid.is_none());
+    }
+
+    #[test]
+    fn find_running_by_name_returns_running_not_exited() {
+        let registry = SessionRegistry {
+            sessions: vec![
+                make_running_entry(UUID_1, "foo", 100),
+                make_exited_entry(UUID_2, "foo"),
+                make_running_entry(UUID_3, "bar", 200),
+            ],
+        };
+        let found = registry.find_running_by_name("foo").unwrap();
+        assert_eq!(found.id, UUID_1);
+        assert_eq!(found.state, SessionState::Running);
+    }
+
+    #[test]
+    fn find_running_by_name_returns_none_for_nonexistent() {
+        let registry = SessionRegistry {
+            sessions: vec![make_running_entry(UUID_1, "foo", 100)],
+        };
+        assert!(registry.find_running_by_name("nonexistent").is_none());
+    }
+
+    #[test]
+    fn resolve_socket_path_uses_id() {
+        let registry = SessionRegistry {
+            sessions: vec![make_running_entry(UUID_1, "my-session", 100)],
+        };
+        let path = registry.resolve_socket_path("my-session").unwrap();
+        assert!(path.ends_with(UUID_1));
+    }
+
+    #[test]
+    fn remove_by_id() {
+        let mut registry = SessionRegistry {
+            sessions: vec![
+                make_running_entry(UUID_1, "a", 1),
+                make_running_entry(UUID_2, "b", 2),
+                make_running_entry(UUID_3, "c", 3),
+            ],
+        };
+        registry.remove_by_id(UUID_2);
+        assert_eq!(registry.sessions.len(), 2);
+        assert!(registry.find_by_id(UUID_2).is_none());
+        assert!(registry.find_by_id(UUID_1).is_some());
+        assert!(registry.find_by_id(UUID_3).is_some());
+    }
+
+    #[test]
+    fn generate_session_id_is_valid_uuid() {
+        let id = generate_session_id();
+        assert_eq!(id.len(), 36);
+        assert_eq!(id.as_bytes()[8], b'-');
+        assert_eq!(id.as_bytes()[13], b'-');
+        assert_eq!(id.as_bytes()[18], b'-');
+        assert_eq!(id.as_bytes()[23], b'-');
+    }
+
+    #[test]
+    fn session_state_roundtrip() {
+        assert_eq!(
+            SessionState::from_str(SessionState::Running.as_str()),
+            Some(SessionState::Running)
+        );
+        assert_eq!(
+            SessionState::from_str(SessionState::Exited.as_str()),
+            Some(SessionState::Exited)
+        );
+        assert_eq!(SessionState::from_str("bogus"), None);
+    }
+}

--- a/zellij-utils/src/sessions.rs
+++ b/zellij-utils/src/sessions.rs
@@ -457,8 +457,14 @@ pub fn ensure_registry() -> SessionRegistry {
     }
 }
 
+/// Ensure the sock dir exists so the lock/registry files can be created in it.
+fn ensure_sock_dir() -> io::Result<()> {
+    fs::create_dir_all(&*ZELLIJ_SOCK_DIR)
+}
+
 /// Write the session registry to disk, acquiring an exclusive lock.
 pub fn write_registry(registry: &SessionRegistry) -> io::Result<()> {
+    ensure_sock_dir()?;
     let _lock = FileLock::exclusive(&ZELLIJ_SESSIONS_LOCK)?;
     fs::write(&*ZELLIJ_SESSIONS_KDL, registry.to_kdl())
 }
@@ -469,6 +475,7 @@ pub fn with_registry<F, R>(f: F) -> io::Result<R>
 where
     F: FnOnce(&mut SessionRegistry) -> R,
 {
+    ensure_sock_dir()?;
     let _lock = FileLock::exclusive(&ZELLIJ_SESSIONS_LOCK)?;
     let mut registry = match fs::read_to_string(&*ZELLIJ_SESSIONS_KDL) {
         Ok(raw) => SessionRegistry::from_kdl(&raw).unwrap_or_default(),

--- a/zellij-utils/src/sessions.rs
+++ b/zellij-utils/src/sessions.rs
@@ -1,7 +1,7 @@
 use crate::{
     consts::{
         is_ipc_socket, session_info_folder_for_session, session_layout_cache_file_name,
-        ZELLIJ_SESSION_INFO_CACHE_DIR, ZELLIJ_SOCK_DIR,
+        ZELLIJ_SESSIONS_KDL, ZELLIJ_SESSIONS_LOCK, ZELLIJ_SESSION_INFO_CACHE_DIR, ZELLIJ_SOCK_DIR,
     },
     envs,
     input::layout::Layout,
@@ -9,37 +9,514 @@ use crate::{
 };
 use anyhow;
 use humantime::format_duration;
+use kdl::{KdlDocument, KdlNode, KdlValue};
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 use std::{fs, io, process};
 use suggest::Suggest;
+use uuid::Uuid;
+
+/// A single session entry in the registry.
+#[derive(Debug, Clone)]
+pub struct SessionEntry {
+    /// UUID v4 identifier (also the socket/marker filename).
+    pub id: String,
+    /// User-visible session name.
+    pub display_name: String,
+    /// Server PID (only meaningful while state == Running).
+    pub pid: Option<u32>,
+    /// Running or exited.
+    pub state: SessionState,
+    /// When the session was created.
+    pub created_at: String,
+    /// When the session exited (only for Exited state).
+    pub exited_at: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionState {
+    Running,
+    Exited,
+}
+
+impl SessionState {
+    pub fn as_str(&self) -> &str {
+        match self {
+            SessionState::Running => "running",
+            SessionState::Exited => "exited",
+        }
+    }
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "running" => Some(SessionState::Running),
+            "exited" => Some(SessionState::Exited),
+            _ => None,
+        }
+    }
+}
+
+/// The full session registry.
+#[derive(Debug, Clone, Default)]
+pub struct SessionRegistry {
+    pub sessions: Vec<SessionEntry>,
+}
+
+/// Generate a new UUID v4 session identifier.
+pub fn generate_session_id() -> String {
+    Uuid::new_v4().as_hyphenated().to_string()
+}
+
+impl SessionRegistry {
+    pub fn new() -> Self {
+        Self {
+            sessions: Vec::new(),
+        }
+    }
+
+    /// Parse a `sessions.kdl` string into a registry.
+    pub fn from_kdl(raw: &str) -> Result<Self, String> {
+        let doc: KdlDocument = raw
+            .parse()
+            .map_err(|e| format!("Failed to parse sessions.kdl: {}", e))?;
+        let mut sessions = Vec::new();
+        for node in doc.nodes() {
+            if node.name().value() != "session" {
+                continue;
+            }
+            let id = node
+                .entries()
+                .iter()
+                .find(|e| e.name().is_none())
+                .and_then(|e| e.value().as_string())
+                .unwrap_or("")
+                .to_string();
+            if id.is_empty() {
+                continue;
+            }
+            let children = match node.children() {
+                Some(c) => c,
+                None => continue,
+            };
+            let display_name = children
+                .get("display_name")
+                .and_then(|n| n.entries().iter().next())
+                .and_then(|e| e.value().as_string())
+                .unwrap_or("")
+                .to_string();
+            let pid = children
+                .get("pid")
+                .and_then(|n| n.entries().iter().next())
+                .and_then(|e| e.value().as_i64())
+                .map(|v| v as u32);
+            let state_str = children
+                .get("state")
+                .and_then(|n| n.entries().iter().next())
+                .and_then(|e| e.value().as_string())
+                .unwrap_or("running");
+            let state = SessionState::from_str(state_str).unwrap_or(SessionState::Running);
+            let created_at = children
+                .get("created_at")
+                .and_then(|n| n.entries().iter().next())
+                .and_then(|e| e.value().as_string())
+                .unwrap_or("")
+                .to_string();
+            let exited_at = children
+                .get("exited_at")
+                .and_then(|n| n.entries().iter().next())
+                .and_then(|e| e.value().as_string())
+                .map(|s| s.to_string());
+
+            sessions.push(SessionEntry {
+                id,
+                display_name,
+                pid,
+                state,
+                created_at,
+                exited_at,
+            });
+        }
+        Ok(SessionRegistry { sessions })
+    }
+
+    /// Serialize the registry to a KDL string.
+    pub fn to_kdl(&self) -> String {
+        let mut doc = KdlDocument::new();
+        for entry in &self.sessions {
+            let mut node = KdlNode::new("session");
+            node.push(KdlValue::String(entry.id.clone()));
+
+            let mut children = KdlDocument::new();
+
+            let mut dn = KdlNode::new("display_name");
+            dn.push(KdlValue::String(entry.display_name.clone()));
+            children.nodes_mut().push(dn);
+
+            if let Some(pid) = entry.pid {
+                let mut pn = KdlNode::new("pid");
+                pn.push(KdlValue::Base10(pid as i64));
+                children.nodes_mut().push(pn);
+            }
+
+            let mut sn = KdlNode::new("state");
+            sn.push(KdlValue::String(entry.state.as_str().to_string()));
+            children.nodes_mut().push(sn);
+
+            if !entry.created_at.is_empty() {
+                let mut cn = KdlNode::new("created_at");
+                cn.push(KdlValue::String(entry.created_at.clone()));
+                children.nodes_mut().push(cn);
+            }
+
+            if let Some(ref exited_at) = entry.exited_at {
+                let mut en = KdlNode::new("exited_at");
+                en.push(KdlValue::String(exited_at.clone()));
+                children.nodes_mut().push(en);
+            }
+
+            node.set_children(children);
+            doc.nodes_mut().push(node);
+        }
+        doc.fmt();
+        doc.to_string()
+    }
+
+    /// Find a running session by display name.
+    pub fn find_running_by_name(&self, name: &str) -> Option<&SessionEntry> {
+        self.sessions
+            .iter()
+            .find(|s| s.display_name == name && s.state == SessionState::Running)
+    }
+
+    /// Find a session (any state) by display name.
+    pub fn find_by_name(&self, name: &str) -> Option<&SessionEntry> {
+        self.sessions.iter().find(|s| s.display_name == name)
+    }
+
+    /// Find a session by UUID.
+    pub fn find_by_id(&self, id: &str) -> Option<&SessionEntry> {
+        self.sessions.iter().find(|s| s.id == id)
+    }
+
+    /// Find a mutable session by UUID.
+    pub fn find_by_id_mut(&mut self, id: &str) -> Option<&mut SessionEntry> {
+        self.sessions.iter_mut().find(|s| s.id == id)
+    }
+
+    /// Get all running sessions.
+    pub fn running_sessions(&self) -> Vec<&SessionEntry> {
+        self.sessions
+            .iter()
+            .filter(|s| s.state == SessionState::Running)
+            .collect()
+    }
+
+    /// Get all exited sessions.
+    pub fn exited_sessions(&self) -> Vec<&SessionEntry> {
+        self.sessions
+            .iter()
+            .filter(|s| s.state == SessionState::Exited)
+            .collect()
+    }
+
+    /// Remove a session by UUID.
+    pub fn remove_by_id(&mut self, id: &str) {
+        self.sessions.retain(|s| s.id != id);
+    }
+
+    /// Resolve a session display name to a socket path.
+    pub fn resolve_socket_path(&self, name: &str) -> Option<PathBuf> {
+        self.find_running_by_name(name)
+            .map(|entry| ZELLIJ_SOCK_DIR.join(&entry.id))
+    }
+}
+
+#[cfg(unix)]
+mod file_lock {
+    use std::fs::{File, OpenOptions};
+    use std::os::unix::io::AsRawFd;
+    use std::path::Path;
+
+    pub struct FileLock {
+        _file: File,
+    }
+
+    impl FileLock {
+        pub fn exclusive(path: &Path) -> std::io::Result<Self> {
+            let file = OpenOptions::new().create(true).write(true).open(path)?;
+            let fd = file.as_raw_fd();
+            let ret = unsafe { libc::flock(fd, libc::LOCK_EX) };
+            if ret != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(FileLock { _file: file })
+        }
+    }
+
+    // Lock is released when _file is dropped (fd closed → flock released).
+}
+
+#[cfg(windows)]
+mod file_lock {
+    use std::fs::{File, OpenOptions};
+    use std::os::windows::io::AsRawHandle;
+    use std::path::Path;
+
+    pub struct FileLock {
+        _file: File,
+    }
+
+    impl FileLock {
+        pub fn exclusive(path: &Path) -> std::io::Result<Self> {
+            let file = OpenOptions::new().create(true).write(true).open(path)?;
+            let handle = file.as_raw_handle();
+            unsafe {
+                use windows_sys::Win32::Foundation::HANDLE;
+                use windows_sys::Win32::Storage::FileSystem::{
+                    LockFileEx, LOCKFILE_EXCLUSIVE_LOCK,
+                };
+                let mut overlapped: windows_sys::Win32::System::IO::OVERLAPPED = std::mem::zeroed();
+                let ret = LockFileEx(
+                    handle as HANDLE,
+                    LOCKFILE_EXCLUSIVE_LOCK,
+                    0,
+                    u32::MAX,
+                    u32::MAX,
+                    &mut overlapped,
+                );
+                if ret == 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+            }
+            Ok(FileLock { _file: file })
+        }
+    }
+
+    // Lock is released when _file is dropped (handle closed → lock released).
+}
+
+#[cfg(not(any(unix, windows)))]
+mod file_lock {
+    use std::fs::{File, OpenOptions};
+    use std::path::Path;
+
+    pub struct FileLock {
+        _file: File,
+    }
+
+    impl FileLock {
+        pub fn exclusive(path: &Path) -> std::io::Result<Self> {
+            let file = OpenOptions::new().create(true).write(true).open(path)?;
+            Ok(FileLock { _file: file })
+        }
+    }
+}
+
+use file_lock::FileLock;
+
+/// Returns true if the session registry file exists on disk.
+pub fn registry_exists() -> bool {
+    ZELLIJ_SESSIONS_KDL.exists()
+}
+
+/// Read the session registry from disk, creating an empty one if it doesn't exist.
+pub fn read_registry() -> SessionRegistry {
+    match fs::read_to_string(&*ZELLIJ_SESSIONS_KDL) {
+        Ok(raw) => match SessionRegistry::from_kdl(&raw) {
+            Ok(reg) => reg,
+            Err(e) => {
+                log::error!("{}", e);
+                SessionRegistry::new()
+            },
+        },
+        Err(_) => SessionRegistry::new(),
+    }
+}
+
+/// Migrate legacy sessions (pre-registry) into a new `sessions.kdl`.
+///
+/// Scans `ZELLIJ_SOCK_DIR` for old-format socket/marker files (named by
+/// session name), creates registry entries for them, and writes the file.
+/// Called once when `sessions.kdl` doesn't exist.
+pub fn migrate_legacy_sessions() -> SessionRegistry {
+    let mut registry = SessionRegistry::new();
+
+    // Migrate live sessions from socket/marker files.
+    if let Ok(files) = fs::read_dir(&*ZELLIJ_SOCK_DIR) {
+        for file in files.flatten() {
+            let file_name = match file.file_name().into_string() {
+                Ok(n) => n,
+                Err(_) => continue,
+            };
+            if file_name == "sessions.kdl" || file_name == "sessions.kdl.lock" {
+                continue;
+            }
+            let file_type = match file.file_type() {
+                Ok(ft) => ft,
+                Err(_) => continue,
+            };
+            if !is_ipc_socket(&file_type) {
+                continue;
+            }
+            if !assert_socket(&file_name) {
+                continue;
+            }
+            // This is a live legacy session — the filename IS the session name.
+            // We keep the original file as-is (don't rename), so the "id" is
+            // the old session name (not a UUID). This allows ipc_connect to
+            // still find it by joining ZELLIJ_SOCK_DIR with the id.
+            let ctime = std::fs::metadata(file.path())
+                .ok()
+                .and_then(|f| f.created().ok().or_else(|| f.modified().ok()))
+                .and_then(|d| d.elapsed().ok())
+                .unwrap_or_default();
+            let created_at = {
+                let secs_ago = ctime.as_secs();
+                let now = chrono::Utc::now();
+                let then = now - chrono::Duration::seconds(secs_ago as i64);
+                then.format("%Y-%m-%dT%H:%M:%SZ").to_string()
+            };
+
+            #[cfg(windows)]
+            let pid = {
+                // Read PID from marker file content (first line).
+                fs::read_to_string(file.path())
+                    .ok()
+                    .and_then(|s| s.lines().next().and_then(|l| l.trim().parse::<u32>().ok()))
+            };
+            #[cfg(not(windows))]
+            let pid: Option<u32> = None;
+
+            registry.sessions.push(SessionEntry {
+                id: file_name.clone(),
+                display_name: file_name,
+                pid,
+                state: SessionState::Running,
+                created_at,
+                exited_at: None,
+            });
+        }
+    }
+
+    // Migrate resurrectable sessions from the session_info cache.
+    if let Ok(dirs) = fs::read_dir(&*ZELLIJ_SESSION_INFO_CACHE_DIR) {
+        for dir in dirs.flatten() {
+            let path = dir.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let session_name = match path.file_name().and_then(|f| f.to_str()) {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+            // Skip if already migrated as a running session.
+            if registry.find_by_name(&session_name).is_some() {
+                continue;
+            }
+            let layout_file = session_layout_cache_file_name(&session_name);
+            if !std::path::Path::new(&layout_file).exists() {
+                continue;
+            }
+            let ctime = std::fs::metadata(&layout_file)
+                .ok()
+                .and_then(|m| m.created().ok().or_else(|| m.modified().ok()))
+                .and_then(|d| d.elapsed().ok())
+                .unwrap_or_default();
+            let created_at = {
+                let secs_ago = ctime.as_secs();
+                let now = chrono::Utc::now();
+                let then = now - chrono::Duration::seconds(secs_ago as i64);
+                then.format("%Y-%m-%dT%H:%M:%SZ").to_string()
+            };
+            registry.sessions.push(SessionEntry {
+                id: generate_session_id(),
+                display_name: session_name,
+                pid: None,
+                state: SessionState::Exited,
+                exited_at: Some(created_at.clone()),
+                created_at,
+            });
+        }
+    }
+
+    // Write the newly created registry.
+    if let Err(e) = write_registry(&registry) {
+        log::error!("Failed to write migrated session registry: {:?}", e);
+    }
+
+    registry
+}
+
+/// Ensure the session registry exists. If not, migrate from legacy format.
+/// Returns the current registry.
+pub fn ensure_registry() -> SessionRegistry {
+    if registry_exists() {
+        read_registry()
+    } else {
+        migrate_legacy_sessions()
+    }
+}
+
+/// Write the session registry to disk, acquiring an exclusive lock.
+pub fn write_registry(registry: &SessionRegistry) -> io::Result<()> {
+    let _lock = FileLock::exclusive(&ZELLIJ_SESSIONS_LOCK)?;
+    fs::write(&*ZELLIJ_SESSIONS_KDL, registry.to_kdl())
+}
+
+/// Read the registry under an exclusive lock, apply a mutation, and write it back.
+/// Returns the return value of the closure.
+pub fn with_registry<F, R>(f: F) -> io::Result<R>
+where
+    F: FnOnce(&mut SessionRegistry) -> R,
+{
+    let _lock = FileLock::exclusive(&ZELLIJ_SESSIONS_LOCK)?;
+    let mut registry = match fs::read_to_string(&*ZELLIJ_SESSIONS_KDL) {
+        Ok(raw) => SessionRegistry::from_kdl(&raw).unwrap_or_default(),
+        Err(_) => SessionRegistry::new(),
+    };
+    let result = f(&mut registry);
+    fs::write(&*ZELLIJ_SESSIONS_KDL, registry.to_kdl())?;
+    Ok(result)
+}
+
+/// Register a new session in the registry. Returns the generated UUID.
+pub fn register_session(display_name: &str) -> io::Result<String> {
+    let id = generate_session_id();
+    let entry = SessionEntry {
+        id: id.clone(),
+        display_name: display_name.to_string(),
+        pid: None,
+        state: SessionState::Running,
+        created_at: chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+        exited_at: None,
+    };
+    with_registry(|reg| {
+        reg.sessions.push(entry);
+    })?;
+    Ok(id)
+}
+
+/// Resolve a session display name to its socket path via the registry.
+pub fn resolve_session_socket_path(name: &str) -> Option<PathBuf> {
+    ensure_registry().resolve_socket_path(name)
+}
 
 pub fn get_sessions() -> Result<Vec<(String, Duration)>, io::ErrorKind> {
-    match fs::read_dir(&*ZELLIJ_SOCK_DIR) {
-        Ok(files) => {
-            let mut sessions = Vec::new();
-            files.for_each(|file| {
-                if let Ok(file) = file {
-                    let file_name = file.file_name().into_string().unwrap();
-                    // try to get creation time, fall back to modification time on platforms where it's not supported (e.g., musl)
-                    // for session creation time these are almost always identical (notable
-                    // exceptions are session name changes)
-                    let ctime = std::fs::metadata(&file.path())
-                        .ok()
-                        .and_then(|f| f.created().ok().or_else(|| f.modified().ok()))
-                        .and_then(|d| d.elapsed().ok())
-                        .unwrap_or_default();
-                    let duration = Duration::from_secs(ctime.as_secs());
-                    if is_ipc_socket(&file.file_type().unwrap()) && assert_socket(&file_name) {
-                        sessions.push((file_name, duration));
-                    }
-                }
-            });
-            Ok(sessions)
-        },
-        Err(err) if io::ErrorKind::NotFound != err.kind() => Err(err.kind()),
-        Err(_) => Ok(Vec::with_capacity(0)),
+    let registry = ensure_registry();
+    let mut sessions = Vec::new();
+    for entry in registry.running_sessions() {
+        let sock_path = ZELLIJ_SOCK_DIR.join(&entry.id);
+        let ctime = std::fs::metadata(&sock_path)
+            .ok()
+            .and_then(|f| f.created().ok().or_else(|| f.modified().ok()))
+            .and_then(|d| d.elapsed().ok())
+            .unwrap_or_default();
+        let duration = Duration::from_secs(ctime.as_secs());
+        if assert_socket(&entry.id) {
+            sessions.push((entry.display_name.clone(), duration));
+        }
     }
+    Ok(sessions)
 }
 
 pub fn get_resurrectable_sessions() -> Vec<(String, Duration)> {
@@ -117,25 +594,20 @@ pub fn get_resurrectable_session_names() -> Vec<String> {
 }
 
 pub fn get_sessions_sorted_by_mtime() -> anyhow::Result<Vec<String>> {
-    match fs::read_dir(&*ZELLIJ_SOCK_DIR) {
-        Ok(files) => {
-            let mut sessions_with_mtime: Vec<(String, SystemTime)> = Vec::new();
-            for file in files {
-                let file = file?;
-                let file_name = file.file_name().into_string().unwrap();
-                let file_modified_at = file.metadata()?.modified()?;
-                if is_ipc_socket(&file.file_type()?) && assert_socket(&file_name) {
-                    sessions_with_mtime.push((file_name, file_modified_at));
+    let registry = ensure_registry();
+    let mut sessions_with_mtime: Vec<(String, SystemTime)> = Vec::new();
+    for entry in registry.running_sessions() {
+        let sock_path = ZELLIJ_SOCK_DIR.join(&entry.id);
+        if let Ok(meta) = std::fs::metadata(&sock_path) {
+            if let Ok(mtime) = meta.modified() {
+                if assert_socket(&entry.id) {
+                    sessions_with_mtime.push((entry.display_name.clone(), mtime));
                 }
             }
-            sessions_with_mtime.sort_by_key(|x| x.1); // the oldest one will be the first
-
-            let sessions = sessions_with_mtime.iter().map(|x| x.0.clone()).collect();
-            Ok(sessions)
-        },
-        Err(err) if io::ErrorKind::NotFound != err.kind() => Err(err.into()),
-        Err(_) => Ok(Vec::with_capacity(0)),
+        }
     }
+    sessions_with_mtime.sort_by_key(|x| x.1);
+    Ok(sessions_with_mtime.into_iter().map(|x| x.0).collect())
 }
 
 /// Probe a session socket to check if a server is alive.
@@ -292,7 +764,8 @@ pub fn get_active_session() -> ActiveSession {
 
 pub fn kill_session(name: &str) {
     use crate::consts::ipc_connect;
-    let path = &*ZELLIJ_SOCK_DIR.join(name);
+    let resolved = resolve_session_socket_path(name).unwrap_or_else(|| ZELLIJ_SOCK_DIR.join(name));
+    let path = &*resolved;
     match ipc_connect(path) {
         Ok(stream) => {
             // On Windows, the server uses a dual-pipe architecture: the main pipe
@@ -329,7 +802,9 @@ pub fn kill_session(name: &str) {
 pub fn delete_session(name: &str, force: bool) {
     if force {
         use crate::consts::ipc_connect;
-        let path = &*ZELLIJ_SOCK_DIR.join(name);
+        let resolved =
+            resolve_session_socket_path(name).unwrap_or_else(|| ZELLIJ_SOCK_DIR.join(name));
+        let path = &*resolved;
         let _ = ipc_connect(path).ok().map(|stream| {
             #[cfg(windows)]
             {


### PR DESCRIPTION
Decouple session names from sockets via a sessions.kdl registry

Introduces a session registry (sessions.kdl) that decouples user-visible session names from socket / marker filenames. Sockets are now named by UUID; the registry maps UUID → display name. This fixes session renaming on windows and sets a single source of truth.

What changes

- New registry: zellij-utils::sessions::SessionRegistry (KDL-backed, file-locked, atomic read-modify-write via with_registry). Tracks UUID, display name, PID, state (running/exited), timestamps. Migrates legacy socket-named sessions on first read.
- Session lifecycle wired through the registry: start_server registers/updates the entry; SessionMetaData::Drop marks it exited; RenameSession updates the display name without renaming the socket.
- Existing call sites switched: read_other_live_session_states, delete_all_dead_sessions, kill_sessions, etc. now enumerate via the registry instead of scanning ZELLIJ_SOCK_DIR. GetSessionList plugin command inherits this through the same path.
- Resurrectable on clean exit: BackgroundJob::Exit now flushes session-layout.kdl synchronously, and SessionMetaData::Drop shuts threads down in pipeline order so the final serialization actually reaches disk. Short-lived sessions (under the 60s serialization interval) now appear in list-sessions.

Tests

- 8 unit tests for SessionRegistry (KDL roundtrip, lookup helpers, UUID format).
- 4 lifecycle tests in zellij-server/src/unit/session_registry_tests.rs exercising with_registry directly.
- A new in-process integration harness at zellij-server/tests/session_integration.rs (TestSession, HarnessOsInput, MockAsyncReader) that spawns a real server thread, drives it through real IPC, and verifies session init, rename-via-action, and PTY-output rendering. 

Notable

- Adds a ZELLIJ_NO_DAEMONIZE env var (test-only escape hatch) so start_server can run from a thread on Unix.
- Cross-platform: tested on Windows and Linux.
- No protocol or plugin-API changes.