### PR TITLE
fix(plugin): require specific permissions for new tab panes

### DIFF
--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -5376,9 +5376,8 @@ fn check_command_permission(
         PluginCommand::GetSessionEnvironmentVariables => {
             PermissionType::ReadSessionEnvironmentVariables
         },
-        PluginCommand::OpenCommandPaneInNewTab(..) | PluginCommand::OpenEditorPaneInNewTab(..) => {
-            PermissionType::ChangeApplicationState
-        },
+        PluginCommand::OpenCommandPaneInNewTab(..) => PermissionType::RunCommands,
+        PluginCommand::OpenEditorPaneInNewTab(..) => PermissionType::OpenFiles,
         _ => return (PermissionStatus::Granted, None),
     };
 


### PR DESCRIPTION
## Summary

This PR tightens plugin permission checks for pane-opening commands that create privileged resources inside a new tab:

- `OpenCommandPaneInNewTab` now requires `RunCommands`
- `OpenEditorPaneInNewTab` now requires `OpenFiles`

## Threat model / impact

Before this change, `OpenCommandPaneInNewTab` was guarded by `ChangeApplicationState`. However, the command builds a `NewTab` action with `initial_panes` containing a `CommandOrPlugin::Command`, which is later converted into a command pane and reaches the normal PTY/OS process creation path.

As a result, a non-builtin plugin that had `ChangeApplicationState` but not `RunCommands` could request a new tab containing an arbitrary command pane. This bypassed the more specific `RunCommands` permission boundary and allowed host command execution under the current user account, subject to the user having installed/loaded the plugin and granted the incorrect permission.

Similarly, `OpenEditorPaneInNewTab` opens an editor/file pane through `initial_panes`, so it should be guarded by `OpenFiles` rather than the broader application-state permission.

## Fix

The permission mapping now matches the operation performed by each command:

```rust
PluginCommand::OpenCommandPaneInNewTab(..) => PermissionType::RunCommands,
PluginCommand::OpenEditorPaneInNewTab(..) => PermissionType::OpenFiles,
```

Ordinary `NewTab` continues to require `ChangeApplicationState`.

## Validation

Verified with:

```console
git diff --check origin/main..HEAD
cargo check -p zellij-server
```
