### PR TITLE
chore: remove duplicate "in" in plugin_loader comment

### DIFF
--- a/zellij-server/src/plugins/plugin_loader.rs
+++ b/zellij-server/src/plugins/plugin_loader.rs
@@ -437,7 +437,7 @@ impl<'a> PluginLoader<'a> {
         let dirs = dirs.into_iter().filter(|(_dir_name, dir)| {
             // note that this does not protect against TOCTOU errors
             // eg. if one or more of these folders existed at the time of check but was deleted
-            // before we mounted in in the wasi environment, we'll crash
+            // before we mounted in the wasi environment, we'll crash
             // when we move to a new wasi environment, we should address this with locking if
             // there's no built-in solution
             dir.try_exists().ok().unwrap_or(false)


### PR DESCRIPTION
`zellij-server/src/plugins/plugin_loader.rs:440` TOCTOU comment said "before we mounted in in the wasi environment" → "before we mounted in the wasi environment". Comment-only.