### PR TITLE
feat(plugin-api): add paste commands for plugins

### DIFF
--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -322,6 +322,7 @@ fn host_run_plugin_command(mut caller: Caller<'_, PluginEnv>) {
                     PluginCommand::EditScrollback => edit_scrollback(env),
                     PluginCommand::Write(bytes) => write(env, bytes),
                     PluginCommand::WriteChars(chars) => write_chars(env, chars),
+                    PluginCommand::Paste(chars) => paste(env, chars),
                     PluginCommand::CopyToClipboard(text) => copy_to_clipboard(env, text)?,
                     PluginCommand::ToggleTab => toggle_tab(env),
                     PluginCommand::MovePane => move_pane(env),
@@ -506,6 +507,9 @@ fn host_run_plugin_command(mut caller: Caller<'_, PluginEnv>) {
                     },
                     PluginCommand::WriteCharsToPaneId(chars, pane_id) => {
                         write_chars_to_pane_id(env, chars, pane_id.into())
+                    },
+                    PluginCommand::PasteToPaneId(chars, pane_id) => {
+                        paste_to_pane_id(env, chars, pane_id)
                     },
                     PluginCommand::SendSigintToPaneId(pane_id) => {
                         send_sigint_to_pane_id(env, pane_id.into())
@@ -3070,6 +3074,15 @@ fn write_chars(env: &PluginEnv, chars_to_write: String) {
     apply_action!(action, error_msg, env);
 }
 
+fn paste(env: &PluginEnv, chars_to_paste: String) {
+    let error_msg = || format!("failed to paste in plugin {}", env.name());
+    let action = Action::Paste {
+        chars: chars_to_paste,
+        pane_id: None,
+    };
+    apply_action!(action, error_msg, env);
+}
+
 fn copy_to_clipboard(env: &PluginEnv, text: String) -> Result<()> {
     env.senders
         .send_to_screen(ScreenInstruction::CopyTextToClipboard(text, env.plugin_id))
@@ -4221,6 +4234,15 @@ fn write_chars_to_pane_id(env: &PluginEnv, chars: String, pane_id: PaneId) {
         let wait_forever = false;
         let _ = wait_for_action_completion(completion_rx, "write_chars_to_pane_id", wait_forever);
     }
+}
+
+fn paste_to_pane_id(env: &PluginEnv, chars_to_paste: String, pane_id: zellij_utils::data::PaneId) {
+    let error_msg = || format!("failed to paste to pane id in plugin {}", env.name());
+    let action = Action::Paste {
+        chars: chars_to_paste,
+        pane_id: Some(pane_id),
+    };
+    apply_action!(action, error_msg, env);
 }
 
 fn send_sigint_to_pane_id(env: &PluginEnv, pane_id: PaneId) {
@@ -5465,7 +5487,9 @@ fn check_command_permission(
         PluginCommand::Write(..)
         | PluginCommand::WriteChars(..)
         | PluginCommand::WriteToPaneId(..)
-        | PluginCommand::WriteCharsToPaneId(..) => PermissionType::WriteToStdin,
+        | PluginCommand::WriteCharsToPaneId(..)
+        | PluginCommand::Paste(..)
+        | PluginCommand::PasteToPaneId(..) => PermissionType::WriteToStdin,
         PluginCommand::CopyToClipboard(..) => PermissionType::WriteToClipboard,
         PluginCommand::SwitchTabTo(..)
         | PluginCommand::SwitchToMode(..)

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -1192,6 +1192,14 @@ pub fn write_chars(chars: &str) {
     unsafe { host_run_plugin_command() };
 }
 
+/// Paste characters to the `STDIN` of the focused pane using Zellij's paste path.
+pub fn paste(chars: &str) {
+    let plugin_command = PluginCommand::Paste(chars.to_owned());
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
 /// Copy arbitrary text to the user's clipboard
 ///
 /// Respects the user's configured clipboard destination (system clipboard or primary selection).
@@ -1929,6 +1937,14 @@ pub fn write_to_pane_id(bytes: Vec<u8>, pane_id: PaneId) {
 /// Write characters to the `STDIN` of the specified pane
 pub fn write_chars_to_pane_id(chars: &str, pane_id: PaneId) {
     let plugin_command = PluginCommand::WriteCharsToPaneId(chars.to_owned(), pane_id);
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
+/// Paste characters to the `STDIN` of the specified pane using Zellij's paste path.
+pub fn paste_to_pane_id(chars: &str, pane_id: PaneId) {
+    let plugin_command = PluginCommand::PasteToPaneId(chars.to_owned(), pane_id);
     let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
     object_to_stdout(&protobuf_plugin_command.encode_to_vec());
     unsafe { host_run_plugin_command() };

--- a/zellij-utils/assets/prost/api.plugin_command.rs
+++ b/zellij-utils/assets/prost/api.plugin_command.rs
@@ -4,7 +4,7 @@
 pub struct PluginCommand {
     #[prost(enumeration="CommandName", tag="1")]
     pub name: i32,
-    #[prost(oneof="plugin_command::Payload", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 168, 169, 170, 171")]
+    #[prost(oneof="plugin_command::Payload", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 168, 169, 170, 171, 172, 173")]
     pub payload: ::core::option::Option<plugin_command::Payload>,
 }
 /// Nested message and enum types in `PluginCommand`.
@@ -320,6 +320,10 @@ pub mod plugin_command {
         SetPaneFrameStylePayload(super::SetPaneFrameStylePayload),
         #[prost(message, tag="171")]
         ToggleFloatingPanesPayload(super::ToggleFloatingPanesPayload),
+        #[prost(string, tag="172")]
+        PastePayload(::prost::alloc::string::String),
+        #[prost(message, tag="173")]
+        PasteToPaneIdPayload(super::PasteToPaneIdPayload),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -719,6 +723,14 @@ pub struct CloseTabWithIndexPayload {
 pub struct WriteCharsToPaneIdPayload {
     #[prost(string, tag="1")]
     pub chars_to_write: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="2")]
+    pub pane_id: ::core::option::Option<PaneId>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PasteToPaneIdPayload {
+    #[prost(string, tag="1")]
+    pub chars_to_paste: ::prost::alloc::string::String,
     #[prost(message, optional, tag="2")]
     pub pane_id: ::core::option::Option<PaneId>,
 }
@@ -2227,6 +2239,8 @@ pub enum CommandName {
     NewPane = 226,
     ToggleFocusNoUiFullscreen = 227,
     FocusHostSession = 228,
+    Paste = 229,
+    PasteToPaneId = 230,
 }
 impl CommandName {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -2438,6 +2452,8 @@ impl CommandName {
             CommandName::NewPane => "NewPane",
             CommandName::ToggleFocusNoUiFullscreen => "ToggleFocusNoUiFullscreen",
             CommandName::FocusHostSession => "FocusHostSession",
+            CommandName::Paste => "Paste",
+            CommandName::PasteToPaneId => "PasteToPaneId",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -2646,6 +2662,8 @@ impl CommandName {
             "NewPane" => Some(Self::NewPane),
             "ToggleFocusNoUiFullscreen" => Some(Self::ToggleFocusNoUiFullscreen),
             "FocusHostSession" => Some(Self::FocusHostSession),
+            "Paste" => Some(Self::Paste),
+            "PasteToPaneId" => Some(Self::PasteToPaneId),
             _ => None,
         }
     }

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -3411,6 +3411,7 @@ pub enum PluginCommand {
     EditScrollback,
     Write(Vec<u8>), // bytes
     WriteChars(String),
+    Paste(String),
     ToggleTab,
     MovePane,
     MovePaneWithDirection(Direction),
@@ -3494,6 +3495,7 @@ pub enum PluginCommand {
     },
     WriteToPaneId(Vec<u8>, PaneId),
     WriteCharsToPaneId(String, PaneId),
+    PasteToPaneId(String, PaneId),
     SendSigintToPaneId(PaneId),
     SendSigkillToPaneId(PaneId),
     GetPanePid {

--- a/zellij-utils/src/plugin_api/plugin_command.proto
+++ b/zellij-utils/src/plugin_api/plugin_command.proto
@@ -218,6 +218,8 @@ enum CommandName {
   NewPane = 226;
   ToggleFocusNoUiFullscreen = 227;
   FocusHostSession = 228;
+  Paste = 229;
+  PasteToPaneId = 230;
 }
 
 message PluginCommand {
@@ -378,6 +380,8 @@ message PluginCommand {
     NewTiledPaneInTabPayload new_tiled_pane_in_tab_payload = 169;
     SetPaneFrameStylePayload set_pane_frame_style_payload = 170;
     ToggleFloatingPanesPayload toggle_floating_panes_payload = 171;
+    string paste_payload = 172;
+    PasteToPaneIdPayload paste_to_pane_id_payload = 173;
   }
 }
 
@@ -630,6 +634,11 @@ message CloseTabWithIndexPayload {
 
 message WriteCharsToPaneIdPayload {
   string chars_to_write = 1;
+  PaneId pane_id = 2;
+}
+
+message PasteToPaneIdPayload {
+  string chars_to_paste = 1;
   PaneId pane_id = 2;
 }
 

--- a/zellij-utils/src/plugin_api/plugin_command.rs
+++ b/zellij-utils/src/plugin_api/plugin_command.rs
@@ -109,13 +109,14 @@ pub use super::generated_api::api::{
         OpenTerminalResponse as ProtobufOpenTerminalResponse, OverrideLayoutPayload,
         PageScrollDownInPaneIdPayload, PageScrollUpInPaneIdPayload, PaneId as ProtobufPaneId,
         PaneIdAndFloatingPaneCoordinates, PaneType as ProtobufPaneType, ParseLayoutPayload,
-        ParseLayoutResponse as ProtobufParseLayoutResponse, PluginCommand as ProtobufPluginCommand,
-        PluginMessagePayload, RebindKeysPayload, ReconfigurePayload,
-        RegexHighlight as ProtobufRegexHighlight, ReloadPluginPayload, RenameLayoutPayload,
-        RenameLayoutResponse as ProtobufRenameLayoutResponse, RenameTabWithIdPayload,
-        RenameWebLoginTokenPayload, RenameWebTokenResponse, ReplacePaneWithExistingPanePayload,
-        RequestPluginPermissionPayload, RerunCommandPanePayload, ResizePaneIdWithDirectionPayload,
-        ResizePayload, RevokeAllWebTokensResponse, RevokeTokenResponse, RevokeWebLoginTokenPayload,
+        ParseLayoutResponse as ProtobufParseLayoutResponse, PasteToPaneIdPayload,
+        PluginCommand as ProtobufPluginCommand, PluginMessagePayload, RebindKeysPayload,
+        ReconfigurePayload, RegexHighlight as ProtobufRegexHighlight, ReloadPluginPayload,
+        RenameLayoutPayload, RenameLayoutResponse as ProtobufRenameLayoutResponse,
+        RenameTabWithIdPayload, RenameWebLoginTokenPayload, RenameWebTokenResponse,
+        ReplacePaneWithExistingPanePayload, RequestPluginPermissionPayload,
+        RerunCommandPanePayload, ResizePaneIdWithDirectionPayload, ResizePayload,
+        RevokeAllWebTokensResponse, RevokeTokenResponse, RevokeWebLoginTokenPayload,
         RunActionPayload, RunCommandPayload, RunningCommand as ProtobufRunningCommand,
         SaveLayoutPayload, SaveLayoutResponse as ProtobufSaveLayoutResponse, SaveSessionPayload,
         SaveSessionResponse as ProtobufSaveSessionResponse, ScrollDownInPaneIdPayload,
@@ -1022,6 +1023,10 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
                 Some(Payload::WriteCharsPayload(chars)) => Ok(PluginCommand::WriteChars(chars)),
                 _ => Err("Mismatched payload for WriteChars"),
             },
+            Some(CommandName::Paste) => match protobuf_plugin_command.payload {
+                Some(Payload::PastePayload(chars)) => Ok(PluginCommand::Paste(chars)),
+                _ => Err("Mismatched payload for Paste"),
+            },
             Some(CommandName::ToggleTab) => {
                 if protobuf_plugin_command.payload.is_some() {
                     return Err("ToggleTab should not have a payload");
@@ -1673,6 +1678,18 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
                     }
                 },
                 _ => Err("Mismatched payload for WriteCharsCharsToPaneId"),
+            },
+            Some(CommandName::PasteToPaneId) => match protobuf_plugin_command.payload {
+                Some(Payload::PasteToPaneIdPayload(paste_to_pane_id_payload)) => {
+                    match paste_to_pane_id_payload.pane_id {
+                        Some(pane_id) => Ok(PluginCommand::PasteToPaneId(
+                            paste_to_pane_id_payload.chars_to_paste,
+                            pane_id.try_into()?,
+                        )),
+                        _ => Err("Malformed paste_to_pane_id payload"),
+                    }
+                },
+                _ => Err("Mismatched payload for PasteToPaneId"),
             },
             Some(CommandName::SendSigintToPaneId) => match protobuf_plugin_command.payload {
                 Some(Payload::SendSigintToPaneIdPayload(pane_id)) => {
@@ -3050,6 +3067,10 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
                 name: CommandName::WriteChars as i32,
                 payload: Some(Payload::WriteCharsPayload(chars)),
             }),
+            PluginCommand::Paste(chars) => Ok(ProtobufPluginCommand {
+                name: CommandName::Paste as i32,
+                payload: Some(Payload::PastePayload(chars)),
+            }),
             PluginCommand::ToggleTab => Ok(ProtobufPluginCommand {
                 name: CommandName::ToggleTab as i32,
                 payload: None,
@@ -3560,6 +3581,13 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
                     )),
                 })
             },
+            PluginCommand::PasteToPaneId(chars_to_paste, pane_id) => Ok(ProtobufPluginCommand {
+                name: CommandName::PasteToPaneId as i32,
+                payload: Some(Payload::PasteToPaneIdPayload(PasteToPaneIdPayload {
+                    chars_to_paste,
+                    pane_id: Some(pane_id.try_into()?),
+                })),
+            }),
             PluginCommand::SendSigintToPaneId(pane_id) => Ok(ProtobufPluginCommand {
                 name: CommandName::SendSigintToPaneId as i32,
                 payload: Some(Payload::SendSigintToPaneIdPayload(pane_id.try_into()?)),


### PR DESCRIPTION
## Summary

This PR adds plugin API commands for pasting text through Zellij's existing paste path.

New plugin APIs:

```rust
paste(chars: &str)
paste_to_pane_id(chars: &str, pane_id: PaneId)
````

These commands allow plugins to paste text into the focused pane or a specific pane using Zellij's existing `Action::Paste` / `ScreenInstruction::Paste` flow, instead of manually writing bracketed paste escape sequences through `write_chars`.

## Motivation

Plugins can currently send input to panes with APIs such as:

```rust
write(...)
write_chars(...)
write_to_pane_id(...)
write_chars_to_pane_id(...)
```

For clipboard-related workflows, plugins can currently use `write_chars` to send the clipboard contents, but this is treated as normal stdin input rather than paste input. To preserve paste semantics, plugins need to manually emit bracketed paste escape sequences.

Zellij already has a dedicated paste path via `Action::Paste`, so this PR exposes that behavior to plugins directly.

## Changes

This PR adds:

* `PluginCommand::Paste(String)`
* `PluginCommand::PasteToPaneId(String, PaneId)`
* protobuf command variants:
  * `Paste`
  * `PasteToPaneId`
  * `paste_payload`
  * `paste_to_pane_id_payload`
* public shim APIs:
  * `paste(chars: &str)`
  * `paste_to_pane_id(chars: &str, pane_id: PaneId)`
* server-side command handling that routes to `Action::Paste`
* permission mapping to the existing `PermissionType::WriteToStdin`

## Permission model

The new paste commands require the existing `WriteToStdin` permission.

This matches the existing write-related plugin commands:

* `Write`
* `WriteChars`
* `WriteToPaneId`
* `WriteCharsToPaneId`
