### PR TITLE
fix(plugins): prevent spawning duplicated aliased plugins

### DIFF
--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -193,30 +193,29 @@ impl RunPluginOrAlias {
             (
                 RunPluginOrAlias::Alias(self_alias),
                 Some(Run::Plugin(RunPluginOrAlias::Alias(run_alias))),
-            ) => {
-                self_alias.name == run_alias.name
-                    && self_alias
-                        .configuration
-                        .as_ref()
-                        // we do the is_empty() checks because an empty configuration is the same as no
-                        // configuration (i.e. None)
-                        .and_then(|c| if c.inner().is_empty() { None } else { Some(c) })
-                        == run_alias.configuration.as_ref().and_then(|c| {
-                            let mut to_compare = c.inner().clone();
-                            // caller_cwd is a special attribute given to alias and should not be
-                            // considered when weighing configuration equivalency
-                            to_compare.remove("caller_cwd");
-                            if to_compare.is_empty() {
-                                None
-                            } else {
-                                Some(c)
-                            }
-                        })
-            },
+            ) => self_alias == run_alias,
             (
                 RunPluginOrAlias::Alias(self_alias),
                 Some(Run::Plugin(RunPluginOrAlias::RunPlugin(other_run_plugin))),
-            ) => self_alias.run_plugin.as_ref() == Some(other_run_plugin),
+            ) => {
+                if self_alias.run_plugin.as_ref() == Some(other_run_plugin) {
+                    // Alias explicitly resolves to this plugin (e.g., via a plugins { ... } block defining file/web locations)
+                    true
+                } else if self_alias.run_plugin.is_none() {
+                    // Built-in aliases (like "session-manager") often don't have run_plugin explicitly populated.
+                    // Their background instance location is typically "zellij:<alias_name>".
+                    let location_str = other_run_plugin.location.to_string();
+                    let name_matches = location_str == self_alias.name || location_str == format!("zellij:{}", self_alias.name);
+
+                    if !name_matches {
+                        return false;
+                    }
+
+                    self_alias.configuration.as_ref().unwrap_or(&PluginUserConfiguration::default()) == &other_run_plugin.configuration
+                } else {
+                    false
+                }
+            },
             (
                 RunPluginOrAlias::RunPlugin(self_run_plugin),
                 Some(Run::Plugin(RunPluginOrAlias::RunPlugin(other_run_plugin))),
@@ -525,8 +524,30 @@ impl PartialEq for RunPlugin {
 }
 impl Eq for RunPlugin {}
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct PluginUserConfiguration(BTreeMap<String, String>);
+
+impl PartialEq for PluginUserConfiguration {
+    fn eq(&self, other: &Self) -> bool {
+        let mut self_config = self.0.clone();
+        self_config.remove("caller_cwd");
+
+        let mut other_config = other.0.clone();
+        other_config.remove("caller_cwd");
+
+        self_config == other_config
+    }
+}
+
+impl Eq for PluginUserConfiguration {}
+
+impl std::hash::Hash for PluginUserConfiguration {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let mut config = self.0.clone();
+        config.remove("caller_cwd");
+        config.hash(state);
+    }
+}
 
 impl PluginUserConfiguration {
     pub fn new(mut configuration: BTreeMap<String, String>) -> Self {


### PR DESCRIPTION
Addresses #3409

When using `LaunchOrFocusPlugin` with a plugin alias (e.g., "session-manager") and custom configuration (like `floating true`), Zellij would incorrectly spawn a new plugin instance instead of focusing the existing one. This caused severe resource leakage (CPU burn/zombie plugins) on rapid keypresses.

The issue occurred because Zellij dynamically injects a `caller_cwd` into an invoked alias's configuration. The equivalence check failed to properly ignore this dynamic `caller_cwd` when matching against the background plugin. Furthermore, `is_equivalent_to_run` lacked the logic to compare an `Alias` directly against a canonical `RunPlugin` instance.

This commit fixes the issue by:
1. Implementing custom `PartialEq` and `Hash` for `PluginUserConfiguration` to explicitly ignore the `caller_cwd` key during comparisons.

2. Enhancing `is_equivalent_to_run` to properly match an `Alias` with a `RunPlugin` instance (e.g. matching alias "session-manager" to location "zellij:session-manager").