### PR TITLE
fix: tab visibility changes must not panic the screen thread when a plugin is unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 * feat: allow tabs to have different sizes if clients aren't focused on the same one (https://github.com/zellij-org/zellij/pull/5133)
 * feat: PWA support for the web client (manifest + icons + iOS meta tags) so the page can be installed as a standalone app (https://github.com/zellij-org/zellij/pull/5184)
+* fix: a tab switch or tab close can no longer panic the screen thread and exit the whole server when a plugin is unreachable (https://github.com/zellij-org/zellij/issues/4805)
 
 ## [0.44.3] - 2026-05-13
 * fix(windows): bump windows-sys to 0.59 to align manifest with code, fixing source builds via `cargo install`/`cargo binstall` (https://github.com/zellij-org/zellij/pull/5139)

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -4863,9 +4863,15 @@ impl Tab {
         for pid in pids_in_this_tab {
             plugin_updates.push((Some(*pid), None, Event::Visible(visible)));
         }
+        // Best-effort: notifying plugins that a tab became visible/hidden is
+        // advisory. A failed send (e.g. a plugin whose thread is already gone)
+        // must not panic the screen thread and process::exit the whole server.
+        // This path is hit on every tab switch (keyboard or mouse) and on tab
+        // close, not just client teardown. See #4805 / #5231.
         self.senders
             .send_to_plugin(PluginInstruction::Update(plugin_updates))
-            .with_context(|| format!("failed to set visibility of tab to {visible}"))?;
+            .with_context(|| format!("failed to set visibility of tab to {visible}"))
+            .non_fatal();
         if !visible {
             self.mouse_hover_pane_id.clear();
         }


### PR DESCRIPTION
## Problem

`Tab::visible()` (`zellij-server/src/tab/mod.rs`) tells plugins a tab became visible/hidden via
`send_to_plugin(Event::Visible)`, and that send was `?`-propagated. `visible()` runs on **every
tab switch** — `switch_active_tab`, reached by the keyboard *and* by mouse/`switch_tab_to` — and
on **tab close** (`close_tab_by_id`). Those run on the screen thread, spawned as
`screen_thread_main(...).fatal()`. So if the plugin send fails (e.g. a plugin whose thread has
already exited), the `?` propagates and `.fatal()` → `process::exit(1)` takes down the whole
server and every pane in it.

It's the same class as #5119 (ClosePane) and #5231 (client teardown, #4805) — a cosmetic plugin
notification treated as fatal — but on the most common operations of all: switching and closing
tabs.

## Fix

Make the notification best-effort with `.non_fatal()` (already the idiom across
`screen.rs`/`tab/mod.rs`). The error is still logged; it just no longer propagates into the fatal
screen-thread path. Bonus: the trailing `mouse_hover_pane_id.clear()` now runs even if the send
failed.

Fixing it at the source (`visible()` itself) covers every caller — tab switch (keyboard + mouse),
tab close, client teardown — in one place.

## Test plan

- `cargo build -p zellij-server` — clean.
- `cargo test -p zellij-server --lib` — 1088 passed, 0 failed, 146 ignored (no regressions).

The existing screen unit harness builds the bus with `.should_silently_fail()`, so `send_to_*`
always returns `Ok` regardless of channel state — the crash isn't reproducible from the current
harness without a non-silent variant (same as #5119/#5231). Kept focused on the fix + changelog.

Generalizes #5231; same class as #5119. Addresses #4805.
