### PR TITLE
upgrade rustls-webpki

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2915,9 +2915,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
This upgrades the rustls-webpki transitive dependency (bumping it 2 patch versions). This is to avoid https://rustsec.org/advisories/RUSTSEC-2026-0104.html

For the removal of doubt: **Zellij is not affected by this vulnerability**.

The only reason I'm issuing the update is because security scanners would often flag an application anyway, even if it doesn't use the vulnerable code-path. This will make it easier for everyone.