### PR TITLE
fix(plugins): close session-manager instead of hiding it when switchi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * feat: allow tabs to have different sizes if clients aren't focused on the same one (https://github.com/zellij-org/zellij/pull/5133)
 * feat: PWA support for the web client (manifest + icons + iOS meta tags) so the page can be installed as a standalone app (https://github.com/zellij-org/zellij/pull/5184)
 * feat: mobile UI (https://github.com/zellij-org/zellij/pull/5241)
+* fix: close session-manager instead of hiding it when switching sessions (https://github.com/zellij-org/zellij/pull/5249)
 
 ## [0.44.3] - 2026-05-13
 * fix(windows): bump windows-sys to 0.59 to align manifest with code, fixing source builds via `cargo install`/`cargo binstall` (https://github.com/zellij-org/zellij/pull/5139)

--- a/default-plugins/session-manager/src/main.rs
+++ b/default-plugins/session-manager/src/main.rs
@@ -1038,19 +1038,19 @@ impl State {
                 if let Some(renaming_session_name) = &self.renaming_session_name.take() {
                     if renaming_session_name.is_empty() {
                         self.show_error("New name must not be empty.");
-                        return; // so that we don't hide self
+                        return; // so that we don't close self
                     } else if self.session_name.as_ref() == Some(renaming_session_name) {
                         // noop - we're already called that!
-                        return; // so that we don't hide self
+                        return; // so that we don't close self
                     } else if self.sessions.has_session(&renaming_session_name) {
                         self.show_error("A session by this name already exists.");
-                        return; // so that we don't hide self
+                        return; // so that we don't close self
                     } else if self
                         .resurrectable_sessions
                         .has_session(&renaming_session_name)
                     {
                         self.show_error("A resurrectable session by this name already exists.");
-                        return; // s that we don't hide self
+                        return; // so that we don't close self
                     } else {
                         if renaming_session_name.contains('/') {
                             self.show_error("Session names cannot contain '/'");
@@ -1058,7 +1058,7 @@ impl State {
                         }
                         self.update_current_session_name_in_ui(&renaming_session_name);
                         rename_session(&renaming_session_name);
-                        return; // s that we don't hide self
+                        return; // so that we don't close self
                     }
                 }
                 if let Some(selected_session_name) = self.sessions.get_selected_session_name() {
@@ -1094,7 +1094,7 @@ impl State {
                     // session so as not to leave garbage sessions behind
                     quit_zellij();
                 } else {
-                    hide_self();
+                    close_self();
                 }
             },
             ActiveScreen::ResurrectSession => {
@@ -1107,7 +1107,7 @@ impl State {
                         // session so as not to leave garbage sessions behind
                         quit_zellij();
                     } else {
-                        hide_self();
+                        close_self();
                     }
                 }
             },
@@ -1163,7 +1163,7 @@ impl State {
                             if self.is_welcome_screen {
                                 quit_zellij();
                             } else {
-                                hide_self();
+                                close_self();
                             }
                         } else {
                             // No navigation - use typed name
@@ -1194,7 +1194,7 @@ impl State {
                                     if self.is_welcome_screen {
                                         quit_zellij();
                                     } else {
-                                        hide_self();
+                                        close_self();
                                     }
                                 }
                                 return;
@@ -1205,7 +1205,7 @@ impl State {
                                 if self.is_welcome_screen {
                                     quit_zellij();
                                 } else {
-                                    hide_self();
+                                    close_self();
                                 }
                                 return;
                             }
@@ -1237,7 +1237,7 @@ impl State {
                         if self.is_welcome_screen {
                             quit_zellij();
                         } else {
-                            hide_self();
+                            close_self();
                         }
                     },
                 }

--- a/default-plugins/session-manager/src/new_session_info.rs
+++ b/default-plugins/session-manager/src/new_session_info.rs
@@ -113,7 +113,7 @@ impl NewSessionInfo {
                                 // session so as not to leave garbage sessions behind
                                 quit_zellij();
                             } else {
-                                hide_self();
+                                close_self();
                             }
                         },
                         None => {
@@ -123,14 +123,14 @@ impl NewSessionInfo {
                                 // session so as not to leave garbage sessions behind
                                 quit_zellij();
                             } else {
-                                hide_self();
+                                close_self();
                             }
                         },
                     }
                 }
                 self.name.clear();
                 self.layout_list.clear_selection();
-                hide_self();
+                close_self();
             },
             EnteringState::EnteringName => {
                 self.entering_new_session_info = EnteringState::EnteringLayoutSearch;


### PR DESCRIPTION
# What this fixes

When switching to another session (or resurrecting one) from the session-manager, the plugin hid itself instead of closing. The hidden pane stayed alive in the session being left, attached to the tab it was launched from. The next `LaunchOrFocusPlugin` in that session would then focus that stale tab instead of the user's current one — even with `move_to_focused_tab true`.

This is the remaining part of #3834. #5055 fixed the Esc/Ctrl-c paths by replacing `hide_self()` with `close_self()`, but the switch-session paths still called `hide_self()`, so the bug kept reproducing whenever a session switch was performed through the manager (see [this comment](https://github.com/zellij-org/zellij/issues/3834#issuecomment-4254399953) from April reporting the issue still occurs).

# Reproduction

1. Create a session with two tabs, focus tab 1
2. Open the session-manager and press Enter to switch to another session
3. Come back to the first session, focus tab 2
4. Open the session-manager again → focus jumps to tab 1, while the manager pane is moved to tab 2

# Changes

Replace `hide_self()` with `close_self()` on all switch/resurrect paths, mirroring what #5055 did for the Esc/Ctrl-c handlers:

- `main.rs`: the `AttachToSession` and `ResurrectSession` Enter handlers, and the three `SingleScreen` flows (search-and-select, typed name match, layout selection)
- `new_session_info.rs`: the `NewSession` screen's Enter handler (both the with-layout and without-layout branches, plus the trailing dismissal)

The welcome-screen `quit_zellij()` branches are untouched, and the comments guarding the rename-validation early `return`s were updated to match ("don't hide self" → "don't close self").

# Testing

- `cargo fmt --all -- --check` — clean
- `cargo xtask test` — all tests pass
- `cargo xtask ci e2e --build` + `cargo xtask ci e2e --test` — 42/42 e2e cases and 146/146 plugin system tests pass