### PR TITLE
feat: allow configuring resize increments

### DIFF
--- a/default-plugins/compact-bar/src/action_types.rs
+++ b/default-plugins/compact-bar/src/action_types.rs
@@ -100,14 +100,17 @@ impl ActionType {
             Action::Resize {
                 resize: Resize::Increase,
                 direction: Some(_),
+                ..
             } => ActionType::ResizeIncrease,
             Action::Resize {
                 resize: Resize::Decrease,
                 direction: Some(_),
+                ..
             } => ActionType::ResizeDecrease,
             Action::Resize {
                 resize: _,
                 direction: None,
+                ..
             } => ActionType::ResizeAny,
             Action::Search { .. } => ActionType::Search,
             Action::NewPane {

--- a/default-plugins/compact-bar/src/keybind_utils.rs
+++ b/default-plugins/compact-bar/src/keybind_utils.rs
@@ -514,7 +514,8 @@ impl KeybindProcessor {
                             action,
                             Action::Resize {
                                 resize: Resize::Increase,
-                                direction: None
+                                direction: None,
+                                ..
                             }
                         )
                     },
@@ -523,7 +524,8 @@ impl KeybindProcessor {
                             action,
                             Action::Resize {
                                 resize: Resize::Decrease,
-                                direction: None
+                                direction: None,
+                                ..
                             }
                         )
                     },
@@ -532,7 +534,8 @@ impl KeybindProcessor {
                             action,
                             Action::Resize {
                                 resize: Resize::Increase,
-                                direction: Some(Direction::Left)
+                                direction: Some(Direction::Left),
+                                ..
                             }
                         )
                     },
@@ -541,7 +544,8 @@ impl KeybindProcessor {
                             action,
                             Action::Resize {
                                 resize: Resize::Increase,
-                                direction: Some(Direction::Down)
+                                direction: Some(Direction::Down),
+                                ..
                             }
                         )
                     },
@@ -550,7 +554,8 @@ impl KeybindProcessor {
                             action,
                             Action::Resize {
                                 resize: Resize::Increase,
-                                direction: Some(Direction::Up)
+                                direction: Some(Direction::Up),
+                                ..
                             }
                         )
                     },
@@ -559,7 +564,8 @@ impl KeybindProcessor {
                             action,
                             Action::Resize {
                                 resize: Resize::Increase,
-                                direction: Some(Direction::Right)
+                                direction: Some(Direction::Right),
+                                ..
                             }
                         )
                     },
@@ -568,7 +574,8 @@ impl KeybindProcessor {
                             action,
                             Action::Resize {
                                 resize: Resize::Decrease,
-                                direction: Some(Direction::Left)
+                                direction: Some(Direction::Left),
+                                ..
                             }
                         )
                     },
@@ -577,7 +584,8 @@ impl KeybindProcessor {
                             action,
                             Action::Resize {
                                 resize: Resize::Decrease,
-                                direction: Some(Direction::Down)
+                                direction: Some(Direction::Down),
+                                ..
                             }
                         )
                     },
@@ -586,7 +594,8 @@ impl KeybindProcessor {
                             action,
                             Action::Resize {
                                 resize: Resize::Decrease,
-                                direction: Some(Direction::Up)
+                                direction: Some(Direction::Up),
+                                ..
                             }
                         )
                     },
@@ -595,7 +604,8 @@ impl KeybindProcessor {
                             action,
                             Action::Resize {
                                 resize: Resize::Decrease,
-                                direction: Some(Direction::Right)
+                                direction: Some(Direction::Right),
+                                ..
                             }
                         )
                     },

