### PR TITLE
make web_server_capability opt-in

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,4 +1,5 @@
 use dialoguer::Confirm;
+#[cfg(feature = "web_server_capability")]
 use std::net::IpAddr;
 use std::{fs::File, io::prelude::*, path::PathBuf, process, time::Duration};
 
@@ -213,25 +214,6 @@ pub(crate) fn start_web_server(
     );
 }
 
-#[cfg(not(feature = "web_server_capability"))]
-pub(crate) fn start_web_server(
-    _opts: CliArgs,
-    _run_daemonized: bool,
-    _ip: Option<IpAddr>,
-    _port: Option<u16>,
-    _cert: Option<PathBuf>,
-    _key: Option<PathBuf>,
-    _startup_timeout: Option<u64>,
-) {
-    log::error!(
-        "This version of Zellij was compiled without web server support, cannot run web server!"
-    );
-    eprintln!(
-        "This version of Zellij was compiled without web server support, cannot run web server!"
-    );
-    std::process::exit(2);
-}
-
 fn create_new_client() -> ClientInfo {
     ClientInfo::New(generate_unique_session_name_or_exit(), None, None)
 }
@@ -240,17 +222,6 @@ fn create_new_client() -> ClientInfo {
 pub(crate) fn stop_web_server() -> Result<(), String> {
     shutdown_all_webserver_instances().map_err(|e| e.to_string())?;
     Ok(())
-}
-
-#[cfg(not(feature = "web_server_capability"))]
-pub(crate) fn stop_web_server() -> Result<(), String> {
-    log::error!(
-        "This version of Zellij was compiled without web server support, cannot stop web server!"
-    );
-    eprintln!(
-        "This version of Zellij was compiled without web server support, cannot stop web server!"
-    );
-    std::process::exit(2);
 }
 
 #[cfg(feature = "web_server_capability")]
@@ -264,48 +235,15 @@ pub(crate) fn create_auth_token(name: Option<String>, read_only: bool) -> Result
         .map_err(|e| e.to_string())
 }
 
-#[cfg(not(feature = "web_server_capability"))]
-pub(crate) fn create_auth_token(_name: Option<String>, _read_only: bool) -> Result<String, String> {
-    log::error!(
-        "This version of Zellij was compiled without web server support, cannot create auth token!"
-    );
-    eprintln!(
-        "This version of Zellij was compiled without web server support, cannot create auth token!"
-    );
-    std::process::exit(2);
-}
-
 #[cfg(feature = "web_server_capability")]
 pub(crate) fn revoke_auth_token(token_name: &str) -> Result<bool, String> {
     revoke_token(token_name).map_err(|e| e.to_string())
-}
-
-#[cfg(not(feature = "web_server_capability"))]
-pub(crate) fn revoke_auth_token(_token_name: &str) -> Result<bool, String> {
-    log::error!(
-        "This version of Zellij was compiled without web server support, cannot revoke auth token!"
-    );
-    eprintln!(
-        "This version of Zellij was compiled without web server support, cannot revoke auth token!"
-    );
-    std::process::exit(2);
 }
 
 #[cfg(feature = "web_server_capability")]
 pub(crate) fn revoke_all_auth_tokens() -> Result<usize, String> {
     // returns the revoked count
     revoke_all_tokens().map_err(|e| e.to_string())
-}
-
-#[cfg(not(feature = "web_server_capability"))]
-pub(crate) fn revoke_all_auth_tokens() -> Result<usize, String> {
-    log::error!(
-        "This version of Zellij was compiled without web server support, cannot revoke all tokens!"
-    );
-    eprintln!(
-        "This version of Zellij was compiled without web server support, cannot revoke all tokens!"
-    );
-    std::process::exit(2);
 }
 
 #[cfg(feature = "web_server_capability")]
@@ -326,18 +264,8 @@ pub(crate) fn list_auth_tokens() -> Result<Vec<String>, String> {
         .map_err(|e| e.to_string())
 }
 
-#[cfg(not(feature = "web_server_capability"))]
-pub(crate) fn list_auth_tokens() -> Result<Vec<String>, String> {
-    log::error!(
-        "This version of Zellij was compiled without web server support, cannot list tokens!"
-    );
-    eprintln!(
-        "This version of Zellij was compiled without web server support, cannot list tokens!"
-    );
-    std::process::exit(2);
-}
-
 /// Default timeout for web server status check (in seconds)
