### PR TITLE
Fix ECH artifacts when erasing wide characters

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -5541,11 +5541,14 @@ impl Row {
             let overwrite_end = x + character.width().max(terminal_character_width);
             self.osc133_markers
                 .retain(|marker| marker.column < x || marker.column >= overwrite_end);
+
+            let mut padding_character = EMPTY_TERMINAL_CHARACTER;
+            padding_character.styles = terminal_character.styles.clone();
             let character = std::mem::replace(character, terminal_character);
             let excess_width = character.width().saturating_sub(terminal_character_width);
             for _ in 0..excess_width {
                 self.columns
-                    .insert(absolute_x_index, EMPTY_TERMINAL_CHARACTER);
+                    .insert(absolute_x_index, padding_character.clone());
             }
         }
         self.width = None;

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -8772,3 +8772,31 @@ fn sixel_dcs_is_not_confused_with_xtgettcap() {
         "a sixel image must not produce an XTGETTCAP reply"
     );
 }
+
+#[test]
+fn ech_over_wide_character_preserves_background_on_padding_cell() {
+    use crate::panes::terminal_character::NamedColor;
+    // Use a wide character to exercise replacement of a wide cell.
+    assert_eq!(crate::panes::TerminalCharacter::new('Ａ').width(), 2);
+
+    let content = "\x1b[44mＡ\x1b[1;1H\x1b[1X".as_bytes();
+    let grid = create_grid_with_size_and_raw(2, 4, content);
+
+    let lines = grid.as_character_lines();
+
+    assert_eq!(lines[0][0].character, ' ');
+    assert_eq!(lines[0][1].character, ' ');
+
+    assert_eq!(
+        lines[0][0].styles.background,
+        Some(crate::panes::terminal_character::AnsiCode::NamedColor(
+            NamedColor::Blue
+        ))
+    );
+    assert_eq!(
+        lines[0][1].styles.background,
+        Some(crate::panes::terminal_character::AnsiCode::NamedColor(
+            NamedColor::Blue
+        ))
+    );
+}


### PR DESCRIPTION
## Description

This fixes rendering artifacts that can appear when Neovim erases wide characters with `CSI X` / ECH inside Zellij.

When a wide character is replaced with a single-width blank, `Row::replace_character_at` inserts padding cells for the remaining width. Previously these padding cells used `EMPTY_TERMINAL_CHARACTER`, which has reset/default styling.

If the replacement character had a non-default background, the first erased cell kept the expected style, but the padding cell lost it. This could leave a small rectangular artifact in otherwise empty buffer areas.

This change makes the padding cell inherit the replacement character's styles.

## Reproduction

This was observed with Neovim inside Zellij:

```sh
zellij --debug --config-dir /tmp/zellij-empty
nvim --clean
````

Then inside Neovim:

```vim
:vs
```

In my case, the Neovim start screen contained wide characters, and opening a vertical split caused small rectangular artifacts in the empty buffer area.

## Fix

When replacing a wide character with a narrower character, use a padding cell that inherits the replacement character's styles instead of using `EMPTY_TERMINAL_CHARACTER` directly.

## Tests

Added a regression test that:

1.  Writes a wide character with a background color
2.  Moves the cursor back to it
3.  Erases it with ECH
4.  Verifies that both cells keep the expected background style

Tested with:

```sh
cargo test -p zellij-server ech_over_wide_character_preserves_background_on_padding_cell
cargo test -p zellij-server --lib
```

Fixes #5101
