### PR TITLE
fix(client): gate any-motion mouse tracking on mouse_hover_effects

### DIFF
--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -153,7 +153,8 @@ impl InputHandler {
         let bracketed_paste_start = vec![27, 91, 50, 48, 48, 126]; // \u{1b}[200~
         let bracketed_paste_end = vec![27, 91, 50, 48, 49, 126]; // \u{1b}[201~
         if self.options.mouse_mode.unwrap_or(true) {
-            self.os_input.enable_mouse().non_fatal();
+            let track_any_motion = self.options.mouse_hover_effects.unwrap_or(true);
+            self.os_input.enable_mouse(track_any_motion).non_fatal();
             self.mouse_mode_active = true;
         }
         loop {
@@ -410,7 +411,8 @@ impl InputHandler {
                     self.os_input.disable_mouse().non_fatal();
                     self.mouse_mode_active = false;
                 } else {
-                    self.os_input.enable_mouse().non_fatal();
+                    let track_any_motion = self.options.mouse_hover_effects.unwrap_or(true);
+                    self.os_input.enable_mouse(track_any_motion).non_fatal();
                     self.mouse_mode_active = true;
                 }
             },

--- a/zellij-client/src/os_input_output.rs
+++ b/zellij-client/src/os_input_output.rs
@@ -28,7 +28,13 @@ use zellij_utils::{
 const SIGWINCH_CB_THROTTLE_DURATION: time::Duration = time::Duration::from_millis(50);
 
 pub(crate) const ENABLE_MOUSE_SUPPORT: &str =
-    "\u{1b}[?1000h\u{1b}[?1002h\u{1b}[?1003h\u{1b}[?1015h\u{1b}[?1006h";
+    "\u{1b}[?1000h\u{1b}[?1002h\u{1b}[?1015h\u{1b}[?1006h";
+pub(crate) const ENABLE_MOUSE_ANY_MOTION_TRACKING: &str = "\u{1b}[?1003h";
+// `?1003l` is always included in the disable sequence, even if we never
+// enabled any-motion tracking ourselves: a pane's inner app may have turned
+// it on via `?1003h`, and we want to guarantee the host terminal is quiet
+// after teardown. Sending `l` for a mode that was never set is a no-op per
+// DEC.
 pub(crate) const DISABLE_MOUSE_SUPPORT: &str =
     "\u{1b}[?1006l\u{1b}[?1015l\u{1b}[?1003l\u{1b}[?1002l\u{1b}[?1000l";
 
@@ -138,7 +144,15 @@ pub trait ClientOsApi: Send + Sync + std::fmt::Debug {
     /// Establish a connection with the server socket.
     fn connect_to_server(&self, path: &Path);
     fn load_palette(&self) -> Palette;
-    fn enable_mouse(&self) -> Result<()>;
+    /// Enable mouse reporting on the host terminal.
+    ///
+    /// `track_any_motion` toggles XTerm any-event mouse tracking (`?1003`),
+    /// which reports bare mouse movement even when no button is down. That
+    /// mode is only needed for the optional hover-highlight UX; leaving it
+    /// off means a dying ssh connection (or any hang that prevents us from
+    /// sending the disable sequence) can't leave the host terminal spraying
+    /// motion escape codes on every hover — see issue #3333.
+    fn enable_mouse(&self, track_any_motion: bool) -> Result<()>;
     fn disable_mouse(&self) -> Result<()>;
     /// Restore console input mode to its pre-Zellij state.
     ///
@@ -306,9 +320,9 @@ impl ClientOsApi for ClientOsInputOutput {
         // };
         default_palette()
     }
-    fn enable_mouse(&self) -> Result<()> {
+    fn enable_mouse(&self, track_any_motion: bool) -> Result<()> {
         let mut stdout = self.get_stdout_writer();
-        enable_mouse_support(&mut *stdout)
+        enable_mouse_support(&mut *stdout, track_any_motion)
     }
 
     fn disable_mouse(&self) -> Result<()> {

--- a/zellij-client/src/os_input_output_unix.rs
+++ b/zellij-client/src/os_input_output_unix.rs
@@ -88,11 +88,16 @@ pub(crate) fn setup_ipc(
     (sender, receiver)
 }
 
-pub(crate) fn enable_mouse_support(stdout: &mut dyn Write) -> Result<()> {
+pub(crate) fn enable_mouse_support(stdout: &mut dyn Write, track_any_motion: bool) -> Result<()> {
     let err_context = "failed to enable mouse mode";
     stdout
         .write_all(super::os_input_output::ENABLE_MOUSE_SUPPORT.as_bytes())
         .context(err_context)?;
+    if track_any_motion {
+        stdout
+            .write_all(super::os_input_output::ENABLE_MOUSE_ANY_MOTION_TRACKING.as_bytes())
+            .context(err_context)?;
+    }
     stdout.flush().context(err_context)?;
     Ok(())
 }
@@ -104,4 +109,35 @@ pub(crate) fn disable_mouse_support(stdout: &mut dyn Write) -> Result<()> {
         .context(err_context)?;
     stdout.flush().context(err_context)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod mouse_support_tests {
+    use super::*;
+
+    /// With hover effects off we must NOT send `?1003h`. Otherwise a dropped
+    /// ssh session leaves the host terminal in any-motion tracking and every
+    /// hover spews escape codes — see issue #3333.
+    #[test]
+    fn enable_mouse_support_omits_any_motion_when_disabled() {
+        let mut buf: Vec<u8> = Vec::new();
+        enable_mouse_support(&mut buf, false).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(
+            !output.contains("\u{1b}[?1003h"),
+            "any-motion tracking must not be enabled when track_any_motion=false; got {:?}",
+            output
+        );
+        assert!(output.contains("\u{1b}[?1000h"));
+        assert!(output.contains("\u{1b}[?1002h"));
+        assert!(output.contains("\u{1b}[?1006h"));
+    }
+
+    #[test]
+    fn enable_mouse_support_includes_any_motion_when_enabled() {
+        let mut buf: Vec<u8> = Vec::new();
+        enable_mouse_support(&mut buf, true).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("\u{1b}[?1003h"));
+    }
 }

--- a/zellij-client/src/os_input_output_windows.rs
+++ b/zellij-client/src/os_input_output_windows.rs
@@ -204,13 +204,18 @@ fn enable_vt_processing_on_stdout() {
 ///
 /// When TERM is not set we're in a native console (cmd, PowerShell,
 /// Windows Terminal) and use crossterm's Console API approach.
-pub(crate) fn enable_mouse_support(stdout: &mut dyn Write) -> Result<()> {
+pub(crate) fn enable_mouse_support(stdout: &mut dyn Write, track_any_motion: bool) -> Result<()> {
     let err_context = "failed to enable mouse mode";
     if std::env::var("TERM").is_ok() {
         enable_vt_processing_on_stdout();
         stdout
             .write_all(super::os_input_output::ENABLE_MOUSE_SUPPORT.as_bytes())
             .context(err_context)?;
+        if track_any_motion {
+            stdout
+                .write_all(super::os_input_output::ENABLE_MOUSE_ANY_MOTION_TRACKING.as_bytes())
+                .context(err_context)?;
+        }
         stdout.flush().context(err_context)?;
     } else {
         // crossterm::execute! requires Sized, so we use std::io::stdout()

--- a/zellij-client/src/remote_attach/unit/remote_attach_tests.rs
+++ b/zellij-client/src/remote_attach/unit/remote_attach_tests.rs
@@ -388,7 +388,7 @@ impl crate::os_input_output::ClientOsApi for MockClientOsApi {
         zellij_utils::shared::default_palette()
     }
 
-    fn enable_mouse(&self) -> anyhow::Result<()> {
+    fn enable_mouse(&self, _track_any_motion: bool) -> anyhow::Result<()> {
         Ok(())
     }
 

--- a/zellij-client/src/unit/terminal_loop_tests.rs
+++ b/zellij-client/src/unit/terminal_loop_tests.rs
@@ -127,7 +127,7 @@ impl ClientOsApi for TestClientOsApi {
         Palette::default()
     }
 
-    fn enable_mouse(&self) -> anyhow::Result<()> {
+    fn enable_mouse(&self, _track_any_motion: bool) -> anyhow::Result<()> {
         Ok(())
     }
 

--- a/zellij-client/src/web_client/message_handlers.rs
+++ b/zellij-client/src/web_client/message_handlers.rs
@@ -338,7 +338,7 @@ mod tests {
         fn load_palette(&self) -> Palette {
             Palette::default()
         }
-        fn enable_mouse(&self) -> anyhow::Result<()> {
+        fn enable_mouse(&self, _track_any_motion: bool) -> anyhow::Result<()> {
             Ok(())
         }
         fn disable_mouse(&self) -> anyhow::Result<()> {

--- a/zellij-client/src/web_client/unit/web_client_tests.rs
+++ b/zellij-client/src/web_client/unit/web_client_tests.rs
@@ -3007,7 +3007,7 @@ impl ClientOsApi for MockClientOsApi {
     fn load_palette(&self) -> Palette {
         Palette::default()
     }
-    fn enable_mouse(&self) -> anyhow::Result<()> {
+    fn enable_mouse(&self, _track_any_motion: bool) -> anyhow::Result<()> {
         Ok(())
     }
     fn disable_mouse(&self) -> anyhow::Result<()> {

--- a/zellij-utils/assets/config/default.kdl
+++ b/zellij-utils/assets/config/default.kdl
@@ -515,6 +515,9 @@ load_plugins {
 // advanced_mouse_actions false
 
 // Whether to enable mouse hover visual effects (frame highlight and help text)
+// This also controls whether XTerm any-event mouse tracking (DECSET 1003) is
+// enabled on the host terminal; set to false if a dropped ssh session ever
+// leaves your terminal emitting raw mouse codes on hover.
 // Default: true
 //
 // mouse_hover_effects false

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -235,7 +235,10 @@ pub struct Options {
     #[serde(default)]
     pub advanced_mouse_actions: Option<bool>,
 
-    /// Whether to enable mouse hover visual effects (frame highlight and help text)
+    /// Whether to enable mouse hover visual effects (frame highlight and help text).
+    /// This also controls whether XTerm any-event mouse tracking (DECSET 1003) is
+    /// enabled on the host terminal; set this to `false` if a dropped ssh session
+    /// ever leaves your terminal emitting raw mouse codes on hover.
     /// default is true
     #[clap(long, value_parser)]
     #[serde(default)]


### PR DESCRIPTION
## Summary

Addresses the unrecoverable hover-flood symptom of #3333.

The client unconditionally enables XTerm any-event mouse tracking (DECSET 1003) as part of the static mouse-enable sequence. When the link between client and host terminal disappears without a graceful teardown — most commonly a dropped ssh session — the host terminal stays in any-motion mode and dumps raw mouse codes onto the prompt on every hover. Because the codes arrive faster than the user can type, recovery via `reset` is itself difficult.

The existing `mouse_hover_effects` option only gated the visual frame-highlight on the server side; the `?1003h` escape was emitted regardless. This PR threads that knob through to the client so `mouse_hover_effects false` actually prevents `?1003h` from being sent. The default stays `true`, so behavior is unchanged for users who don't opt out.

The disable sequence keeps `?1003l` unconditionally — harmless if `?1003` was never enabled and useful if a pane's inner app turned it on itself.

## Scope

This fix targets the hover-flood, which is the part that prevents recovery. Click and Ctrl+C may still emit stray codes after a disconnect (those originate from `?1000`/`?1006` and the kitty keyboard protocol respectively), but those are quiet enough that `reset` becomes typable. Same place tmux/vim sit on a dropped ssh.

## Test plan

- [x] `cargo xtask build` — clean
- [x] `cargo xtask test` — 24 binaries, 1788 passed, 0 failed
- [x] `cargo fmt --check` — clean
- [x] Two new unit tests in `zellij-client/src/os_input_output_unix.rs` asserting `?1003h` is omitted when `track_any_motion=false` and present when `true`
- [x] Manual repro: ssh into a host running zellij, drop the connection with `~.`; with `mouse_hover_effects false` the local terminal no longer floods on hover, `reset` recovers cleanly. Without the patch, hover spam makes the prompt unusable.

## Usage for affected users

```kdl
mouse_hover_effects false
```

Trade-off: lose the bare-hover pane-frame highlight. Click/drag/scroll/copy-via-drag are unaffected.