--- a/default-plugins/configuration/src/rebind_leaders_screen.rs
+++ b/default-plugins/configuration/src/rebind_leaders_screen.rs
@@ -1075,6 +1075,7 @@ impl RebindLeadersScreen {
             &[actions::Action::Resize {
                 resize: Resize::Increase,
                 direction: None,
+                resize_percent: None,
             }],
             KeyWithModifier::new_with_modifiers(
                 BareKey::Char('+'),
@@ -1087,6 +1088,7 @@ impl RebindLeadersScreen {
             &[actions::Action::Resize {
                 resize: Resize::Increase,
                 direction: None,
+                resize_percent: None,
             }],
             KeyWithModifier::new_with_modifiers(
                 BareKey::Char('='),
@@ -1099,6 +1101,7 @@ impl RebindLeadersScreen {
             &[actions::Action::Resize {
                 resize: Resize::Decrease,
                 direction: None,
+                resize_percent: None,
             }],
             KeyWithModifier::new_with_modifiers(
                 BareKey::Char('-'),

--- a/default-plugins/status-bar/src/one_line_ui.rs
+++ b/default-plugins/status-bar/src/one_line_ui.rs
@@ -794,6 +794,7 @@ fn secondary_keybinds(help: &ModeInfo, tab_info: Option<&TabInfo>, max_len: usiz
         &[Action::Resize {
             resize: Resize::Increase,
             direction: None,
+            resize_percent: None,
         }],
     );
     let resize_increase_key = resize_increase_action_key
@@ -805,6 +806,7 @@ fn secondary_keybinds(help: &ModeInfo, tab_info: Option<&TabInfo>, max_len: usiz
         &[Action::Resize {
             resize: Resize::Decrease,
             direction: None,
+            resize_percent: None,
         }],
     );
     let resize_decrease_key = resize_decrease_action_key
@@ -1432,20 +1434,60 @@ fn get_keys_and_hints(mi: &ModeInfo) -> Vec<(String, String, Vec<KeyWithModifier
     ]} else if mi.mode == IM::Resize { vec![
         (s("Increase/Decrease size"), s("Increase/Decrease"),
             action_key_group(&km, &[
-                &[A::Resize{resize: Resize::Increase, direction: None}],
-                &[A::Resize{resize: Resize::Decrease, direction: None}]
+                &[A::Resize {
+                    resize: Resize::Increase,
+                    direction: None,
+                    resize_percent: None,
+                }],
+                &[A::Resize {
+                    resize: Resize::Decrease,
+                    direction: None,
+                    resize_percent: None,
+                }]
             ])),
         (s("Increase to"), s("Increase"), action_key_group(&km, &[
-            &[A::Resize{resize: Resize::Increase, direction: Some(Dir::Left)}],
-            &[A::Resize{resize: Resize::Increase, direction: Some(Dir::Down)}],
-            &[A::Resize{resize: Resize::Increase, direction: Some(Dir::Up)}],
-            &[A::Resize{resize: Resize::Increase, direction: Some(Dir::Right)}]
+            &[A::Resize {
+                    resize: Resize::Increase,
+                    direction: Some(Dir::Left),
+                    resize_percent: None,
+                }],
+            &[A::Resize {
+                    resize: Resize::Increase,
+                    direction: Some(Dir::Down),
+                    resize_percent: None,
+                }],
+            &[A::Resize {
+                    resize: Resize::Increase,
+                    direction: Some(Dir::Up),
+                    resize_percent: None,
+                }],
+            &[A::Resize {
+                    resize: Resize::Increase,
+                    direction: Some(Dir::Right),
+                    resize_percent: None,
+                }]
             ])),
         (s("Decrease from"), s("Decrease"), action_key_group(&km, &[
-            &[A::Resize{resize: Resize::Decrease, direction: Some(Dir::Left)}],
-            &[A::Resize{resize: Resize::Decrease, direction: Some(Dir::Down)}],
-            &[A::Resize{resize: Resize::Decrease, direction: Some(Dir::Up)}],
-            &[A::Resize{resize: Resize::Decrease, direction: Some(Dir::Right)}]
+            &[A::Resize {
+                    resize: Resize::Decrease,
+                    direction: Some(Dir::Left),
+                    resize_percent: None,
+                }],
+            &[A::Resize {
+                    resize: Resize::Decrease,
+                    direction: Some(Dir::Down),
+                    resize_percent: None,
+                }],
+            &[A::Resize {
+                    resize: Resize::Decrease,
+                    direction: Some(Dir::Up),
+                    resize_percent: None,
+                }],
+            &[A::Resize {
+                    resize: Resize::Decrease,
+                    direction: Some(Dir::Right),
+                    resize_percent: None,
+                }]
             ])),
         (s("Select pane"), s("Select"), to_basemode_key),
     ]} else if mi.mode == IM::Move { vec![

--- a/default-plugins/status-bar/src/second_line.rs
+++ b/default-plugins/status-bar/src/second_line.rs
@@ -199,20 +199,60 @@ fn get_keys_and_hints(mi: &ModeInfo) -> Vec<(String, String, Vec<KeyWithModifier
     ]} else if mi.mode == IM::Resize { vec![
         (s("Increase/Decrease size"), s("Increase/Decrease"),
             action_key_group(&km, &[
-                &[A::Resize{resize: Resize::Increase, direction: None}],
-                &[A::Resize{resize: Resize::Decrease, direction: None}]
+                &[A::Resize {
+                    resize: Resize::Increase,
+                    direction: None,
+                    resize_percent: None,
+                }],
+                &[A::Resize {
+                    resize: Resize::Decrease,
+                    direction: None,
+                    resize_percent: None,
+                }]
             ])),
         (s("Increase to"), s("Increase"), action_key_group(&km, &[
-            &[A::Resize{resize: Resize::Increase, direction: Some(Dir::Left)}],
-            &[A::Resize{resize: Resize::Increase, direction: Some(Dir::Down)}],
-            &[A::Resize{resize: Resize::Increase, direction: Some(Dir::Up)}],
-            &[A::Resize{resize: Resize::Increase, direction: Some(Dir::Right)}]
+            &[A::Resize {
+                    resize: Resize::Increase,
+                    direction: Some(Dir::Left),
+                    resize_percent: None,
+                }],
+            &[A::Resize {
+                    resize: Resize::Increase,
+                    direction: Some(Dir::Down),
+                    resize_percent: None,
+                }],
+            &[A::Resize {
+                    resize: Resize::Increase,
+                    direction: Some(Dir::Up),
+                    resize_percent: None,
+                }],
+            &[A::Resize {
+                    resize: Resize::Increase,
+                    direction: Some(Dir::Right),
+                    resize_percent: None,
+                }]
             ])),
         (s("Decrease from"), s("Decrease"), action_key_group(&km, &[
-            &[A::Resize{resize: Resize::Decrease, direction: Some(Dir::Left)}],
-            &[A::Resize{resize: Resize::Decrease, direction: Some(Dir::Down)}],
-            &[A::Resize{resize: Resize::Decrease, direction: Some(Dir::Up)}],
-            &[A::Resize{resize: Resize::Decrease, direction: Some(Dir::Right)}]
+            &[A::Resize {
+                    resize: Resize::Decrease,
+                    direction: Some(Dir::Left),
+                    resize_percent: None,
+                }],
+            &[A::Resize {
+                    resize: Resize::Decrease,
+                    direction: Some(Dir::Down),
+                    resize_percent: None,
+                }],
+            &[A::Resize {
+                    resize: Resize::Decrease,
+                    direction: Some(Dir::Up),
+                    resize_percent: None,
+                }],
+            &[A::Resize {
+                    resize: Resize::Decrease,
+                    direction: Some(Dir::Right),
+                    resize_percent: None,
+                }]
             ])),
         (s("Select pane"), s("Select"), to_normal_key),
     ]} else if mi.mode == IM::Move { vec![

--- a/default-plugins/status-bar/src/tip/data/quicknav.rs
+++ b/default-plugins/status-bar/src/tip/data/quicknav.rs
@@ -82,10 +82,12 @@ fn add_keybinds<'a>(help: &'a ModeInfo) -> Keygroups<'a> {
             &[Action::Resize {
                 resize: Resize::Increase,
                 direction: None,
+                resize_percent: None,
             }],
             &[Action::Resize {
                 resize: Resize::Decrease,
                 direction: None,
+                resize_percent: None,
             }],
         ],
     );

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -1345,16 +1345,15 @@ impl TiledPanes {
         &mut self,
         client_id: ClientId,
         strategy: &ResizeStrategy,
+        resize_percent: Option<(f64, f64)>,
     ) -> Result<()> {
         if *self.stacked_resize.borrow() && strategy.direction.is_none() {
             if let Some(active_pane_id) = self.get_active_pane_id(client_id) {
-                self.stacked_resize_pane_with_id(active_pane_id, strategy, None)?;
+                self.stacked_resize_pane_with_id(active_pane_id, strategy, resize_percent)?;
                 self.reapply_pane_frames();
             }
-        } else {
-            if let Some(active_pane_id) = self.get_active_pane_id(client_id) {
-                self.resize_pane_with_id(*strategy, active_pane_id, None)?;
-            }
+        } else if let Some(active_pane_id) = self.get_active_pane_id(client_id) {
+            self.resize_pane_with_id(*strategy, active_pane_id, resize_percent)?;
         }
 
         Ok(())

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -2823,6 +2823,7 @@ fn resize(env: &PluginEnv, resize: Resize) {
     let action = Action::Resize {
         resize,
         direction: None,
+        resize_percent: None,
     };
     apply_action!(action, error_msg, env);
 }
@@ -2832,6 +2833,7 @@ fn resize_with_direction(env: &PluginEnv, resize: ResizeStrategy) {
     let action = Action::Resize {
         resize: resize.resize,
         direction: resize.direction,
+        resize_percent: None,
     };
     apply_action!(action, error_msg, env);
 }

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -336,10 +336,15 @@ pub(crate) fn route_action(
                 .send_to_screen(ScreenInstruction::Render)
                 .with_context(err_context)?;
         },
-        Action::Resize { resize, direction } => {
+        Action::Resize {
+            resize,
+            direction,
+            resize_percent,
+        } => {
             let screen_instr = ScreenInstruction::Resize(
                 client_id,
                 ResizeStrategy::new(resize, direction),
+                resize_percent.map(|percent| (percent as f64, percent as f64)),
                 Some(NotificationEnd::new(completion_tx)),
             );
             senders

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -359,7 +359,12 @@ pub enum ScreenInstruction {
         Option<NotificationEnd>,
     ), // bool ->
     // is_kitty_keyboard_protocol
-    Resize(ClientId, ResizeStrategy, Option<NotificationEnd>),
+    Resize(
+        ClientId,
+        ResizeStrategy,
+        Option<(f64, f64)>,
+        Option<NotificationEnd>,
+    ),
     SwitchFocus(ClientId, Option<NotificationEnd>),
     FocusNextPane(ClientId, Option<NotificationEnd>),
     FocusPreviousPane(ClientId, Option<NotificationEnd>),
@@ -892,7 +897,7 @@ impl From<&ScreenInstruction> for ScreenContext {
                 ScreenContext::AreFloatingPanesVisible
             },
             ScreenInstruction::WriteCharacter(..) => ScreenContext::WriteCharacter,
-            ScreenInstruction::Resize(.., strategy, _) => match strategy {
+            ScreenInstruction::Resize(_, strategy, ..) => match strategy {
                 ResizeStrategy {
                     resize: Resize::Increase,
                     direction,
@@ -6142,13 +6147,16 @@ pub(crate) fn screen_thread_main(
             ScreenInstruction::Resize(
                 client_id,
                 strategy,
+                resize_percent,
                 _completion_tx, // the action ends here, dropping this will release anything
                                 // waiting for it
             ) => {
                 active_tab_and_connected_client_id!(
                     screen,
                     client_id,
-                    |tab: &mut Tab, client_id: ClientId| tab.resize(client_id, strategy),
+                    |tab: &mut Tab, client_id: ClientId| {
+                        tab.resize(client_id, strategy, resize_percent)
+                    },
                     ?
                 );
                 screen.render(None)?;

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -3558,7 +3558,12 @@ impl Tab {
         }
         Ok(())
     }
-    pub fn resize(&mut self, client_id: ClientId, strategy: ResizeStrategy) -> Result<()> {
+    pub fn resize(
+        &mut self,
+        client_id: ClientId,
+        strategy: ResizeStrategy,
+        resize_percent: Option<(f64, f64)>,
+    ) -> Result<()> {
         let err_context = || format!("unable to resize pane");
         if self.floating_panes.panes_are_visible() {
             let successfully_resized = self
@@ -3570,7 +3575,10 @@ impl Tab {
                 self.set_force_render(); // we force render here to make sure the panes under the floating pane render and don't leave "garbage" in case of a decrease
             }
         } else {
-            match self.tiled_panes.resize_active_pane(client_id, &strategy) {
+            match self
+                .tiled_panes
+                .resize_active_pane(client_id, &strategy, resize_percent)
+            {
                 Ok(_) => {
                     self.swap_layouts.set_is_tiled_damaged();
                 },

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -1023,7 +1023,7 @@ fn increase_tiled_pane_sizes_with_stacked_resizes() {
 
     // first we increase until fullscreen and once more to make sure we don't increase beyond it
     for _ in 0..=6 {
-        tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None))
+        tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None), None)
             .unwrap();
         tab.render(&mut output, None).unwrap();
         let snapshot = take_snapshot(
@@ -1037,7 +1037,7 @@ fn increase_tiled_pane_sizes_with_stacked_resizes() {
 
     // then we decrease until the original position
     for _ in 0..=5 {
-        tab.resize(client_id, ResizeStrategy::new(Resize::Decrease, None))
+        tab.resize(client_id, ResizeStrategy::new(Resize::Decrease, None), None)
             .unwrap();
         tab.render(&mut output, None).unwrap();
         let snapshot = take_snapshot(
@@ -1085,7 +1085,7 @@ fn increase_tiled_pane_sizes_with_stacked_resizes_into_uneven_panes() {
     // increase twice, once to add the short pane into the stack and shorten the larger one, and
     // once to add the remaining two panes (the one we shortened and the extra one near it)
     for _ in 0..2 {
-        tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None))
+        tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None), None)
             .unwrap();
         tab.render(&mut output, None).unwrap();
         let snapshot = take_snapshot(
@@ -1099,7 +1099,7 @@ fn increase_tiled_pane_sizes_with_stacked_resizes_into_uneven_panes() {
 
     // then we decrease until the original position
     for _ in 0..2 {
-        tab.resize(client_id, ResizeStrategy::new(Resize::Decrease, None))
+        tab.resize(client_id, ResizeStrategy::new(Resize::Decrease, None), None)
             .unwrap();
         tab.render(&mut output, None).unwrap();
         let snapshot = take_snapshot(
@@ -1136,9 +1136,9 @@ fn split_stack_vertically() {
         .unwrap();
     }
     // the below resizes will end up stacking the panes
-    tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None))
+    tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None), None)
         .unwrap();
-    tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None))
+    tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None), None)
         .unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, client_id, None, None)
         .unwrap();
@@ -1177,9 +1177,9 @@ fn split_stack_horizontally() {
         .unwrap();
     }
     // the below resizes will end up stacking the panes
-    tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None))
+    tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None), None)
         .unwrap();
-    tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None))
+    tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None), None)
         .unwrap();
     tab.horizontal_split(PaneId::Terminal(4), None, client_id, None, None)
         .unwrap();
@@ -1220,9 +1220,9 @@ fn render_stacks_without_pane_frames() {
         .unwrap();
     }
     // the below resizes will end up stacking the panes
-    tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None))
+    tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None), None)
         .unwrap();
