### PR TITLE
fix(plugins): fallback without caller_cwd when matching pipe targets

### DIFF
--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -1673,11 +1673,30 @@ impl WasmBridge {
         if self.cached_plugin_map.is_empty() {
             self.cached_plugin_map = self.plugin_map.lock().unwrap().clone_plugin_assets();
         }
-        match self
+
+        let plugin_and_client_ids = self
             .cached_plugin_map
             .get(plugin_location)
-            .and_then(|m| m.get(plugin_configuration))
+            .and_then(|m| m.get(plugin_configuration));
+
+        // Try an exact configuration match first. If it misses, retry without
+        // `caller_cwd` because it is caller-context metadata rather than part of the
+        // target plugin's logical identity.
+        let plugin_and_client_ids = if plugin_and_client_ids.is_none()
+            && plugin_configuration.inner().contains_key("caller_cwd")
         {
+            let mut configuration_without_caller_cwd = plugin_configuration.inner().clone();
+            configuration_without_caller_cwd.remove("caller_cwd");
+            let configuration_without_caller_cwd =
+                PluginUserConfiguration::new(configuration_without_caller_cwd);
+            self.cached_plugin_map
+                .get(plugin_location)
+                .and_then(|m| m.get(&configuration_without_caller_cwd))
+        } else {
+            plugin_and_client_ids
+        };
+
+        match plugin_and_client_ids {
             Some(plugin_and_client_ids) => plugin_and_client_ids
                 .iter()
                 .map(|(plugin_id, client_id)| (*plugin_id, Some(*client_id)))


### PR DESCRIPTION
Fixes #5234.

When a plugin sends a pipe message using `MessageToPlugin::with_plugin_url`,
Zellij may add `caller_cwd` to the destination plugin configuration.

This is useful contextual metadata for the target plugin, but it can also affect
how Zellij looks up an already-running plugin. Running plugins are matched by
plugin location and plugin configuration. If the existing plugin was started
without `caller_cwd`, but the pipe destination lookup includes `caller_cwd`, the
lookup misses and Zellij launches a new plugin instance instead of sending the
pipe to the existing one.

This can happen with a plugin alias such as:

```kdl
plugins {
    pipe-target location="file:/path/to/pipe-target.wasm"
}

load_plugins {
    pipe-target
}
````

and another plugin sending:

```rust
pipe_message_to_plugin(
    MessageToPlugin::new("hello")
        .with_plugin_url("pipe-target")
);
```

In this case, the already-running `pipe-target` can be registered with:

```text
configuration = {}
```

while the pipe destination lookup uses:

```text
configuration = { "caller_cwd": "/some/path" }
```

This causes the existing plugin to be missed.

## Solution

This keeps the existing exact lookup behavior first.

If the exact lookup fails and the requested plugin configuration contains
`caller_cwd`, Zellij retries the lookup with `caller_cwd` removed from the
requested configuration.

If the fallback lookup also fails, Zellij still launches the new plugin using
the original configuration, including `caller_cwd`.

This means:

* plugins explicitly started with matching `caller_cwd` are still matched by the
  exact lookup
* plugins with a different existing `caller_cwd` are not incorrectly matched
* existing plugins without `caller_cwd` can still receive pipe messages where
  `caller_cwd` was added automatically
* newly launched plugins still receive the original `caller_cwd` configuration

## Why this is safe

The fallback only runs after the exact lookup misses.

It also only removes `caller_cwd` from the lookup key used for the fallback
search. It does not mutate the original plugin configuration used to launch a
new plugin if no existing plugin is found.

`caller_cwd` represents caller context rather than the logical identity of the
target plugin. Treating it as a fallback-ignored key prevents accidental duplicate
plugin launches while preserving exact matching behavior when a matching
`caller_cwd` instance exists.

## Testing

Manually tested with the reproduction from #5234.

Before this change, sending the pipe from `pipe-sender` caused a new
`pipe-target` instance to be launched.

After this change, the existing `pipe-target` instance receives the pipe.
