### PR TITLE
fix: convert paste body \n to \r for panes without bracketed paste

### DIFF
--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -166,6 +166,15 @@ pub struct TerminalPane {
     /// remaining bytes in the queue to be drained after the host reply
     /// has been written.
     pending_pty_input: VecDeque<u8>,
+    /// `true` while a host paste is being forwarded into a pane whose inner program
+    /// has not enabled bracketed paste mode. Set when the `\x1b[200~` begin marker is
+    /// stripped, cleared by the matching `\x1b[201~` end marker. While set, `\n`
+    /// bytes in the body are translated to `\r` before reaching the inner program —
+    /// matching the convention used by Alacritty's own non-bracketed paste path and
+    /// macOS Terminal.app. Without this, inner programs that don't speak bracketed
+    /// paste (e.g. UW pico, where `^J` is bound to Justify Paragraph) interpret the
+    /// `\n` bytes as commands and mangle the paste.
+    pending_paste_passthrough: bool,
 }
 
 impl Pane for TerminalPane {
@@ -251,7 +260,7 @@ impl Pane for TerminalPane {
     fn adjust_input_to_terminal(
         &mut self,
         key_with_modifier: &Option<KeyWithModifier>,
-        raw_input_bytes: Vec<u8>,
+        mut raw_input_bytes: Vec<u8>,
         raw_input_bytes_are_kitty: bool,
         client_id: Option<ClientId>,
     ) -> Option<AdjustedInput> {
@@ -265,12 +274,34 @@ impl Pane for TerminalPane {
             // Zellij itself operates in bracketed paste mode, so the terminal sends these
             // instructions (bracketed paste start and bracketed paste end respectively)
             // when pasting input. We only need to make sure not to send them to terminal
-            // panes who do not work in this mode
+            // panes who do not work in this mode.
+            //
+            // The paste body arrives between the markers as a separate write. While the
+            // inner program isn't speaking bracketed paste, we additionally translate any
+            // `\n` (0x0a) bytes in the body to `\r` (0x0d). Single-terminal pasting
+            // conventions (Alacritty's non-bracketed paste path, macOS Terminal.app, etc.)
+            // perform the same translation so that pasted multi-line text reaches the
+            // inner program as a sequence of Enter keypresses. Without this, programs
+            // that bind `^J` to a command (e.g. UW pico's Justify Paragraph) interpret
+            // each `\n` as that command and silently mangle the paste.
             match raw_input_bytes.as_slice() {
-                BRACKETED_PASTE_BEGIN | BRACKETED_PASTE_END => {
-                    return Some(AdjustedInput::WriteBytesToTerminal(vec![]))
+                BRACKETED_PASTE_BEGIN => {
+                    self.pending_paste_passthrough = true;
+                    return Some(AdjustedInput::WriteBytesToTerminal(vec![]));
                 },
-                _ => {},
+                BRACKETED_PASTE_END => {
+                    self.pending_paste_passthrough = false;
+                    return Some(AdjustedInput::WriteBytesToTerminal(vec![]));
+                },
+                _ => {
+                    if self.pending_paste_passthrough {
+                        for byte in raw_input_bytes.iter_mut() {
+                            if *byte == b'\n' {
+                                *byte = b'\r';
+                            }
+                        }
+                    }
+                },
             }
         }
 
@@ -1140,6 +1171,7 @@ impl TerminalPane {
             notification_end,
             forward_paused: false,
             pending_pty_input: VecDeque::new(),
+            pending_paste_passthrough: false,
         }
     }
     pub fn get_x(&self) -> usize {

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -4619,6 +4619,71 @@ fn pane_bracketed_paste_ignored_when_not_in_bracketed_paste_mode() {
 }
 
 #[test]
+fn pane_bracketed_paste_body_newlines_translated_to_cr_when_not_in_bracketed_paste_mode() {
+    // When the inner program has not enabled bracketed paste mode, zellij strips the
+    // begin/end markers. The body between them must additionally have \n translated to
+    // \r, matching the convention used by alacritty's non-bracketed paste path and
+    // Terminal.app, so that programs binding ^J to a command (e.g. UW pico's Justify
+    // Paragraph) don't shred multi-line pastes.
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let client_id: u16 = 1;
+
+    let mut pty_instruction_bus = MockPtyInstructionBus::new();
+    let mut tab = create_new_tab_with_mock_pty_writer(
+        size,
+        ModeInfo::default(),
+        pty_instruction_bus.pty_write_sender(),
+    );
+    pty_instruction_bus.start();
+
+    let bracketed_paste_start = vec![27, 91, 50, 48, 48, 126]; // \u{1b}[200~
+    let bracketed_paste_end = vec![27, 91, 50, 48, 49, 126]; // \u{1b}[201~
+    let body = b"line one\nline two\nline three".to_vec();
+    tab.write_to_active_terminal(&None, bracketed_paste_start, false, client_id)
+        .unwrap();
+    tab.write_to_active_terminal(&None, body, false, client_id)
+        .unwrap();
+    tab.write_to_active_terminal(&None, bracketed_paste_end, false, client_id)
+        .unwrap();
+
+    pty_instruction_bus.exit();
+
+    assert_eq!(
+        pty_instruction_bus.clone_output(),
+        vec!["", "line one\rline two\rline three", ""]
+    );
+}
+
+#[test]
+fn pane_input_newlines_left_alone_outside_bracketed_paste_window() {
+    // Outside an active bracketed-paste window, the pane must not transform `\n` bytes
+    // arriving as ordinary input — only paste body content should be translated.
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let client_id: u16 = 1;
+
+    let mut pty_instruction_bus = MockPtyInstructionBus::new();
+    let mut tab = create_new_tab_with_mock_pty_writer(
+        size,
+        ModeInfo::default(),
+        pty_instruction_bus.pty_write_sender(),
+    );
+    pty_instruction_bus.start();
+
+    tab.write_to_active_terminal(&None, b"raw\ninput".to_vec(), false, client_id)
+        .unwrap();
+
+    pty_instruction_bus.exit();
+
+    assert_eq!(pty_instruction_bus.clone_output(), vec!["raw\ninput"]);
+}
+
+#[test]
 fn pane_faux_scrolling_in_alternate_mode() {
     let size = Size {
         cols: 121,


### PR DESCRIPTION
Closes #5207.

Diagnostic and reproducer are in the issue. Short version: when
forwarding a bracketed paste to a pane whose inner program hasn't
enabled BP, zellij strips the markers but leaves `\n` bytes in the body
unchanged. Programs like UW pico that bind `^J` to a command mangle the
paste. Other terminal emulators do `\n` → `\r` translation in this case;
this PR brings zellij in line.

The fix is a per-pane `pending_paste_passthrough` flag on `TerminalPane`,
set when the `\x1b[200~` BEGIN marker is stripped, cleared by `\x1b[201~`.
While set, `\n` bytes in the body are rewritten to `\r` before
forwarding. Outside the paste window the flag is off and bytes pass
through untouched — so ordinary input is never affected.

*(A short screen recording verifying the fix end-to-end — pasting the
same multi-line snippet from the issue into UW pico through alacritty +
patched zellij — will be attached as a comment below.)*

## Tests

Two new tests next to the existing BP regression test:

- **positive**: body `line one\nline two\nline three` arrives at the
  inner program as `line one\rline two\rline three`
- **negative**: ordinary `\n` arriving outside a paste window is left
  alone (no false positives on normal input)

All 1090 existing `zellij-server` unit tests still pass.

## End-to-end verification

Verified on macOS by pasting a multi-line snippet into UW pico through
alacritty + patched zellij — the file saved by pico now contains real
newlines instead of justified paragraphs. Behavior unchanged for panes
with bracketed-paste mode enabled (vim, GNU nano, shells at prompt,
etc.) since those receive the markers and full body verbatim, same as
today.

## Platform safety

Platform-independent — no `cfg(target_os)` or OS-specific paths anywhere
in the diff. Linux/BSD users running UW pico (or any other program with
`^J` bound to a command) through zellij benefit identically. The bug
just happens to be most visible on macOS because that's where
`/usr/bin/nano` ships as UW pico.