### PR TITLE
query terminal size for all clients on attach, not just web clients

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -7493,18 +7493,16 @@ pub(crate) fn screen_thread_main(
                 }
                 screen.log_and_report_session_state()?;
 
-                if is_web_client {
-                    // we do this because
-                    // we need to query the client for its size, and we must do it only after we've
-                    // added it to our state.
-                    //
-                    // we have to do this specifically for web clients because the browser (as opposed
-                    // to a traditional terminal) can only figure out its dimensions after we sent it relevant
-                    // state (eg. font, which is controlled by our config and it needs to determine cell size)
-                    if let Some(os_input) = &mut screen.bus.os_input {
-                        let _ = os_input
-                            .send_to_client(client_id, ServerToClientMsg::QueryTerminalSize);
-                    }
+                // Query the client for its terminal size after adding it to our state.
+                // For web clients, the browser can only determine its dimensions after receiving
+                // font/config state from us (eg. font, which controls cell size).
+                // For terminal clients, this resolves a race condition where the terminal emulator
+                // (eg. Tilix/VTE) initializes at a default column count and resizes to the actual
+                // window size shortly after - meaning the size read at startup may be stale by the
+                // time the client is fully attached.
+                if let Some(os_input) = &mut screen.bus.os_input {
+                    let _ = os_input
+                        .send_to_client(client_id, ServerToClientMsg::QueryTerminalSize);
                 }
 
                 screen.render(None)?;


### PR DESCRIPTION
## Problem

Terminal emulators like Tilix (VTE-based) initialize the terminal widget at a profile default (often 80 columns) before the window finishes rendering at its actual size. Zellij reads the terminal size at startup and can get this stale value.

When the window resizes to its real dimensions, the terminal sends `SIGWINCH`. But there is a race between that signal arriving and Zellij being fully initialized and ready to handle it. If the signal is missed, the session stays locked at 80 columns and never fills the terminal window horizontally.

## Fix

Web clients already receive a `QueryTerminalSize` message after `AddClient`, because the browser needs font/config state from Zellij before it can calculate its own dimensions. The same round-trip fixes the race condition for regular terminal clients: by the time the message travels to the client and the client reads the terminal size and responds, the terminal emulator has finished initializing at its real dimensions.

The change removes the `if is_web_client` guard so `QueryTerminalSize` is sent to all clients on attach. The overhead is one extra message round-trip per attach, which is negligible.

## Testing

Reproduced with Zellij 0.44.1 + Tilix on Linux. Session attached at 80 columns, window maximized, Zellij never updated. With this fix, the session resizes to the correct terminal dimensions on attach.