### PR TITLE
fix(grid): preserve background when EL erases wide chars

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -5881,9 +5881,7 @@ impl Row {
     ) {
         self.osc133_markers.retain(|marker| marker.column <= from);
         let from_position_accounting_for_widechars = self.position_accounting_for_widechars(from);
-        let to_position_accounting_for_widechars = self.position_accounting_for_widechars(to);
-        let replacement_length = to_position_accounting_for_widechars
-            .saturating_sub(from_position_accounting_for_widechars);
+        let replacement_length = to.saturating_sub(from);
         let mut replace_with = VecDeque::from(vec![terminal_character; replacement_length]);
         self.columns
             .truncate(from_position_accounting_for_widechars);

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -5393,9 +5393,7 @@ impl Row {
         terminal_character: TerminalCharacter,
     ) {
         let from_position_accounting_for_widechars = self.position_accounting_for_widechars(from);
-        let to_position_accounting_for_widechars = self.position_accounting_for_widechars(to);
-        let replacement_length = to_position_accounting_for_widechars
-            .saturating_sub(from_position_accounting_for_widechars);
+        let replacement_length = to.saturating_sub(from);
         let mut replace_with = VecDeque::from(vec![terminal_character; replacement_length]);
         self.columns
             .truncate(from_position_accounting_for_widechars);

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -8342,3 +8342,26 @@ fn xtsmgraphics_geometry_reports_failure_when_host_does_not_support_sixel() {
     vte_parser.advance(&mut grid, b"\x1b[?2;1S");
     assert_eq!(grid.pending_messages_to_pty, vec![b"\x1b[?2;3;0S".to_vec()]);
 }
+
+#[test]
+fn erase_to_end_of_line_after_wide_characters_preserves_background_to_line_end() {
+    use crate::panes::terminal_character::NamedColor;
+    // Use a wide character to exercise clearing a line that contains wide cells.
+    assert_eq!(crate::panes::TerminalCharacter::new('Ａ').width(), 2);
+
+    let content = "\x1b[44mAＡＡＡＡ\x1b[1;2H\x1b[K".as_bytes();
+    let grid = create_grid_with_size_and_raw(2, 10, content);
+
+    let lines = grid.as_character_lines();
+
+    assert_eq!(lines[0][0].character, 'A');
+
+    for cell in &lines[0] {
+        assert_eq!(
+            cell.styles.background,
+            Some(crate::panes::terminal_character::AnsiCode::NamedColor(
+                NamedColor::Blue
+            ))
+        );
+    }
+}

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -9147,3 +9147,26 @@ fn a_character_wider_than_two_columns_advances_the_cursor_by_its_full_width() {
     assert_eq!(row.width(), 4);
     assert_eq!(cursor_position(&grid), Some((4, 0)));
 }
+
+#[test]
+fn erase_to_end_of_line_after_wide_characters_preserves_background_to_line_end() {
+    use crate::panes::terminal_character::NamedColor;
+    // Use a wide character to exercise clearing a line that contains wide cells.
+    assert_eq!(crate::panes::TerminalCharacter::new('Ａ').width(), 2);
+
+    let content = "\x1b[44mAＡＡＡＡ\x1b[1;2H\x1b[K".as_bytes();
+    let grid = create_grid_with_size_and_raw(2, 10, content);
+
+    let lines = grid.as_character_lines();
+
+    assert_eq!(lines[0][0].character, 'A');
+
+    for cell in &lines[0] {
+        assert_eq!(
+            cell.styles.background,
+            Some(crate::panes::terminal_character::AnsiCode::NamedColor(
+                NamedColor::Blue
+            ))
+        );
+    }
+}

--- a/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__bash_delete_wide_characters.snap
+++ b/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__bash_delete_wide_characters.snap
@@ -1,11 +1,10 @@
 ---
 source: zellij-server/src/panes/./unit/grid_tests.rs
-assertion_line: 875
 expression: "format!(\"{:?}\", grid)"
 ---
 00 (C): Welcome to fish, the friendly interactive shell                                                         
 01 (C): ⋊> ~/c/zellij on wide-char ⨯ bash                                                               15:35:20
-02 (C): [aram@green zellij]$ ＨＨＨＨＨＨ                                                                      
+02 (C): [aram@green zellij]$ ＨＨＨＨＨＨ                                                                       
 03 (C): 
 04 (C): 
 05 (C): 
@@ -23,5 +22,4 @@ expression: "format!(\"{:?}\", grid)"
 17 (C): 
 18 (C): 
 19 (C): 
-20 (C): 
-
+20 (C):


### PR DESCRIPTION
## Description

Fixes #5239.

When erasing to the end of a line after wide characters, Zellij could leave
cells at the visual end of the line with the terminal default background instead
of the active background color.

This happened because the erase operation needs to mix two coordinate systems:

- the start position needs to account for wide characters in the row storage
- the replacement length needs to remain in terminal-cell coordinates

If the replacement length is shortened by wide-character accounting, the erased
range is not padded all the way to the visual end of the line.

## Changes

- Calculate the erase-to-end-of-line replacement width from the visual terminal
  cell range, rather than from the number of characters.
- Add a regression test covering `CSI K` after fullwidth characters.
- Update the affected grid snapshot.

## Testing

- Ran the full grid test suite, including the new regression test.
- Updated the `bash_delete_wide_characters` snapshot because the corrected
  erase-to-end-of-line width now emits one additional replacement space after
  wide characters.
