### PR TITLE
fix: don't panic the screen thread when client teardown can't reach plugins/background_jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 * feat: allow tabs to have different sizes if clients aren't focused on the same one (https://github.com/zellij-org/zellij/pull/5133)
 * feat: PWA support for the web client (manifest + icons + iOS meta tags) so the page can be installed as a standalone app (https://github.com/zellij-org/zellij/pull/5184)
+* fix: a disconnecting client can no longer panic the screen thread and exit the whole server when a plugin or the background_jobs thread is unreachable during teardown (https://github.com/zellij-org/zellij/pull/5231)
 
 ## [0.44.3] - 2026-05-13
 * fix(windows): bump windows-sys to 0.59 to align manifest with code, fixing source builds via `cargo install`/`cargo binstall` (https://github.com/zellij-org/zellij/pull/5139)

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -3163,7 +3163,10 @@ impl Screen {
         for (_, tab) in self.tabs.iter_mut() {
             tab.remove_client(client_id);
             if tab.has_no_connected_clients() {
-                tab.visible(false).with_context(err_context)?;
+                // Best-effort: a disconnecting client must not abort the server (and
+                // must complete structural cleanup below) just because a plugin can no
+                // longer be notified that this tab became hidden. See #4805.
+                tab.visible(false).with_context(err_context).non_fatal();
             }
         }
         let previously_active_tab_id = self.active_tab_ids.get(&client_id).copied();
@@ -7510,9 +7513,13 @@ pub(crate) fn screen_thread_main(
                 screen.render(None)?;
             },
             ScreenInstruction::RemoveClient(client_id) => {
-                screen.remove_client(client_id)?;
-                screen.log_and_report_session_state()?;
-                screen.render(None)?;
+                // Client teardown must be best-effort: if a plugin or the
+                // background_jobs thread is already gone, notifying it must not panic
+                // the screen thread (which would process::exit the whole server). See
+                // #4805 and the deferred sweep noted in #5119.
+                screen.remove_client(client_id).non_fatal();
+                screen.log_and_report_session_state().non_fatal();
+                screen.render(None).non_fatal();
             },
             ScreenInstruction::UpdateSearch(
                 c,


### PR DESCRIPTION
## Problem

When a client disconnects, the screen thread handles `ScreenInstruction::RemoveClient`:

```rust
ScreenInstruction::RemoveClient(client_id) => {
    screen.remove_client(client_id)?;
    screen.log_and_report_session_state()?;
    screen.render(None)?;
},
```

`screen_thread_main` is spawned as `screen_thread_main(...).fatal()` (`zellij-server/src/lib.rs`),
and `.fatal()` (`zellij-utils/src/errors.rs`) unwraps the error and terminates the process. So
**any** `Err` returned from this handler `process::exit(1)`s the whole server — every pane in the
session dies, the session shows `EXITED`, and it cannot be resurrected.

All three calls send to other threads during teardown:

- `remove_client()` hides the departing client's now-empty tabs; `Tab::visible(false)` sends
  `Event::Visible` to the tab's plugins. `remove_client()` then tail-calls
  `log_and_report_session_state()`.
- `log_and_report_session_state()` sends `PaneUpdate`/`TabUpdate` to the plugin thread and to
  `background_jobs`.

If a plugin or the `background_jobs` thread has already exited — which is exactly what happens
while a session is tearing down — those sends return `Err`, the `?` propagates, and the server
exits. This is **independent of any particular plugin**: it is on the generic client-disconnect
path. It is the same class of bug as #5119 (which fixed the `ClosePane` arm) and is reported in
the wild in #4805 (VSCode Remote SSH client disconnects → "the server panics and exits" → session
`EXITED`, unresurrectable), with no custom plugins involved.

## Fix

Make the `RemoveClient` teardown path best-effort, using the `.non_fatal()` idiom already used
throughout `screen.rs` (and matching #5119's treatment of `ClosePane`):

- `Tab::visible(false)` inside `remove_client()` → `.non_fatal()`, so a dead plugin channel can no
  longer abort teardown **and structural client cleanup always completes** (the code after the
  loop — removing the client from `connected_clients`, `client_sizes`, `pane_render_subscribers`,
  etc. — now always runs).
- The `RemoveClient` arm's `remove_client()` / `log_and_report_session_state()` / `render()` →
  `.non_fatal()`, so an unreachable plugin/`background_jobs` thread logs an error instead of
  exiting the server.

Errors are still logged (`non_fatal()` → `to_log()`), so genuine faults stay visible — they just
no longer take the whole server down with them.

## Scope

This hardens the **screen-thread** client-teardown path. The parallel `.fatal()` in `pty.rs`
(`TerminalBytes::listen`), which also appears in #4805's log and which #5119 already called out as
a separate cascade, is intentionally left out of scope here to keep the change focused; it likely
warrants the same best-effort treatment in a follow-up.

## Test plan

- `cargo build -p zellij-server` — clean.
- `cargo test -p zellij-server --lib` — 1088 passed, 0 failed, 146 ignored (no regressions).

The existing screen unit harness builds the bus with `.should_silently_fail()`, so every
`send_to_*` returns `Ok` regardless of channel state — which is why this crash (like #5119's) is
not reproducible from the current unit harness without a non-silent variant. Following #5119's
precedent, this PR keeps the change focused on the fix + changelog; a non-silent regression
harness can be added separately if the maintainers would like one.

Addresses #4805 (the screen-thread teardown fatality).
