### PR TITLE
fix(windows): bump windows-sys to 0.59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 * feat: allow tabs to have different sizes if clients aren't focused on the same one (https://github.com/zellij-org/zellij/pull/5133)
+* fix(windows): bump windows-sys to 0.59 to align manifest with code, fixing source builds via `cargo install`/`cargo binstall` (https://github.com/zellij-org/zellij/pull/5139)
 
 ## [0.44.2] - 2026-05-05
 * fix: idle CPU + disk i/o, CommandChanged plugin Event, GetSessionList plugin command (https://github.com/zellij-org/zellij/pull/5063)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4857,7 +4857,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "zellij-utils",
 ]
 
@@ -4907,7 +4907,7 @@ dependencies = [
  "vte 0.11.0",
  "wasmi",
  "wasmi_wasi",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "zellij-utils",
 ]
 
@@ -4983,7 +4983,7 @@ dependencies = [
  "url",
  "uuid",
  "winapi",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ unicode-width = { version = "0.1.8", default-features = false }
 url = { version = "2.2.2", default-features = false, features = ["serde"] }
 uuid = { version = "1.4.1", default-features = false, features = ["serde", "v4", "std"] }
 vte = { version = "0.11.0", default-features = false }
-windows-sys = { version = "0.52", default-features = false }
+windows-sys = { version = "0.59", default-features = false }
 names = { version = "0.14.0", default-features = false }
 include_dir = { version = "0.7.3", default-features = false }
 sha2 = { version = "0.10", default-features = false }

--- a/zellij-client/src/stdin_handler_windows.rs
+++ b/zellij-client/src/stdin_handler_windows.rs
@@ -29,7 +29,7 @@ static ORIGINAL_CONSOLE_MODE: OnceLock<u32> = OnceLock::new();
 pub(crate) fn enable_vt_input() -> bool {
     unsafe {
         let handle = GetStdHandle(STD_INPUT_HANDLE);
-        if handle == 0 || handle == INVALID_HANDLE_VALUE {
+        if handle.is_null() || handle == INVALID_HANDLE_VALUE {
             return false;
         }
         let mut mode: u32 = 0;
@@ -77,7 +77,7 @@ pub(crate) fn restore_vt_input() {
     if let Some(&original_mode) = ORIGINAL_CONSOLE_MODE.get() {
         unsafe {
             let handle = GetStdHandle(STD_INPUT_HANDLE);
-            if handle != 0 && handle != INVALID_HANDLE_VALUE {
+            if !handle.is_null() && handle != INVALID_HANDLE_VALUE {
                 SetConsoleMode(handle, original_mode);
             }
         }

--- a/zellij-server/src/os_input_output_windows.rs
+++ b/zellij-server/src/os_input_output_windows.rs
@@ -55,7 +55,8 @@ struct ConPtyTerminal {
     input_write_handle: HANDLE,
 }
 
-// HANDLE/HPCON are isize (plain integers), safe to send across threads.
+// HANDLE/HPCON are raw pointers in windows-sys >= 0.59; OS handles are
+// safe to send across threads.
 unsafe impl Send for ConPtyTerminal {}
 unsafe impl Sync for ConPtyTerminal {}
 
@@ -222,11 +223,11 @@ fn create_overlapped_output_pipe(terminal_id: u32) -> io::Result<(HANDLE, HANDLE
         CreateFileW(
             wide_name.as_ptr(),
             GENERIC_WRITE,
-            0,                // no sharing
-            std::ptr::null(), // default security
-            OPEN_EXISTING,    // pipe already exists
-            0,                // synchronous
-            0,                // no template
+            0,                    // no sharing
+            std::ptr::null(),     // default security
+            OPEN_EXISTING,        // pipe already exists
+            0,                    // synchronous
+            std::ptr::null_mut(), // no template
         )
     };
     if client == INVALID_HANDLE_VALUE {
@@ -350,7 +351,7 @@ fn spawn_child_process(
 fn terminate_process(pid: u32) -> std::result::Result<(), std::io::Error> {
     unsafe {
         let handle = OpenProcess(PROCESS_TERMINATE, 0, pid);
-        if handle == 0 {
+        if handle.is_null() {
             return Err(std::io::Error::last_os_error());
         }
         let ok = TerminateProcess(handle, 1);
@@ -400,8 +401,8 @@ impl WindowsPtyBackend {
             create_overlapped_output_pipe(terminal_id).with_context(|| err_context(&cmd))?;
 
         // 2. Input pipe pair (anonymous, both synchronous)
-        let mut input_read: HANDLE = 0;
-        let mut input_write: HANDLE = 0;
+        let mut input_read: HANDLE = std::ptr::null_mut();
+        let mut input_write: HANDLE = std::ptr::null_mut();
         if unsafe { CreatePipe(&mut input_read, &mut input_write, std::ptr::null(), 0) } == 0 {
             unsafe {
                 CloseHandle(output_read);
@@ -457,8 +458,12 @@ impl WindowsPtyBackend {
         );
 
         // 7. Exit-monitoring thread (zero CPU — spends all time in kernel wait)
+        // Pass the HANDLE through as `usize` because raw pointers are not
+        // Send. Windows OS handles are safe to use cross-thread.
         let cmd_for_monitor = cmd.clone();
+        let process_handle_addr = process_handle as usize;
         std::thread::spawn(move || {
+            let process_handle = process_handle_addr as HANDLE;
             let exit_code = unsafe {
                 WaitForSingleObject(process_handle, INFINITE);
                 let mut code: u32 = 0;

--- a/zellij-utils/src/sessions.rs
+++ b/zellij-utils/src/sessions.rs
@@ -191,7 +191,7 @@ fn assert_socket(name: &str) -> bool {
     };
     let alive = unsafe {
         let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
-        if handle == 0 {
+        if handle.is_null() {
             false
         } else {
             CloseHandle(handle);


### PR DESCRIPTION
The workspace `windows-sys` constraint was pinned to 0.52 while the Windows source uses APIs and namespaces from 0.59 (e.g. WriteFile in Win32::Storage::FileSystem). CI built fine because Cargo.lock pinned 0.59, but downstream `cargo install`/`cargo binstall` did fresh resolution and selected 0.52, breaking the build for users on Windows.

Align the manifest with the code:
- Bump workspace dep `windows-sys` from 0.52 to 0.59.
- HANDLE is now `*mut c_void` instead of `isize`: replace `handle == 0` / `!= 0` with `is_null()`, initialise HANDLE locals with `std::ptr::null_mut()`, and pass `null_mut()` as the hTemplateFile argument to CreateFileW.
- Pass the process HANDLE through the exit-monitor thread as `usize` (raw pointers are not Send; OS handles are safe to use cross-thread).
- Note: HPCON is still `isize` in 0.59, so its zero-init is unchanged.

fixes https://github.com/zellij-org/zellij/issues/5136