### PR TITLE
Fix stale plugin mode updates after closing tabs

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1686,6 +1686,9 @@ impl Screen {
             .next()
             .context("screen contained no tabs")
             .with_context(err_context)?;
+
+        let mut tabs_to_update = HashSet::new();
+
         for (client_id, client_mode_info) in client_ids_and_mode_infos {
             let client_tab_history = self.tab_history.entry(client_id).or_insert_with(Vec::new);
             if let Some(client_previous_tab) = client_tab_history.pop() {
@@ -1694,6 +1697,7 @@ impl Screen {
                     client_active_tab
                         .add_client(client_id, Some(client_mode_info))
                         .with_context(err_context)?;
+                    tabs_to_update.insert(client_previous_tab);
                     continue;
                 }
             }
@@ -1703,7 +1707,18 @@ impl Screen {
                 .with_context(err_context)?
                 .add_client(client_id, Some(client_mode_info))
                 .with_context(err_context)?;
+            tabs_to_update.insert(first_tab_index);
         }
+
+        // Closing a tab moves its clients without going through the normal tab-switch path.
+        // Refresh ModeUpdate for the destination tabs so tab-local plugins such as
+        // tab-bar/status-bar do not render stale mode information when they become visible again.
+        for tab_id in tabs_to_update {
+            if let Some(tab) = self.tabs.get_mut(&tab_id) {
+                tab.update_input_modes().with_context(err_context)?;
+            }
+        }
+
         Ok(())
     }
 

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -7764,6 +7764,70 @@ pub fn inactive_tab_plugins_get_fresh_state_on_activation() {
 }
 
 #[test]
+pub fn closing_active_tab_sends_fresh_mode_update_to_revealed_tab_plugins() {
+    // Tab 0: plugin pane 2 (from new_tab_with_plugins, queued before run)
+    // Tab 1: terminal panes only (from run, starts screen thread and becomes active)
+    //
+    // Closing Tab 1 moves the client back to Tab 0. The plugin pane in Tab 0
+    // becomes visible for this client again, so it must receive a fresh ModeUpdate.
+    //
+    // This guards against stale tab-local plugin state in tab-bar/status-bar-like
+    // plugins after closing the currently active tab.
+    let size = Size { cols: 80, rows: 10 };
+    let client_id = 10;
+
+    let mut mock_screen = MockScreen::new(size);
+
+    // Queue a first tab containing a plugin pane. `run(None, vec![])` below
+    // creates another tab and makes it active, so closing it should reveal this one.
+    mock_screen.new_tab_with_plugins(vec![2]);
+
+    let session_metadata = mock_screen.clone_session_metadata();
+    let screen_thread = mock_screen.run(None, vec![]);
+
+    let received_plugin_instructions = Arc::new(Mutex::new(vec![]));
+    let plugin_receiver = mock_screen.plugin_receiver.take().unwrap();
+    let plugin_thread = log_actions_in_thread!(
+        received_plugin_instructions,
+        PluginInstruction::Exit,
+        plugin_receiver
+    );
+
+    // Drain initial setup/plugin state messages before the close action.
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    let instructions_before_close = received_plugin_instructions.lock().unwrap().len();
+
+    // Close the active tab. The client should return to the tab with plugin 2.
+    let close_tab = CliAction::CloseTab { tab_id: None };
+    send_cli_action_to_server(&session_metadata, close_tab, client_id);
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    mock_screen.teardown(vec![plugin_thread, screen_thread]);
+
+    let instructions = received_plugin_instructions.lock().unwrap();
+    let instructions_after_close = &instructions[instructions_before_close..];
+
+    let mut plugin_ids_that_received_mode_update: Vec<u32> = vec![];
+    for instruction in instructions_after_close.iter() {
+        if let PluginInstruction::Update(updates) = instruction {
+            for (pid, _cid, event) in updates {
+                if matches!(event, Event::ModeUpdate(..)) {
+                    if let Some(id) = pid {
+                        plugin_ids_that_received_mode_update.push(*id);
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        plugin_ids_that_received_mode_update.contains(&2),
+        "Plugin 2 in the revealed tab should receive a fresh ModeUpdate after closing the active tab, got: {:?}",
+        plugin_ids_that_received_mode_update
+    );
+}
+
+#[test]
 pub fn send_cli_new_tab_action_with_layout_string() {
     let size = Size { cols: 80, rows: 10 };
     let client_id = 10;


### PR DESCRIPTION
## Summary

Fixes #5114.

When a tab is closed, clients are moved to another tab through `move_clients_from_closed_tab()`. This path did not refresh the destination tab's plugin mode state, unlike the regular tab-switch path, which calls `update_input_modes()` for the destination tab.

As a result, tab-local plugins such as `tab-bar` / `status-bar` could render stale mode information after the previous tab became visible again.

Also addresses #5128.

## Changes

- Track the tabs that receive clients after a tab is closed.
- Call `update_input_modes()` for those destination tabs.
- Add a regression test to ensure a tab-local plugin receives a fresh `ModeUpdate` after the active tab is closed and a previous tab becomes visible again.

## Testing

```bash
cargo test -p zellij-server closing_active_tab_sends_fresh_mode_update_to_revealed_tab_plugins
````

Manually verified that the stale tab-bar/status-bar mode display no longer reproduces after closing a tab.
