### PR TITLE
fix(web-client): encode functional keys with proper Kitty codepoints

### DIFF
--- a/zellij-client/assets/keyboard.js
+++ b/zellij-client/assets/keyboard.js
@@ -3,6 +3,64 @@
  */
 
 /**
+ * Map from `KeyboardEvent.key` (the JS-side name of a non-printable key)
+ * to the codepoint the Kitty keyboard protocol expects in its
+ * functional-key CSI u encoding.
+ *
+ * Without this table the previous implementation did
+ * `ev.key.charCodeAt(0)` for every key — which works for printable keys
+ * like "a" (97) but produces garbage for multi-character names:
+ *   - "Backspace".charCodeAt(0) → 66 ('B')
+ *   - "Delete".charCodeAt(0)    → 68 ('D')
+ *   - "Enter".charCodeAt(0)     → 69 ('E')
+ *
+ * The host then receives e.g. `\x1b[66;9u` for Cmd+Backspace and the
+ * shell ignores it. Visible symptom: Cmd+Backspace, Cmd+Delete, etc.
+ * appear to do nothing in the web client.
+ *
+ * Reference: https://sw.kovidgoyal.net/kitty/keyboard-protocol/#functional-key-definitions
+ */
+const FUNCTIONAL_KEY_CODES = {
+    // Whitespace / control
+    Escape: 27,
+    Enter: 13,
+    Tab: 9,
+    Backspace: 127,
+    // Editing
+    Insert: 0xe001,
+    Delete: 0xe002,
+    // Cursor movement
+    ArrowLeft: 0xe004,
+    ArrowRight: 0xe005,
+    ArrowUp: 0xe006,
+    ArrowDown: 0xe007,
+    PageUp: 0xe008,
+    PageDown: 0xe009,
+    Home: 0xe00a,
+    End: 0xe00b,
+    // Mode keys
+    CapsLock: 0xe00c,
+    ScrollLock: 0xe00d,
+    NumLock: 0xe00e,
+    PrintScreen: 0xe00f,
+    Pause: 0xe010,
+    ContextMenu: 0xe011, // Menu key
+    // Function keys (Kitty PUA assignments)
+    F1: 0xe012,
+    F2: 0xe013,
+    F3: 0xe014,
+    F4: 0xe015,
+    F5: 0xe016,
+    F6: 0xe017,
+    F7: 0xe018,
+    F8: 0xe019,
+    F9: 0xe01a,
+    F10: 0xe01b,
+    F11: 0xe01c,
+    F12: 0xe01d,
+};
+
+/**
  * Encode a keyboard event into kitty protocol ANSI escape sequence
  * @param {KeyboardEvent} ev - The keyboard event to encode
  * @param {function} send_ansi_key - Function to send the ANSI key sequence
@@ -25,6 +83,23 @@ export function encode_kitty_key(ev, send_ansi_key) {
     if (ev.metaKey) {
         modifier_string += super_value;
     }
-    let key_code = ev.key.charCodeAt(0);
+    // For named functional keys, use the Kitty PUA codepoint; otherwise
+    // (printable keys), take the unicode codepoint of the character.
+    // `String.fromCodePoint(...)` round-trip is not needed since we just
+    // want the integer code.
+    let key_code;
+    if (Object.prototype.hasOwnProperty.call(FUNCTIONAL_KEY_CODES, ev.key)) {
+        key_code = FUNCTIONAL_KEY_CODES[ev.key];
+    } else if (ev.key.length === 1) {
+        // Printable key (single Unicode unit). `codePointAt(0)` handles
+        // BMP and surrogate pairs equivalently for length-1 strings.
+        key_code = ev.key.codePointAt(0);
+    } else {
+        // Unknown multi-character key name. Don't emit a garbage
+        // sequence — fall through silently. The browser may still emit
+        // the key via xterm.js's normal path; we just don't add a
+        // Kitty wrapping on top.
+        return;
+    }
     send_ansi_key(`\x1b[${key_code};${modifier_string}u`);
 }


### PR DESCRIPTION
## Problem

In the web client, `encode_kitty_key` in `zellij-client/assets/keyboard.js` used `ev.key.charCodeAt(0)` for every key. That's correct for printable keys (`"a"` → 97) but produces garbage for multi-character key names:

- `"Backspace".charCodeAt(0)` → 66 (`'B'`) — should be 127
- `"Delete".charCodeAt(0)` → 68 (`'D'`)
- `"Enter".charCodeAt(0)` → 69 (`'E'`) — should be 13

When a modifier is held (e.g. **Cmd+Backspace** on macOS, `metaKey=true`), `hasModifiersToHandle` in `input.js` routes the event through `encode_kitty_key`, so the host received e.g. `\x1b[66;9u` (`B` + super) and the shell silently ignored it. Visible symptom: Cmd+Backspace, Cmd+Delete, and similar modified functional-key combos appear to do nothing in the web client.

Plain Backspace/Delete (no modifier) were unaffected — `hasModifiersToHandle` returns false for them, so they fall through to xterm.js's default handler which sends the correct legacy sequences.

## Fix

Add a `FUNCTIONAL_KEY_CODES` table mapping JavaScript `KeyboardEvent.key` names to the codepoints the Kitty keyboard protocol expects (PUA assignments for editing/navigation keys per the [spec](https://sw.kovidgoyal.net/kitty/keyboard-protocol/#functional-key-definitions); legacy values for control chars like Backspace=127, Enter=13, Tab=9). `encode_kitty_key` now consults the table for known names and only falls back to `codePointAt(0)` for single-character (printable) keys. Unknown multi-char names emit nothing rather than garbage.

## Scope

Single file, `zellij-client/assets/keyboard.js` (+76/-1). Client-side encoding only; no server changes.

## Testing

No JS test infra in the workspace (the asset is bundled via `include_dir!`), so verified by walking each branch with representative `ev.key` values (`"Backspace"`, `"Delete"`, `"Enter"`). Reproduced and confirmed the original symptom against a 0.44.3 web client on macOS Chrome.

## Related

Modified-key half of the family of web-client Backspace/Delete issues. The *plain* Backspace symptom in #4564 has a different root cause (unset `$TERM`, fixed by #5145).