### PR TITLE
fix(plugin-api): preserve ansi flag for EditScrollback

### DIFF
--- a/zellij-utils/assets/prost/api.action.rs
+++ b/zellij-utils/assets/prost/api.action.rs
@@ -302,7 +302,7 @@ pub struct OverrideLayoutPayload {
 pub struct Action {
     #[prost(enumeration="ActionName", tag="1")]
     pub name: i32,
-    #[prost(oneof="action::OptionalPayload", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61")]
+    #[prost(oneof="action::OptionalPayload", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62")]
     pub optional_payload: ::core::option::Option<action::OptionalPayload>,
 }
 /// Nested message and enum types in `Action`.
@@ -424,6 +424,8 @@ pub mod action {
         AreFloatingPanesVisiblePayload(super::AreFloatingPanesVisiblePayload),
         #[prost(message, tag="61")]
         SetPaneFrameStylePayload(super::SetPaneFrameStylePayload),
+        #[prost(message, tag="62")]
+        EditScrollbackPayload(super::EditScrollbackPayload),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -640,6 +642,12 @@ pub struct DumpScreenPayload {
     #[prost(bool, tag="4")]
     pub dump_to_stdout: bool,
     #[prost(bool, tag="5")]
+    pub ansi: bool,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EditScrollbackPayload {
+    #[prost(bool, tag="1")]
     pub ansi: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/zellij-utils/src/plugin_api/action.proto
+++ b/zellij-utils/src/plugin_api/action.proto
@@ -247,6 +247,7 @@ message Action {
     HideFloatingPanesPayload hide_floating_panes_payload = 59;
     AreFloatingPanesVisiblePayload are_floating_panes_visible_payload = 60;
     SetPaneFrameStylePayload set_pane_frame_style_payload = 61;
+    EditScrollbackPayload edit_scrollback_payload = 62;
   }
 }
 
@@ -395,6 +396,10 @@ message DumpScreenPayload {
   optional PaneId pane_id = 3;
   bool dump_to_stdout = 4;
   bool ansi = 5;
+}
+
+message EditScrollbackPayload {
+  bool ansi = 1;
 }
 
 enum ActionName {

--- a/zellij-utils/src/plugin_api/action.rs
+++ b/zellij-utils/src/plugin_api/action.rs
@@ -13,6 +13,7 @@ pub use super::generated_api::api::{
         CommandOrPlugin as ProtobufCommandOrPlugin,
         DumpScreenPayload,
         EditFilePayload,
+        EditScrollbackPayload,
         FloatingPaneCoordinates as ProtobufFloatingPaneCoordinates,
         FloatingPaneLayout as ProtobufFloatingPaneLayout,
         FloatingPlacement as ProtobufFloatingPlacement,
@@ -235,8 +236,11 @@ impl TryFrom<ProtobufAction> for Action {
                 _ => Err("Wrong payload for Action::DumpScreen"),
             },
             Some(ProtobufActionName::EditScrollback) => match protobuf_action.optional_payload {
-                Some(_) => Err("EditScrollback should not have a payload"),
+                Some(OptionalPayload::EditScrollbackPayload(payload)) => {
+                    Ok(Action::EditScrollback { ansi: payload.ansi })
+                },
                 None => Ok(Action::EditScrollback { ansi: false }),
+                Some(_) => Err("Wrong payload for Action::EditScrollback"),
             },
             Some(ProtobufActionName::ScrollUp) => match protobuf_action.optional_payload {
                 Some(_) => Err("ScrollUp should not have a payload"),
@@ -1252,9 +1256,11 @@ impl TryFrom<Action> for ProtobufAction {
                     })),
                 })
             },
-            Action::EditScrollback { .. } => Ok(ProtobufAction {
+            Action::EditScrollback { ansi } => Ok(ProtobufAction {
                 name: ProtobufActionName::EditScrollback as i32,
-                optional_payload: None,
+                optional_payload: Some(OptionalPayload::EditScrollbackPayload(
+                    EditScrollbackPayload { ansi },
+                )),
             }),
             Action::ScrollUp => Ok(ProtobufAction {
                 name: ProtobufActionName::ScrollUp as i32,


### PR DESCRIPTION
## Description

Fixes #5237.

`Action::EditScrollback` has an `ansi` flag, but the plugin API protobuf
representation did not include a payload for it. As a result, converting
`Action::EditScrollback { ansi: true }` through the plugin API would drop the
flag and decode it as `ansi: false`.

This PR adds `EditScrollbackPayload` to the plugin API protobuf definition and
uses it when converting `EditScrollback` actions to and from protobuf.

## Changes

- Add `EditScrollbackPayload` with an `ansi` field to `action.proto`
- Add `edit_scrollback_payload` to the `Action` protobuf payload oneof
- Deserialize `EditScrollbackPayload` into `Action::EditScrollback { ansi }`
- Serialize `Action::EditScrollback { ansi }` with `EditScrollbackPayload`
- Keep payload-less `EditScrollback` actions backward-compatible by decoding
  them as `ansi: false`

## Testing

- Verified from a plugin that `run_action(Action::EditScrollback { ansi: true }, ...)` opens the scrollback editor with ANSI escape sequences preserved.
- Verified from a plugin that `run_action(Action::EditScrollback { ansi: false }, ...)` opens the scrollback editor without ANSI escape sequences.
