### PR TITLE
Allow targeting specific clients when detaching a session

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -585,6 +585,18 @@ fn attach_with_cli_client(
     session_name: &str,
     config: Option<Config>,
 ) {
+    if let zellij_utils::cli::CliAction::Detach {
+        client_id: Some(client_id),
+    } = &cli_action
+    {
+        let os_input = get_os_input(zellij_client::os_input_output::get_cli_client_os_input);
+        zellij_client::cli_client::start_cli_client_detach(
+            Box::new(os_input),
+            session_name,
+            *client_id,
+        );
+        std::process::exit(0);
+    }
     let os_input = get_os_input(zellij_client::os_input_output::get_cli_client_os_input);
     let get_current_dir = || std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     match Action::actions_from_cli(cli_action, Box::new(get_current_dir), config) {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -585,17 +585,17 @@ fn attach_with_cli_client(
     session_name: &str,
     config: Option<Config>,
 ) {
-    if let zellij_utils::cli::CliAction::Detach {
-        client_id: Some(client_id),
-    } = &cli_action
-    {
-        let os_input = get_os_input(zellij_client::os_input_output::get_cli_client_os_input);
-        zellij_client::cli_client::start_cli_client_detach(
-            Box::new(os_input),
-            session_name,
-            *client_id,
-        );
-        std::process::exit(0);
+    if let zellij_utils::cli::CliAction::Detach { client_id, all } = &cli_action {
+        if *all || client_id.is_some() {
+            let os_input = get_os_input(zellij_client::os_input_output::get_cli_client_os_input);
+            zellij_client::cli_client::start_cli_client_detach(
+                Box::new(os_input),
+                session_name,
+                *client_id,
+                *all,
+            );
+            std::process::exit(0);
+        }
     }
     let os_input = get_os_input(zellij_client::os_input_output::get_cli_client_os_input);
     let get_current_dir = || std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));

--- a/zellij-client/src/cli_client.rs
+++ b/zellij-client/src/cli_client.rs
@@ -10,7 +10,7 @@ use crate::os_input_output::ClientOsApi;
 use uuid::Uuid;
 use zellij_utils::{
     cli::{SubscribeCli, SubscribeFormat},
-    data::PaneId,
+    data::{ClientId, PaneId},
     errors::prelude::*,
     input::actions::Action,
     ipc::{ClientToServerMsg, ExitReason, ServerToClientMsg},
@@ -73,6 +73,25 @@ pub fn start_cli_client(
         }
     }
     os_input.send_to_server(ClientToServerMsg::ClientExited);
+}
+
+pub fn start_cli_client_detach(
+    os_input: Box<dyn ClientOsApi>,
+    session_name: &str,
+    client_id: ClientId,
+) {
+    let zellij_ipc_pipe: PathBuf = {
+        let mut sock_dir = zellij_utils::consts::ZELLIJ_SOCK_DIR.clone();
+        fs::create_dir_all(&sock_dir).unwrap();
+        zellij_utils::shared::set_permissions(&sock_dir, 0o700).unwrap();
+        sock_dir.push(session_name);
+        sock_dir
+    };
+    crate::check_ipc_pipe_length(&zellij_ipc_pipe);
+    os_input.connect_to_server(&*zellij_ipc_pipe);
+    os_input.send_to_server(ClientToServerMsg::DetachSession {
+        client_ids: vec![client_id],
+    });
 }
 
 fn pipe_client(

--- a/zellij-client/src/cli_client.rs
+++ b/zellij-client/src/cli_client.rs
@@ -78,7 +78,8 @@ pub fn start_cli_client(
 pub fn start_cli_client_detach(
     os_input: Box<dyn ClientOsApi>,
     session_name: &str,
-    client_id: ClientId,
+    client_id: Option<ClientId>,
+    all: bool,
 ) {
     let zellij_ipc_pipe: PathBuf = {
         let mut sock_dir = zellij_utils::consts::ZELLIJ_SOCK_DIR.clone();
@@ -90,7 +91,11 @@ pub fn start_cli_client_detach(
     crate::check_ipc_pipe_length(&zellij_ipc_pipe);
     os_input.connect_to_server(&*zellij_ipc_pipe);
     os_input.send_to_server(ClientToServerMsg::DetachSession {
-        client_ids: vec![client_id],
+        client_ids: if all {
+            vec![]
+        } else {
+            client_id.into_iter().collect()
+        },
     });
 }
 

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -1474,6 +1474,11 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                 }
             },
             ServerInstruction::DetachSession(client_ids, completion_tx) => {
+                let client_ids = if client_ids.is_empty() {
+                    session_state.read().unwrap().client_ids()
+                } else {
+                    client_ids
+                };
                 for client_id in &client_ids {
                     let _ = os_input.send_to_client(
                         *client_id,

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -1622,8 +1622,11 @@ tail -f /tmp/my-live-logfile | zellij action pipe --name logs --plugin https://e
     /// Detach from the current session or disconnect a specific client
     Detach {
         /// Target a specific client ID to disconnect from the server
-        #[clap(long, value_parser)]
+        #[clap(long, value_parser, conflicts_with = "all")]
         client_id: Option<ClientId>,
+        /// Disconnect all connected clients from the session
+        #[clap(long, value_parser, takes_value(false), conflicts_with = "client-id")]
+        all: bool,
     },
     /// Switch the theme to dark (uses configured `theme_dark`).
     SetDarkTheme,
@@ -1757,10 +1760,42 @@ mod tests {
 
         match cli.command {
             Some(Command::Action(action)) => match *action {
-                CliAction::Detach { client_id } => assert_eq!(client_id, Some(7)),
+                CliAction::Detach { client_id, all } => {
+                    assert_eq!(client_id, Some(7));
+                    assert!(!all);
+                },
                 other => panic!("Expected Detach action, got {:?}", other),
             },
             other => panic!("Expected Action command, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn action_detach_accepts_all_flag() {
+        let cli = CliArgs::try_parse_from(["zellij", "action", "detach", "--all"]).unwrap();
+
+        match cli.command {
+            Some(Command::Action(action)) => match *action {
+                CliAction::Detach { client_id, all } => {
+                    assert_eq!(client_id, None);
+                    assert!(all);
+                },
+                other => panic!("Expected Detach action, got {:?}", other),
+            },
+            other => panic!("Expected Action command, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn action_detach_rejects_all_with_client_id() {
+        let result = CliArgs::try_parse_from([
+            "zellij",
+            "action",
+            "detach",
+            "--all",
+            "--client-id",
+            "7",
+        ]);
+        assert!(result.is_err());
     }
 }

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::data::{Direction, InputMode, Resize, UnblockCondition};
+use crate::data::{ClientId, Direction, InputMode, Resize, UnblockCondition};
 use crate::setup::Setup;
 use crate::{
     consts::{ZELLIJ_CONFIG_DIR_ENV, ZELLIJ_CONFIG_FILE_ENV},
@@ -1619,8 +1619,12 @@ tail -f /tmp/my-live-logfile | zellij action pipe --name logs --plugin https://e
         #[clap(short, long, value_parser)]
         borderless: bool,
     },
-    /// Detach from the current session
-    Detach,
+    /// Detach from the current session or disconnect a specific client
+    Detach {
+        /// Target a specific client ID to disconnect from the server
+        #[clap(long, value_parser)]
+        client_id: Option<ClientId>,
+    },
     /// Switch the theme to dark (uses configured `theme_dark`).
     SetDarkTheme,
     /// Switch the theme to light (uses configured `theme_light`).
@@ -1738,5 +1742,25 @@ mod tests {
     fn subscribe_requires_pane_id() {
         let result = CliArgs::try_parse_from(["zellij", "subscribe"]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn action_detach_accepts_optional_client_id() {
+        let cli = CliArgs::try_parse_from([
+            "zellij",
+            "action",
+            "detach",
+            "--client-id",
+            "7",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Command::Action(action)) => match *action {
+                CliAction::Detach { client_id } => assert_eq!(client_id, Some(7)),
+                other => panic!("Expected Detach action, got {:?}", other),
+            },
+            other => panic!("Expected Action command, got {:?}", other),
+        }
     }
 }

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -2057,7 +2057,10 @@ impl Action {
                     )),
                 }
             },
-            CliAction::Detach { client_id: _ } => Ok(vec![Action::Detach]),
+            CliAction::Detach {
+                client_id: _,
+                all: _,
+            } => Ok(vec![Action::Detach]),
             CliAction::SetDarkTheme => Ok(vec![Action::SetDarkTheme]),
             CliAction::SetLightTheme => Ok(vec![Action::SetLightTheme]),
             CliAction::ToggleTheme => Ok(vec![Action::ToggleTheme]),

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -2057,7 +2057,7 @@ impl Action {
                     )),
                 }
             },
-            CliAction::Detach => Ok(vec![Action::Detach]),
+            CliAction::Detach { client_id: _ } => Ok(vec![Action::Detach]),
             CliAction::SetDarkTheme => Ok(vec![Action::SetDarkTheme]),
             CliAction::SetLightTheme => Ok(vec![Action::SetLightTheme]),
             CliAction::ToggleTheme => Ok(vec![Action::ToggleTheme]),


### PR DESCRIPTION
## Summary
- add `zellij -s <session> action detach --client-id <id>` support so the CLI can disconnect one attached client without attaching first
- add `zellij -s <session> action detach --all` support to detach every connected client from the target session
- cover the new CLI parsing modes with tests and route the detach request directly through the CLI client/server IPC path