### PR TITLE
fix: Startup prompt leak

### DIFF
--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -257,11 +257,13 @@ impl InputHandler {
                     InputInstruction::ForwardedReplyFromHostComplete { token, reply_bytes },
                     _error_context,
                 )) => {
-                    self.os_input
-                        .send_to_server(ClientToServerMsg::ForwardedReplyFromHost {
-                            token,
-                            reply_bytes,
-                        });
+                    if token != 0 {
+                        self.os_input
+                            .send_to_server(ClientToServerMsg::ForwardedReplyFromHost {
+                                token,
+                                reply_bytes,
+                            });
+                    }
                 },
                 Ok((InputInstruction::Exit, _error_context)) => {
                     self.should_exit = true;

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -756,14 +756,13 @@ pub fn start_client(
                 .write_all(ENTER_KITTY_KEYBOARD_MODE.as_bytes())
                 .unwrap();
         }
-        // Subscribe to host CSI 2031 theme notifications and query the
-        // current mode. Sent right after CLEAR_CLIENT_TERMINAL_ATTRIBUTES
-        // so there's no window in which the host is unsubscribed.
+        // Subscribe to host CSI 2031 theme notifications. Sent right
+        // after CLEAR_CLIENT_TERMINAL_ATTRIBUTES so there's no window
+        // in which the host is unsubscribed.
         // Hosts that don't support 2031 ignore both sequences.
         stdout
             .write_all(ENABLE_HOST_THEME_NOTIFY.as_bytes())
             .unwrap();
-        stdout.write_all(QUERY_HOST_THEME.as_bytes()).unwrap();
     }
     envs::set_zellij("0".to_string());
     config.env.set_vars();
@@ -948,9 +947,6 @@ pub fn start_client(
         },
     };
 
-    os_input.connect_to_server(&*ipc_pipe);
-    os_input.send_to_server(first_msg);
-
     let mut command_is_executing = CommandIsExecuting::new();
 
     os_input.set_raw_mode();
@@ -984,6 +980,7 @@ pub fn start_client(
     let stdin_ansi_parser = Arc::new(Mutex::new(StdinAnsiParser::new()));
 
     let (resize_sender, resize_receiver) = std::sync::mpsc::channel::<()>();
+    let (startup_finished_tx, startup_finished_rx) = std::sync::mpsc::channel();
 
     let _stdin_thread = thread::Builder::new()
         .name("stdin_handler".to_string())
@@ -998,9 +995,22 @@ pub fn start_client(
                     stdin_ansi_parser,
                     explicitly_disable_kitty_keyboard_protocol,
                     Some(resize_sender),
+                    Some(startup_finished_tx),
+                    is_a_reconnect,
                 )
             }
         });
+
+    // Wait for the fire-and-forget startup queries to finish (via the
+    // Primary-DA barrier) before telling the server we're attached.
+    // This ensures that the client's own queries are not co-mingled
+    // with any forwards the server might dispatch immediately on
+    // attach (e.g. from an already-running shell's init).
+    // 500ms timeout to avoid hanging on a non-responsive host.
+    let _ = startup_finished_rx.recv_timeout(std::time::Duration::from_millis(500));
+
+    os_input.connect_to_server(&*ipc_pipe);
+    os_input.send_to_server(first_msg);
 
     // Apps running inside Zellij panes can issue a whitelisted set
     // of queries to the host terminal (bg/fg colour, palette

--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -17,6 +17,8 @@ pub(crate) fn stdin_loop(
     stdin_ansi_parser: Arc<Mutex<StdinAnsiParser>>,
     explicitly_disable_kitty_keyboard_protocol: bool,
     resize_sender: Option<std::sync::mpsc::Sender<()>>,
+    mut startup_finished_tx: Option<std::sync::mpsc::Sender<()>>,
+    is_a_reconnect: bool,
 ) {
     // On Windows, choose between two input strategies early — we need this
     // decision before the startup ANSI query below.
@@ -47,11 +49,16 @@ pub(crate) fn stdin_loop(
         let can_query_terminal = true;
 
         if can_query_terminal {
-            let query_string = build_startup_query_string();
+            stdin_ansi_parser.lock().unwrap().open_forward(0);
+            let query_string = build_startup_query_string(is_a_reconnect);
             let _ = os_input
                 .get_stdout_writer()
                 .write(query_string.as_bytes())
                 .unwrap();
+        } else {
+            if let Some(tx) = startup_finished_tx.take() {
+                let _ = tx.send(());
+            }
         }
     }
 
@@ -123,12 +130,18 @@ pub(crate) fn stdin_loop(
                             );
                         }
                         if let Some((token, reply_bytes)) = parse_output.completed_forward {
-                            let _ = send_input_instructions.send(
-                                InputInstruction::ForwardedReplyFromHostComplete {
-                                    token,
-                                    reply_bytes,
-                                },
-                            );
+                            if token == 0 {
+                                if let Some(tx) = startup_finished_tx.take() {
+                                    let _ = tx.send(());
+                                }
+                            } else {
+                                let _ = send_input_instructions.send(
+                                    InputInstruction::ForwardedReplyFromHostComplete {
+                                        token,
+                                        reply_bytes,
+                                    },
+                                );
+                            }
                         }
                         for payload in parse_output.desktop_notifications {
                             let _ = send_input_instructions
@@ -271,15 +284,22 @@ fn finalize_events(
 /// Build the fire-and-forget host-query batch sent at client startup.
 /// The host's replies refine `Screen`'s cached state asynchronously as
 /// they arrive; the UI does not block on them.
-fn build_startup_query_string() -> String {
+fn build_startup_query_string(is_a_reconnect: bool) -> String {
     // <ESC>[14t => get text area size in pixels,
     // <ESC>[16t => get character cell size in pixels
     // <ESC>]11;?<ESC>\ => get background color
     // <ESC>]10;?<ESC>\ => get foreground color
     // <ESC>[?2026$p => get synchronised output mode
+    // <ESC>[?996n => get host terminal theme (DSR 996)
+    // <ESC>[c => Primary Device Attributes (barrier)
     let mut query_string = String::from(
         "\u{1b}[14t\u{1b}[16t\u{1b}]11;?\u{1b}\u{5c}\u{1b}]10;?\u{1b}\u{5c}\u{1b}[?2026$p",
     );
+    if !is_a_reconnect {
+        query_string.push_str("\u{1b}[?996n");
+    }
+    query_string.push_str("\u{1b}[c");
+
     // query colors
     // eg. <ESC>]4;5;?<ESC>\ => query color register number 5
     for i in 0..256 {


### PR DESCRIPTION
This is a potential fix for https://github.com/zellij-org/zellij/issues/5164. It solves the problem on my side but I'm entirely unfamiliar with this codebase so can't speak to its broader correctness.

I used gemini to make the change; I already see some ugly things (hardcoded 0 as the startup token, arbitrary 500ms timeout).