### PR TITLE
fix: Preserve z-order of floating panes when using MoveFocusOrTab

### DIFF
--- a/zellij-server/src/panes/floating_panes/floating_pane_grid.rs
+++ b/zellij-server/src/panes/floating_panes/floating_pane_grid.rs
@@ -625,7 +625,8 @@ impl<'a> FloatingPaneGrid<'a> {
             .copied();
         next_index
     }
-    pub fn pane_id_on_edge(&self, direction: Direction) -> Option<PaneId> {
+    pub fn pane_id_on_edge(&self, direction: Direction, z_indices: &[PaneId]) -> Option<PaneId> {
+        let z_pos = |pane_id: &PaneId| z_indices.iter().position(|p_id| p_id == pane_id);
         let panes = self.panes.borrow();
         let panes: Vec<(PaneId, &&mut Box<dyn Pane>)> = panes
             .iter()
@@ -635,32 +636,32 @@ impl<'a> FloatingPaneGrid<'a> {
         let next_index = panes
             .iter()
             .enumerate()
-            .max_by(|(_, (_, a)), (_, (_, b))| match direction {
+            .max_by(|(_, (a_id, a)), (_, (b_id, b))| match direction {
                 Direction::Left => {
                     let x_comparison = a.x().cmp(&b.x());
                     match x_comparison {
-                        Ordering::Equal => a.y().cmp(&b.y()),
+                        Ordering::Equal => z_pos(a_id).cmp(&z_pos(b_id)),
                         _ => x_comparison,
                     }
                 },
                 Direction::Right => {
                     let x_comparison = b.x().cmp(&a.x());
                     match x_comparison {
-                        Ordering::Equal => a.y().cmp(&b.y()),
+                        Ordering::Equal => z_pos(a_id).cmp(&z_pos(b_id)),
                         _ => x_comparison,
                     }
                 },
                 Direction::Up => {
                     let y_comparison = a.y().cmp(&b.y());
                     match y_comparison {
-                        Ordering::Equal => a.x().cmp(&b.x()),
+                        Ordering::Equal => z_pos(a_id).cmp(&z_pos(b_id)),
                         _ => y_comparison,
                     }
                 },
                 Direction::Down => {
                     let y_comparison = b.y().cmp(&a.y());
                     match y_comparison {
-                        Ordering::Equal => b.x().cmp(&a.x()),
+                        Ordering::Equal => z_pos(a_id).cmp(&z_pos(b_id)),
                         _ => y_comparison,
                     }
                 },

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -733,7 +733,7 @@ impl FloatingPanes {
             display_area,
             viewport,
         );
-        if let Some(pane_id) = floating_pane_grid.pane_id_on_edge(direction) {
+        if let Some(pane_id) = floating_pane_grid.pane_id_on_edge(direction, &self.z_indices) {
             self.focus_pane(pane_id, client_id);
             self.set_force_render();
         }

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -884,7 +884,7 @@ impl FloatingPanes {
             display_area,
             viewport,
         );
-        if let Some(pane_id) = floating_pane_grid.pane_id_on_edge(direction) {
+        if let Some(pane_id) = floating_pane_grid.pane_id_on_edge(direction, &self.z_indices) {
             self.focus_pane(pane_id, client_id);
             self.set_force_render();
         }


### PR DESCRIPTION
fix: preserve z-order of floating panes when using MoveFocusOrTab

MoveFocusOrTab is often more convenient than the modal Tab mode. When switching tabs normally, z-order is preserved. However when using MoveFocusOrTab, an "edge" floating window is selected. It is far more convenient to not re-focus on an "edge" floating window. That way we can quickly move between tabs with the relevant floating panes remaining visible.



Before (always go to pane with "bar" even if "foo" was on top):
<img width="1914" height="1114" alt="wrong_zellij" src="https://github.com/user-attachments/assets/ac7a44ac-34db-4e30-8250-1d79ec1b761e" />




After (always go to pane that was on top last time):
<img width="1912" height="1118" alt="correct_zellij" src="https://github.com/user-attachments/assets/2ffcdcb9-3a0a-47c7-a223-47018411130d" />
