### PR TITLE
fix: use / as daemon working directory instead of cwd

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -804,7 +804,7 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
         let current_umask = umask(Mode::all());
         umask(current_umask);
         daemonize::Daemonize::new()
-            .working_directory(std::env::current_dir().unwrap())
+            .working_directory("/")
             .umask(current_umask.bits() as u32)
             .start()
             .expect("could not daemonize the server process");


### PR DESCRIPTION
## Problem

Spawning a new session panics with:

```
thread 'main' panicked at zellij-server/src/lib.rs:810:
could not daemonize the server process: Error { kind: ChangeDirectory(13) }
```

This happens when the caller's working directory is a path the forked daemon process can't `chdir` into — for example `/root` when running as a non-root user (EACCES, errno 13).

## Root cause

```rust
daemonize::Daemonize::new()
    .working_directory(std::env::current_dir().unwrap())  // <-- problematic
```

`current_dir()` captures the caller's cwd. The caller can be in that directory (they have an open fd for it), but after `fork()` the daemon may not have permission to `chdir` into it fresh — `/root` is typically `700`.

## Fix

Use `/` as the daemon working directory. This follows POSIX daemon conventions (Linux `daemon(7)`, Stevens APUE §13.3): a daemon should `chdir("/")` so it never holds a reference to an arbitrary caller directory and the path is always accessible.

The server uses absolute paths for all its state (sockets, logs, config), so the working directory has no functional impact.

This code path is already `#[cfg(unix)]` only — no Windows impact.

## Reproduction

```bash
cd /root  # or any directory the user lacks execute permission on after fork
zellij attach --create some-session
```

Closes #5171 (related — separate from the web client control channel race)