### PR TITLE
fix(zellij-tile): propagate host-call errors instead of panicking

### DIFF
--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -375,13 +375,13 @@ pub fn save_session() -> Result<(), String> {
 /// ```
 pub fn current_session_last_saved_time() -> Option<u64> {
     let plugin_command = PluginCommand::CurrentSessionLastSavedTime;
-    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().ok()?;
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
     unsafe { host_run_plugin_command() };
 
+    let bytes = bytes_from_stdin().ok()?;
     let protobuf_response =
-        ProtobufCurrentSessionLastSavedTimeResponse::decode(bytes_from_stdin().unwrap().as_slice())
-            .unwrap();
+        ProtobufCurrentSessionLastSavedTimeResponse::decode(bytes.as_slice()).ok()?;
 
     protobuf_response.timestamp_millis
 }
@@ -1909,12 +1909,16 @@ pub fn get_pane_running_command(pane_id: PaneId) -> Result<Vec<String>, String> 
 /// * `ReadApplicationState`
 pub fn get_session_list() -> Result<SessionListSnapshot, String> {
     let plugin_command = PluginCommand::GetSessionList;
-    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command
+        .try_into()
+        .map_err(|e| format!("failed to encode plugin command: {}", e))?;
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
     unsafe { host_run_plugin_command() };
 
-    let protobuf_response =
-        ProtobufGetSessionListResponse::decode(bytes_from_stdin().unwrap().as_slice()).unwrap();
+    let bytes = bytes_from_stdin()
+        .map_err(|e| format!("failed to read host response (permission denied?): {}", e))?;
+    let protobuf_response = ProtobufGetSessionListResponse::decode(bytes.as_slice())
+        .map_err(|e| format!("failed to decode host response: {}", e))?;
 
     match protobuf_response.result {
         Some(get_session_list_response::Result::Snapshot(snapshot)) => {


### PR DESCRIPTION
## Summary

`current_session_last_saved_time()` and `get_session_list()` in `zellij-tile/src/shim.rs` currently call `bytes_from_stdin().unwrap().as_slice()` on the host response. When the host declines to write a response, both `unwrap()`s panic and abort the plugin with the unhelpful `<NO PAYLOAD>` panic message.

This PR converts those two helpers to the same fallible-decode pattern that `open_file()` already uses, surfacing `None` / `Err(String)` on read or decode failure rather than aborting.

## When this matters

The host **does** legitimately suppress responses — for example, when a `ReadApplicationState`-gated command is rejected because the plugin's permission grant is still pending. Built-in plugins almost never see this because their permissions are auto-granted, but plugins loaded via `file:` (the documented mechanism for forks and custom builds) hit it on every reload.

Concrete repro from a custom session-manager fork loaded via `file:` after upgrading to v0.44.2:

```
ERROR:  <NO PAYLOAD>
PanicHookInfo {
    payload: Any { .. },
    location: Location {
        file: "zellij-tile/src/shim.rs",
        line: 1917,
        column: 67,
    },
    ...
}
```

The same class of panic was reported earlier at `shim.rs:382` (the `current_session_last_saved_time()` site) in PR #5063's session-manager rework — that one is also resolved here.

## Why this fix and not something else

- The shim helpers already have proper return types for failure (`Option<u64>`, `Result<_, String>`). The `.unwrap()`s are a holdover; `open_file()` (shim.rs ~line 398) demonstrates the intended safe pattern.
- Fixing the shim is **decoupled** — every plugin, including third-party ones that load via `file:`, immediately benefits without each plugin having to defer host calls behind a `permissions_granted` flag in its own state machine.

## Scope

Intentionally limited to the two confirmed panic sites. There are ~47 other `bytes_from_stdin().unwrap().as_slice()).unwrap()` occurrences in `shim.rs` that share the same defect; happy to expand the PR to cover them in a follow-up commit if maintainers prefer a single sweep — left out here to keep the diff focused and easy to review.

## Test plan
- [x] `cargo build --release -p session-manager --target wasm32-wasip1` — compiles
- [x] `cargo check -p zellij-tile` — compiles for host target
- [x] Verified panic at `shim.rs:1917` no longer reproduces on a `file:`-loaded session-manager whose permission grant is still pending; `get_session_list()` returns `Err(...)` and the plugin keeps running.
- [ ] Maintainer check: behavior on built-in load (permissions auto-granted) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)