### PR TITLE
fix(windows): break server out of parent job on spawn

### DIFF
--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -375,20 +375,44 @@ pub fn spawn_server(socket_path: &Path, debug: bool) -> io::Result<()> {
 /// process with a hidden console.  We use CREATE_NO_WINDOW (not
 /// DETACHED_PROCESS) so the server gets valid standard handles;
 /// DETACHED_PROCESS leaves stdin/stdout/stderr as NULL, which breaks PTY
-/// creation, WASM plugin loading, and logging.
+/// creation, WASM plugin loading, and logging. CREATE_BREAKAWAY_FROM_JOB
+/// is the closest equivalent to Unix daemonization: it detaches the server
+/// from the parent's job object so it can outlive things like the
+/// per-connection sshd-session.exe job on SSH disconnect.
 #[cfg(windows)]
 pub fn spawn_server(socket_path: &Path, debug: bool) -> io::Result<()> {
     use std::os::windows::process::CommandExt;
-    let mut cmd = Command::new(current_exe()?);
-    cmd.arg("--server").arg(socket_path);
-    if debug {
-        cmd.arg("--debug");
-    }
+
     const CREATE_NO_WINDOW: u32 = 0x08000000;
     const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
-    cmd.creation_flags(CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP);
-    cmd.spawn()?;
-    Ok(())
+    const CREATE_BREAKAWAY_FROM_JOB: u32 = 0x01000000;
+    const ERROR_ACCESS_DENIED: i32 = 5;
+
+    let build_cmd = |flags: u32| -> io::Result<Command> {
+        let mut cmd = Command::new(current_exe()?);
+        cmd.arg("--server").arg(socket_path);
+        if debug {
+            cmd.arg("--debug");
+        }
+        cmd.creation_flags(flags);
+        Ok(cmd)
+    };
+
+    let base_flags = CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP;
+    match build_cmd(base_flags | CREATE_BREAKAWAY_FROM_JOB)?.spawn() {
+        Ok(_) => Ok(()),
+        // Some job objects forbid breakaway; retry without the flag so the
+        // server still starts (it just won't outlive the parent's job).
+        Err(e) if e.raw_os_error() == Some(ERROR_ACCESS_DENIED) => {
+            log::warn!(
+                "spawn_server: parent job denied CREATE_BREAKAWAY_FROM_JOB; \
+                 server will inherit the parent's job and may not outlive it"
+            );
+            build_cmd(base_flags)?.spawn()?;
+            Ok(())
+        },
+        Err(e) => Err(e),
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
On Windows, `spawn_server` did not break the Zellij server out of the parent's job object. When the parent is the per-connection `sshd-session.exe` from Windows OpenSSH, that job is terminated on SSH disconnect and the server dies with it - there's nothing left to `zellij attach` to.

Spawn with `CREATE_BREAKAWAY_FROM_JOB`, the Windows analogue of the Unix `daemonize::Daemonize` call already used in `start_server` on Unix. If the parent's job disallows breakaway, `CreateProcess` returns `ERROR_ACCESS_DENIED`; log a warning and retry without the flag so the server still starts (it just won't outlive that job). The flag is a no-op when the parent isn't in a job, so the common local-terminal startup path is unchanged.

Background on the OpenSSH-on-Windows behavior: [PowerShell/Win32-OpenSSH#1751](https://github.com/PowerShell/Win32-OpenSSH/issues/1751).

## Validation

Manual, on Windows 11 with Windows OpenSSH server enabled:

1. `ssh user@localhost`, then `zellij -s breakawaytest`.
2. From a different shell on the host, `Stop-Process -Id <sshd-session.exe leaf PID> -Force`.
3. Before this fix: the Zellij `--server` process is gone, session shows `(EXITED - attach to resurrect)`.
4. With this fix: the server PID is still alive; reconnect via SSH and `zellij attach breakawaytest` resumes the session.
