### PR TITLE
Fix: clamp floating panes against absolute viewport bounds

### DIFF
--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -317,15 +317,17 @@ impl FloatingPanes {
         if position.rows.as_usize() > viewport.rows {
             position.rows = Dimension::fixed(viewport.rows);
         }
-        if position.x + position.cols.as_usize() > viewport.cols {
+        let viewport_right = viewport.x + viewport.cols;
+        let viewport_bottom = viewport.y + viewport.rows;
+        if position.x + position.cols.as_usize() > viewport_right {
             position.x = position
                 .x
-                .saturating_sub((position.x + position.cols.as_usize()) - viewport.cols);
+                .saturating_sub((position.x + position.cols.as_usize()) - viewport_right);
         }
-        if position.y + position.rows.as_usize() > viewport.rows {
+        if position.y + position.rows.as_usize() > viewport_bottom {
             position.y = position
                 .y
-                .saturating_sub((position.y + position.rows.as_usize()) - viewport.rows);
+                .saturating_sub((position.y + position.rows.as_usize()) - viewport_bottom);
         }
         Ok(position)
     }


### PR DESCRIPTION
## What
Fix the clamp logic in `position_floating_pane_layout` to compare floating pane positions against the absolute right/bottom edges of the viewport (`viewport.x + viewport.cols`, `viewport.y + viewport.rows`) rather than against the viewport dimensions alone.

## Why
When a tab has borderless UI panes (tab-bar, status-bar) reserving space, the floating-panes viewport has a non-zero `viewport.y`. The previous clamp treated `viewport.rows` as the bottom edge, so a floating pane positioned at `y "100%"` ended up shifted up by exactly `rows`, leaving its bottom edge at `viewport.rows` instead of `viewport.y + viewport.rows` — a gap equal to `viewport.y` rows.

The matching move-down clamp in `floating_pane_grid.rs:can_move_pane_down` already uses `self.viewport.y + self.viewport.rows`. This change makes the layout-time path consistent.

## Repro (before fix)
```kdl
swap_floating_layout name="quarters" {
    floating_panes max_panes=4 {
        pane { x "0%";  y 1;      width "50%"; height "50%" }
        pane { x "50%"; y 1;      width "50%"; height "50%" }
        pane { x "0%";  y "100%"; width "50%"; height "50%" }
        pane { x "50%"; y "100%"; width "50%"; height "50%" }
    }
}
```

The bottom panes don't reach the bottom of the floating viewport. With this fix, they do.