-    tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None))
+    tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None), None)
         .unwrap();
     tab.vertical_split(PaneId::Terminal(4), None, client_id, None, None)
         .unwrap();
@@ -1273,6 +1273,7 @@ fn render_stacks_without_pane_frames() {
     tab.resize(
         client_id,
         ResizeStrategy::new(Resize::Increase, Some(Direction::Right)),
+        None,
     )
     .unwrap();
     let _ = tab.focus_pane_with_id(PaneId::Terminal(7), false, false, client_id);
@@ -1683,7 +1684,7 @@ fn increase_floating_pane_size() {
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
     )
     .unwrap();
-    tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None))
+    tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None), None)
         .unwrap();
     tab.render(&mut output, None).unwrap();
     let snapshot = take_snapshot(
@@ -1723,7 +1724,7 @@ fn decrease_floating_pane_size() {
         Vec::from("\n\n\n                   I am scratch terminal".as_bytes()),
     )
     .unwrap();
-    tab.resize(client_id, ResizeStrategy::new(Resize::Decrease, None))
+    tab.resize(client_id, ResizeStrategy::new(Resize::Decrease, None), None)
         .unwrap();
     tab.render(&mut output, None).unwrap();
     let snapshot = take_snapshot(
@@ -1766,6 +1767,7 @@ fn resize_floating_pane_left() {
     tab.resize(
         client_id,
         ResizeStrategy::new(Resize::Increase, Some(Direction::Left)),
+        None,
     )
     .unwrap();
     tab.render(&mut output, None).unwrap();
@@ -1809,6 +1811,7 @@ fn resize_floating_pane_right() {
     tab.resize(
         client_id,
         ResizeStrategy::new(Resize::Increase, Some(Direction::Right)),
+        None,
     )
     .unwrap();
     tab.render(&mut output, None).unwrap();
@@ -1852,6 +1855,7 @@ fn resize_floating_pane_up() {
     tab.resize(
         client_id,
         ResizeStrategy::new(Resize::Increase, Some(Direction::Up)),
+        None,
     )
     .unwrap();
     tab.render(&mut output, None).unwrap();
@@ -1895,6 +1899,7 @@ fn resize_floating_pane_down() {
     tab.resize(
         client_id,
         ResizeStrategy::new(Resize::Increase, Some(Direction::Down)),
+        None,
     )
     .unwrap();
     tab.render(&mut output, None).unwrap();
@@ -5092,7 +5097,7 @@ fn swapping_layouts_after_resize_snaps_to_current_layout() {
     )
     .unwrap();
     tab.next_swap_layout().unwrap();
-    tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None))
+    tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None), None)
         .unwrap();
     tab.next_swap_layout().unwrap();
     tab.render(&mut output, None).unwrap();
@@ -6294,6 +6299,7 @@ fn can_increase_size_of_main_pane_in_stack_horizontally() {
     tab.resize(
         client_id,
         ResizeStrategy::new(Resize::Increase, Some(Direction::Left)),
+        None,
     )
     .unwrap();
     tab.render(&mut output, None).unwrap();
@@ -6405,6 +6411,7 @@ fn can_increase_size_of_main_pane_in_stack_vertically() {
     tab.resize(
         client_id,
         ResizeStrategy::new(Resize::Increase, Some(Direction::Down)),
+        None,
     )
     .unwrap();
     tab.render(&mut output, None).unwrap();
@@ -6513,7 +6520,7 @@ fn can_increase_size_of_main_pane_in_stack_non_directionally() {
     )
     .unwrap();
     let _ = tab.move_focus_right(client_id);
-    tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None))
+    tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None), None)
         .unwrap();
     tab.render(&mut output, None).unwrap();
     let snapshot = take_snapshot(
@@ -6621,6 +6628,7 @@ fn can_increase_size_into_pane_stack_horizontally() {
     tab.resize(
         client_id,
         ResizeStrategy::new(Resize::Increase, Some(Direction::Right)),
+        None,
     )
     .unwrap();
     tab.render(&mut output, None).unwrap();
@@ -6733,6 +6741,7 @@ fn can_increase_size_into_pane_stack_vertically() {
     tab.resize(
         client_id,
         ResizeStrategy::new(Resize::Increase, Some(Direction::Up)),
+        None,
     )
     .unwrap();
     tab.render(&mut output, None).unwrap();
@@ -6841,7 +6850,7 @@ fn can_increase_size_into_pane_stack_non_directionally() {
         None,
     )
     .unwrap();
-    tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None))
+    tab.resize(client_id, ResizeStrategy::new(Resize::Increase, None), None)
         .unwrap();
     tab.render(&mut output, None).unwrap();
     let snapshot = take_snapshot(
@@ -7170,6 +7179,7 @@ fn cannot_decrease_stack_size_beyond_minimum_height() {
         tab.resize(
             client_id,
             ResizeStrategy::new(Resize::Increase, Some(Direction::Up)),
+            None,
         )
         .unwrap();
     }
@@ -8666,6 +8676,7 @@ fn when_swapping_tiled_layouts_in_a_damaged_state_layout_and_pane_focus_are_unch
     tab.resize(
         client_id,
         ResizeStrategy::new(Resize::Increase, Some(Direction::Down)),
+        None,
     )
     .unwrap();
     tab.next_swap_layout().unwrap();
@@ -9615,6 +9626,7 @@ fn when_swapping_floating_layouts_in_a_damaged_state_layout_and_pane_focus_are_u
     tab.resize(
         client_id,
         ResizeStrategy::new(Resize::Increase, Some(Direction::Down)),
+        None,
     )
     .unwrap();
     tab.next_swap_layout().unwrap();

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -109,7 +109,7 @@ impl ServerOsApi for FakeInputOutput {
 }
 
 fn tab_resize_increase(tab: &mut Tab, id: ClientId) {
-    tab.resize(id, ResizeStrategy::new(Resize::Increase, None))
+    tab.resize(id, ResizeStrategy::new(Resize::Increase, None), None)
         .unwrap();
 }
 
@@ -117,6 +117,7 @@ fn tab_resize_left(tab: &mut Tab, id: ClientId) {
     tab.resize(
         id,
         ResizeStrategy::new(Resize::Increase, Some(Direction::Left)),
+        None,
     )
     .unwrap();
 }
@@ -125,6 +126,7 @@ fn tab_resize_down(tab: &mut Tab, id: ClientId) {
     tab.resize(
         id,
         ResizeStrategy::new(Resize::Increase, Some(Direction::Down)),
+        None,
     )
     .unwrap();
 }
@@ -133,6 +135,7 @@ fn tab_resize_up(tab: &mut Tab, id: ClientId) {
     tab.resize(
         id,
         ResizeStrategy::new(Resize::Increase, Some(Direction::Up)),
+        None,
     )
     .unwrap();
 }
@@ -141,6 +144,7 @@ fn tab_resize_right(tab: &mut Tab, id: ClientId) {
     tab.resize(
         id,
         ResizeStrategy::new(Resize::Increase, Some(Direction::Right)),
+        None,
     )
     .unwrap();
 }

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -154,6 +154,7 @@ pub enum Action {
     Resize {
         resize: Resize,
         direction: Option<Direction>,
+        resize_percent: Option<usize>,
     },
     /// Switch focus to next pane in specified direction.
     FocusNextPane,
@@ -816,7 +817,11 @@ impl Action {
                         direction,
                     }])
                 },
