### PR TITLE
fix(resize): propagate actual resize result in stacked pane resize

### DIFF
--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -1365,7 +1365,7 @@ impl TiledPanes {
         strategy.invert_on_boundaries = false;
         let successfully_resized_up =
             match self.resize_pane_with_id(strategy, pane_id, Some(resize_percent)) {
-                Ok(_) => true,
+                Ok(changed) => changed,
                 Err(_) => false,
             };
         if successfully_resized_up {
@@ -1395,7 +1395,7 @@ impl TiledPanes {
         strategy.invert_on_boundaries = false;
         let successfully_resized_up =
             match self.resize_pane_with_id(strategy, pane_id, Some(resize_percent)) {
-                Ok(_) => true,
+                Ok(changed) => changed,
                 Err(_) => false,
             };
         if successfully_resized_up {
@@ -1425,7 +1425,7 @@ impl TiledPanes {
         strategy.invert_on_boundaries = false;
         let successfully_resized_up =
             match self.resize_pane_with_id(strategy, pane_id, Some(resize_percent)) {
-                Ok(_) => true,
+                Ok(changed) => changed,
                 Err(_) => false,
             };
         if successfully_resized_up {
@@ -1455,7 +1455,7 @@ impl TiledPanes {
         strategy.invert_on_boundaries = false;
         let successfully_resized_up =
             match self.resize_pane_with_id(strategy, pane_id, Some(resize_percent)) {
-                Ok(_) => true,
+                Ok(changed) => changed,
                 Err(_) => false,
             };
         if successfully_resized_up {
@@ -1762,7 +1762,9 @@ impl TiledPanes {
                         )
                         .with_context(err_context)
                     {
-                        Ok(_) => {},
+                        Ok(changed) => {
+                            pane_size_changed = changed;
+                        },
                         Err(err) => match err.downcast_ref::<ZellijError>() {
                             Some(ZellijError::PaneSizeUnchanged) => Err::<(), _>(err).non_fatal(),
                             _ => {


### PR DESCRIPTION
## Summary

Fix two sites where `Result<bool>` return values are silently discarded,
causing stacked pane resize to skip its fallback path.

### `resize_or_stack_pane_*`: stacking fallback never triggers

These functions match `Ok(_) => true`, so `Ok(false)` (no cell change)
is treated as success. The else branch — `stack_pane_up/down/left/right` —
is never reached.

**Fix**: `Ok(_) => true` → `Ok(changed) => changed` (4 sites)

### `resize_pane_with_id`: 2× retry result discarded

When `PaneSizeUnchanged` triggers a retry with double the resize percent,
the result is discarded (`Ok(_) => {}`). `pane_size_changed` stays `false`
even when the retry succeeded.

**Fix**: `Ok(_) => {}` → `Ok(changed) => { pane_size_changed = changed; }`

### Effect on callers

`stacked_resize_pane_with_id` uses the return value of
`resize_or_stack_pane_*` to decide whether to record tombstones via
`update_tombstones_before_increase/decrease`. When a no-op resize
reports success, tombstones may record unchanged state and the stacking
fallback is skipped, making resize appear unresponsive near pane boundaries.

## Related issues

- #3418 — Resizing panes only resizes multiple lines at a time (this fix addresses the stacking fallback part of the symptom)
- #1063 — Make resizes stable

## Test plan

- [x] `cargo check -p zellij-server` passes
- [x] `cargo test -p zellij-server` — 1087 passed, 0 failed
- [ ] Manual: repeated resize keypresses respond every time
- [ ] Manual: stacked pane resize correctly falls back to stacking
