### PR TITLE
fix(server): handle inaccessible cwd spawn errors

### DIFF
--- a/zellij-server/src/os_input_output_unix.rs
+++ b/zellij-server/src/os_input_output_unix.rs
@@ -230,8 +230,13 @@ fn handle_openpty(
                 Ok(())
             })
             .spawn()
-            .expect("failed to spawn")
-    };
+    }
+    .map_err(|e| {
+        let _ = unistd::close(pid_primary);
+        let _ = unistd::close(pid_secondary);
+        e
+    })
+    .with_context(|| err_context(&cmd))?;
 
     let child_id = child.id();
     thread::spawn(move || {

--- a/zellij-server/src/unit/os_input_output_tests.rs
+++ b/zellij-server/src/unit/os_input_output_tests.rs
@@ -255,3 +255,41 @@ fn tcgetpgrp_returns_foreground_group() {
         let _ = server.force_kill(child_pid);
     }
 }
+
+#[cfg(not(windows))]
+#[test]
+fn spawn_terminal_with_inaccessible_cwd_returns_error() {
+    use crate::panes::PaneId;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use zellij_utils::input::command::TerminalAction;
+
+    let server = make_server();
+    let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let inaccessible_dir = temp_dir.path().join("inaccessible");
+    fs::create_dir(&inaccessible_dir).expect("failed to create inaccessible dir");
+    let original_permissions = fs::metadata(&inaccessible_dir)
+        .expect("failed to stat inaccessible dir")
+        .permissions();
+    fs::set_permissions(&inaccessible_dir, fs::Permissions::from_mode(0o000))
+        .expect("failed to make dir inaccessible");
+
+    let cmd = RunCommand {
+        command: PathBuf::from("echo"),
+        args: vec!["hello".to_string()],
+        cwd: Some(inaccessible_dir.clone()),
+        ..Default::default()
+    };
+    let action = TerminalAction::RunCommand(cmd);
+    let quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send> =
+        Box::new(|_pane_id, _exit_status, _run_command| {});
+
+    let spawn_result = server.spawn_terminal(action, quit_cb, None);
+
+    fs::set_permissions(&inaccessible_dir, original_permissions)
+        .expect("failed to restore dir permissions");
+    assert!(
+        spawn_result.is_err(),
+        "spawning with an inaccessible cwd should return an error"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #5201.

Opening a pane with a `cwd` that exists but cannot be entered currently panics in the Unix PTY spawn path because `Command::spawn()` returns `PermissionDenied` and the result is unwrapped. This changes that spawn failure into the existing `Result` error path and closes the PTY file descriptors opened for the failed spawn.

## Changes

- Return a contextual error instead of panicking when Unix PTY command spawning fails.
- Add a Unix regression test for an inaccessible pane `cwd`.

## Testing

- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p zellij-server spawn_terminal_with_inaccessible_cwd_returns_error -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p zellij-server os_input_output_tests -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --check`
- `git diff --check`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p zellij-server`

Note: I used Codex while preparing this change, and I reviewed the final diff and ran the listed checks locally.