-                None => Ok(vec![Action::Resize { resize, direction }]),
+                None => Ok(vec![Action::Resize {
+                    resize,
+                    direction,
+                    resize_percent: None,
+                }]),
             },
             CliAction::FocusNextPane => Ok(vec![Action::FocusNextPane]),
             CliAction::FocusPreviousPane => Ok(vec![Action::FocusPreviousPane]),
@@ -2672,7 +2677,11 @@ mod tests {
         let actions = result.unwrap();
         assert_eq!(actions.len(), 1);
         match &actions[0] {
-            Action::Resize { resize, direction } => {
+            Action::Resize {
+                resize,
+                direction,
+                resize_percent: None,
+            } => {
                 assert!(matches!(resize, Resize::Increase));
                 assert!(matches!(direction, Some(Direction::Left)));
             },

--- a/zellij-utils/src/input/unit/keybinds_test.rs
+++ b/zellij-utils/src/input/unit/keybinds_test.rs
@@ -1,9 +1,36 @@
 use super::super::actions::*;
 use super::super::keybinds::*;
-use crate::data::{BareKey, Direction, KeyWithModifier};
+use crate::data::{BareKey, Direction, KeyWithModifier, Resize};
 use crate::input::config::Config;
 use insta::assert_snapshot;
 use strum::IntoEnumIterator;
+
+#[test]
+fn can_define_resize_keybinding_with_custom_increment() {
+    let config_contents = r#"
+        keybinds {
+            normal {
+                bind "Alt h" { Resize "Increase Left" 1; }
+            }
+        }
+    "#;
+
+    let config = Config::from_kdl(config_contents, None).unwrap();
+    let alt_h_normal_mode_action = config.keybinds.get_actions_for_key_in_mode(
+        &InputMode::Normal,
+        &KeyWithModifier::new(BareKey::Char('h')).with_alt_modifier(),
+    );
+
+    assert_eq!(
+        alt_h_normal_mode_action,
+        Some(&vec![Action::Resize {
+            resize: Resize::Increase,
+            direction: Some(Direction::Left),
+            resize_percent: Some(1),
+        }]),
+        "Resize keybinding successfully parsed with custom increment"
+    );
+}
 
 #[test]
 fn can_define_keybindings_in_configfile() {

--- a/zellij-utils/src/ipc/protobuf_conversion.rs
+++ b/zellij-utils/src/ipc/protobuf_conversion.rs
@@ -1027,12 +1027,12 @@ impl From<crate::input::actions::Action>
                     input_mode: input_mode_to_proto_i32(input_mode),
                 })
             },
-            crate::input::actions::Action::Resize { resize, direction } => {
-                ActionType::Resize(ResizeAction {
-                    resize: resize_to_proto_i32(resize),
-                    direction: direction.map(|d| direction_to_proto_i32(d)),
-                })
-            },
+            crate::input::actions::Action::Resize {
+                resize, direction, ..
+            } => ActionType::Resize(ResizeAction {
+                resize: resize_to_proto_i32(resize),
+                direction: direction.map(|d| direction_to_proto_i32(d)),
+            }),
             crate::input::actions::Action::FocusNextPane => {
                 ActionType::FocusNextPane(FocusNextPaneAction {})
             },
@@ -1902,6 +1902,7 @@ impl TryFrom<crate::client_server_contract::client_server_contract::Action>
                     .direction
                     .map(|d| proto_i32_to_direction(d))
                     .transpose()?,
+                resize_percent: None,
             }),
             ActionType::FocusNextPane(_) => Ok(crate::input::actions::Action::FocusNextPane),
             ActionType::FocusPreviousPane(_) => {

--- a/zellij-utils/src/ipc/tests/roundtrip_tests.rs
+++ b/zellij-utils/src/ipc/tests/roundtrip_tests.rs
@@ -764,6 +764,7 @@ fn test_client_messages() {
         action: Action::Resize {
             resize: Resize::Increase,
             direction: None,
+            resize_percent: None,
         },
         terminal_id: Some(1),
         client_id: Some(100),
@@ -773,6 +774,7 @@ fn test_client_messages() {
         action: Action::Resize {
             resize: Resize::Decrease,
             direction: None,
+            resize_percent: None,
         },
         terminal_id: Some(1),
         client_id: Some(100),
@@ -782,6 +784,7 @@ fn test_client_messages() {
         action: Action::Resize {
             resize: Resize::Decrease,
             direction: Some(Direction::Left),
+            resize_percent: None,
         },
         terminal_id: Some(1),
         client_id: Some(100),
@@ -791,6 +794,7 @@ fn test_client_messages() {
         action: Action::Resize {
             resize: Resize::Decrease,
             direction: Some(Direction::Right),
+            resize_percent: None,
         },
         terminal_id: Some(1),
         client_id: Some(100),
@@ -800,6 +804,7 @@ fn test_client_messages() {
         action: Action::Resize {
             resize: Resize::Decrease,
             direction: Some(Direction::Up),
+            resize_percent: None,
         },
         terminal_id: Some(1),
         client_id: Some(100),
@@ -809,6 +814,7 @@ fn test_client_messages() {
         action: Action::Resize {
             resize: Resize::Decrease,
             direction: Some(Direction::Down),
+            resize_percent: None,
         },
         terminal_id: Some(1),
         client_id: Some(100),

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -471,6 +471,9 @@ impl Action {
                         Ok(value) => resize = Some(value),
                         Err(_) => match Direction::from_str(word) {
                             Ok(value) => direction = Some(value),
+                            Err(_) if word.parse::<i64>().is_ok() => {
+                                // resize increment is parsed separately from the KDL node entries
+                            },
                             Err(_) => {
                                 return Err(ConfigError::new_kdl_error(
                                     format!(
@@ -485,7 +488,29 @@ impl Action {
                     }
                 }
                 let resize = resize.unwrap_or(Resize::Increase);
-                Ok(Action::Resize { resize, direction })
+                let resize_percent = action_node
+                    .entries()
+                    .iter()
+                    .skip(1)
+                    .find_map(|entry| entry.value().as_i64())
+                    .map(|resize_percent| {
+                        if resize_percent <= 0 {
+                            Err(ConfigError::new_kdl_error(
+                                "resize percent must be a positive integer".into(),
+                                action_node.span().offset(),
+                                action_node.span().len(),
+                            ))
+                        } else {
+                            Ok(resize_percent as usize)
+                        }
+                    })
+                    .transpose()?;
+
+                Ok(Action::Resize {
+                    resize,
+                    direction,
+                    resize_percent,
+                })
             },
             "MoveFocus" => {
                 let direction = Direction::from_str(string.as_str()).map_err(|_| {
@@ -638,6 +663,7 @@ impl Action {
             Action::Resize {
                 resize,
                 direction: resize_direction,
+                resize_percent,
             } => {
                 let mut node = KdlNode::new("Resize");
                 let resize = match resize {
@@ -655,6 +681,11 @@ impl Action {
                 } else {
                     node.push(format!("{}", resize));
                 }
+
+                if let Some(resize_percent) = resize_percent {
+                    node.push(KdlValue::Base10(*resize_percent as i64));
+                }
+
                 Some(node)
             },
             Action::FocusNextPane => Some(KdlNode::new("FocusNextPane")),
@@ -1647,11 +1678,28 @@ impl TryFrom<(&KdlNode, &Options)> for Action {
                 action_arguments,
                 kdl_action
             ),
-            "Resize" => parse_kdl_action_char_or_string_arguments!(
-                action_name,
-                action_arguments,
-                kdl_action
-            ),
+            "Resize" => {
+                let action_arguments = action_arguments
+                    .into_iter()
+                    .map(|argument| {
+                        if let Some(argument) = argument.value().as_string() {
+                            Ok(argument.to_string())
+                        } else if let Some(argument) = argument.value().as_i64() {
+                            Ok(argument.to_string())
+                        } else {
+                            Err(ConfigError::new_kdl_error(
+                                format!(
+                                    "All entries for action '{}' must be strings or integers",
+                                    action_name
+                                ),
+                                kdl_action.span().offset(),
+                                kdl_action.span().len(),
+                            ))
+                        }
+                    })
+                    .collect::<Result<Vec<String>, ConfigError>>()?;
+                Action::new_from_string(action_name, action_arguments.join(" "), kdl_action)
+            },
             "ResizeNew" => parse_kdl_action_char_or_string_arguments!(
                 action_name,
                 action_arguments,

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -156,6 +156,7 @@ impl TryFrom<ProtobufAction> for Action {
                     Ok(Action::Resize {
                         resize: resize_strategy.resize,
                         direction: resize_strategy.direction,
+                        resize_percent: None,
                     })
                 },
                 _ => Err("Wrong payload for Action::Resize"),
@@ -1154,7 +1155,9 @@ impl TryFrom<Action> for ProtobufAction {
                     )),
                 })
             },
-            Action::Resize { resize, direction } => {
+            Action::Resize {
+                resize, direction, ..
+            } => {
                 let mut resize: ProtobufResize = resize.try_into()?;
                 resize.direction = direction.and_then(|d| {
                     let resize_direction: ProtobufResizeDirection = d.try_into().ok()?;

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 692
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -56,6 +57,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -69,6 +71,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -82,6 +85,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -352,6 +356,7 @@ Config {
                     direction: Some(
                         Left,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -373,6 +378,7 @@ Config {
                     direction: Some(
                         Down,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -394,6 +400,7 @@ Config {
                     direction: Some(
                         Up,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -415,6 +422,7 @@ Config {
                     direction: Some(
                         Right,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -436,6 +444,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -449,6 +458,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -460,6 +470,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -473,6 +484,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -484,6 +496,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -497,6 +510,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -510,6 +524,7 @@ Config {
                     direction: Some(
                         Left,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -523,6 +538,7 @@ Config {
                     direction: Some(
                         Down,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -536,6 +552,7 @@ Config {
                     direction: Some(
                         Up,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -549,6 +566,7 @@ Config {
                     direction: Some(
                         Right,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -616,6 +634,7 @@ Config {
                     direction: Some(
                         Left,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -665,6 +684,7 @@ Config {
                     direction: Some(
                         Down,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -690,6 +710,7 @@ Config {
                     direction: Some(
                         Up,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -715,6 +736,7 @@ Config {
                     direction: Some(
                         Right,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -947,6 +969,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -960,6 +983,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -973,6 +997,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -1505,6 +1530,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -1518,6 +1544,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -1648,6 +1675,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2127,6 +2155,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2140,6 +2169,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2153,6 +2183,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2564,6 +2595,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2577,6 +2609,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2590,6 +2623,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2952,6 +2986,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2965,6 +3000,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2978,6 +3014,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3411,6 +3448,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3424,6 +3462,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3437,6 +3476,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3764,6 +3804,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3777,6 +3818,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3790,6 +3832,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4117,6 +4160,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4130,6 +4174,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4143,6 +4188,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4691,6 +4737,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4704,6 +4751,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4717,6 +4765,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5105,6 +5154,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5118,6 +5168,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5131,6 +5182,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5531,6 +5583,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5554,6 +5607,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5567,6 +5621,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 762
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -56,6 +57,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -69,6 +71,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -82,6 +85,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -352,6 +356,7 @@ Config {
                     direction: Some(
                         Left,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -373,6 +378,7 @@ Config {
                     direction: Some(
                         Down,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -394,6 +400,7 @@ Config {
                     direction: Some(
                         Up,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -415,6 +422,7 @@ Config {
                     direction: Some(
                         Right,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -436,6 +444,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -449,6 +458,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -460,6 +470,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -473,6 +484,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -484,6 +496,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -497,6 +510,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -510,6 +524,7 @@ Config {
                     direction: Some(
                         Left,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -523,6 +538,7 @@ Config {
                     direction: Some(
                         Down,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -536,6 +552,7 @@ Config {
                     direction: Some(
                         Up,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -549,6 +566,7 @@ Config {
                     direction: Some(
                         Right,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -616,6 +634,7 @@ Config {
                     direction: Some(
                         Left,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -665,6 +684,7 @@ Config {
                     direction: Some(
                         Down,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -690,6 +710,7 @@ Config {
                     direction: Some(
                         Up,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -715,6 +736,7 @@ Config {
                     direction: Some(
                         Right,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -947,6 +969,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -960,6 +983,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -973,6 +997,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -1505,6 +1530,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -1518,6 +1544,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -1648,6 +1675,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2127,6 +2155,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2140,6 +2169,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2153,6 +2183,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2564,6 +2595,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2577,6 +2609,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2590,6 +2623,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2952,6 +2986,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2965,6 +3000,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2978,6 +3014,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3411,6 +3448,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3424,6 +3462,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3437,6 +3476,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3764,6 +3804,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3777,6 +3818,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3790,6 +3832,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4117,6 +4160,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4130,6 +4174,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4143,6 +4188,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4691,6 +4737,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4704,6 +4751,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4717,6 +4765,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5105,6 +5154,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5118,6 +5168,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5131,6 +5182,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5531,6 +5583,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5554,6 +5607,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5567,6 +5621,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 790
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -56,6 +57,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -69,6 +71,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -82,6 +85,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -352,6 +356,7 @@ Config {
                     direction: Some(
                         Left,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -373,6 +378,7 @@ Config {
                     direction: Some(
                         Down,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -394,6 +400,7 @@ Config {
                     direction: Some(
                         Up,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -415,6 +422,7 @@ Config {
                     direction: Some(
                         Right,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -436,6 +444,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -449,6 +458,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -460,6 +470,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -473,6 +484,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -484,6 +496,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -497,6 +510,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -510,6 +524,7 @@ Config {
                     direction: Some(
                         Left,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -523,6 +538,7 @@ Config {
                     direction: Some(
                         Down,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -536,6 +552,7 @@ Config {
                     direction: Some(
                         Up,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -549,6 +566,7 @@ Config {
                     direction: Some(
                         Right,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -616,6 +634,7 @@ Config {
                     direction: Some(
                         Left,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -665,6 +684,7 @@ Config {
                     direction: Some(
                         Down,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -690,6 +710,7 @@ Config {
                     direction: Some(
                         Up,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -715,6 +736,7 @@ Config {
                     direction: Some(
                         Right,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -947,6 +969,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -960,6 +983,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -973,6 +997,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -1505,6 +1530,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -1518,6 +1544,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -1648,6 +1675,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2127,6 +2155,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2140,6 +2169,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2153,6 +2183,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2564,6 +2595,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2577,6 +2609,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2590,6 +2623,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2952,6 +2986,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2965,6 +3000,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2978,6 +3014,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3411,6 +3448,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3424,6 +3462,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3437,6 +3476,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3764,6 +3804,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3777,6 +3818,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3790,6 +3832,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4117,6 +4160,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4130,6 +4174,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4143,6 +4188,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4691,6 +4737,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4704,6 +4751,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4717,6 +4765,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5105,6 +5154,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5118,6 +5168,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5131,6 +5182,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5531,6 +5583,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5554,6 +5607,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5567,6 +5621,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 776
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -56,6 +57,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -69,6 +71,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -82,6 +85,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -352,6 +356,7 @@ Config {
                     direction: Some(
                         Left,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -373,6 +378,7 @@ Config {
                     direction: Some(
                         Down,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -394,6 +400,7 @@ Config {
                     direction: Some(
                         Up,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -415,6 +422,7 @@ Config {
                     direction: Some(
                         Right,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -436,6 +444,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -449,6 +458,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -460,6 +470,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -473,6 +484,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -484,6 +496,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -497,6 +510,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -510,6 +524,7 @@ Config {
                     direction: Some(
                         Left,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -523,6 +538,7 @@ Config {
                     direction: Some(
                         Down,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -536,6 +552,7 @@ Config {
                     direction: Some(
                         Up,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -549,6 +566,7 @@ Config {
                     direction: Some(
                         Right,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -616,6 +634,7 @@ Config {
                     direction: Some(
                         Left,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -665,6 +684,7 @@ Config {
                     direction: Some(
                         Down,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -690,6 +710,7 @@ Config {
                     direction: Some(
                         Up,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -715,6 +736,7 @@ Config {
                     direction: Some(
                         Right,
                     ),
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -947,6 +969,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -960,6 +983,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -973,6 +997,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -1505,6 +1530,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -1518,6 +1544,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -1648,6 +1675,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2127,6 +2155,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2140,6 +2169,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2153,6 +2183,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2564,6 +2595,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2577,6 +2609,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2590,6 +2623,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2952,6 +2986,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2965,6 +3000,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -2978,6 +3014,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3411,6 +3448,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3424,6 +3462,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3437,6 +3476,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3764,6 +3804,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3777,6 +3818,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -3790,6 +3832,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4117,6 +4160,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4130,6 +4174,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4143,6 +4188,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4691,6 +4737,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4704,6 +4751,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -4717,6 +4765,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5105,6 +5154,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5118,6 +5168,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5131,6 +5182,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5531,6 +5583,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5554,6 +5607,7 @@ Config {
                 Resize {
                     resize: Decrease,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {
@@ -5567,6 +5621,7 @@ Config {
                 Resize {
                     resize: Increase,
                     direction: None,
+                    resize_percent: None,
                 },
             ],
             KeyWithModifier {


### PR DESCRIPTION
## Summary

Adds an optional resize percentage argument to the `Resize` action, allowing users to configure fine-grained pane resizing from keybindings while preserving the existing default behavior.

Example:

    bind "Alt h" { Resize "Increase Left" 1; }

Existing resize bindings continue to work unchanged:

    bind "Alt h" { Resize "Increase Left"; }

Closes #647.

## Testing

- `cargo fmt --all --check`
- `cargo test -p zellij-utils`
- `cargo test -p zellij-server resize`
- `cargo test -p zellij-server`
- `cargo xtask build`
