### PR TITLE
fix: report session state to plugins on FocusNextPane

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -6181,6 +6181,7 @@ pub(crate) fn screen_thread_main(
                         |tab: &mut Tab, client_id: ClientId| tab.focus_next_pane(client_id)
                     );
                     screen.render(None)?;
+                    screen.log_and_report_session_state()?;
                 }
             },
             ScreenInstruction::FocusPreviousPane(client_id, mut _completion_tx) => {


### PR DESCRIPTION
Fixes #5244

## What this does

Adds the missing `screen.log_and_report_session_state()?;` call to the `ScreenInstruction::FocusNextPane` handler, mirroring `FocusPreviousPane` and `SwitchFocus`.

## Why

`FocusNextPane` was the only focus-cycling instruction that moved focus without re-reporting session state. Since `log_and_report_session_state()` → `generate_and_report_pane_state()` is the only path that emits `Event::PaneUpdate`, plugins subscribed to it (tab-bar-style plugins highlighting the focused pane, etc.) never learned that focus moved — the stale state persisted until some unrelated action happened to report.

The asymmetry is visible in the handlers themselves: `FocusPreviousPane` makes the call after rendering, and `SwitchFocus` — which invokes the very same `tab.focus_next_pane` — makes it too. Full analysis, including instrumented-plugin measurements (keybound `FocusNextPane` delivered 0 `PaneUpdate` events, `FocusPreviousPane` exactly 1, reproduced across two independent bindings), is in #5244 and the linked investigation issue.

## Verification

- `cargo check -p zellij-server` passes.
- The added line is identical to the one in the `FocusPreviousPane` arm (same scope, same error propagation).
- Note for reviewers reproducing this: drive focus via **keybindings on an attached client** — `zellij action focus-next-pane` masks the bug, because the temporary CLI client's attach/detach triggers its own session-state report (details in #5244).
