### PR TITLE
Allow full (scrollback) dump-screen from keybindings

### DIFF
--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -697,18 +697,34 @@ impl Action {
             },
             Action::MovePaneBackwards => Some(KdlNode::new("MovePaneBackwards")),
             Action::DumpScreen {
-                file_path: Some(file),
-                include_scrollback: _,
+                file_path,
+                include_scrollback,
                 pane_id: _,
-                ansi: _,
+                ansi,
             } => {
+                if file_path.is_none() && !*include_scrollback && !*ansi {
+                    return None;
+                }
                 let mut node = KdlNode::new("DumpScreen");
-                node.push(file.clone());
+                if let Some(file) = file_path {
+                    node.push(file.clone());
+                }
+                if *include_scrollback || *ansi {
+                    let mut children = KdlDocument::new();
+                    if *include_scrollback {
+                        let mut full_node = KdlNode::new("full");
+                        full_node.push(KdlValue::Bool(true));
+                        children.nodes_mut().push(full_node);
+                    }
+                    if *ansi {
+                        let mut ansi_node = KdlNode::new("ansi");
+                        ansi_node.push(KdlValue::Bool(true));
+                        children.nodes_mut().push(ansi_node);
+                    }
+                    node.set_children(children);
+                }
                 Some(node)
             },
-            Action::DumpScreen {
-                file_path: None, ..
-            } => None,
             Action::DumpLayout => Some(KdlNode::new("DumpLayout")),
             Action::EditScrollback { ansi } => {
                 let mut node = KdlNode::new("EditScrollback");
@@ -1682,11 +1698,35 @@ impl TryFrom<(&KdlNode, &Options)> for Action {
                 action_arguments,
                 kdl_action
             ),
-            "DumpScreen" => parse_kdl_action_char_or_string_arguments!(
-                action_name,
-                action_arguments,
-                kdl_action
-            ),
+            "DumpScreen" => {
+                let mut file_path = String::new();
+                for kdl_entry in action_arguments.iter() {
+                    match kdl_entry.value().as_string() {
+                        Some(string_value) => file_path.push_str(string_value),
+                        None => {
+                            return Err(ConfigError::new_kdl_error(
+                                format!(
+                                    "All entries for action '{}' must be strings",
+                                    action_name
+                                ),
+                                kdl_entry.span().offset(),
+                                kdl_entry.span().len(),
+                            ))
+                        },
+                    }
+                }
+                let include_scrollback =
+                    crate::kdl_get_bool_property_or_child_value!(kdl_action, "full")
+                        .unwrap_or(false);
+                let ansi = crate::kdl_get_bool_property_or_child_value!(kdl_action, "ansi")
+                    .unwrap_or(false);
+                Ok(Action::DumpScreen {
+                    file_path: Some(file_path),
+                    include_scrollback,
+                    pane_id: None,
+                    ansi,
+                })
+            },
             "DumpLayout" => parse_kdl_action_char_or_string_arguments!(
                 action_name,
                 action_arguments,
@@ -6457,6 +6497,55 @@ fn keybinds_to_string_with_multiple_actions() {
         "Deserialized serialized config equals original config"
     );
     insta::assert_snapshot!(serialized.to_string());
+}
+
+#[test]
+fn keybinds_to_string_with_dump_screen_full_and_ansi() {
+    let fake_config = r#"
+        keybinds {
+            normal {
+                bind "Ctrl n" {
+                    DumpScreen "/tmp/dumped" {
+                        full true;
+                        ansi true;
+                    }
+                }
+            }
+        }"#;
+    let document: KdlDocument = fake_config.parse().unwrap();
+    let deserialized = Keybinds::from_kdl(
+        document.get("keybinds").unwrap(),
+        Default::default(),
+        &Default::default(),
+    )
+    .unwrap();
+    let clear_defaults = true;
+    let serialized = Keybinds::to_kdl(&deserialized, clear_defaults);
+    let serialized_string = serialized.to_string();
+    assert!(
+        serialized_string.contains("full"),
+        "Serialized keybinding should preserve the `full` (scrollback) flag, got:\n{}",
+        serialized_string
+    );
+    assert!(
+        serialized_string.contains("ansi"),
+        "Serialized keybinding should preserve the `ansi` flag, got:\n{}",
+        serialized_string
+    );
+    let deserialized_from_serialized = Keybinds::from_kdl(
+        serialized_string
+            .parse::<KdlDocument>()
+            .unwrap()
+            .get("keybinds")
+            .unwrap(),
+        Default::default(),
+        &Default::default(),
+    )
+    .unwrap();
+    assert_eq!(
+        deserialized, deserialized_from_serialized,
+        "DumpScreen with `full`/`ansi` flags should survive a serialize/deserialize round-trip"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`DumpScreen` can already dump the full scrollback when invoked from the CLI
(`zellij action dump-screen --full`) — `Action::DumpScreen` carries an
`include_scrollback` field and `CliAction::DumpScreen` maps `--full` onto it.
The KDL keybinding parser, however, hard-coded that flag (and `ansi`) to
`false`, so there was no way to bind a key that dumps the *whole* screen.

This adds optional `full` and `ansi` flags to the `DumpScreen` keybinding
action, mirroring the existing `EditScrollback` action which already reads an
`ansi` child node.

Closes #1460.

## What changed

Only `zellij-utils/src/kdl/mod.rs`:

- **Parser** (`TryFrom<(&KdlNode, &Options)> for Action`): the `DumpScreen` arm
  now reads `full` → `include_scrollback` and `ansi` → `ansi` via
  `kdl_get_bool_property_or_child_value!` (the same helper `EditScrollback`
  uses), instead of always parsing them as `false`. The positional file-path
  argument is parsed exactly as before.
- **Serializer** (`Action::to_kdl`): the `DumpScreen` arm now emits `full true`
  / `ansi true` child nodes when those flags are set, so the configuration
  round-trips.

### Usage

```kdl
keybinds {
    normal {
        // Dump the whole screen, including the scrollback buffer
        bind "Ctrl s" { DumpScreen "/tmp/dump" { full true; }; }
        // ...optionally keeping the ANSI escape codes
        bind "Alt s" { DumpScreen "/tmp/dump" { full true; ansi true; }; }
    }
}
```

### Backwards compatibility

A plain `DumpScreen "/path"` keybinding is unaffected: it still parses to
`include_scrollback: false`, `ansi: false`, and serializes back to exactly
`DumpScreen "/path"` with no child nodes.

## Testing

- Added `keybinds_to_string_with_dump_screen_full_and_ansi`, which parses a
  `DumpScreen` keybinding with `full`/`ansi` set, checks the flags survive
  serialization, and asserts a parse → serialize → parse round-trip.
- The existing `keybinds_to_string_with_all_actions` snapshot is unchanged
  (it binds a plain `DumpScreen`, which still serializes identically).
- **Not built locally** (no `protoc` available in my environment), so I'm
  relying on CI for `cargo test` / `cargo fmt` / clippy. The change is small
  and follows the established `EditScrollback` pattern.
