### PR TITLE
fix(plugin): prevent duplicate WASM instances for background plugins on startup

### DIFF
--- a/zellij-server/src/plugins/plugin_map.rs
+++ b/zellij-server/src/plugins/plugin_map.rs
@@ -208,6 +208,9 @@ impl PluginMap {
         }
         cloned_plugin_assets
     }
+    pub fn contains(&self, plugin_id: PluginId, client_id: ClientId) -> bool {
+        self.plugin_assets.contains_key(&(plugin_id, client_id))
+    }
     pub fn all_plugin_ids(&self) -> Vec<(PluginId, ClientId)> {
         self.plugin_assets
             .iter()

--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -706,6 +706,9 @@ impl WasmBridge {
             new_plugins.insert(plugin_id);
         }
         for plugin_id in new_plugins {
+            if self.plugin_map.lock().unwrap().contains(plugin_id, client_id) {
+                continue;
+            }
             let Some(run_plugin) = self.run_plugin_of_plugin_id(plugin_id).map(|r| r.clone())
             else {
                 log::error!("Failed to find plugin with id: {}", plugin_id);


### PR DESCRIPTION
## Summary

Fixes #5177

Background plugins configured via `load_plugins` can get instantiated twice on startup due to a race condition between `load_background_plugin` and `add_client`. When `AddClient` arrives while a background plugin is already loaded (or loading), `add_client()` creates a second WASM instance for the same `(plugin_id, client_id)` pair because it doesn't check for existing entries in the plugin map.

This PR adds a simple guard: before creating a new plugin instance in the `add_client()` loop, check if the `(plugin_id, client_id)` pair already exists in the plugin map and skip if so.

## Changes

- **`plugin_map.rs`**: Add `contains(plugin_id, client_id)` method to `PluginMap` (the internal `plugin_assets` HashMap is private)
- **`wasm_bridge.rs`**: Add guard in `add_client()` to skip instance creation when the plugin/client pair already exists

## Root Cause

1. `plugin_thread_main` calls `load_background_plugin` for each `load_plugins` entry *before* entering the event loop, using `initiating_client_id` as a dummy client
2. The event loop starts and `AddClient(client_id)` arrives
3. `add_client()` iterates all `plugin_ids()` from the plugin map and unconditionally creates new instances for the connecting client
4. If `initiating_client_id == client_id` (common case) and the background plugin load already completed, `plugin_map.insert` overwrites the first instance. The original WASM store stays in memory as an orphan, still receiving cached events.

## Testing

- All existing tests pass (`cargo test` in `zellij-server/`, 1088 tests)
- Validated with the [standalone reproducer](https://github.com/rhuss/zellij-duplicate-instance-repro): 20/20 runs pass (0% failure rate, previously ~10%)

Assisted-By: 🤖 Claude Code