### PR TITLE
fix: line_wrap ignoring scroll region (autowrap corruption)

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1993,7 +1993,34 @@ impl Grid {
     }
     fn line_wrap(&mut self) {
         self.cursor.x = 0;
-        if self.cursor.y == self.height.saturating_sub(1) {
+        let (scroll_region_top, scroll_region_bottom) = self.scroll_region;
+        if self.cursor.y == scroll_region_bottom {
+            // Autowrap at the bottom of the scroll region: scroll the region
+            // up by one line (same as what add_canonical_line does for '\n').
+            if scroll_region_top >= self.viewport.len() {
+                // the state is corrupted (same guard as in add_canonical_line)
+                return;
+            }
+            if scroll_region_top == 0
+                && self.alternate_screen_state.is_none()
+                && !self.viewport.is_empty()
+            {
+                self.transfer_rows_to_lines_above(1);
+                self.hyperlink_tracker.offset_cursor_lines(1);
+                self.selection.move_up(1);
+            } else if scroll_region_top < self.viewport.len() {
+                self.viewport.remove(scroll_region_top);
+            }
+            let wrapped_row = Row::new();
+            if self.viewport.len() >= scroll_region_bottom {
+                self.viewport.insert(scroll_region_bottom, wrapped_row);
+            } else {
+                self.viewport.push_back(wrapped_row);
+            }
+            self.output_buffer.update_all_lines();
+        } else if self.cursor.y == self.height.saturating_sub(1) {
+            // Autowrap at the very bottom of the viewport (cursor below
+            // scroll region or scroll region spans entire height).
             if self.alternate_screen_state.is_none() {
                 self.transfer_rows_to_lines_above(1);
                 self.hyperlink_tracker.offset_cursor_lines(1);

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -6102,3 +6102,44 @@ fn csi_5n_status_query_still_handled_locally() {
         "DSR 5 must still produce its local 'all good' reply"
     );
 }
+
+#[test]
+fn line_wrap_inside_scroll_region_scrolls_region() {
+    // Set up a 10-row, 10-col grid with scroll region rows 1-8 (0-based: 0-7).
+    // Fill to the bottom of the scroll region, then print a line long enough
+    // to trigger autowrap. The wrap should scroll within the region (like a
+    // newline does), NOT move the cursor past the region boundary.
+    let cols = 10;
+
+    // Fill viewport first so all 10 rows exist, then set scroll region.
+    let mut content: Vec<u8> = Vec::new();
+    // Fill all 10 rows with placeholder content
+    content.extend_from_slice(b".\r\n.\r\n.\r\n.\r\n.\r\n.\r\n.\r\n.\r\n.\r\n.");
+    // Set scroll region rows 1-8 (1-based), which is 0-7 in 0-based.
+    // DECSTBM moves cursor to (0,0).
+    content.extend_from_slice(b"\x1b[1;8r");
+    // Fill the 8 rows of the scroll region
+    content.extend_from_slice(b"AAA\r\nBBB\r\nCCC\r\nDDD\r\nEEE\r\nFFF\r\nGGG\r\n");
+    // Now on row 7 (last row of scroll region). Print exactly 10 chars.
+    content.extend_from_slice(b"HHHHHHHHHH"); // fills the row
+    content.extend_from_slice(b"X"); // 11th char triggers line_wrap
+
+    let grid = create_grid_with_size_and_raw(10, cols, &content);
+
+    // The cursor should still be within the scroll region (row <= 7)
+    assert!(
+        grid.cursor.y <= 7,
+        "cursor escaped scroll region: cursor.y = {} (should be <= 7)",
+        grid.cursor.y
+    );
+
+    // "AAA" should have been scrolled off the top of the region
+    let vp = viewport_texts(&grid);
+    assert_eq!(vp[0], "BBB", "first visible row after scroll");
+    assert_eq!(vp[6], "HHHHHHHHHH", "wrapped line's first part");
+    assert_eq!(vp[7], "X", "wrapped character on new line");
+
+    // Rows 8 and 9 (outside scroll region) should retain original content
+    assert_eq!(vp[8], ".", "row below scroll region should be untouched");
+    assert_eq!(vp[9], ".", "last row should be untouched");
+}


### PR DESCRIPTION
AI disclosure: this fix was generated with AI and reviewed by myself.

When a character exceeded the line width inside a scroll region, line_wrap() would blindly increment cursor.y without checking whether the cursor was at the scroll region bottom. This caused the cursor to escape the scroll region boundary, corrupting the display in terminal multiplexers like zellij.

The fix adds a scroll-region-aware branch to line_wrap() that mirrors the existing logic in add_canonical_line(): when the cursor is at scroll_region_bottom, remove the top line of the region and insert a new empty line at the bottom, keeping the cursor within bounds.

This matches the DEC VT behavior: autowrap at the last column of the last row in a scroll region should scroll the region, not move the cursor below it.

Changes:
- zellij-server/src/panes/grid.rs: Added scroll_region_bottom check to line_wrap(), scrolling within the region when the cursor is at its bottom boundary.
- zellij-server/src/panes/unit/grid_tests.rs: Added regression test line_wrap_inside_scroll_region_scrolls_region that verifies the cursor stays within the region and rows outside are untouched.

A possible followup would be to unify (some of) the three places that do "scroll within region" logic:
1. `add_canonical_line()` — handles `\n`
2. `rotate_scroll_region_down()` — handles CSI S
3. `line_wrap()` — our fix (handles autowrap)

The AI also pointed out that the hyperlink handling in `line_wrap` is suspicious. I don't know enough one way or the other.

Also not sure if this change should handle the bg color propagation a la ecac12f3 - the existing code doesn't.