### PR TITLE
feat(web): support Unix socket listener

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -5,6 +5,9 @@ use std::{fs::File, io::prelude::*, path::PathBuf, process, time::Duration};
 #[cfg(feature = "web_server_capability")]
 use isahc::{config::RedirectPolicy, prelude::*, HttpClient, Request};
 
+#[cfg(all(feature = "web_server_capability", unix))]
+use isahc::config::Dialer;
+
 use zellij_client::{
     old_config_converter::{
         config_yaml_to_config_kdl, convert_old_yaml_files, layout_yaml_to_layout_kdl,
@@ -182,6 +185,7 @@ pub(crate) fn start_web_server(
     run_daemonized: bool,
     ip: Option<IpAddr>,
     port: Option<u16>,
+    socket: Option<PathBuf>,
     cert: Option<PathBuf>,
     key: Option<PathBuf>,
     startup_timeout: Option<u64>,
@@ -207,6 +211,7 @@ pub(crate) fn start_web_server(
         run_daemonized,
         ip,
         port,
+        socket,
         cert,
         key,
         startup_timeout,
@@ -219,6 +224,7 @@ pub(crate) fn start_web_server(
     _run_daemonized: bool,
     _ip: Option<IpAddr>,
     _port: Option<u16>,
+    _socket: Option<PathBuf>,
     _cert: Option<PathBuf>,
     _key: Option<PathBuf>,
     _startup_timeout: Option<u64>,
@@ -341,18 +347,11 @@ pub(crate) fn list_auth_tokens() -> Result<Vec<String>, String> {
 pub const DEFAULT_WEB_SERVER_STATUS_TIMEOUT_SECS: u64 = 30;
 
 #[cfg(feature = "web_server_capability")]
-pub(crate) fn web_server_status(
-    web_server_base_url: &str,
-    timeout_secs: Option<u64>,
+fn send_web_server_status_request(
+    http_client: HttpClient,
+    request_url: String,
 ) -> Result<String, String> {
-    let timeout =
-        Duration::from_secs(timeout_secs.unwrap_or(DEFAULT_WEB_SERVER_STATUS_TIMEOUT_SECS));
-    let http_client = HttpClient::builder()
-        .timeout(timeout)
-        .redirect_policy(RedirectPolicy::Follow)
-        .build()
-        .map_err(|e| e.to_string())?;
-    let request = Request::get(format!("{}/info/version", web_server_base_url,));
+    let request = Request::get(request_url);
     let req = request.body(()).map_err(|e| e.to_string())?;
     let mut res = http_client.send(req).map_err(|e| e.to_string())?;
     let status_code = res.status();
@@ -361,15 +360,50 @@ pub(crate) fn web_server_status(
         Ok(String::from_utf8_lossy(&body).to_string())
     } else {
         Err(format!(
-            "Failed to stop web server, got status code: {}",
+            "Failed to query web server status, got status code: {}",
             status_code
         ))
     }
 }
 
+#[cfg(feature = "web_server_capability")]
+pub(crate) fn web_server_status(
+    web_server_base_url: &str,
+    web_server_socket: Option<PathBuf>,
+    timeout_secs: Option<u64>,
+) -> Result<String, String> {
+    let timeout =
+        Duration::from_secs(timeout_secs.unwrap_or(DEFAULT_WEB_SERVER_STATUS_TIMEOUT_SECS));
+    let http_client = HttpClient::builder()
+        .timeout(timeout)
+        .redirect_policy(RedirectPolicy::Follow);
+    let request_url = match web_server_socket {
+        Some(socket) => {
+            #[cfg(unix)]
+            {
+                let http_client = http_client.dial(Dialer::unix_socket(socket));
+                let http_client = http_client.build().map_err(|e| e.to_string())?;
+                return send_web_server_status_request(
+                    http_client,
+                    "http://localhost/info/version".to_owned(),
+                );
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = socket;
+                return Err("Unix socket web server status is only supported on Unix".to_owned());
+            }
+        },
+        None => format!("{}/info/version", web_server_base_url),
+    };
+    let http_client = http_client.build().map_err(|e| e.to_string())?;
+    send_web_server_status_request(http_client, request_url)
+}
+
 #[cfg(not(feature = "web_server_capability"))]
 pub(crate) fn web_server_status(
     _web_server_base_url: &str,
+    _web_server_socket: Option<PathBuf>,
     _timeout_secs: Option<u64>,
 ) -> Result<String, String> {
     log::error!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -295,6 +295,10 @@ fn main() {
         opts.layout = Some(layout_for_new_session.clone());
         commands::start_client(opts);
     } else if let Some(Command::Web(web_opts)) = &opts.command {
+        if let Err(e) = web_opts.validate_socket_args() {
+            eprintln!("{}", e);
+            std::process::exit(2);
+        }
         if web_opts.get_start() {
             let daemonize = web_opts.daemonize;
             commands::start_web_server(
@@ -302,6 +306,7 @@ fn main() {
                 daemonize,
                 web_opts.ip,
                 web_opts.port,
+                web_opts.web_socket.clone(),
                 web_opts.cert.clone(),
                 web_opts.key.clone(),
                 web_opts.server_startup_timeout,
@@ -326,12 +331,21 @@ fn main() {
                 config_options.web_server_port = Some(port);
             }
             let web_server_base_url = web_server_base_url_from_config(config_options);
-            match commands::web_server_status(&web_server_base_url, web_opts.timeout) {
+            let checked = web_opts
+                .web_socket
+                .as_ref()
+                .map(|socket| format!("unix socket: {}", socket.display()))
+                .unwrap_or_else(|| web_server_base_url.clone());
+            match commands::web_server_status(
+                &web_server_base_url,
+                web_opts.web_socket.clone(),
+                web_opts.timeout,
+            ) {
                 Ok(version) => {
                     let version = version.trim();
                     println!(
                         "Web server online with version: {}. Checked: {}",
-                        version, web_server_base_url
+                        version, checked
                     );
                     if version != VERSION {
                         println!("");
@@ -344,7 +358,7 @@ fn main() {
                     }
                 },
                 Err(_e) => {
-                    println!("Web server is offline, checked: {}", web_server_base_url);
+                    println!("Web server is offline, checked: {}", checked);
                 },
             }
         } else if web_opts.create_token {

--- a/src/tests/cli.rs
+++ b/src/tests/cli.rs
@@ -1,127 +1,237 @@
-use std::net::{IpAddr, Ipv4Addr};
+use std::{
+    net::{IpAddr, Ipv4Addr},
+    path::PathBuf,
+};
 
 use clap::{CommandFactory, Parser};
 use zellij_utils::cli::{CliArgs, Command};
 
+const CLI_TEST_STACK_SIZE: usize = 16 * 1024 * 1024;
+
+fn run_cli_test(test: impl FnOnce() + Send + 'static) {
+    // clap 3 recursively walks this large command graph, and the default test thread stack is too
+    // small once the web subcommand gains another option.
+    let handle = std::thread::Builder::new()
+        .stack_size(CLI_TEST_STACK_SIZE)
+        .spawn(test)
+        .expect("failed to spawn CLI test thread");
+    if let Err(payload) = handle.join() {
+        std::panic::resume_unwind(payload);
+    }
+}
+
 #[test]
 fn verify_cli() {
-    CliArgs::command().debug_assert();
+    run_cli_test(|| {
+        CliArgs::command().debug_assert();
+    });
 }
 
 #[test]
 fn web_cli_status_alone_works() {
-    let args = CliArgs::try_parse_from(["zellij", "web", "--status"]);
-    assert!(args.is_ok());
-    if let Ok(CliArgs {
-        command: Some(Command::Web(web)),
-        ..
-    }) = args
-    {
-        assert!(web.status);
-        assert!(web.timeout.is_none());
-    } else {
-        panic!("Expected Web command");
-    }
+    run_cli_test(|| {
+        let args = CliArgs::try_parse_from(["zellij", "web", "--status"]);
+        assert!(args.is_ok());
+        if let Ok(CliArgs {
+            command: Some(Command::Web(web)),
+            ..
+        }) = args
+        {
+            assert!(web.status);
+            assert!(web.timeout.is_none());
+        } else {
+            panic!("Expected Web command");
+        }
+    });
 }
 
 #[test]
 fn web_cli_status_with_timeout_works() {
-    let args = CliArgs::try_parse_from(["zellij", "web", "--status", "--timeout", "5"]);
-    assert!(args.is_ok());
-    if let Ok(CliArgs {
-        command: Some(Command::Web(web)),
-        ..
-    }) = args
-    {
-        assert!(web.status);
-        assert_eq!(web.timeout, Some(5));
-    } else {
-        panic!("Expected Web command");
-    }
+    run_cli_test(|| {
+        let args = CliArgs::try_parse_from(["zellij", "web", "--status", "--timeout", "5"]);
+        assert!(args.is_ok());
+        if let Ok(CliArgs {
+            command: Some(Command::Web(web)),
+            ..
+        }) = args
+        {
+            assert!(web.status);
+            assert_eq!(web.timeout, Some(5));
+        } else {
+            panic!("Expected Web command");
+        }
+    });
 }
 
 #[test]
 fn web_cli_timeout_with_status_works() {
-    // Test with --timeout before --status (order shouldn't matter)
-    let args = CliArgs::try_parse_from(["zellij", "web", "--timeout", "10", "--status"]);
-    assert!(args.is_ok());
-    if let Ok(CliArgs {
-        command: Some(Command::Web(web)),
-        ..
-    }) = args
-    {
-        assert!(web.status);
-        assert_eq!(web.timeout, Some(10));
-    } else {
-        panic!("Expected Web command");
-    }
+    run_cli_test(|| {
+        // Test with --timeout before --status (order shouldn't matter)
+        let args = CliArgs::try_parse_from(["zellij", "web", "--timeout", "10", "--status"]);
+        assert!(args.is_ok());
+        if let Ok(CliArgs {
+            command: Some(Command::Web(web)),
+            ..
+        }) = args
+        {
+            assert!(web.status);
+            assert_eq!(web.timeout, Some(10));
+        } else {
+            panic!("Expected Web command");
+        }
+    });
 }
 
 #[test]
 fn web_cli_timeout_without_status_fails() {
-    let args = CliArgs::try_parse_from(["zellij", "web", "--timeout", "5"]);
-    assert!(args.is_err());
+    run_cli_test(|| {
+        let args = CliArgs::try_parse_from(["zellij", "web", "--timeout", "5"]);
+        assert!(args.is_err());
+    });
 }
 
 #[test]
 fn web_cli_status_with_start_fails() {
-    let args = CliArgs::try_parse_from(["zellij", "web", "--status", "--start"]);
-    assert!(args.is_err());
+    run_cli_test(|| {
+        let args = CliArgs::try_parse_from(["zellij", "web", "--status", "--start"]);
+        assert!(args.is_err());
+    });
 }
 
 #[test]
 fn web_cli_status_with_stop_fails() {
-    let args = CliArgs::try_parse_from(["zellij", "web", "--status", "--stop"]);
-    assert!(args.is_err());
+    run_cli_test(|| {
+        let args = CliArgs::try_parse_from(["zellij", "web", "--status", "--stop"]);
+        assert!(args.is_err());
+    });
 }
 
 #[test]
 fn web_cli_status_with_ip_works() {
-    let args = CliArgs::try_parse_from(["zellij", "web", "--status", "--ip", "127.0.0.1"]);
-    assert!(args.is_ok());
-    if let Ok(CliArgs {
-        command: Some(Command::Web(web)),
-        ..
-    }) = args
-    {
-        assert!(web.status);
-        assert_eq!(web.ip, Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
-    } else {
-        panic!("Expected Web command");
-    }
+    run_cli_test(|| {
+        let args = CliArgs::try_parse_from(["zellij", "web", "--status", "--ip", "127.0.0.1"]);
+        assert!(args.is_ok());
+        if let Ok(CliArgs {
+            command: Some(Command::Web(web)),
+            ..
+        }) = args
+        {
+            assert!(web.status);
+            assert_eq!(web.ip, Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
+        } else {
+            panic!("Expected Web command");
+        }
+    });
 }
 
 #[test]
 fn web_cli_status_with_port_works() {
-    let args = CliArgs::try_parse_from(["zellij", "web", "--status", "--port", "9000"]);
-    assert!(args.is_ok());
-    if let Ok(CliArgs {
-        command: Some(Command::Web(web)),
-        ..
-    }) = args
-    {
-        assert!(web.status);
-        assert_eq!(web.port, Some(9000));
-    } else {
-        panic!("Expected Web command");
-    }
+    run_cli_test(|| {
+        let args = CliArgs::try_parse_from(["zellij", "web", "--status", "--port", "9000"]);
+        assert!(args.is_ok());
+        if let Ok(CliArgs {
+            command: Some(Command::Web(web)),
+            ..
+        }) = args
+        {
+            assert!(web.status);
+            assert_eq!(web.port, Some(9000));
+        } else {
+            panic!("Expected Web command");
+        }
+    });
 }
 
 #[test]
 fn web_cli_status_with_ip_and_port_works() {
-    let args = CliArgs::try_parse_from([
-        "zellij", "web", "--status", "--ip", "0.0.0.0", "--port", "9000",
-    ]);
-    assert!(args.is_ok());
-    if let Ok(CliArgs {
-        command: Some(Command::Web(web)),
-        ..
-    }) = args
-    {
-        assert!(web.status);
-        assert_eq!(web.ip, Some(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))));
-        assert_eq!(web.port, Some(9000));
-    } else {
-        panic!("Expected Web command");
-    }
+    run_cli_test(|| {
+        let args = CliArgs::try_parse_from([
+            "zellij", "web", "--status", "--ip", "0.0.0.0", "--port", "9000",
+        ]);
+        assert!(args.is_ok());
+        if let Ok(CliArgs {
+            command: Some(Command::Web(web)),
+            ..
+        }) = args
+        {
+            assert!(web.status);
+            assert_eq!(web.ip, Some(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))));
+            assert_eq!(web.port, Some(9000));
+        } else {
+            panic!("Expected Web command");
+        }
+    });
+}
+
+#[test]
+fn web_cli_status_with_socket_works() {
+    run_cli_test(|| {
+        let args = CliArgs::try_parse_from([
+            "zellij",
+            "web",
+            "--status",
+            "--socket",
+            "/tmp/zellij-web.sock",
+        ]);
+        assert!(args.is_ok());
+        if let Ok(CliArgs {
+            command: Some(Command::Web(web)),
+            ..
+        }) = args
+        {
+            assert!(web.status);
+            assert_eq!(web.web_socket, Some(PathBuf::from("/tmp/zellij-web.sock")));
+            assert!(web.validate_socket_args().is_ok());
+        } else {
+            panic!("Expected Web command");
+        }
+    });
+}
+
+#[test]
+fn web_cli_socket_with_ip_fails_validation() {
+    run_cli_test(|| {
+        let args = CliArgs::try_parse_from([
+            "zellij",
+            "web",
+            "--socket",
+            "/tmp/zellij-web.sock",
+            "--ip",
+            "127.0.0.1",
+        ]);
+        assert!(args.is_ok());
+        if let Ok(CliArgs {
+            command: Some(Command::Web(web)),
+            ..
+        }) = args
+        {
+            assert!(web.validate_socket_args().is_err());
+        } else {
+            panic!("Expected Web command");
+        }
+    });
+}
+
+#[test]
+fn web_cli_socket_with_cert_fails_validation() {
+    run_cli_test(|| {
+        let args = CliArgs::try_parse_from([
+            "zellij",
+            "web",
+            "--socket",
+            "/tmp/zellij-web.sock",
+            "--cert",
+            "/tmp/cert.pem",
+        ]);
+        assert!(args.is_ok());
+        if let Ok(CliArgs {
+            command: Some(Command::Web(web)),
+            ..
+        }) = args
+        {
+            assert!(web.validate_socket_args().is_err());
+        } else {
+            panic!("Expected Web command");
+        }
+    });
 }

--- a/zellij-client/src/web_client/ipc_listener.rs
+++ b/zellij-client/src/web_client/ipc_listener.rs
@@ -8,6 +8,38 @@ use zellij_utils::web_server_commands::{InstructionForWebServer, VersionInfo, We
 use zellij_utils::web_server_contract::web_server_contract::InstructionForWebServer as ProtoInstructionForWebServer;
 use zellij_utils::web_server_contract::web_server_contract::WebServerResponse as ProtoWebServerResponse;
 
+#[derive(Clone)]
+pub enum WebServerShutdownHandle {
+    AxumServer(Handle),
+    #[cfg(unix)]
+    UnixSocket(tokio::sync::watch::Sender<bool>),
+}
+
+impl WebServerShutdownHandle {
+    fn shutdown(&self) {
+        match self {
+            WebServerShutdownHandle::AxumServer(handle) => handle.shutdown(),
+            #[cfg(unix)]
+            WebServerShutdownHandle::UnixSocket(shutdown_tx) => {
+                let _ = shutdown_tx.send(true);
+            },
+        }
+    }
+}
+
+impl From<Handle> for WebServerShutdownHandle {
+    fn from(handle: Handle) -> Self {
+        WebServerShutdownHandle::AxumServer(handle)
+    }
+}
+
+#[cfg(unix)]
+impl From<tokio::sync::watch::Sender<bool>> for WebServerShutdownHandle {
+    fn from(shutdown_tx: tokio::sync::watch::Sender<bool>) -> Self {
+        WebServerShutdownHandle::UnixSocket(shutdown_tx)
+    }
+}
+
 pub async fn create_webserver_receiver(
     id: &str,
 ) -> Result<interprocess::local_socket::tokio::Stream, Box<dyn std::error::Error + Send + Sync>> {
@@ -61,7 +93,7 @@ pub async fn send_webserver_response(
 }
 
 pub async fn listen_to_web_server_instructions(
-    server_handle: Handle,
+    shutdown_handle: WebServerShutdownHandle,
     id: &str,
     web_server_ip: IpAddr,
     web_server_port: u16,
@@ -72,7 +104,7 @@ pub async fn listen_to_web_server_instructions(
             Ok(mut receiver) => match receive_webserver_instruction(&mut receiver).await {
                 Ok(instruction) => match instruction {
                     InstructionForWebServer::ShutdownWebServer => {
-                        server_handle.shutdown();
+                        shutdown_handle.shutdown();
                         break;
                     },
                     InstructionForWebServer::QueryVersion => {

--- a/zellij-client/src/web_client/mod.rs
+++ b/zellij-client/src/web_client/mod.rs
@@ -11,6 +11,8 @@ mod types;
 mod utils;
 mod websocket_handlers;
 
+#[cfg(unix)]
+use std::path::Path;
 use std::{
     net::{IpAddr, Ipv4Addr},
     path::PathBuf,
@@ -65,6 +67,7 @@ pub fn start_web_client(
     run_daemonized: bool,
     custom_ip: Option<IpAddr>,
     custom_port: Option<u16>,
+    custom_socket: Option<PathBuf>,
     custom_server_cert: Option<PathBuf>,
     custom_server_key: Option<PathBuf>,
     startup_timeout: Option<u64>,
@@ -98,6 +101,46 @@ pub fn start_web_client(
     let web_server_cert = custom_server_cert.or_else(|| config.options.web_server_cert.clone());
     let web_server_key = custom_server_key.or_else(|| config.options.web_server_key.clone());
     let has_https_certificate = web_server_cert.is_some() && web_server_key.is_some();
+
+    if let Some(web_server_socket) = custom_socket {
+        #[cfg(unix)]
+        {
+            let (runtime, listener) = if run_daemonized {
+                daemonize_web_server_unix_socket(web_server_socket.clone())
+            } else {
+                let runtime = Runtime::new().unwrap();
+                let listener = match bind_unix_listener(&web_server_socket) {
+                    Ok(listener) => listener,
+                    Err(e) => {
+                        eprintln!("{}", e);
+                        std::process::exit(2);
+                    },
+                };
+                println!(
+                    "Web Server started on Unix socket {}",
+                    web_server_socket.display()
+                );
+                (runtime, listener)
+            };
+            runtime.block_on(serve_web_client_on_unix_socket(
+                config,
+                config_options,
+                config_file_path,
+                listener,
+                web_server_socket,
+                None,
+                None,
+                web_server_ip,
+                web_server_port,
+            ));
+            return;
+        }
+        #[cfg(not(unix))]
+        {
+            eprintln!("Unix socket web server listening is only supported on Unix.");
+            std::process::exit(2);
+        }
+    }
 
     if let Err(e) = should_use_https(
         web_server_ip,
@@ -174,6 +217,71 @@ pub fn start_web_client(
     ));
 }
 
+fn build_web_client_app(
+    config: Config,
+    config_options: Options,
+    config_file_path: Option<PathBuf>,
+    session_manager: Option<Arc<dyn SessionManager>>,
+    client_os_api_factory: Option<Arc<dyn ClientOsApiFactory>>,
+    is_https: bool,
+) -> Option<Router> {
+    let Some(config_file_path) = config_file_path.or_else(|| Config::default_config_file_path())
+    else {
+        log::error!("Failed to find default config file path");
+        return None;
+    };
+    let connection_table = Arc::new(Mutex::new(ConnectionTable::default()));
+    let session_manager = session_manager.unwrap_or_else(|| Arc::new(RealSessionManager));
+    let client_os_api_factory =
+        client_os_api_factory.unwrap_or_else(|| Arc::new(RealClientOsApiFactory));
+
+    let state = AppState {
+        connection_table: connection_table.clone(),
+        config: Arc::new(Mutex::new(config)),
+        config_options,
+        config_file_path,
+        session_manager,
+        client_os_api_factory,
+        is_https,
+    };
+
+    Some(
+        Router::new()
+            .route("/ws/control", any(ws_handler_control))
+            .route("/ws/terminal", any(ws_handler_terminal))
+            .route("/ws/terminal/{session}", any(ws_handler_terminal))
+            .route("/session", post(create_new_client))
+            .route_layer(middleware::from_fn(auth_middleware))
+            .route("/", get(serve_html))
+            .route("/{session}", get(serve_html))
+            .route("/assets/{*path}", get(get_static_asset))
+            .route("/command/login", post(login_handler))
+            .route("/info/version", get(version_handler))
+            .with_state(state)
+            .layer(axum::middleware::from_fn(move |request, next: axum::middleware::Next| {
+                async move {
+                    let mut response = next.run(request).await;
+                    let headers = response.headers_mut();
+                    headers.insert("X-Content-Type-Options", "nosniff".parse().unwrap());
+                    headers.insert("X-Frame-Options", "DENY".parse().unwrap());
+                    headers
+                        .insert("Referrer-Policy", "strict-origin-when-cross-origin".parse().unwrap());
+                    headers.insert(
+                        "Content-Security-Policy",
+                        "default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' ws: wss:; img-src 'self' data:".parse().unwrap(),
+                    );
+                    if is_https {
+                        headers.insert(
+                            "Strict-Transport-Security",
+                            "max-age=31536000; includeSubDomains".parse().unwrap(),
+                        );
+                    }
+                    response
+                }
+            })),
+    )
+}
+
 pub async fn serve_web_client(
     config: Config,
     config_options: Options,
@@ -185,16 +293,7 @@ pub async fn serve_web_client(
     web_server_ip: IpAddr,
     web_server_port: u16,
 ) {
-    let Some(config_file_path) = config_file_path.or_else(|| Config::default_config_file_path())
-    else {
-        log::error!("Failed to find default config file path");
-        return;
-    };
-    let connection_table = Arc::new(Mutex::new(ConnectionTable::default()));
     let server_handle = Handle::new();
-    let session_manager = session_manager.unwrap_or_else(|| Arc::new(RealSessionManager));
-    let client_os_api_factory =
-        client_os_api_factory.unwrap_or_else(|| Arc::new(RealClientOsApiFactory));
 
     // we use a short version here to bypass macos socket path length limitations
     // since there likely aren't going to be more than a handful of web instances on the same
@@ -207,21 +306,22 @@ pub async fn serve_web_client(
         .collect();
 
     let is_https = rustls_config.is_some();
-    let state = AppState {
-        connection_table: connection_table.clone(),
-        config: Arc::new(Mutex::new(config)),
+    let Some(app) = build_web_client_app(
+        config,
         config_options,
         config_file_path,
         session_manager,
         client_os_api_factory,
         is_https,
+    ) else {
+        return;
     };
 
     tokio::spawn({
         let server_handle = server_handle.clone();
         async move {
             listen_to_web_server_instructions(
-                server_handle,
+                server_handle.into(),
                 &format!("{}", id),
                 web_server_ip,
                 web_server_port,
@@ -229,40 +329,6 @@ pub async fn serve_web_client(
             .await;
         }
     });
-
-    let is_https = state.is_https;
-    let app = Router::new()
-        .route("/ws/control", any(ws_handler_control))
-        .route("/ws/terminal", any(ws_handler_terminal))
-        .route("/ws/terminal/{session}", any(ws_handler_terminal))
-        .route("/session", post(create_new_client))
-        .route_layer(middleware::from_fn(auth_middleware))
-        .route("/", get(serve_html))
-        .route("/{session}", get(serve_html))
-        .route("/assets/{*path}", get(get_static_asset))
-        .route("/command/login", post(login_handler))
-        .route("/info/version", get(version_handler))
-        .with_state(state)
-        .layer(axum::middleware::from_fn(move |request, next: axum::middleware::Next| {
-            async move {
-                let mut response = next.run(request).await;
-                let headers = response.headers_mut();
-                headers.insert("X-Content-Type-Options", "nosniff".parse().unwrap());
-                headers.insert("X-Frame-Options", "DENY".parse().unwrap());
-                headers.insert("Referrer-Policy", "strict-origin-when-cross-origin".parse().unwrap());
-                headers.insert(
-                    "Content-Security-Policy",
-                    "default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' ws: wss:; img-src 'self' data:".parse().unwrap(),
-                );
-                if is_https {
-                    headers.insert(
-                        "Strict-Transport-Security",
-                        "max-age=31536000; includeSubDomains".parse().unwrap(),
-                    );
-                }
-                response
-            }
-        }));
 
     match rustls_config {
         Some(rustls_config) => {
@@ -278,6 +344,72 @@ pub async fn serve_web_client(
                 .await;
         },
     }
+}
+
+#[cfg(unix)]
+pub async fn serve_web_client_on_unix_socket(
+    config: Config,
+    config_options: Options,
+    config_file_path: Option<PathBuf>,
+    listener: tokio::net::UnixListener,
+    socket_path: PathBuf,
+    session_manager: Option<Arc<dyn SessionManager>>,
+    client_os_api_factory: Option<Arc<dyn ClientOsApiFactory>>,
+    web_server_ip: IpAddr,
+    web_server_port: u16,
+) {
+    let Some(app) = build_web_client_app(
+        config,
+        config_options,
+        config_file_path,
+        session_manager,
+        client_os_api_factory,
+        false,
+    ) else {
+        return;
+    };
+
+    let id: String = Uuid::new_v4()
+        .simple()
+        .to_string()
+        .chars()
+        .take(5)
+        .collect();
+    let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
+
+    tokio::spawn(async move {
+        listen_to_web_server_instructions(
+            shutdown_tx.into(),
+            &format!("{}", id),
+            web_server_ip,
+            web_server_port,
+        )
+        .await;
+    });
+
+    let shutdown_signal = async move {
+        while shutdown_rx.changed().await.is_ok() {
+            if *shutdown_rx.borrow() {
+                break;
+            }
+        }
+    };
+
+    let _ = axum::serve(listener, app.into_make_service())
+        .with_graceful_shutdown(shutdown_signal)
+        .await;
+    let _ = tokio::fs::remove_file(socket_path).await;
+}
+
+#[cfg(unix)]
+fn bind_unix_listener(socket_path: &Path) -> std::io::Result<tokio::net::UnixListener> {
+    if let Some(parent) = socket_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    if socket_path.exists() {
+        std::fs::remove_file(socket_path)?;
+    }
+    tokio::net::UnixListener::bind(socket_path)
 }
 
 #[cfg(unix)]
@@ -367,6 +499,76 @@ fn daemonize_web_server(
                     exit_message_tx,
                     "Web Server started on {} port {}",
                     web_server_ip, web_server_port
+                );
+                let _ = exit_status_tx.write_all(&[0]);
+                listener_and_runtime
+            },
+            Err(e) => {
+                let _ = exit_status_tx.write_all(&[2]);
+                let _ = writeln!(exit_message_tx, "{}", e);
+                std::process::exit(2);
+            },
+        },
+        _ => {
+            eprintln!("Failed to start server");
+            std::process::exit(2);
+        },
+    }
+}
+
+#[cfg(unix)]
+fn daemonize_web_server_unix_socket(
+    web_server_socket: PathBuf,
+) -> (Runtime, tokio::net::UnixListener) {
+    let (mut exit_message_tx, exit_message_rx) = pipe().unwrap();
+    let (mut exit_status_tx, mut exit_status_rx) = pipe().unwrap();
+    let current_umask = umask(Mode::all());
+    umask(current_umask);
+    let web_server_socket_for_child = web_server_socket.clone();
+    let daemonization_outcome = daemonize::Daemonize::new()
+        .working_directory(std::env::current_dir().unwrap())
+        .umask(current_umask.bits() as u32)
+        .privileged_action(
+            move || -> Result<(Runtime, tokio::net::UnixListener), String> {
+                let runtime = Runtime::new().map_err(|e| e.to_string())?;
+                let listener =
+                    bind_unix_listener(&web_server_socket_for_child).map_err(|e| e.to_string())?;
+                Ok((runtime, listener))
+            },
+        )
+        .execute();
+    match daemonization_outcome {
+        Outcome::Parent(Ok(parent)) => {
+            if parent.first_child_exit_code == 0 {
+                let mut buf = [0; 1];
+                match exit_status_rx.read_exact(&mut buf) {
+                    Ok(_) => {
+                        let exit_status = buf.iter().next().copied().unwrap_or(0) as i32;
+                        let mut message = String::new();
+                        let mut reader = BufReader::new(exit_message_rx);
+                        let _ = reader.read_line(&mut message);
+                        if exit_status == 0 {
+                            println!("{}", message.trim());
+                        } else {
+                            eprintln!("{}", message.trim());
+                        }
+                        std::process::exit(exit_status);
+                    },
+                    Err(e) => {
+                        eprintln!("{}", e);
+                        std::process::exit(2);
+                    },
+                }
+            } else {
+                std::process::exit(parent.first_child_exit_code);
+            }
+        },
+        Outcome::Child(Ok(child)) => match child.privileged_action_result {
+            Ok(listener_and_runtime) => {
+                let _ = writeln!(
+                    exit_message_tx,
+                    "Web Server started on Unix socket {}",
+                    web_server_socket.display()
                 );
                 let _ = exit_status_tx.write_all(&[0]);
                 listener_and_runtime

--- a/zellij-client/src/web_client/unit/web_client_tests.rs
+++ b/zellij-client/src/web_client/unit/web_client_tests.rs
@@ -62,6 +62,46 @@ mod web_client_tests {
         ))
     }
 
+    #[cfg(unix)]
+    async fn wait_for_unix_socket_server(
+        socket_path: &std::path::Path,
+        timeout: Duration,
+    ) -> Result<(), String> {
+        let start = Instant::now();
+        let socket_path = socket_path.to_path_buf();
+
+        while start.elapsed() < timeout {
+            match tokio::task::spawn_blocking({
+                let socket_path = socket_path.clone();
+                move || {
+                    let http_client = isahc::HttpClient::builder()
+                        .dial(isahc::config::Dialer::unix_socket(socket_path))
+                        .build()?;
+                    let request = isahc::Request::get("http://localhost/info/version").body(())?;
+                    http_client.send(request)
+                }
+            })
+            .await
+            {
+                Ok(Ok(_)) => {
+                    return Ok(());
+                },
+                Ok(Err(e)) => {
+                    eprintln!("Unix socket HTTP request failed: {:?}", e);
+                },
+                Err(e) => {
+                    eprintln!("Task spawn failed: {:?}", e);
+                },
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        Err(format!(
+            "HTTP server failed to start on Unix socket {} within {:?}",
+            socket_path.display(),
+            timeout
+        ))
+    }
+
     #[tokio::test]
     #[serial]
     async fn test_version_endpoint() {
@@ -114,6 +154,68 @@ mod web_client_tests {
         server_handle.abort();
 
         // time for cleanup
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    #[serial]
+    async fn test_version_endpoint_over_unix_socket() {
+        let _ = delete_db();
+
+        let session_manager = Arc::new(MockSessionManager::new());
+        let client_os_api_factory = Arc::new(MockClientOsApiFactory::new());
+
+        let config = Config::default();
+        let options = Options::default();
+
+        let socket_dir = tempfile::tempdir().unwrap();
+        let socket_path = socket_dir.path().join("zellij-web.sock");
+        let listener = tokio::net::UnixListener::bind(&socket_path).unwrap();
+        let temp_config_path = std::env::temp_dir().join("test_config.kdl");
+
+        let server_handle = tokio::spawn(serve_web_client_on_unix_socket(
+            config,
+            options,
+            Some(temp_config_path),
+            listener,
+            socket_path.clone(),
+            Some(session_manager),
+            Some(client_os_api_factory),
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            0,
+        ));
+
+        wait_for_unix_socket_server(&socket_path, Duration::from_secs(5))
+            .await
+            .expect("Server failed to start");
+
+        let socket_path_for_request = socket_path.clone();
+        let mut response = timeout(
+            Duration::from_secs(5),
+            tokio::task::spawn_blocking(move || {
+                let http_client = isahc::HttpClient::builder()
+                    .dial(isahc::config::Dialer::unix_socket(socket_path_for_request))
+                    .build()
+                    .expect("Failed to build client");
+                let request = isahc::Request::get("http://localhost/info/version")
+                    .body(())
+                    .expect("Failed to build request");
+                http_client.send(request)
+            }),
+        )
+        .await
+        .expect("Request timed out")
+        .expect("Spawn blocking failed")
+        .expect("Request failed");
+
+        assert!(response.status().is_success());
+
+        let version_text = response.text().expect("Failed to read response body");
+        assert_eq!(version_text, VERSION);
+
+        server_handle.abort();
+
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -244,12 +244,21 @@ pub struct WebCli {
         display_order = 14
     )]
     pub port: Option<u16>,
+    /// The Unix socket path to listen on locally for connections
+    #[clap(
+        long = "socket",
+        value_parser,
+        value_name = "SOCKET",
+        display_order = 15
+    )]
+    #[serde(rename = "socket")]
+    pub web_socket: Option<PathBuf>,
     /// The path to the SSL certificate (required if not listening on 127.0.0.1)
     #[clap(
         long,
         value_parser,
         conflicts_with_all(&["stop", "status", "create-token", "revoke-token", "revoke-all-tokens"]),
-        display_order = 15
+        display_order = 16
     )]
     pub cert: Option<PathBuf>,
     /// The path to the SSL key (required if not listening on 127.0.0.1)
@@ -257,12 +266,59 @@ pub struct WebCli {
         long,
         value_parser,
         conflicts_with_all(&["stop", "status", "create-token", "revoke-token", "revoke-all-tokens"]),
-        display_order = 16
+        display_order = 17
     )]
     pub key: Option<PathBuf>,
 }
 
 impl WebCli {
+    pub fn validate_socket_args(&self) -> Result<(), String> {
+        if self.web_socket.is_none() {
+            return Ok(());
+        }
+
+        let mut incompatible_args = vec![];
+        if self.ip.is_some() {
+            incompatible_args.push("--ip");
+        }
+        if self.port.is_some() {
+            incompatible_args.push("--port");
+        }
+        if self.cert.is_some() {
+            incompatible_args.push("--cert");
+        }
+        if self.key.is_some() {
+            incompatible_args.push("--key");
+        }
+        if self.stop {
+            incompatible_args.push("--stop");
+        }
+        if self.create_token {
+            incompatible_args.push("--create-token");
+        }
+        if self.create_read_only_token {
+            incompatible_args.push("--create-read-only-token");
+        }
+        if self.revoke_token.is_some() {
+            incompatible_args.push("--revoke-token");
+        }
+        if self.revoke_all_tokens {
+            incompatible_args.push("--revoke-all-tokens");
+        }
+        if self.list_tokens {
+            incompatible_args.push("--list-tokens");
+        }
+
+        if incompatible_args.is_empty() {
+            Ok(())
+        } else {
+            Err(format!(
+                "--socket cannot be used with {}",
+                incompatible_args.join(", ")
+            ))
+        }
+    }
+
     pub fn get_start(&self) -> bool {
         self.start
             || !(self.stop


### PR DESCRIPTION
## Summary
- add `zellij web --socket <SOCKET>` to serve the web client over a Unix domain socket
- support `zellij web --status --socket <SOCKET>` using Isahc Unix socket dialing
- share the web-client router between TCP/TLS and Unix listeners while keeping web-server shutdown support
- add CLI coverage and a Unix-socket version endpoint test

## Motivation
This gives reverse proxies a secure local backend path without binding Zellij to a non-loopback TCP interface or requiring backend TLS certificates. Caddy, Nginx, Traefik, and similar proxies can proxy to the socket while public TLS remains at the reverse proxy.

## Notes
This PR intentionally keeps the change CLI-only. A config key and public URL/share integration can be a follow-up because the current status/share plumbing assumes an IP/port URL.

The CLI tests now run their Clap parser work on a larger test-thread stack. Clap 3 recursively validates this large command graph, and adding another web option exceeded the default test thread stack even though normal binary execution parses the flag correctly.

## Validation
- `cargo fmt`
- `git diff --check`
- `cargo test -p zellij --no-default-features --features web_server_capability,disable_automatic_asset_installation tests::cli -- --nocapture`
- `cargo test -p zellij-client --features web_server_capability test_version_endpoint_over_unix_socket -- --nocapture`
- `cargo check -p zellij-utils`
- `cargo check -p zellij-client --features web_server_capability`
- `cargo check -p zellij --no-default-features --features web_server_capability,disable_automatic_asset_installation`

I used the `disable_automatic_asset_installation` top-level check because this checkout does not include the prebuilt default-plugin WASM files needed by the default `cargo check --features web_server_capability` path.
