### PR TITLE
fix: when publishing, publish current branch rather than hardcoded main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * feat: support `CSI 2031` + dark/light mode theme switching (https://github.com/zellij-org/zellij/pull/5105, https://github.com/zellij-org/zellij/pull/5111 and https://github.com/zellij-org/zellij/pull/5113)
 * fix: incorrect interpretation of unicode characters in KKP STDIN (https://github.com/zellij-org/zellij/pull/5110)
 * fix: some issues regarding the interaction of fullscreen panes with resize/scrollback-editing (https://github.com/zellij-org/zellij/pull/5117)
+* fix: allow releasing from non-main branches in our build system (https://github.com/zellij-org/zellij/pull/5127)
 
 ## [0.44.1] - 2026-04-07
 * fix: don't display default ports as offline in `share` plugin (https://github.com/zellij-org/zellij/pull/4908)

--- a/xtask/src/pipelines.rs
+++ b/xtask/src/pipelines.rs
@@ -359,7 +359,10 @@ pub fn publish(sh: &Shell, flags: flags::Publish) -> anyhow::Result<()> {
         } else if flags.no_push {
             println!("Skipping push due to no-push");
         } else {
-            cmd!(sh, "git push --atomic {remote} main v{version}")
+            let branch = cmd!(sh, "git rev-parse --abbrev-ref HEAD")
+                .read()
+                .context(err_context)?;
+            cmd!(sh, "git push --atomic {remote} {branch} v{version}")
                 .run()
                 .context(err_context)?;
         }


### PR DESCRIPTION
Small fix to our release process, in preparation to working with release branches.