### PR TITLE
fix(server): forward Ctrl+LeftClick when requested

### DIFF
--- a/zellij-server/src/tab/mouse_handler.rs
+++ b/zellij-server/src/tab/mouse_handler.rs
@@ -1291,6 +1291,13 @@ impl MouseHandler {
                     });
                 }
             }
+            let is_active_pane = Some(details.pane_id) == ctx.active_pane_id;
+            if is_active_pane && details.terminal_wants_mouse {
+                return Ok(MouseAction::SendToTerminal {
+                    pane_id: details.pane_id,
+                    event: *event,
+                });
+            }
             return Ok(MouseAction::NoAction);
         }
 

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -10632,6 +10632,60 @@ fn test_ctrl_click_on_pane_body_does_nothing() {
 }
 
 #[test]
+fn test_ctrl_click_on_pane_body_forwards_when_terminal_wants_mouse() {
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let client_id = 1;
+
+    let mut pty_instruction_bus = MockPtyInstructionBus::new();
+    let mut tab = create_new_tab_with_mock_pty_writer(
+        size,
+        ModeInfo::default(),
+        pty_instruction_bus.pty_write_sender(),
+    );
+    pty_instruction_bus.start();
+
+    let new_pane_id = PaneId::Terminal(2);
+    tab.vertical_split(new_pane_id, None, client_id, None, None)
+        .unwrap();
+
+    // After vertical split, pane 2 (right) is the active pane.
+    assert_eq!(tab.get_active_pane_id(client_id), Some(PaneId::Terminal(2)));
+
+    // Enable SGR mouse mode on the active pane (pane 2).
+    let sgr_mouse_mode = String::from("\u{1b}[?1000;1006h");
+    tab.handle_pty_bytes(2, sgr_mouse_mode.as_bytes().to_vec())
+        .unwrap();
+
+    // Ctrl+click in the body of pane 2 (column 90 is in the right pane of a 121-col split).
+    let body_position = Position::new(10, 90);
+    let effect = tab
+        .handle_mouse_event(
+            &MouseEvent::new_left_press_with_ctrl_event(body_position),
+            client_id,
+        )
+        .unwrap();
+
+    assert!(effect.state_changed);
+
+    pty_instruction_bus.exit();
+
+    let output = pty_instruction_bus.clone_output();
+    assert!(
+        !output.is_empty(),
+        "Expected Ctrl+click to be forwarded to terminal"
+    );
+    // SGR encoding: button 0 (left) + ctrl modifier (16) = 16.
+    assert!(
+        output[0].starts_with("\u{1b}[<16;"),
+        "Expected SGR Ctrl+left-click sequence, got: {:?}",
+        output[0]
+    );
+}
+
+#[test]
 fn test_ctrl_drag_resizes_floating_pane_from_edge() {
     let size = Size {
         cols: 121,

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -10661,14 +10661,11 @@ fn test_ctrl_click_on_pane_body_forwards_when_terminal_wants_mouse() {
 
     // Ctrl+click in the body of pane 2 (column 90 is in the right pane of a 121-col split).
     let body_position = Position::new(10, 90);
-    let effect = tab
-        .handle_mouse_event(
-            &MouseEvent::new_left_press_with_ctrl_event(body_position),
-            client_id,
-        )
-        .unwrap();
-
-    assert!(effect.state_changed);
+    tab.handle_mouse_event(
+        &MouseEvent::new_left_press_with_ctrl_event(body_position),
+        client_id,
+    )
+    .unwrap();
 
     pty_instruction_bus.exit();
 


### PR DESCRIPTION
## Summary (Human)

Currently, with Ctrl held a mouse-aware TUI inside the active pane receives LeftDrag and LeftRelease events but not the preceding LeftClick. This PR conditions the swallow of Ctrl+LeftClick (`MouseAction::NoAction` at [mouse_handler.rs:1294](https://github.com/zellij-org/zellij/blob/b558b31ed192652f75ecc35d6753a7d5d0046023/zellij-server/src/tab/mouse_handler.rs#L1294)), forwarding it to the TUI if requested to align with Ctrl+LeftDrag and Ctrl+LeftRelease.

As a Rust novice, I utilized AI in the drafting of this PR. I've personally reviewed every line and believe that it's not slop, but unfortunately don't have the expertise to be certain. Thank you maintainers, I recognize the prevalence of generative AI dramatically increases your burden and have no expectation of quick review. 🙏 

## Tests Added/Performed

- [x] New unit test: `test_ctrl_click_on_pane_body_forwards_when_terminal_wants_mouse` — verifies Ctrl+LeftPress on the active pane's body forwards an SGR mouse sequence to the pty when the inner terminal has enabled mouse reporting via DECSET.
- [x] Existing `test_ctrl_click_on_pane_body_does_nothing` still passes — the click is on an inactive pane with no mouse reporting, so behavior is unchanged.
- [x] All 23 existing `ctrl_*` tests pass (frame-edge resize, ctrl+drag resize, ctrl+scroll resize, floating pane pin toggle).
- [x] Manual: built `target/release/zellij` and verified in Ghostty + `leaf` on macOS — Ctrl+Click opens links; drag-to-resize and Ctrl+Scroll resize still work.
