### PR TITLE
set TERM=xterm-256color for the web server

### DIFF
--- a/zellij-client/src/web_client/mod.rs
+++ b/zellij-client/src/web_client/mod.rs
@@ -69,6 +69,9 @@ pub fn start_web_client(
     custom_server_key: Option<PathBuf>,
     startup_timeout: Option<u64>,
 ) {
+    // Web server may launch without a TTY; ensure spawned panes inherit a usable TERM.
+    std::env::set_var("TERM", "xterm-256color");
+
     std::panic::set_hook({
         Box::new(move |info| {
             let thread = thread::current();


### PR DESCRIPTION
This fixes #5144

Sets TERM when spinning up the web server so the terminal has full text support