### PR TITLE
fix: clear screen should not destroy scrollback and current line

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1676,11 +1676,29 @@ impl Grid {
     }
     /// Clears all buffers with text for a current screen
     pub fn clear_screen(&mut self) {
-        if self.alternate_screen_state.is_some() {
-            log::warn!("Tried to clear pane with alternate_screen_state");
-            return;
+        let cursor_y = self.cursor.y;
+        let replace_with = EMPTY_TERMINAL_CHARACTER;
+        let replace_with_columns = VecDeque::from(vec![replace_with.clone(); self.width]);
+
+        if cursor_y > 0 {
+            self.transfer_rows_to_lines_above(cursor_y);
         }
-        self.reset_terminal_state();
+
+        for row in self.viewport.iter_mut().skip(1) {
+            row.replace_columns(replace_with_columns.clone());
+        }
+
+        while self.viewport.len() < self.height {
+            self.viewport
+                .push_back(Row::from_columns(replace_with_columns.clone()).canonical());
+        }
+
+        self.cursor.y = 0;
+        self.set_scroll_region_to_viewport_size();
+        if let Some(images_to_reap) = self.sixel_grid.clear() {
+            self.sixel_grid.reap_images(images_to_reap);
+        }
+        self.output_buffer.update_all_lines();
         self.mark_for_rerender();
     }
     /// Dumps all lines above terminal vieport and the viewport itself to a string

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -1356,10 +1356,15 @@ fn clear_screen() {
     tab.clear_active_terminal_screen(client_id).unwrap();
     tab.dump_active_terminal_screen(Some(file.to_string()), client_id, false)
         .unwrap();
+    let dump = map.lock().unwrap().get(file).unwrap().clone();
+    assert!(
+        dump.starts_with("scratch"),
+        "screen was cleared but the cursor line should be preserved"
+    );
     assert_eq!(
-        map.lock().unwrap().get(file).unwrap(),
-        "",
-        "screen was cleared properly"
+        dump.chars().filter(|c| *c != '\n').collect::<String>(),
+        "scratch",
+        "only the cursor line should have content"
     );
 }
 


### PR DESCRIPTION
Fixes #5242

## Problem

`Grid::clear_screen()` was calling `reset_terminal_state()`, which performs a full terminal reset — wiping all scrollback, resetting viewport to a single empty row, and resetting all terminal modes.

The Zellij `ClearScreen` action (triggered by keybindings and `zellij clear` CLI) bypasses the shell entirely. The shell never knows the screen was cleared, so it never redraws its prompt. The user's current line (prompt + typed input) is lost.

## Fix

Changed `clear_screen()` to preserve the cursor line:

- **Lines above the cursor** are moved to scrollback (preserved)
- **The cursor line** (prompt + user input) is kept intact  
- **Lines below the cursor** are cleared
- **Cursor** moves to (0, 0)

This mimics what readline does when handling Ctrl+L in a normal terminal — the current line appears at the top of the cleared screen.