### PR TITLE
Renaming an already-renamed tab preserves the name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+* feat: renaming a tab that already has a custom name now keeps the existing name (with an edit cursor) instead of clearing it; default-named tabs ("Tab #1") still start from an empty buffer
 * feat: allow tabs to have different sizes if clients aren't focused on the same one (https://github.com/zellij-org/zellij/pull/5133)
 * feat: PWA support for the web client (manifest + icons + iOS meta tags) so the page can be installed as a standalone app (https://github.com/zellij-org/zellij/pull/5184)
 

--- a/default-plugins/compact-bar/src/main.rs
+++ b/default-plugins/compact-bar/src/main.rs
@@ -539,6 +539,9 @@ impl State {
 
         for tab in &self.tabs {
             let tab_name = self.get_tab_display_name(tab);
+            let show_rename_cursor = tab.active
+                && self.mode_info.mode == InputMode::RenameTab
+                && tab.is_editing_existing_name;
 
             if tab.active {
                 active_tab_index = tab.position;
@@ -554,6 +557,7 @@ impl State {
                 is_alternate_tab,
                 self.mode_info.style.colors,
                 self.mode_info.capabilities,
+                show_rename_cursor,
             );
 
             is_alternate_tab = !is_alternate_tab;

--- a/default-plugins/compact-bar/src/tab.rs
+++ b/default-plugins/compact-bar/src/tab.rs
@@ -27,6 +27,7 @@ pub fn render_tab(
     is_alternate_tab: bool,
     palette: Styling,
     separator: &str,
+    show_rename_cursor: bool,
 ) -> LinePart {
     let focused_clients = tab.other_focused_clients.as_slice();
     let separator_width = separator.width();
@@ -57,9 +58,23 @@ pub fn render_tab(
     let left_separator = style!(separator_fill_color, background_color).paint(separator);
     let mut tab_text_len = text.width() + (separator_width * 2) + 2; // + 2 for padding
 
-    let tab_styled_text = style!(foreground_color, background_color)
-        .bold()
-        .paint(format!(" {} ", text));
+    // The padded, styled tab label. While renaming an existing name in place we
+    // insert a reverse-video block cursor (swapped fg/bg) at the editable end of
+    // the name, themed from the current colors.
+    let tab_label = if show_rename_cursor {
+        tab_text_len += 1; // the cursor cell
+        let name = style!(foreground_color, background_color)
+            .bold()
+            .paint(format!(" {}", text));
+        let cursor = style!(background_color, foreground_color).bold().paint(" ");
+        let trailing_pad = style!(foreground_color, background_color).bold().paint(" ");
+        format!("{}{}{}", name, cursor, trailing_pad)
+    } else {
+        style!(foreground_color, background_color)
+            .bold()
+            .paint(format!(" {} ", text))
+            .to_string()
+    };
 
     let right_separator = style!(background_color, separator_fill_color).paint(separator);
     let tab_styled_text = if !focused_clients.is_empty() {
@@ -77,14 +92,14 @@ pub fn render_tab(
             .paint("]")
             .to_string();
         s.push_str(&left_separator.to_string());
-        s.push_str(&tab_styled_text.to_string());
+        s.push_str(&tab_label);
         s.push_str(&cursor_beginning);
         s.push_str(&cursor_section);
         s.push_str(&cursor_end);
         s.push_str(&right_separator.to_string());
         s
     } else {
-        ANSIStrings(&[left_separator, tab_styled_text, right_separator]).to_string()
+        format!("{}{}{}", left_separator, tab_label, right_separator)
     };
 
     LinePart {
@@ -100,6 +115,7 @@ pub fn tab_style(
     mut is_alternate_tab: bool,
     palette: Styling,
     capabilities: PluginCapabilities,
+    show_rename_cursor: bool,
 ) -> LinePart {
     let separator = tab_separator(capabilities);
 
@@ -116,7 +132,14 @@ pub fn tab_style(
         is_alternate_tab = false;
     }
 
-    render_tab(tabname, tab, is_alternate_tab, palette, separator)
+    render_tab(
+        tabname,
+        tab,
+        is_alternate_tab,
+        palette,
+        separator,
+        show_rename_cursor,
+    )
 }
 
 pub(crate) fn get_tab_to_focus(

--- a/default-plugins/tab-bar/src/main.rs
+++ b/default-plugins/tab-bar/src/main.rs
@@ -125,8 +125,12 @@ impl ZellijPlugin for State {
         let mut is_alternate_tab = false;
         for t in &mut self.tabs {
             let mut tabname = t.name.clone();
+            let mut show_rename_cursor = false;
             if t.active && self.mode_info.mode == InputMode::RenameTab {
-                if tabname.is_empty() {
+                if t.is_editing_existing_name {
+                    // editing an existing name in place: keep it and mark the edit point
+                    show_rename_cursor = true;
+                } else if tabname.is_empty() {
                     tabname = String::from("Enter name...");
                 }
                 active_tab_index = t.position;
@@ -139,6 +143,7 @@ impl ZellijPlugin for State {
                 is_alternate_tab,
                 self.mode_info.style.colors,
                 self.mode_info.capabilities,
+                show_rename_cursor,
             );
             is_alternate_tab = !is_alternate_tab;
             all_tabs.push(tab);

--- a/default-plugins/tab-bar/src/tab.rs
+++ b/default-plugins/tab-bar/src/tab.rs
@@ -26,6 +26,7 @@ pub fn render_tab(
     is_alternate_tab: bool,
     palette: Styling,
     separator: &str,
+    show_rename_cursor: bool,
 ) -> LinePart {
     let focused_clients = tab.other_focused_clients.as_slice();
     let separator_width = separator.width();
@@ -57,9 +58,24 @@ pub fn render_tab(
     let separator_fill_color = palette.text_unselected.background;
     let left_separator = style!(separator_fill_color, background_color).paint(separator);
     let mut tab_text_len = text.width() + (separator_width * 2) + 2; // +2 for padding
-    let tab_styled_text = style!(foreground_color, background_color)
-        .bold()
-        .paint(format!(" {} ", text));
+
+    // The padded, styled tab label. While renaming an existing name in place we
+    // insert a reverse-video block cursor (swapped fg/bg) at the editable end of
+    // the name, themed from the current colors.
+    let tab_label = if show_rename_cursor {
+        tab_text_len += 1; // the cursor cell
+        let name = style!(foreground_color, background_color)
+            .bold()
+            .paint(format!(" {}", text));
+        let cursor = style!(background_color, foreground_color).bold().paint(" ");
+        let trailing_pad = style!(foreground_color, background_color).bold().paint(" ");
+        format!("{}{}{}", name, cursor, trailing_pad)
+    } else {
+        style!(foreground_color, background_color)
+            .bold()
+            .paint(format!(" {} ", text))
+            .to_string()
+    };
 
     let right_separator = style!(background_color, separator_fill_color).paint(separator);
     let tab_styled_text = if !focused_clients.is_empty() {
@@ -77,14 +93,14 @@ pub fn render_tab(
             .paint("]")
             .to_string();
         s.push_str(&left_separator.to_string());
-        s.push_str(&tab_styled_text.to_string());
+        s.push_str(&tab_label);
         s.push_str(&cursor_beginning);
         s.push_str(&cursor_section);
         s.push_str(&cursor_end);
         s.push_str(&right_separator.to_string());
         s
     } else {
-        ANSIStrings(&[left_separator, tab_styled_text, right_separator]).to_string()
+        format!("{}{}{}", left_separator, tab_label, right_separator)
     };
 
     LinePart {
@@ -100,6 +116,7 @@ pub fn tab_style(
     mut is_alternate_tab: bool,
     palette: Styling,
     capabilities: PluginCapabilities,
+    show_rename_cursor: bool,
 ) -> LinePart {
     let separator = tab_separator(capabilities);
 
@@ -116,7 +133,14 @@ pub fn tab_style(
         is_alternate_tab = false;
     }
 
-    render_tab(tabname, tab, is_alternate_tab, palette, separator)
+    render_tab(
+        tabname,
+        tab,
+        is_alternate_tab,
+        palette,
+        separator,
+        show_rename_cursor,
+    )
 }
 
 pub(crate) fn get_tab_to_focus(

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -3257,6 +3257,7 @@ impl Screen {
                     && !self.active_tab_ids.values().any(|i| i == &tab.id),
                 is_flashing_bell: tab.tab_bell_flash
                     && !self.active_tab_ids.values().any(|i| i == &tab.id),
+                is_editing_existing_name: tab.is_editing_existing_name,
             };
             tab_infos_for_screen_state.insert(tab.position, tab_info_for_screen);
         }
@@ -3300,6 +3301,7 @@ impl Screen {
                     tab_id: tab.id,
                     has_bell_notification: tab.tab_has_pending_bell && *active_tab_index != tab.id,
                     is_flashing_bell: tab.tab_bell_flash && *active_tab_index != tab.id,
+                    is_editing_existing_name: tab.is_editing_existing_name,
                 };
                 plugin_tab_updates.push(tab_info_for_plugins);
             }
@@ -3561,7 +3563,11 @@ impl Screen {
                     Ok(active_tab) => {
                         match s {
                             "\0" => {
-                                active_tab.name = String::new();
+                                // A default-templated name is wiped so the user starts fresh; a name the
+                                // user has set is kept in place so they can edit it (see `change_mode`).
+                                if active_tab.has_default_name() {
+                                    active_tab.name = String::new();
+                                }
                             },
                             "\u{007F}" | "\u{0008}" => {
                                 // delete and backspace keys
@@ -3798,6 +3804,13 @@ impl Screen {
         if mode_info.mode == InputMode::RenameTab {
             if let Ok(active_tab) = self.get_active_tab_mut(client_id) {
                 active_tab.prev_name = active_tab.name.clone();
+                active_tab.is_editing_existing_name = !active_tab.has_default_name();
+            }
+        }
+
+        if previous_mode == InputMode::RenameTab && mode_info.mode != InputMode::RenameTab {
+            if let Ok(active_tab) = self.get_active_tab_mut(client_id) {
+                active_tab.is_editing_existing_name = false;
             }
         }
 
@@ -5266,6 +5279,7 @@ impl Screen {
                     && !self.active_tab_ids.values().any(|i| i == &tab.id),
                 is_flashing_bell: tab.tab_bell_flash
                     && !self.active_tab_ids.values().any(|i| i == &tab.id),
+                is_editing_existing_name: tab.is_editing_existing_name,
             }
         })
     }

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -158,6 +158,10 @@ pub(crate) struct Tab {
     pub position: usize,
     pub name: String,
     pub prev_name: String,
+    /// Whether this tab is currently being renamed with its existing (non-default) name
+    /// pre-filled as the editable starting point, rather than from an empty buffer. Only
+    /// meaningful while the active client is in `RenameTab` mode.
+    pub is_editing_existing_name: bool,
     /// The tab's current viewport size, computed as `min(rows)` and `min(cols)`
     /// independently across the clients whose `active_tab_id` equals this tab.
     /// When the tab has no viewers it retains its most recent value (the
@@ -765,7 +769,7 @@ impl Tab {
         web_server_port: u16,
     ) -> Self {
         let name = if name.is_empty() {
-            format!("Tab #{}", id + 1)
+            Tab::default_name(id)
         } else {
             name
         };
@@ -879,6 +883,7 @@ impl Tab {
             tab_has_pending_bell: false,
             tab_bell_flash: false,
             tab_bell_ring: false,
+            is_editing_existing_name: false,
         }
     }
 
@@ -1059,6 +1064,17 @@ impl Tab {
                 (None, false)
             }
         }
+    }
+
+    /// The templated name a tab is auto-assigned at creation when no explicit name is given.
+    fn default_name(id: usize) -> String {
+        format!("Tab #{}", id + 1)
+    }
+
+    /// Whether this tab still carries its auto-assigned templated name, as opposed
+    /// to a name the user has explicitly set.
+    pub fn has_default_name(&self) -> bool {
+        self.name == Tab::default_name(self.id)
     }
     fn relayout_floating_panes(&mut self, search_backwards: bool) -> Result<()> {
         if let Some(layout_candidate) = self

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -5022,6 +5022,177 @@ pub fn rename_tab_by_id_verifies_screen_state() {
 }
 
 #[test]
+fn null_clear_wipes_default_named_tab_but_keeps_custom() {
+    // The core of the sticky-rename feature: the `\0` reset (sent when entering
+    // rename mode) clears the buffer only for a default-templated name; a name the
+    // user has set is kept in place so it can be edited.
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let mut screen = create_new_screen(size, true, true);
+    new_tab(&mut screen, 1, 0); // ID 0 -> "Tab #1" (default)
+    let client_id = 1;
+
+    assert!(screen.get_active_tab(client_id).unwrap().has_default_name());
+    screen.update_active_tab_name(vec![0], client_id).unwrap();
+    assert_eq!(
+        screen.get_active_tab(client_id).unwrap().name,
+        "",
+        "a default-named tab is wiped to an empty buffer"
+    );
+
+    screen.get_tab_by_id_mut(0).unwrap().name = "staging".to_string();
+    screen.update_active_tab_name(vec![0], client_id).unwrap();
+    assert_eq!(
+        screen.get_active_tab(client_id).unwrap().name,
+        "staging",
+        "a custom-named tab is left untouched"
+    );
+}
+
+#[test]
+fn editing_existing_name_flag_tracks_mode_transitions() {
+    // The render hint is snapshotted on entering RenameTab and cleared on leaving it.
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let mut screen = create_new_screen(size, true, true);
+    new_tab(&mut screen, 1, 0);
+    let client_id = 1;
+
+    // Default name -> not editing an existing name.
+    screen
+        .change_mode(InputMode::RenameTab, None, client_id)
+        .unwrap();
+    assert!(
+        !screen
+            .get_active_tab(client_id)
+            .unwrap()
+            .is_editing_existing_name
+    );
+    screen
+        .change_mode(InputMode::Normal, None, client_id)
+        .unwrap();
+    assert!(
+        !screen
+            .get_active_tab(client_id)
+            .unwrap()
+            .is_editing_existing_name
+    );
+
+    // Custom name -> editing an existing name on entry, cleared on exit.
+    screen.get_tab_by_id_mut(0).unwrap().name = "db".to_string();
+    screen
+        .change_mode(InputMode::RenameTab, None, client_id)
+        .unwrap();
+    assert!(
+        screen
+            .get_active_tab(client_id)
+            .unwrap()
+            .is_editing_existing_name
+    );
+    screen
+        .change_mode(InputMode::Normal, None, client_id)
+        .unwrap();
+    assert!(
+        !screen
+            .get_active_tab(client_id)
+            .unwrap()
+            .is_editing_existing_name
+    );
+}
+
+#[test]
+fn undo_rename_of_custom_named_tab_restores_original() {
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let mut screen = create_new_screen(size, true, true);
+    new_tab(&mut screen, 1, 0);
+    let client_id = 1;
+
+    screen.get_tab_by_id_mut(0).unwrap().name = "production".to_string();
+
+    // Entering rename snapshots the name and keeps it in place for editing.
+    screen
+        .change_mode(InputMode::RenameTab, None, client_id)
+        .unwrap();
+    assert_eq!(screen.get_active_tab(client_id).unwrap().name, "production");
+
+    screen
+        .update_active_tab_name(" v2".as_bytes().to_vec(), client_id)
+        .unwrap();
+    assert_eq!(
+        screen.get_active_tab(client_id).unwrap().name,
+        "production v2"
+    );
+
+    screen.undo_active_rename_tab(client_id).unwrap();
+    assert_eq!(screen.get_active_tab(client_id).unwrap().name, "production");
+}
+
+#[test]
+fn name_typed_to_match_template_is_treated_as_default() {
+    // `has_default_name` is a string-equality oracle: a name that exactly equals the
+    // template is intentionally indistinguishable from an auto-assigned one.
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let mut screen = create_new_screen(size, true, true);
+    new_tab(&mut screen, 1, 0); // ID 0 -> template "Tab #1"
+    let client_id = 1;
+
+    screen.get_tab_by_id_mut(0).unwrap().name = "Tab #1".to_string();
+
+    screen
+        .change_mode(InputMode::RenameTab, None, client_id)
+        .unwrap();
+    assert!(
+        !screen
+            .get_active_tab(client_id)
+            .unwrap()
+            .is_editing_existing_name,
+        "a name equal to the template is treated as default"
+    );
+    screen.update_active_tab_name(vec![0], client_id).unwrap();
+    assert_eq!(screen.get_active_tab(client_id).unwrap().name, "");
+}
+
+#[test]
+fn undo_rename_of_default_named_tab_restores_template() {
+    // The common case: the buffer is wiped on entry, so undo must restore the
+    // original template name rather than the emptied/half-typed buffer.
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let mut screen = create_new_screen(size, true, true);
+    new_tab(&mut screen, 1, 0); // ID 0 -> "Tab #1" (default)
+    let client_id = 1;
+
+    assert!(screen.get_active_tab(client_id).unwrap().has_default_name());
+
+    // Entering rename snapshots prev_name; the client then sends `\0` to wipe.
+    screen
+        .change_mode(InputMode::RenameTab, None, client_id)
+        .unwrap();
+    screen.update_active_tab_name(vec![0], client_id).unwrap();
+    assert_eq!(screen.get_active_tab(client_id).unwrap().name, "");
+
+    screen
+        .update_active_tab_name("scratch".as_bytes().to_vec(), client_id)
+        .unwrap();
+    assert_eq!(screen.get_active_tab(client_id).unwrap().name, "scratch");
+
+    screen.undo_active_rename_tab(client_id).unwrap();
+    assert_eq!(screen.get_active_tab(client_id).unwrap().name, "Tab #1");
+}
+
+#[test]
 pub fn send_cli_rename_tab_by_id_action() {
     let size = Size {
         cols: 121,

--- a/zellij-utils/assets/prost/api.event.rs
+++ b/zellij-utils/assets/prost/api.event.rs
@@ -627,6 +627,8 @@ pub struct TabInfo {
     pub has_bell_notification: bool,
     #[prost(bool, tag="19")]
     pub is_flashing_bell: bool,
+    #[prost(bool, tag="20")]
+    pub is_editing_existing_name: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -2272,6 +2272,9 @@ pub struct TabInfo {
     pub has_bell_notification: bool,
     /// Whether this tab is currently flashing its bell (transient 400ms state)
     pub is_flashing_bell: bool,
+    /// Whether this tab is being renamed with its existing (non-default) name
+    /// pre-filled as the editable starting point, rather than from an empty buffer.
+    pub is_editing_existing_name: bool,
 }
 
 /// The `PaneManifest` contains a dictionary of panes, indexed by the tab position (0 indexed).

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -5871,6 +5871,7 @@ impl TabInfo {
             tab_id,
             has_bell_notification: false,
             is_flashing_bell: false,
+            is_editing_existing_name: false,
         })
     }
     pub fn encode_to_kdl(&self) -> KdlDocument {
@@ -6310,6 +6311,7 @@ fn serialize_and_deserialize_session_info_with_data() {
                 tab_id: 0,
                 is_flashing_bell: false,
                 has_bell_notification: false,
+                is_editing_existing_name: false,
             },
             TabInfo {
                 position: 1,
@@ -6331,6 +6333,7 @@ fn serialize_and_deserialize_session_info_with_data() {
                 tab_id: 1,
                 is_flashing_bell: false,
                 has_bell_notification: false,
+                is_editing_existing_name: false,
             },
         ],
         panes: PaneManifest { panes },

--- a/zellij-utils/src/plugin_api/event.proto
+++ b/zellij-utils/src/plugin_api/event.proto
@@ -462,6 +462,7 @@ message TabInfo {
     uint32 tab_id = 17;
     bool has_bell_notification = 18;
     bool is_flashing_bell = 19;
+    bool is_editing_existing_name = 20;
 }
 
 message ModeUpdatePayload {

--- a/zellij-utils/src/plugin_api/event.rs
+++ b/zellij-utils/src/plugin_api/event.rs
@@ -1811,6 +1811,7 @@ impl TryFrom<ProtobufTabInfo> for TabInfo {
             tab_id: protobuf_tab_info.tab_id as usize,
             has_bell_notification: protobuf_tab_info.has_bell_notification,
             is_flashing_bell: protobuf_tab_info.is_flashing_bell,
+            is_editing_existing_name: protobuf_tab_info.is_editing_existing_name,
         })
     }
 }
@@ -1842,6 +1843,7 @@ impl TryFrom<TabInfo> for ProtobufTabInfo {
             tab_id: tab_info.tab_id as u32,
             has_bell_notification: tab_info.has_bell_notification,
             is_flashing_bell: tab_info.is_flashing_bell,
+            is_editing_existing_name: tab_info.is_editing_existing_name,
         })
     }
 }
@@ -2360,6 +2362,7 @@ fn serialize_tab_update_event_with_non_default_values() {
             tab_id: 0,
             has_bell_notification: false,
             is_flashing_bell: false,
+            is_editing_existing_name: false,
         },
         TabInfo {
             position: 1,
@@ -2381,6 +2384,7 @@ fn serialize_tab_update_event_with_non_default_values() {
             tab_id: 1,
             has_bell_notification: false,
             is_flashing_bell: false,
+            is_editing_existing_name: false,
         },
         TabInfo::default(),
     ]);
@@ -2657,6 +2661,7 @@ fn serialize_session_update_event_with_non_default_values() {
             tab_id: 0,
             has_bell_notification: false,
             is_flashing_bell: false,
+            is_editing_existing_name: false,
         },
         TabInfo {
             position: 1,
@@ -2678,6 +2683,7 @@ fn serialize_session_update_event_with_non_default_values() {
             tab_id: 1,
             has_bell_notification: false,
             is_flashing_bell: false,
+            is_editing_existing_name: false,
         },
         TabInfo::default(),
     ];


### PR DESCRIPTION
Default behavior when renaming a tab: wipe the name, show "Enter name..." and let user change the name. This is also the behavior for tabs that were previously renamed.

New behavior: a tab that was previously renamed isn't wiped; instead, a cursor is shown at the end, allowing the user to append to the name or backspace to remove the existing name.