+#[cfg(feature = "web_server_capability")]
 pub const DEFAULT_WEB_SERVER_STATUS_TIMEOUT_SECS: u64 = 30;
 
 #[cfg(feature = "web_server_capability")]
@@ -365,20 +293,6 @@ pub(crate) fn web_server_status(
             status_code
         ))
     }
-}
-
-#[cfg(not(feature = "web_server_capability"))]
-pub(crate) fn web_server_status(
-    _web_server_base_url: &str,
-    _timeout_secs: Option<u64>,
-) -> Result<String, String> {
-    log::error!(
-        "This version of Zellij was compiled without web server support, cannot get web server status!"
-    );
-    eprintln!(
-        "This version of Zellij was compiled without web server support, cannot get web server status!"
-    );
-    std::process::exit(2);
 }
 
 fn find_indexed_session(
@@ -1094,6 +1008,7 @@ fn reload_config_from_disk(
     };
 }
 
+#[cfg(feature = "web_server_capability")]
 pub fn get_config_options_from_cli_args(opts: &CliArgs) -> Result<Options, String> {
     Setup::from_cli_args(&opts)
         .map(|(_, _, config_options, _, _)| config_options)

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,15 +3,16 @@ mod commands;
 mod tests;
 
 use clap::Parser;
+#[cfg(feature = "web_server_capability")]
+use zellij_utils::{consts::VERSION, shared::web_server_base_url_from_config};
 use zellij_utils::{
     cli::{CliAction, CliArgs, Command, Sessions},
-    consts::{create_config_and_cache_folders, VERSION},
+    consts::create_config_and_cache_folders,
     data::UnblockCondition,
     envs,
     input::config::Config,
     logging::*,
     setup::Setup,
-    shared::web_server_base_url_from_config,
 };
 
 fn main() {
@@ -294,124 +295,132 @@ fn main() {
         opts.new_session_with_layout = None;
         opts.layout = Some(layout_for_new_session.clone());
         commands::start_client(opts);
-    } else if let Some(Command::Web(web_opts)) = &opts.command {
-        if web_opts.get_start() {
-            let daemonize = web_opts.daemonize;
-            commands::start_web_server(
-                opts.clone(),
-                daemonize,
-                web_opts.ip,
-                web_opts.port,
-                web_opts.cert.clone(),
-                web_opts.key.clone(),
-                web_opts.server_startup_timeout,
-            );
-        } else if web_opts.stop {
-            match commands::stop_web_server() {
-                Ok(()) => {
-                    println!("Stopped web server.");
-                },
-                Err(e) => {
-                    eprintln!("Failed to stop web server: {}", e);
-                    std::process::exit(2)
-                },
-            }
-        } else if web_opts.status {
-            let mut config_options = commands::get_config_options_from_cli_args(&opts)
-                .expect("Can't find config options");
-            if let Some(ip) = web_opts.ip {
-                config_options.web_server_ip = Some(ip);
-            }
-            if let Some(port) = web_opts.port {
-                config_options.web_server_port = Some(port);
-            }
-            let web_server_base_url = web_server_base_url_from_config(config_options);
-            match commands::web_server_status(&web_server_base_url, web_opts.timeout) {
-                Ok(version) => {
-                    let version = version.trim();
-                    println!(
-                        "Web server online with version: {}. Checked: {}",
-                        version, web_server_base_url
-                    );
-                    if version != VERSION {
-                        println!("");
-                        println!(
-                            "Note: this version differs from the current Zellij version: {}.",
-                            VERSION
-                        );
-                        println!("Consider stopping the server with: zellij web --stop");
-                        println!("And then restarting it with: zellij web --start");
-                    }
-                },
-                Err(_e) => {
-                    println!("Web server is offline, checked: {}", web_server_base_url);
-                },
-            }
-        } else if web_opts.create_token {
-            let read_only = false;
-            match commands::create_auth_token(web_opts.token_name.clone(), read_only) {
-                Ok(token_and_name) => {
-                    println!("Created token successfully");
-                    println!("");
-                    println!("{}", token_and_name);
-                },
-                Err(e) => {
-                    eprintln!("Failed to create token: {}", e);
-                    std::process::exit(2)
-                },
-            }
-        } else if web_opts.create_read_only_token {
-            let read_only = true;
-            match commands::create_auth_token(web_opts.token_name.clone(), read_only) {
-                Ok(token_and_name) => {
-                    println!("Created token successfully");
-                    println!("");
-                    println!("{}", token_and_name);
-                },
-                Err(e) => {
-                    eprintln!("Failed to create token: {}", e);
-                    std::process::exit(2)
-                },
-            }
-        } else if let Some(token_name_to_revoke) = &web_opts.revoke_token {
-            match commands::revoke_auth_token(token_name_to_revoke) {
-                Ok(revoked) => {
-                    if revoked {
-                        println!("Successfully revoked token.");
-                    } else {
-                        eprintln!("Token by that name does not exist.");
-                        std::process::exit(2)
-                    }
-                },
-                Err(e) => {
-                    eprintln!("Failed to revoke token: {}", e);
-                    std::process::exit(2)
-                },
-            }
-        } else if web_opts.revoke_all_tokens {
-            match commands::revoke_all_auth_tokens() {
-                Ok(_) => {
-                    println!("Successfully revoked all auth tokens");
-                },
-                Err(e) => {
-                    eprintln!("Failed to revoke all auth tokens: {}", e);
-                    std::process::exit(2)
-                },
-            }
-        } else if web_opts.list_tokens {
-            match commands::list_auth_tokens() {
-                Ok(token_list) => {
-                    for item in token_list {
-                        println!("{}", item);
-                    }
-                },
-                Err(e) => {
-                    eprintln!("Failed to list tokens: {}", e);
-                    std::process::exit(2)
-                },
-            }
-        }
     } else {
+        #[cfg(feature = "web_server_capability")]
+        if let Some(Command::Web(web_opts)) = &opts.command {
+            handle_web_command(&opts, web_opts);
+            return;
+        }
         commands::start_client(opts);
+    }
+}
+
+#[cfg(feature = "web_server_capability")]
+fn handle_web_command(opts: &CliArgs, web_opts: &zellij_utils::cli::WebCli) {
+    if web_opts.get_start() {
+        let daemonize = web_opts.daemonize;
+        commands::start_web_server(
+            opts.clone(),
+            daemonize,
+            web_opts.ip,
+            web_opts.port,
+            web_opts.cert.clone(),
+            web_opts.key.clone(),
+            web_opts.server_startup_timeout,
+        );
+    } else if web_opts.stop {
+        match commands::stop_web_server() {
+            Ok(()) => {
+                println!("Stopped web server.");
+            },
+            Err(e) => {
+                eprintln!("Failed to stop web server: {}", e);
+                std::process::exit(2)
+            },
+        }
+    } else if web_opts.status {
+        let mut config_options = commands::get_config_options_from_cli_args(opts)
+            .expect("Can't find config options");
+        if let Some(ip) = web_opts.ip {
+            config_options.web_server_ip = Some(ip);
+        }
+        if let Some(port) = web_opts.port {
+            config_options.web_server_port = Some(port);
+        }
+        let web_server_base_url = web_server_base_url_from_config(config_options);
+        match commands::web_server_status(&web_server_base_url, web_opts.timeout) {
+            Ok(version) => {
+                let version = version.trim();
+                println!(
+                    "Web server online with version: {}. Checked: {}",
+                    version, web_server_base_url
+                );
+                if version != VERSION {
+                    println!("");
+                    println!(
+                        "Note: this version differs from the current Zellij version: {}.",
+                        VERSION
+                    );
+                    println!("Consider stopping the server with: zellij web --stop");
+                    println!("And then restarting it with: zellij web --start");
+                }
+            },
+            Err(_e) => {
+                println!("Web server is offline, checked: {}", web_server_base_url);
+            },
+        }
+    } else if web_opts.create_token {
+        let read_only = false;
+        match commands::create_auth_token(web_opts.token_name.clone(), read_only) {
+            Ok(token_and_name) => {
+                println!("Created token successfully");
+                println!("");
+                println!("{}", token_and_name);
+            },
+            Err(e) => {
+                eprintln!("Failed to create token: {}", e);
+                std::process::exit(2)
+            },
+        }
+    } else if web_opts.create_read_only_token {
+        let read_only = true;
+        match commands::create_auth_token(web_opts.token_name.clone(), read_only) {
+            Ok(token_and_name) => {
+                println!("Created token successfully");
+                println!("");
+                println!("{}", token_and_name);
+            },
+            Err(e) => {
+                eprintln!("Failed to create token: {}", e);
+                std::process::exit(2)
+            },
+        }
+    } else if let Some(token_name_to_revoke) = &web_opts.revoke_token {
+        match commands::revoke_auth_token(token_name_to_revoke) {
+            Ok(revoked) => {
+                if revoked {
+                    println!("Successfully revoked token.");
+                } else {
+                    eprintln!("Token by that name does not exist.");
+                    std::process::exit(2)
+                }
+            },
+            Err(e) => {
+                eprintln!("Failed to revoke token: {}", e);
+                std::process::exit(2)
+            },
+        }
+    } else if web_opts.revoke_all_tokens {
+        match commands::revoke_all_auth_tokens() {
+            Ok(_) => {
+                println!("Successfully revoked all auth tokens");
+            },
+            Err(e) => {
+                eprintln!("Failed to revoke all auth tokens: {}", e);
+                std::process::exit(2)
+            },
+        }
+    } else if web_opts.list_tokens {
+        match commands::list_auth_tokens() {
+            Ok(token_list) => {
+                for item in token_list {
+                    println!("{}", item);
+                }
+            },
+            Err(e) => {
+                eprintln!("Failed to list tokens: {}", e);
+                std::process::exit(2)
+            },
+        }
     }
 }

--- a/src/tests/cli.rs
+++ b/src/tests/cli.rs
@@ -1,13 +1,17 @@
+#[cfg(feature = "web_server_capability")]
 use std::net::{IpAddr, Ipv4Addr};
 
 use clap::{CommandFactory, Parser};
-use zellij_utils::cli::{CliArgs, Command};
+use zellij_utils::cli::CliArgs;
+#[cfg(feature = "web_server_capability")]
+use zellij_utils::cli::Command;
 
 #[test]
 fn verify_cli() {
     CliArgs::command().debug_assert();
 }
 
+#[cfg(feature = "web_server_capability")]
 #[test]
 fn web_cli_status_alone_works() {
     let args = CliArgs::try_parse_from(["zellij", "web", "--status"]);
@@ -24,6 +28,7 @@ fn web_cli_status_alone_works() {
     }
 }
 
+#[cfg(feature = "web_server_capability")]
 #[test]
 fn web_cli_status_with_timeout_works() {
     let args = CliArgs::try_parse_from(["zellij", "web", "--status", "--timeout", "5"]);
@@ -40,6 +45,7 @@ fn web_cli_status_with_timeout_works() {
     }
 }
 
+#[cfg(feature = "web_server_capability")]
 #[test]
 fn web_cli_timeout_with_status_works() {
     // Test with --timeout before --status (order shouldn't matter)
@@ -57,24 +63,28 @@ fn web_cli_timeout_with_status_works() {
     }
 }
 
+#[cfg(feature = "web_server_capability")]
 #[test]
 fn web_cli_timeout_without_status_fails() {
     let args = CliArgs::try_parse_from(["zellij", "web", "--timeout", "5"]);
     assert!(args.is_err());
 }
 
+#[cfg(feature = "web_server_capability")]
 #[test]
 fn web_cli_status_with_start_fails() {
     let args = CliArgs::try_parse_from(["zellij", "web", "--status", "--start"]);
     assert!(args.is_err());
 }
 
+#[cfg(feature = "web_server_capability")]
 #[test]
 fn web_cli_status_with_stop_fails() {
     let args = CliArgs::try_parse_from(["zellij", "web", "--status", "--stop"]);
     assert!(args.is_err());
 }
 
+#[cfg(feature = "web_server_capability")]
 #[test]
 fn web_cli_status_with_ip_works() {
     let args = CliArgs::try_parse_from(["zellij", "web", "--status", "--ip", "127.0.0.1"]);
@@ -91,6 +101,7 @@ fn web_cli_status_with_ip_works() {
     }
 }
 
+#[cfg(feature = "web_server_capability")]
 #[test]
 fn web_cli_status_with_port_works() {
     let args = CliArgs::try_parse_from(["zellij", "web", "--status", "--port", "9000"]);
@@ -107,6 +118,7 @@ fn web_cli_status_with_port_works() {
     }
 }
 
+#[cfg(feature = "web_server_capability")]
 #[test]
 fn web_cli_status_with_ip_and_port_works() {
     let args = CliArgs::try_parse_from([

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -4,8 +4,11 @@ use crate::{
     consts::{ZELLIJ_CONFIG_DIR_ENV, ZELLIJ_CONFIG_FILE_ENV},
     input::{layout::PluginUserConfiguration, options::Options},
 };
-use clap::{ArgEnum, Args, Parser, Subcommand};
+#[cfg(feature = "web_server_capability")]
+use clap::Args;
+use clap::{ArgEnum, Parser, Subcommand};
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "web_server_capability")]
 use std::net::IpAddr;
 use std::path::PathBuf;
 use url::Url;
@@ -36,6 +39,12 @@ fn validate_session(name: &str) -> Result<String, String> {
 
 #[derive(Parser, Default, Debug, Clone, Serialize, Deserialize)]
 #[clap(version, name = "zellij")]
+#[cfg_attr(
+    not(feature = "web_server_capability"),
+    clap(
+        after_help = "Note: web server functionality is unavailable in this build (compiled without the `web_server_capability` feature)."
+    )
+)]
 pub struct CliArgs {
     /// Maximum panes on screen, caution: opening more panes will close old ones
     #[clap(long, value_parser)]
@@ -114,6 +123,7 @@ pub enum Command {
     Setup(Setup),
 
     /// Run a web server to serve terminal sessions
+    #[cfg(feature = "web_server_capability")]
     #[clap(name = "web", value_parser)]
     Web(WebCli),
 
@@ -171,6 +181,7 @@ pub enum SubscribeFormat {
     Json,
 }
 
+#[cfg(feature = "web_server_capability")]
 #[derive(Debug, Clone, Args, Serialize, Deserialize)]
 pub struct WebCli {
     /// Start the server (default unless other arguments are specified)
@@ -262,6 +273,7 @@ pub struct WebCli {
     pub key: Option<PathBuf>,
 }
 
+#[cfg(feature = "web_server_capability")]
 impl WebCli {
     pub fn get_start(&self) -> bool {
         self.start


### PR DESCRIPTION
## Summary

This PR proposes changes to how the embedded web server / remote-attach
capability is exposed in zellij:

1. The `web` CLI subcommand is gated on the `web_server_capability` Cargo
   feature, so it appears in `--help` and is accepted by the parser if and
   only if the feature is built in.

EDIT: part-2 was removed from this PR.

~~2. `web_server_capability` is removed from the workspace's default feature
set. It remains a one-flag opt-in (`--features web_server_capability`).~~

~~`xtask` is updated internally to compensate for the new default, so its
user-facing behavior is unchanged. CI and release workflows do not require
modifications.~~

~~## Motivation~~

~~Three considerations support making this feature opt-in rather than
opt-out:~~

~~1. **Default-build dependency surface.** With the feature enabled by
default, every build links axum, axum-server, axum-extra, tokio-rustls,
isahc, time, futures, and their transitive dependencies. For users
who do not use the web server, those dependencies still occupy the
binary's audit and CVE-tracking surface. Making the feature opt-in
keeps that surface available to users who want it while reducing it
for users who do not.~~

~~2. **Downstream packaging defaults.** Distribution maintainers (Debian,
Arch, Homebrew, Nix, etc.) typically build with default features
unless they patch the feature list. The current default therefore
ships network-listening capability through every packaged binary,
including to users who may be unaware that capability is present.
An opt-in default lets each distribution decide explicitly whether
to enable it.~~

~~3. **Convention for opt-in network capabilities.** Capabilities that
open network listeners and authenticate remote callers are commonly
opt-in elsewhere in the ecosystem. Aligning with that convention
does not remove the feature — it remains one flag away — and makes
the feature's presence in a given build more transparent to users.~~
