### PR TITLE
fix(grid): avoid extra empty line in ANSI scrollback output

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -404,6 +404,7 @@ macro_rules! dump_screen_with_ansi {
         let mut is_first = true;
         let mut buf = String::new();
         let mut last_styles: Option<RcCharacterStyles> = None;
+        let mut emitted_cell = false;
 
         for line in &$lines {
             if line.is_canonical && !is_first {
@@ -429,10 +430,15 @@ macro_rules! dump_screen_with_ansi {
                     last_styles = Some(tc.styles.clone());
                 }
                 buf.push(tc.character);
+                emitted_cell = true;
             }
             is_first = false;
         }
-        buf.push_str("\u{1b}[m");
+
+        if emitted_cell {
+            buf.push_str("\u{1b}[m");
+        }
+
         buf
     }};
 }


### PR DESCRIPTION
## Summary

Fixes #5256.

This fixes an issue where ANSI-enabled scrollback output could include an extra empty line before the viewport content.

This affected both:

```bash
zellij action edit-scrollback --ansi
````

and:

```bash
zellij action dump-screen --full --ansi
```

when the viewport was not yet fully filled.

## Cause

`dump_screen_with_ansi` always appended the final ANSI reset sequence (`ESC[m`), even when no cells were emitted.

Because of this, an otherwise empty scrollback dump became non-empty. When the full output was assembled, the empty scrollback part was treated as existing content, which caused a separator newline to be inserted before the viewport.

As a result, the output started with an extra line containing only `ESC[m`.

## Changes

This PR tracks whether `dump_screen_with_ansi` actually emitted any cells.

The final ANSI reset sequence is now appended only when at least one cell was emitted.

This keeps empty ANSI dumps empty, while preserving the final reset sequence for non-empty dumps.