### PR TITLE
feat(osc): support and forward OSC 9 / OSC 777 desktop notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+* feat: support and forward OSC 9 (iTerm2) / OSC 777 (rxvt) desktop notification sequences from panes to the host terminal, behind a new `allow_osc_passthrough` option (default `true`)
 * feat: allow tabs to have different sizes if clients aren't focused on the same one (https://github.com/zellij-org/zellij/pull/5133)
 * feat: PWA support for the web client (manifest + icons + iOS meta tags) so the page can be installed as a standalone app (https://github.com/zellij-org/zellij/pull/5184)
 * feat: mobile UI (https://github.com/zellij-org/zellij/pull/5241)

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -437,6 +437,7 @@ impl SessionMetaData {
                     visual_bell: new_config.options.visual_bell.unwrap_or(true),
                     focus_follows_mouse: new_config.options.focus_follows_mouse.unwrap_or(false),
                     mouse_click_through: new_config.options.mouse_click_through.unwrap_or(false),
+                    allow_osc_passthrough: new_config.options.allow_osc_passthrough.unwrap_or(true),
                 })
                 .unwrap();
             self.senders

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -630,6 +630,14 @@ pub struct Grid {
     pub is_scrolled: bool,
     pub link_handler: Rc<RefCell<LinkHandler>>,
     pub ring_bell: bool,
+    /// Visual-only bell signal: set by OSC 9 / OSC 777 dispatch to drive
+    /// the in-Zellij pane/tab/folded-stacked-pane indicators **without**
+    /// forwarding an ANSI BEL byte to the host terminal. The desktop
+    /// notification itself is the audible/visible alert; layering an
+    /// audio BEL on top would be a double-notification, and ST-terminated
+    /// OSC sequences carry no BEL in the input at all so synthesizing one
+    /// is surprising. Consumed by `Tab::check_and_handle_bell_notifications`.
+    pub pending_visual_bell: bool,
     scrollback_buffer_lines: usize,
     pub mouse_mode: MouseMode,
     pub mouse_tracking: MouseTracking,
@@ -959,6 +967,7 @@ impl Grid {
             is_scrolled: false,
             link_handler,
             ring_bell: false,
+            pending_visual_bell: false,
             scrollback_buffer_lines: 0,
             mouse_mode: MouseMode::default(),
             mouse_tracking: MouseTracking::default(),
@@ -3781,6 +3790,60 @@ impl Perform for Grid {
                         // Store raw payload and terminator; namespacing applied at Tab level
                         self.pending_desktop_notifications
                             .push((payload, terminator.to_string()));
+                    }
+                }
+            },
+
+            // OSC 9 (iTerm2 desktop notification): ESC ] 9 ; <body> ST
+            // Unidirectional, no metadata, no response. Trigger the in-Zellij
+            // visual indicator (pane/tab frame flash + [!] suffix) but
+            // explicitly NOT an audio bell: the desktop notification IS the
+            // alert, and synthesizing an ANSI BEL byte to the host on top of
+            // it would be a double-notification (and a non-sequitur for
+            // ST-terminated OSC 9 which has no BEL in the input at all). The
+            // distinction between `ring_bell` and `pending_visual_bell` lets
+            // Tab/Screen drive the visual pipeline without forwarding `\u{7}`
+            // to the host terminal. Payload is prefixed with the OSC code so
+            // the Tab-level forwarder can disambiguate from OSC 99 / OSC 777
+            // and skip namespacing.
+            b"9" => {
+                self.pending_visual_bell = true;
+                if params.len() > 1 {
+                    let body = params
+                        .get(1..)
+                        .unwrap_or_default()
+                        .iter()
+                        .flat_map(|x| str::from_utf8(x))
+                        .collect::<Vec<&str>>()
+                        .join(";");
+                    if !body.is_empty() {
+                        self.pending_desktop_notifications
+                            .push((format!("9;{}", body), terminator.to_string()));
+                    }
+                }
+            },
+
+            // OSC 777 (rxvt-style desktop notification): ESC ] 777 ; notify ; <title> ; <body> ST
+            // Only the `notify` sub-command is in scope; other sub-commands
+            // are silently ignored (no visual indicator, no passthrough).
+            // See the OSC 9 arm above for the `pending_visual_bell` vs
+            // `ring_bell` rationale.
+            b"777" => {
+                if params.len() >= 2 && params[1] == b"notify" {
+                    self.pending_visual_bell = true;
+                    if params.len() >= 3 {
+                        let title = str::from_utf8(params[2]).unwrap_or("");
+                        let body = params
+                            .get(3..)
+                            .unwrap_or_default()
+                            .iter()
+                            .flat_map(|x| str::from_utf8(x))
+                            .collect::<Vec<&str>>()
+                            .join(";");
+                        self.pending_desktop_notifications.push((
+                            format!("777;notify;{};{}", title, body),
+                            terminator.to_string(),
+                        ));
                     }
                 }
             },

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -857,6 +857,12 @@ impl Pane for TerminalPane {
     fn get_bell_notification(&self) -> bool {
         self.has_bell_notification
     }
+    fn has_pending_visual_bell(&self) -> bool {
+        self.grid.pending_visual_bell
+    }
+    fn consume_pending_visual_bell(&mut self) {
+        self.grid.pending_visual_bell = false;
+    }
     fn add_red_pane_frame_color_override(&mut self, error_text: Option<String>) {
         self.pane_frame_color_override = Some((self.style.colors.exit_code_error.base, error_text));
     }

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -751,6 +751,7 @@ pub enum ScreenInstruction {
         visual_bell: bool,
         focus_follows_mouse: bool,
         mouse_click_through: bool,
+        allow_osc_passthrough: bool,
     },
     RerunCommandPane(u32, Option<NotificationEnd>), // u32 - terminal pane id
     ResizePaneWithId(ResizeStrategy, PaneId),
@@ -1458,6 +1459,7 @@ pub(crate) struct Screen {
     visual_bell: bool,
     focus_follows_mouse: bool,
     mouse_click_through: bool,
+    allow_osc_passthrough: bool,
     currently_marking_pane_group: Rc<RefCell<HashMap<ClientId, bool>>>,
     // the below are the configured values - the ones that will be set if and when the web server
     // is brought online
@@ -1560,6 +1562,7 @@ impl Screen {
         visual_bell: bool,
         focus_follows_mouse: bool,
         mouse_click_through: bool,
+        allow_osc_passthrough: bool,
         web_server_ip: IpAddr,
         web_server_port: u16,
     ) -> Self {
@@ -1620,6 +1623,7 @@ impl Screen {
             visual_bell,
             focus_follows_mouse,
             mouse_click_through,
+            allow_osc_passthrough,
             web_server_ip,
             web_server_port,
             render_blocker: RenderBlocker::new(100),
@@ -2930,7 +2934,7 @@ impl Screen {
 
                 for tab in self.tabs.values_mut() {
                     let is_active = active_tab_ids_snapshot.contains(&tab.id);
-                    let (new_panes, tab_newly_set) =
+                    let (new_panes, tab_newly_set, had_audio_bell) =
                         tab.check_and_handle_bell_notifications(is_active);
                     if !new_panes.is_empty() {
                         panes_to_flash.extend(new_panes);
@@ -2940,9 +2944,16 @@ impl Screen {
                         tabs_to_flash.push(tab.id);
                         bell_state_changed = true;
                     }
+                    if had_audio_bell {
+                        has_bell = true;
+                    }
                 }
 
-                has_bell = !panes_to_flash.is_empty() || !tabs_to_flash.is_empty();
+                // `has_bell` here gates ANSI BEL forwarding to the host
+                // terminal. Visual-only signals (OSC 9 / 777 visual
+                // indicators) populate `panes_to_flash` / `tabs_to_flash`
+                // but must NOT cause us to forward `\u{7}` — those are
+                // already handled by the desktop notification itself.
                 if !panes_to_flash.is_empty() {
                     let _ = self
                         .bus
@@ -3347,6 +3358,7 @@ impl Screen {
             self.mouse_hover_effects,
             self.focus_follows_mouse,
             self.mouse_click_through,
+            self.allow_osc_passthrough,
             self.web_server_ip,
             self.web_server_port,
             mobile_tab_count,
@@ -5040,6 +5052,7 @@ impl Screen {
         visual_bell: bool,
         focus_follows_mouse: bool,
         mouse_click_through: bool,
+        allow_osc_passthrough: bool,
         client_id: ClientId,
     ) -> Result<()> {
         let should_support_arrow_fonts = !simplified_ui;
@@ -5065,6 +5078,7 @@ impl Screen {
         self.visual_bell = visual_bell;
         self.focus_follows_mouse = focus_follows_mouse;
         self.mouse_click_through = mouse_click_through;
+        self.allow_osc_passthrough = allow_osc_passthrough;
         self.default_mode_info
             .update_arrow_fonts(should_support_arrow_fonts);
         self.default_mode_info
@@ -5092,6 +5106,7 @@ impl Screen {
             tab.update_focus_follows_mouse(focus_follows_mouse);
             tab.update_mouse_click_through(mouse_click_through);
             tab.sync_stacked_pane_list_mode();
+            tab.update_allow_osc_passthrough(allow_osc_passthrough);
         }
 
         // Clear hover state when disabled
@@ -6226,6 +6241,7 @@ pub(crate) fn screen_thread_main(
     let visual_bell = config_options.visual_bell.unwrap_or(true);
     let focus_follows_mouse = config_options.focus_follows_mouse.unwrap_or(false);
     let mouse_click_through = config_options.mouse_click_through.unwrap_or(false);
+    let allow_osc_passthrough = config_options.allow_osc_passthrough.unwrap_or(true);
 
     let thread_senders = bus.senders.clone();
     let mut screen = Screen::new(
@@ -6268,6 +6284,7 @@ pub(crate) fn screen_thread_main(
         visual_bell,
         focus_follows_mouse,
         mouse_click_through,
+        allow_osc_passthrough,
         web_server_ip,
         web_server_port,
     );
@@ -9412,6 +9429,7 @@ pub(crate) fn screen_thread_main(
                 visual_bell,
                 focus_follows_mouse,
                 mouse_click_through,
+                allow_osc_passthrough,
             } => {
                 screen.host_theme_dark_styling = host_theme_dark;
                 screen.host_theme_light_styling = host_theme_light;
@@ -9437,6 +9455,7 @@ pub(crate) fn screen_thread_main(
                         visual_bell,
                         focus_follows_mouse,
                         mouse_click_through,
+                        allow_osc_passthrough,
                         client_id,
                     )
                     .non_fatal();

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -264,6 +264,11 @@ pub(crate) struct Tab {
     pub tab_has_pending_bell: bool,
     pub tab_bell_flash: bool, // currently in mid-notification-flash
     pub tab_bell_ring: bool,  // need to send ANSI BEL to the controlling terminal
+    /// Forward OSC 9 / OSC 777 desktop-notification sequences to the host
+    /// terminal. When false, the visual indicator still fires but the OSC
+    /// bytes are dropped at `forward_desktop_notifications`. Does not
+    /// affect OSC 99 (its passthrough is unconditional).
+    pub allow_osc_passthrough: bool,
 }
 
 // FIXME: Use a struct that has a pane_type enum, to reduce all of the duplication
@@ -644,6 +649,14 @@ pub trait Pane {
     fn get_bell_notification(&self) -> bool {
         false
     }
+    /// Visual-only bell pending: set by OSC 9 / OSC 777 dispatch on the
+    /// underlying Grid. Distinct from `has_bell` (real ANSI BEL byte) so
+    /// the Tab visual pipeline can fire pane/tab indicators without
+    /// forwarding an `\u{7}` to the host terminal.
+    fn has_pending_visual_bell(&self) -> bool {
+        false
+    }
+    fn consume_pending_visual_bell(&mut self) {}
     fn add_red_pane_frame_color_override(&mut self, _error_text: Option<String>);
     fn add_highlight_pane_frame_color_override(
         &mut self,
@@ -810,6 +823,7 @@ impl Tab {
         mouse_hover_effects: bool,
         focus_follows_mouse: bool,
         mouse_click_through: bool,
+        allow_osc_passthrough: bool,
         web_server_ip: IpAddr,
         web_server_port: u16,
         mobile_tab_count: usize,
@@ -951,6 +965,7 @@ impl Tab {
             tab_has_pending_bell: false,
             tab_bell_flash: false,
             tab_bell_ring: false,
+            allow_osc_passthrough,
         }
     }
 
@@ -3452,12 +3467,32 @@ impl Tab {
             None
         }
     }
+    /// Drive the visual-indicator pipeline (pane frame flash, tab `[!]`,
+    /// folded stacked-pane indicator) for any pane that has signalled a
+    /// pending bell since the last render tick.
+    ///
+    /// Two flavours of pending bell:
+    ///   * `has_bell()` — a real ANSI BEL byte (0x07) was processed by the
+    ///     pane's parser. Sets `tab_bell_ring`, which the Screen-level
+    ///     render loop translates into an `\u{7}` byte forwarded to the
+    ///     host terminal (so the host can ring its audible bell).
+    ///   * `has_pending_visual_bell()` — set by OSC 9 / OSC 777 dispatch.
+    ///     The desktop notification IS the alert; we only want the in-
+    ///     Zellij visual cue, NOT a second audible bell on the host. So
+    ///     visual-only panes drive `panes_with_pending_bell` and
+    ///     `tab_has_pending_bell` but explicitly do not set
+    ///     `tab_bell_ring`.
+    ///
+    /// Returns `(newly_notified_panes, tab_bell_newly_set, had_audio_bell)`
+    /// where `had_audio_bell` flags whether the caller should forward an
+    /// ANSI BEL to the host terminal on this render tick.
     pub fn check_and_handle_bell_notifications(
         &mut self,
         is_active_tab: bool,
-    ) -> (Vec<PaneId>, bool) {
+    ) -> (Vec<PaneId>, bool, bool) {
         let mut newly_notified_panes = vec![];
         let mut tab_bell_newly_set = false;
+        let mut had_audio_bell = false;
 
         let focused_pane_ids: HashSet<PaneId> = self
             .connected_clients
@@ -3466,7 +3501,7 @@ impl Tab {
             .filter_map(|c_id| self.get_active_pane_id(*c_id))
             .collect();
 
-        // Collect ringing pane IDs first (immutable borrow)
+        // Collect audio-bell pane IDs first (immutable borrow)
         let ringing_panes: Vec<PaneId> = self
             .tiled_panes
             .get_panes()
@@ -3481,6 +3516,7 @@ impl Tab {
             if let Some(pane) = self.get_pane_with_id_mut(pane_id) {
                 pane.consume_bell();
             }
+            had_audio_bell = true;
             let is_focused = focused_pane_ids.contains(&pane_id);
             if !is_focused && !self.panes_with_pending_bell.contains(&pane_id) {
                 if let Some(pane) = self.get_pane_with_id_mut(pane_id) {
@@ -3497,7 +3533,37 @@ impl Tab {
                 self.tab_has_pending_bell = true;
             }
         }
-        (newly_notified_panes, tab_bell_newly_set)
+
+        // Visual-only pending bells (OSC 9 / OSC 777): drive the same
+        // visual indicator state as a real bell, but do NOT touch
+        // `tab_bell_ring` or `had_audio_bell` — those are what cause an
+        // ANSI BEL to be forwarded to the host.
+        let visual_only_panes: Vec<PaneId> = self
+            .tiled_panes
+            .get_panes()
+            .chain(self.floating_panes.get_panes())
+            .filter(|(_, pane)| pane.has_pending_visual_bell())
+            .map(|(pane_id, _)| *pane_id)
+            .collect();
+
+        for pane_id in visual_only_panes {
+            if let Some(pane) = self.get_pane_with_id_mut(pane_id) {
+                pane.consume_pending_visual_bell();
+            }
+            let is_focused = focused_pane_ids.contains(&pane_id);
+            if !is_focused && !self.panes_with_pending_bell.contains(&pane_id) {
+                if let Some(pane) = self.get_pane_with_id_mut(pane_id) {
+                    pane.set_bell_notification(true);
+                }
+                self.panes_with_pending_bell.insert(pane_id);
+                newly_notified_panes.push(pane_id);
+            }
+            if !is_active_tab {
+                self.tab_has_pending_bell = true;
+            }
+        }
+
+        (newly_notified_panes, tab_bell_newly_set, had_audio_bell)
     }
     pub fn clear_bell_notification_for_pane(&mut self, pane_id: PaneId) {
         self.panes_with_pending_bell.remove(&pane_id);
@@ -3529,6 +3595,21 @@ impl Tab {
         for pane_id in ringing_panes {
             if let Some(pane) = self.get_pane_with_id_mut(pane_id) {
                 pane.consume_bell();
+            }
+        }
+        // Visual-only pending bells (OSC 9 / OSC 777) are consumed but
+        // never forwarded as audible BEL — that is the whole point of
+        // tracking them separately from `ring_bell`.
+        let visual_only_panes: Vec<PaneId> = self
+            .tiled_panes
+            .get_panes()
+            .chain(self.floating_panes.get_panes())
+            .filter(|(_, pane)| pane.has_pending_visual_bell())
+            .map(|(pane_id, _)| *pane_id)
+            .collect();
+        for pane_id in visual_only_panes {
+            if let Some(pane) = self.get_pane_with_id_mut(pane_id) {
+                pane.consume_pending_visual_bell();
             }
         }
         had_bell
@@ -5931,8 +6012,36 @@ impl Tab {
         };
         output.add_clients(&all_clients, self.link_handler.clone(), None);
         for (payload, terminator) in notifications {
-            // Apply identifier namespacing (Phase 3)
-            // The first semicolon-delimited part of payload is the metadata
+            // Disambiguate OSC code by payload prefix:
+            //   OSC 9   → payload starts with "9;"   (no namespacing — unidirectional)
+            //   OSC 777 → payload starts with "777;" (no namespacing — unidirectional)
+            //   OSC 99  → metadata-prefixed payload (always namespaced)
+            //
+            // Legitimate OSC 99 metadata is `key=value:key=value`, so the
+            // first semicolon-delimited segment always contains `=` or `:` and
+            // can never collide with the literal "9" / "777" prefix used by
+            // OSC 9 / 777 entries.
+            let is_osc9 = payload.starts_with("9;");
+            let is_osc777 = payload.starts_with("777;");
+
+            if is_osc9 || is_osc777 {
+                // Honor user opt-out: drop the OSC bytes but leave the visual
+                // bell alone (it has already been triggered at OSC dispatch
+                // time inside `Grid::osc_dispatch`).
+                if !self.allow_osc_passthrough {
+                    continue;
+                }
+                // Forward as-is, no namespacing, no metadata rewriting.
+                let raw = format!("\x1b]{}{}", payload, terminator);
+                output.add_post_vte_instruction_to_multiple_clients(
+                    all_clients.iter().copied(),
+                    &raw,
+                );
+                continue;
+            }
+
+            // OSC 99 path — apply identifier namespacing.
+            // The first semicolon-delimited part of payload is the metadata.
             let (metadata, rest) = match payload.find(';') {
                 Some(idx) => (
                     payload.get(..idx).unwrap_or_default(),
@@ -6862,6 +6971,9 @@ impl Tab {
     }
     pub fn update_mouse_click_through(&mut self, mouse_click_through: bool) {
         self.mouse_click_through = mouse_click_through;
+    }
+    pub fn update_allow_osc_passthrough(&mut self, allow_osc_passthrough: bool) {
+        self.allow_osc_passthrough = allow_osc_passthrough;
     }
     pub fn clear_mouse_hover_state(&mut self) {
         self.mouse_hover_pane_id.clear();

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -277,6 +277,7 @@ fn create_new_tab(size: Size, default_mode: ModeInfo) -> Tab {
         true,  // mouse_hover_effects
         false, // focus_follows_mouse
         false, // mouse_click_through
+        true,  // allow_osc_passthrough
         web_server_ip,
         web_server_port,
         0, // mobile_tab_count
@@ -366,6 +367,7 @@ fn create_new_tab_without_pane_frames(size: Size, default_mode: ModeInfo) -> Tab
         true,  // mouse_hover_effects
         false, // focus_follows_mouse
         false, // mouse_click_through
+        true,  // allow_osc_passthrough
         web_server_ip,
         web_server_port,
         0, // mobile_tab_count
@@ -474,6 +476,7 @@ fn create_new_tab_with_swap_layouts(
         true,  // mouse_hover_effects
         false, // focus_follows_mouse
         false, // mouse_click_through
+        true,  // allow_osc_passthrough
         web_server_ip,
         web_server_port,
         0, // mobile_tab_count
@@ -579,6 +582,7 @@ fn create_new_tab_with_os_api(
         true,  // mouse_hover_effects
         false, // focus_follows_mouse
         false, // mouse_click_through
+        true,  // allow_osc_passthrough
         web_server_ip,
         web_server_port,
         0, // mobile_tab_count
@@ -670,6 +674,7 @@ fn create_new_tab_with_layout(size: Size, default_mode: ModeInfo, layout: &str) 
         true,  // mouse_hover_effects
         false, // focus_follows_mouse
         false, // mouse_click_through
+        true,  // allow_osc_passthrough
         web_server_ip,
         web_server_port,
         0, // mobile_tab_count
@@ -775,6 +780,7 @@ fn create_new_tab_with_mock_pty_writer(
         true,  // mouse_hover_effects
         false, // focus_follows_mouse
         false, // mouse_click_through
+        true,  // allow_osc_passthrough
         web_server_ip,
         web_server_port,
         0, // mobile_tab_count
@@ -871,6 +877,7 @@ fn create_new_tab_with_sixel_support(
         true,  // mouse_hover_effects
         false, // focus_follows_mouse
         false, // mouse_click_through
+        true,  // allow_osc_passthrough
         web_server_ip,
         web_server_port,
         0, // mobile_tab_count
@@ -12765,6 +12772,7 @@ fn create_new_tab_with_plugin_receiver(
         true,  // mouse_hover_effects
         false, // focus_follows_mouse
         false, // mouse_click_through
+        true,  // allow_osc_passthrough
         web_server_ip,
         web_server_port,
         0, // mobile_tab_count
@@ -14551,6 +14559,7 @@ fn create_new_tab_with_server_receiver(
         true,  // mouse_hover_effects
         false, // focus_follows_mouse
         false, // mouse_click_through
+        true,  // allow_osc_passthrough
         IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
         8080,
         0, // mobile_tab_count
@@ -15038,5 +15047,400 @@ fn hidden_cursor_still_emits_cup_for_host_terminal_positioning() {
     assert!(
         !client_output.contains("\u{1b}[?25h"),
         "Show-cursor sequence must not be present when app has hidden the cursor"
+    );
+}
+
+// ========================================================================
+// OSC 9 / OSC 777 Desktop Notification Integration Tests
+// ========================================================================
+
+/// Build a stand-alone Grid for direct VTE-parser tests (no Tab plumbing).
+fn build_test_grid() -> crate::panes::grid::Grid {
+    use crate::panes::grid::Grid;
+    use crate::panes::link_handler::LinkHandler;
+
+    let sixel_image_store = Rc::new(RefCell::new(SixelImageStore::default()));
+    let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
+    let character_cell_size = Rc::new(RefCell::new(Some(SizeInPixels {
+        width: 8,
+        height: 21,
+    })));
+
+    Grid::new(
+        24,
+        80,
+        Rc::new(RefCell::new(Palette::default())),
+        terminal_emulator_color_codes,
+        Rc::new(RefCell::new(LinkHandler::new())),
+        character_cell_size,
+        sixel_image_store,
+        Style::default(),
+        false, // debug
+        true,  // arrow_fonts
+        true,  // styled_underlines
+        true,  // osc8_hyperlinks
+        false, // explicitly_disable_kitty_keyboard_protocol
+    )
+}
+
+#[test]
+fn osc9_grid_parses_and_stores_notification() {
+    // Direct Grid-level test: feed OSC 9 bytes, verify queue + ring_bell.
+    let mut grid = build_test_grid();
+    let mut vte_parser = vte::Parser::new();
+    for &byte in b"\x1b]9;Build complete\x07" {
+        vte_parser.advance(&mut grid, byte);
+    }
+
+    assert_eq!(
+        grid.pending_desktop_notifications.len(),
+        1,
+        "OSC 9 should produce exactly one pending notification"
+    );
+    let (payload, terminator) = grid.pending_desktop_notifications.first().unwrap();
+    assert_eq!(payload, "9;Build complete", "Payload prefixed with '9;'");
+    assert_eq!(terminator, "\x07", "BEL terminator preserved");
+    assert!(
+        grid.pending_visual_bell,
+        "OSC 9 must set pending_visual_bell for the in-Zellij indicator",
+    );
+    assert!(
+        !grid.ring_bell,
+        "OSC 9 must NOT set ring_bell — that would forward `\\u{{7}}` to the host",
+    );
+}
+
+#[test]
+fn osc9_grid_st_terminator_preserved() {
+    // ST-terminated OSC 9 should record terminator as ESC \\.
+    let mut grid = build_test_grid();
+    let mut vte_parser = vte::Parser::new();
+    for &byte in b"\x1b]9;hello\x1b\\" {
+        vte_parser.advance(&mut grid, byte);
+    }
+
+    assert_eq!(grid.pending_desktop_notifications.len(), 1);
+    let (payload, terminator) = grid.pending_desktop_notifications.first().unwrap();
+    assert_eq!(payload, "9;hello");
+    assert_eq!(terminator, "\x1b\\", "ST terminator preserved");
+    assert!(grid.pending_visual_bell);
+    assert!(
+        !grid.ring_bell,
+        "ST-terminated OSC 9 has no BEL byte in input, must not synthesize one",
+    );
+}
+
+#[test]
+fn osc9_empty_body_triggers_bell_but_no_push() {
+    // Empty body — visual indicator fires, but nothing is queued for forward.
+    let mut grid = build_test_grid();
+    let mut vte_parser = vte::Parser::new();
+    for &byte in b"\x1b]9;\x07" {
+        vte_parser.advance(&mut grid, byte);
+    }
+
+    assert!(
+        grid.pending_desktop_notifications.is_empty(),
+        "Empty OSC 9 body should not enqueue"
+    );
+    assert!(
+        grid.pending_visual_bell,
+        "Empty OSC 9 still triggers the visual indicator",
+    );
+    assert!(!grid.ring_bell);
+}
+
+#[test]
+fn osc777_grid_parses_and_stores_notification() {
+    // OSC 777 with title + body — payload is "777;notify;<title>;<body>".
+    let mut grid = build_test_grid();
+    let mut vte_parser = vte::Parser::new();
+    for &byte in b"\x1b]777;notify;Build Done;Tests passed\x07" {
+        vte_parser.advance(&mut grid, byte);
+    }
+
+    assert_eq!(
+        grid.pending_desktop_notifications.len(),
+        1,
+        "OSC 777 notify should produce one pending notification"
+    );
+    let (payload, terminator) = grid.pending_desktop_notifications.first().unwrap();
+    assert_eq!(payload, "777;notify;Build Done;Tests passed");
+    assert_eq!(terminator, "\x07");
+    assert!(grid.pending_visual_bell);
+    assert!(!grid.ring_bell);
+}
+
+#[test]
+fn osc777_unknown_subcommand_ignored() {
+    // OSC 777 sub-commands other than `notify` are not in scope; queue should stay empty
+    // and neither bell flag should fire.
+    let mut grid = build_test_grid();
+    let mut vte_parser = vte::Parser::new();
+    for &byte in b"\x1b]777;Beep\x07" {
+        vte_parser.advance(&mut grid, byte);
+    }
+
+    assert!(
+        grid.pending_desktop_notifications.is_empty(),
+        "Non-notify OSC 777 sub-commands must not enqueue"
+    );
+    assert!(
+        !grid.pending_visual_bell,
+        "Non-notify OSC 777 should not fire the visual indicator either",
+    );
+    assert!(!grid.ring_bell);
+}
+
+#[test]
+fn osc777_st_terminator_preserved() {
+    let mut grid = build_test_grid();
+    let mut vte_parser = vte::Parser::new();
+    for &byte in b"\x1b]777;notify;Title;Body\x1b\\" {
+        vte_parser.advance(&mut grid, byte);
+    }
+
+    let (payload, terminator) = grid.pending_desktop_notifications.first().unwrap();
+    assert_eq!(payload, "777;notify;Title;Body");
+    assert_eq!(terminator, "\x1b\\");
+}
+
+#[test]
+fn osc9_forwarded_through_tab_without_namespacing() {
+    // End-to-end: Tab should wrap the OSC 9 entry as `\x1b]9;<body>\x07`
+    // with no namespacing, and route via ServerInstruction::Render.
+    let size = Size { cols: 80, rows: 24 };
+    let (mut tab, server_receiver) = create_new_tab_with_server_receiver(size, ModeInfo::default());
+
+    tab.handle_pty_bytes(1, Vec::from("\x1b]9;hello world\x07"))
+        .unwrap();
+
+    let output = collect_render_output(&server_receiver);
+    assert!(
+        output.contains("\x1b]9;hello world\x07"),
+        "OSC 9 should be forwarded verbatim, got: {:?}",
+        output
+    );
+    assert!(
+        !output.contains("\x1b]99;"),
+        "OSC 9 must not be wrapped as OSC 99, got: {:?}",
+        output
+    );
+    assert!(
+        !output.contains("i=p1."),
+        "OSC 9 must not receive namespacing, got: {:?}",
+        output
+    );
+}
+
+#[test]
+fn osc777_forwarded_through_tab_without_namespacing() {
+    let size = Size { cols: 80, rows: 24 };
+    let (mut tab, server_receiver) = create_new_tab_with_server_receiver(size, ModeInfo::default());
+
+    tab.handle_pty_bytes(
+        1,
+        Vec::from("\x1b]777;notify;Build Done;All tests passed\x07"),
+    )
+    .unwrap();
+
+    let output = collect_render_output(&server_receiver);
+    assert!(
+        output.contains("\x1b]777;notify;Build Done;All tests passed\x07"),
+        "OSC 777 should be forwarded verbatim, got: {:?}",
+        output
+    );
+    assert!(
+        !output.contains("i=p1."),
+        "OSC 777 must not receive namespacing, got: {:?}",
+        output
+    );
+}
+
+#[test]
+fn osc9_passthrough_disabled_drops_bytes_but_keeps_visual_bell() {
+    // With allow_osc_passthrough=false the OSC bytes should NOT appear in
+    // forwarded output, AND the visual-indicator pipeline should fire
+    // through the `pending_visual_bell` path (NOT the `ring_bell`
+    // audio-bell path, which would forward `\u{7}` to the host).
+    //
+    // This is a regression test for the audio-bell side-effect originally
+    // flagged in zellij-org/zellij#5166 review (yamam): OSC 9 / OSC 777
+    // are unidirectional desktop notifications, so synthesising an ANSI
+    // BEL on top would be a double-notification.
+    let size = Size { cols: 80, rows: 24 };
+    let (mut tab, server_receiver) = create_new_tab_with_server_receiver(size, ModeInfo::default());
+    tab.update_allow_osc_passthrough(false);
+
+    tab.handle_pty_bytes(1, Vec::from("\x1b]9;should be dropped\x07"))
+        .unwrap();
+
+    // Drive the bell pipeline the way `Screen::render` does. The visual
+    // pipeline must record an event, but `had_audio_bell` and
+    // `tab_bell_ring` must both stay false because the desktop
+    // notification IS the alert.
+    let (_new_panes, _tab_newly_set, had_audio_bell) =
+        tab.check_and_handle_bell_notifications(true);
+    assert!(
+        !had_audio_bell,
+        "OSC 9 must not produce an audio bell (no `\\u{{7}}` forwarding to host)",
+    );
+    assert!(
+        !tab.tab_bell_ring,
+        "tab_bell_ring must stay false for OSC 9 / 777 — it's the visual indicator, not the host bell",
+    );
+
+    let output = collect_render_output(&server_receiver);
+    assert!(
+        !output.contains("\x1b]9;"),
+        "OSC 9 bytes must not be forwarded when passthrough is off, got: {:?}",
+        output
+    );
+}
+
+#[test]
+fn osc9_does_not_synthesize_audio_bell_on_host() {
+    // Even with default (passthrough on) config, OSC 9 must not cause an
+    // ANSI BEL to be forwarded to the host terminal — the desktop
+    // notification itself is the alert, and an extra audio bell would
+    // also be wrong for ST-terminated OSC 9 which has no BEL in input.
+    let size = Size { cols: 80, rows: 24 };
+    let (mut tab, _server_receiver) =
+        create_new_tab_with_server_receiver(size, ModeInfo::default());
+
+    tab.handle_pty_bytes(1, Vec::from("\x1b]9;build done\x07"))
+        .unwrap();
+    let (_new_panes, _tab_newly_set, had_audio_bell) =
+        tab.check_and_handle_bell_notifications(true);
+    assert!(
+        !had_audio_bell,
+        "BEL-terminated OSC 9 must not trigger audio-bell forwarding to host",
+    );
+
+    // ST-terminated form — even more obvious: there's no BEL byte in the
+    // input at all, so synthesizing one would be a clear bug.
+    tab.handle_pty_bytes(1, Vec::from("\x1b]9;build done\x1b\\"))
+        .unwrap();
+    let (_new_panes, _tab_newly_set, had_audio_bell) =
+        tab.check_and_handle_bell_notifications(true);
+    assert!(
+        !had_audio_bell,
+        "ST-terminated OSC 9 must not synthesize an audio BEL out of thin air",
+    );
+}
+
+#[test]
+fn osc777_does_not_synthesize_audio_bell_on_host() {
+    let size = Size { cols: 80, rows: 24 };
+    let (mut tab, _server_receiver) =
+        create_new_tab_with_server_receiver(size, ModeInfo::default());
+
+    tab.handle_pty_bytes(1, Vec::from("\x1b]777;notify;Build Done;Tests passed\x07"))
+        .unwrap();
+    let (_new_panes, _tab_newly_set, had_audio_bell) =
+        tab.check_and_handle_bell_notifications(true);
+    assert!(
+        !had_audio_bell,
+        "OSC 777 notify must not trigger audio-bell forwarding to host",
+    );
+}
+
+#[test]
+fn real_bel_byte_still_triggers_audio_bell() {
+    // Sanity check: the visual-only path for OSC 9 / 777 must NOT
+    // accidentally regress the existing behavior for a literal BEL byte
+    // (0x07) coming through the pane's PTY. A real BEL should still set
+    // `had_audio_bell` / `tab_bell_ring` so the host's audible bell can
+    // ring.
+    let size = Size { cols: 80, rows: 24 };
+    let (mut tab, _server_receiver) =
+        create_new_tab_with_server_receiver(size, ModeInfo::default());
+
+    tab.handle_pty_bytes(1, vec![0x07_u8]).unwrap();
+    let (_new_panes, _tab_newly_set, had_audio_bell) =
+        tab.check_and_handle_bell_notifications(true);
+    assert!(
+        had_audio_bell,
+        "A literal BEL byte must still trigger audio-bell forwarding to host",
+    );
+    assert!(
+        tab.tab_bell_ring,
+        "tab_bell_ring must still fire for a literal BEL byte",
+    );
+}
+
+#[test]
+fn osc777_passthrough_disabled_drops_bytes() {
+    let size = Size { cols: 80, rows: 24 };
+    let (mut tab, server_receiver) = create_new_tab_with_server_receiver(size, ModeInfo::default());
+    tab.update_allow_osc_passthrough(false);
+
+    tab.handle_pty_bytes(1, Vec::from("\x1b]777;notify;dropped;dropped body\x07"))
+        .unwrap();
+
+    let output = collect_render_output(&server_receiver);
+    assert!(
+        !output.contains("\x1b]777;"),
+        "OSC 777 bytes must not be forwarded when passthrough is off, got: {:?}",
+        output
+    );
+}
+
+#[test]
+fn osc9_does_not_interfere_with_osc99() {
+    // Mixed payload: an OSC 99 followed by an OSC 9. Both must pass through
+    // their respective wrappers without contamination.
+    let size = Size { cols: 80, rows: 24 };
+    let (mut tab, server_receiver) = create_new_tab_with_server_receiver(size, ModeInfo::default());
+
+    tab.handle_pty_bytes(
+        1,
+        Vec::from("\x1b]99;i=alpha:p=title;OSC99 body\x07\x1b]9;OSC9 body\x07"),
+    )
+    .unwrap();
+
+    let output = collect_render_output(&server_receiver);
+    // OSC 99 — namespaced
+    assert!(
+        output.contains("i=p1.alpha"),
+        "OSC 99 namespacing must remain intact, got: {:?}",
+        output
+    );
+    assert!(
+        output.contains("OSC99 body"),
+        "OSC 99 body must be present, got: {:?}",
+        output
+    );
+    // OSC 9 — verbatim, not wrapped as OSC 99
+    assert!(
+        output.contains("\x1b]9;OSC9 body\x07"),
+        "OSC 9 must be forwarded verbatim, got: {:?}",
+        output
+    );
+}
+
+#[test]
+fn osc99_passthrough_flag_does_not_affect_osc99() {
+    // The allow_osc_passthrough flag is scoped to OSC 9/777. OSC 99 is
+    // governed by its own (always-on) protocol contract from PR #4931.
+    let size = Size { cols: 80, rows: 24 };
+    let (mut tab, server_receiver) = create_new_tab_with_server_receiver(size, ModeInfo::default());
+    tab.update_allow_osc_passthrough(false);
+
+    tab.handle_pty_bytes(1, Vec::from("\x1b]99;i=foo:p=title;still works\x07"))
+        .unwrap();
+
+    let output = collect_render_output(&server_receiver);
+    assert!(
+        output.contains("\x1b]99;"),
+        "OSC 99 must still pass through when allow_osc_passthrough=false"
+    );
+    assert!(
+        output.contains("i=p1.foo"),
+        "OSC 99 namespacing remains active"
+    );
+    assert!(
+        output.contains("still works"),
+        "OSC 99 body still forwarded"
     );
 }

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -219,6 +219,7 @@ fn create_new_tab(size: Size, stacked_resize: bool) -> Tab {
         true,  // mouse_hover_effects
         false, // focus_follows_mouse
         false, // mouse_click_through
+        true,  // allow_osc_passthrough
         web_server_ip,
         web_server_port,
         0, // mobile_tab_count
@@ -307,6 +308,7 @@ fn create_new_tab_with_layout(size: Size, layout: TiledPaneLayout) -> Tab {
         true,  // mouse_hover_effects
         false, // focus_follows_mouse
         false, // mouse_click_through
+        true,  // allow_osc_passthrough
         web_server_ip,
         web_server_port,
         0, // mobile_tab_count
@@ -401,6 +403,7 @@ fn create_new_tab_with_cell_size(
         true,  // mouse_hover_effects
         false, // focus_follows_mouse
         false, // mouse_click_through
+        true,  // allow_osc_passthrough
         web_server_ip,
         web_server_port,
         0, // mobile_tab_count
@@ -15702,7 +15705,8 @@ pub fn bell_in_unfocused_pane_sets_notification() {
     tab.handle_pty_bytes(2, vec![7u8]).unwrap();
 
     // Now call check_and_handle_bell_notifications as non-active tab
-    let (new_panes, tab_newly_set) = tab.check_and_handle_bell_notifications(false);
+    let (new_panes, tab_newly_set, _had_audio_bell) =
+        tab.check_and_handle_bell_notifications(false);
 
     assert!(
         new_panes.contains(&new_pane_id),

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -315,6 +315,7 @@ fn create_new_screen(
         visual_bell,
         false, // focus_follows_mouse
         false, // mouse_click_through
+        true,  // allow_osc_passthrough
         web_server_ip,
         web_server_port,
     );
@@ -5436,6 +5437,7 @@ fn create_new_screen_with_message_capture(
         visual_bell,
         false, // focus_follows_mouse
         false, // mouse_click_through
+        true,  // allow_osc_passthrough
         web_server_ip,
         web_server_port,
     );
@@ -8511,6 +8513,7 @@ fn create_new_screen_with_forward_capture(size: Size) -> (Screen, ForwardCapture
         visual_bell,
         false, // focus_follows_mouse
         false, // mouse_click_through
+        true,  // allow_osc_passthrough
         web_server_ip,
         web_server_port,
     );
@@ -9095,6 +9098,7 @@ fn create_new_screen_with_theme_capture(size: Size) -> (Screen, ThemeCapture) {
         true,
         false,
         false,
+        true, // allow_osc_passthrough
         web_server_ip,
         web_server_port,
     );
@@ -9575,6 +9579,7 @@ fn create_non_mirrored_screen(size: Size) -> Screen {
         true,  // visual_bell
         false, // focus_follows_mouse
         false, // mouse_click_through
+        true,  // allow_osc_passthrough
         IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
         8080,
     )

--- a/zellij-utils/assets/prost_ipc/client_server_contract.rs
+++ b/zellij-utils/assets/prost_ipc/client_server_contract.rs
@@ -1983,6 +1983,8 @@ pub struct Options {
     pub pane_frame_style: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(bool, optional, tag="52")]
     pub stacked_pane_list: ::core::option::Option<bool>,
+    #[prost(bool, optional, tag="53")]
+    pub allow_osc_passthrough: ::core::option::Option<bool>,
 }
 /// Pane-targeting action messages
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/zellij-utils/src/client_server_contract/common_types.proto
+++ b/zellij-utils/src/client_server_contract/common_types.proto
@@ -1189,6 +1189,7 @@ message Options {
   optional uint32 mobile_threshold_rows = 50;
   optional string pane_frame_style = 51;
   optional bool stacked_pane_list = 52;
+  optional bool allow_osc_passthrough = 53;
 }
 
 enum OnForceClose {

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -375,6 +375,15 @@ pub struct Options {
     #[serde(default)]
     pub mouse_click_through: Option<bool>,
 
+    /// Whether to forward OSC 9 (iTerm2) and OSC 777 (rxvt) desktop-notification
+    /// sequences from panes to the host terminal. When false, the visual indicator
+    /// (pane/tab frame flash + [!] suffix) still fires, but the OSC bytes are not
+    /// forwarded. Does not affect OSC 99, which has its own established passthrough
+    /// behavior. Default: true.
+    #[clap(long, value_parser)]
+    #[serde(default)]
+    pub allow_osc_passthrough: Option<bool>,
+
     // these are intentionally excluded from the CLI options as they must be specified in the
     // configuration file
     pub web_server_ip: Option<IpAddr>,
@@ -502,6 +511,7 @@ impl Options {
         let visual_bell = other.visual_bell.or(self.visual_bell);
         let focus_follows_mouse = other.focus_follows_mouse.or(self.focus_follows_mouse);
         let mouse_click_through = other.mouse_click_through.or(self.mouse_click_through);
+        let allow_osc_passthrough = other.allow_osc_passthrough.or(self.allow_osc_passthrough);
         let web_server_ip = other.web_server_ip.or(self.web_server_ip);
         let web_server_port = other.web_server_port.or(self.web_server_port);
         let web_server_cert = other
@@ -564,6 +574,7 @@ impl Options {
             visual_bell,
             focus_follows_mouse,
             mouse_click_through,
+            allow_osc_passthrough,
             web_server_ip,
             web_server_port,
             web_server_cert,
@@ -647,6 +658,8 @@ impl Options {
         let visual_bell = other.visual_bell.or(self.visual_bell);
         let focus_follows_mouse = merge_bool(other.focus_follows_mouse, self.focus_follows_mouse);
         let mouse_click_through = merge_bool(other.mouse_click_through, self.mouse_click_through);
+        let allow_osc_passthrough =
+            merge_bool(other.allow_osc_passthrough, self.allow_osc_passthrough);
         let web_server_ip = other.web_server_ip.or(self.web_server_ip);
         let web_server_port = other.web_server_port.or(self.web_server_port);
         let web_server_cert = other
@@ -709,6 +722,7 @@ impl Options {
             visual_bell,
             focus_follows_mouse,
             mouse_click_through,
+            allow_osc_passthrough,
             web_server_ip,
             web_server_port,
             web_server_cert,

--- a/zellij-utils/src/ipc/protobuf_conversion.rs
+++ b/zellij-utils/src/ipc/protobuf_conversion.rs
@@ -774,6 +774,7 @@ impl From<crate::input::options::Options>
                 crate::input::options::PaneFrameStyle::Titles => "titles".to_owned(),
                 crate::input::options::PaneFrameStyle::None => "none".to_owned(),
             }),
+            allow_osc_passthrough: options.allow_osc_passthrough,
         }
     }
 }
@@ -895,6 +896,7 @@ impl TryFrom<crate::client_server_contract::client_server_contract::Options>
                 .transpose()?,
             mobile_threshold_cols: options.mobile_threshold_cols.map(|v| v as u16),
             mobile_threshold_rows: options.mobile_threshold_rows.map(|v| v as u16),
+            allow_osc_passthrough: options.allow_osc_passthrough,
         })
     }
 }

--- a/zellij-utils/src/ipc/tests/roundtrip_tests.rs
+++ b/zellij-utils/src/ipc/tests/roundtrip_tests.rs
@@ -486,6 +486,7 @@ fn test_client_messages() {
                 mobile_layout: Some(MobileLayoutConfiguration::Always),
                 mobile_threshold_cols: Some(72),
                 mobile_threshold_rows: Some(40),
+                allow_osc_passthrough: Some(true),
             }),
             layout: None,
             terminal_window_size: Size { rows: 80, cols: 42 },

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -2905,6 +2905,9 @@ impl Options {
                 },
                 None => None,
             };
+        let allow_osc_passthrough =
+            kdl_property_first_arg_as_bool_or_error!(kdl_options, "allow_osc_passthrough")
+                .map(|(v, _)| v);
 
         Ok(Options {
             simplified_ui,
@@ -2949,6 +2952,7 @@ impl Options {
             visual_bell,
             focus_follows_mouse,
             mouse_click_through,
+            allow_osc_passthrough,
             web_server_ip,
             web_server_port,
             web_server_cert,
@@ -4284,6 +4288,35 @@ impl Options {
             None
         }
     }
+    fn allow_osc_passthrough_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
+        let comment_text = format!(
+            "{}\n{}\n{}\n{}\n{}",
+            " ",
+            "// Forward OSC 9 (iTerm2) and OSC 777 (rxvt) desktop-notification",
+            "// sequences from panes to the host terminal. When false, the visual",
+            "// indicator still fires but the OSC bytes are not forwarded.",
+            "// default is true",
+        );
+
+        let create_node = |node_value: bool| -> KdlNode {
+            let mut node = KdlNode::new("allow_osc_passthrough");
+            node.push(KdlValue::Bool(node_value));
+            node
+        };
+        if let Some(allow_osc_passthrough) = self.allow_osc_passthrough {
+            let mut node = create_node(allow_osc_passthrough);
+            if add_comments {
+                node.set_leading(format!("{}\n", comment_text));
+            }
+            Some(node)
+        } else if add_comments {
+            let mut node = create_node(true);
+            node.set_leading(format!("{}\n// ", comment_text));
+            Some(node)
+        } else {
+            None
+        }
+    }
     fn web_server_ip_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
         let comment_text = format!(
             "{}\n{}\n{}\n{}",
@@ -4626,6 +4659,9 @@ impl Options {
         }
         if let Some(mouse_click_through) = self.mouse_click_through_to_kdl(add_comments) {
             nodes.push(mouse_click_through);
+        }
+        if let Some(allow_osc_passthrough) = self.allow_osc_passthrough_to_kdl(add_comments) {
+            nodes.push(allow_osc_passthrough);
         }
         if let Some(web_server_ip) = self.web_server_ip_to_kdl(add_comments) {
             nodes.push(web_server_ip);

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__bare_config_from_default_assets_to_string_with_comments.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__bare_config_from_default_assets_to_string_with_comments.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/kdl/mod.rs
+assertion_line: 7270
 expression: fake_config_stringified
 ---
 keybinds clear-defaults=true {
@@ -571,6 +572,12 @@ web_client {
 // Whether clicking a pane to focus it also sends the click into the pane
 // default is false
 // mouse_click_through false
+ 
+// Forward OSC 9 (iTerm2) and OSC 777 (rxvt) desktop-notification
+// sequences from panes to the host terminal. When false, the visual
+// indicator still fires but the OSC bytes are not forwarded.
+// default is true
+// allow_osc_passthrough true
  
 // The ip address the web server should listen on when it starts
 // Default: "127.0.0.1"

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__config_options_to_string_with_comments.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__config_options_to_string_with_comments.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/kdl/mod.rs
+assertion_line: 7209
 expression: fake_document.to_string()
 ---
  
@@ -289,6 +290,12 @@ web_sharing "disabled"
 // Whether clicking a pane to focus it also sends the click into the pane
 // default is false
 // mouse_click_through false
+ 
+// Forward OSC 9 (iTerm2) and OSC 777 (rxvt) desktop-notification
+// sequences from panes to the host terminal. When false, the visual
+// indicator still fires but the OSC bytes are not forwarded.
+// default is true
+// allow_osc_passthrough true
  
 // The ip address the web server should listen on when it starts
 // Default: "127.0.0.1"

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 704
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -47,6 +48,7 @@ Options {
     visual_bell: None,
     focus_follows_mouse: None,
     mouse_click_through: None,
+    allow_osc_passthrough: None,
     web_server_ip: None,
     web_server_port: None,
     web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 738
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -47,6 +48,7 @@ Options {
     visual_bell: None,
     focus_follows_mouse: None,
     mouse_click_through: None,
+    allow_osc_passthrough: None,
     web_server_ip: None,
     web_server_port: None,
     web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 694
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -45,6 +46,7 @@ Options {
     visual_bell: None,
     focus_follows_mouse: None,
     mouse_click_through: None,
+    allow_osc_passthrough: None,
     web_server_ip: None,
     web_server_port: None,
     web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 692
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -6023,6 +6024,7 @@ Config {
         visual_bell: None,
         focus_follows_mouse: None,
         mouse_click_through: None,
+        allow_osc_passthrough: None,
         web_server_ip: None,
         web_server_port: None,
         web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 762
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -6023,6 +6024,7 @@ Config {
         visual_bell: None,
         focus_follows_mouse: None,
         mouse_click_through: None,
+        allow_osc_passthrough: None,
         web_server_ip: None,
         web_server_port: None,
         web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 804
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -132,6 +133,7 @@ Config {
         visual_bell: None,
         focus_follows_mouse: None,
         mouse_click_through: None,
+        allow_osc_passthrough: None,
         web_server_ip: None,
         web_server_port: None,
         web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 714
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -47,6 +48,7 @@ Options {
     visual_bell: None,
     focus_follows_mouse: None,
     mouse_click_through: None,
+    allow_osc_passthrough: None,
     web_server_ip: None,
     web_server_port: None,
     web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 790
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -6023,6 +6024,7 @@ Config {
         visual_bell: None,
         focus_follows_mouse: None,
         mouse_click_through: None,
+        allow_osc_passthrough: None,
         web_server_ip: None,
         web_server_port: None,
         web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 776
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -6023,6 +6024,7 @@ Config {
         visual_bell: None,
         focus_follows_mouse: None,
         mouse_click_through: None,
+        allow_osc_passthrough: None,
         web_server_ip: None,
         web_server_port: None,
         web_server_cert: None,


### PR DESCRIPTION
Extends the unidirectional desktop-notification passthrough chain introduced by upstream PR #4931 (OSC 99) to also handle the simpler single-shot protocols spoken by other terminal ecosystems:

  - OSC 9   (iTerm2):  ESC ] 9 ; <body> ST
  - OSC 777 (rxvt):    ESC ] 777 ; notify ; <title> ; <body> ST

Both protocols are pushed onto the existing pending_desktop_notifications queue and forwarded byte-for-byte to the host terminal. They reuse the established BEL visual-bell pipeline (pane/tab frame flash + [!] suffix
+ folded stacked-pane indicator) by setting Grid::ring_bell on dispatch.

A new top-level configuration option allow_osc_passthrough (default true) lets users opt out of forwarding while still seeing the in-zellij visual indicator. The flag is scoped to OSC 9 / 777; OSC 99 retains its own contract from PR #4931 and is not affected.

Implementation notes:
  - OSC 9 / 777 entries are disambiguated from OSC 99 in the shared queue by a payload prefix ("9;..." or "777;..."). OSC 99 metadata is always key=value:key=value, so collisions are not possible with well-formed input.
  - The gate lives at Tab::forward_desktop_notifications instead of Grid::osc_dispatch to avoid plumbing a 13th positional param through ~135 Grid::new test sites.
  - OSC 777 sub-commands other than `notify` are silently ignored (no queue push, no visual bell). OSC 9 with empty body still rings the bell but does not forward.

Tests:
  - 6 new Grid-level tests covering payload shape, BEL/ST terminator handling, empty body, and unknown OSC 777 sub-command
  - 5 new Tab-level integration tests covering verbatim forwarding, no namespacing leakage, allow_osc_passthrough=false gate, OSC 9 / OSC 99 non-interference, and OSC 99 unaffected by the new flag

Snapshots updated for new KDL output / Options dump.