### PR TITLE
fix(grid): preserve spaces in wrapped scrollback dumps

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -383,15 +383,22 @@ macro_rules! dump_screen {
     ($lines:expr) => {{
         let mut is_first = true;
         let mut buf = String::with_capacity($lines.iter().map(|l| l.len()).sum());
+        let mut lines = $lines.iter().peekable();
 
-        for line in &$lines {
+        while let Some(line) = lines.next() {
             if line.is_canonical && !is_first {
                 buf.push_str("\n");
             }
             let s: String = (&line.columns).into_iter().map(|x| x.character).collect();
+            let next_line_is_wrap = lines.peek().map(|l| !l.is_canonical).unwrap_or(false);
             // Replace the spaces at the end of the line. Sometimes, the lines are
-            // collected with spaces until the end of the panel.
-            buf.push_str(&s.trim_end_matches(' '));
+            // collected with spaces until the end of the panel. Preserve them when
+            // the next line is a wrapped continuation.
+            if next_line_is_wrap {
+                buf.push_str(&s);
+            } else {
+                buf.push_str(&s.trim_end_matches(' '));
+            }
             is_first = false;
         }
         buf
@@ -404,23 +411,28 @@ macro_rules! dump_screen_with_ansi {
         let mut is_first = true;
         let mut buf = String::new();
         let mut last_styles: Option<RcCharacterStyles> = None;
+        let mut lines = $lines.iter().peekable();
 
-        for line in &$lines {
+        while let Some(line) = lines.next() {
             if line.is_canonical && !is_first {
                 buf.push_str("\n");
                 last_styles = None;
             }
 
-            let last_non_space = line
-                .columns
-                .iter()
-                .rposition(|tc| {
-                    let space = tc.character == ' ';
-                    let styled = !matches!(tc.styles.background, Some(AnsiCode::Reset) | None);
-                    !space || styled // it's, something drawable
-                })
-                .map(|i| i + 1)
-                .unwrap_or(0);
+            let next_line_is_wrap = lines.peek().map(|l| !l.is_canonical).unwrap_or(false);
+            let last_non_space = if next_line_is_wrap {
+                line.columns.len()
+            } else {
+                line.columns
+                    .iter()
+                    .rposition(|tc| {
+                        let space = tc.character == ' ';
+                        let styled = !matches!(tc.styles.background, Some(AnsiCode::Reset) | None);
+                        !space || styled // it's, something drawable
+                    })
+                    .map(|i| i + 1)
+                    .unwrap_or(0)
+            };
 
             for tc in line.columns.iter().take(last_non_space) {
                 // Only output style codes if style changed

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -463,15 +463,22 @@ macro_rules! dump_screen {
     ($lines:expr) => {{
         let mut is_first = true;
         let mut buf = String::with_capacity($lines.iter().map(|l| l.len()).sum());
+        let mut lines = $lines.iter().peekable();
 
-        for line in &$lines {
+        while let Some(line) = lines.next() {
             if line.is_canonical && !is_first {
                 buf.push_str("\n");
             }
             let s: String = (&line.columns).into_iter().map(|x| x.character).collect();
+            let next_line_is_wrap = lines.peek().map(|l| !l.is_canonical).unwrap_or(false);
             // Replace the spaces at the end of the line. Sometimes, the lines are
-            // collected with spaces until the end of the panel.
-            buf.push_str(&s.trim_end_matches(' '));
+            // collected with spaces until the end of the panel. Preserve them when
+            // the next line is a wrapped continuation.
+            if next_line_is_wrap {
+                buf.push_str(&s);
+            } else {
+                buf.push_str(&s.trim_end_matches(' '));
+            }
             is_first = false;
         }
         buf
@@ -484,23 +491,28 @@ macro_rules! dump_screen_with_ansi {
         let mut is_first = true;
         let mut buf = String::new();
         let mut last_styles: Option<RcCharacterStyles> = None;
+        let mut lines = $lines.iter().peekable();
 
-        for line in &$lines {
+        while let Some(line) = lines.next() {
             if line.is_canonical && !is_first {
                 buf.push_str("\n");
                 last_styles = None;
             }
 
-            let last_non_space = line
-                .columns
-                .iter()
-                .rposition(|tc| {
-                    let space = tc.character == ' ';
-                    let styled = !matches!(tc.styles.background, Some(AnsiCode::Reset) | None);
-                    !space || styled // it's, something drawable
-                })
-                .map(|i| i + 1)
-                .unwrap_or(0);
+            let next_line_is_wrap = lines.peek().map(|l| !l.is_canonical).unwrap_or(false);
+            let last_non_space = if next_line_is_wrap {
+                line.columns.len()
+            } else {
+                line.columns
+                    .iter()
+                    .rposition(|tc| {
+                        let space = tc.character == ' ';
+                        let styled = !matches!(tc.styles.background, Some(AnsiCode::Reset) | None);
+                        !space || styled // it's, something drawable
+                    })
+                    .map(|i| i + 1)
+                    .unwrap_or(0)
+            };
 
             for tc in line.columns.iter().take(last_non_space) {
                 // Only output style codes if style changed

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -6102,3 +6102,20 @@ fn csi_5n_status_query_still_handled_locally() {
         "DSR 5 must still produce its local 'all good' reply"
     );
 }
+
+#[test]
+fn dump_screen_preserves_trailing_spaces_before_wrapped_continuation() {
+    let grid = create_grid_with_size_and_raw(3, 10, b"a   b     c");
+
+    assert_eq!(grid.dump_screen(false), "a   b     c");
+}
+
+#[test]
+fn dump_screen_with_ansi_preserves_trailing_spaces_before_wrapped_continuation() {
+    let grid = create_grid_with_size_and_raw(3, 10, b"\x1b[31ma   b     c\x1b[0m");
+    let ansi_escape = regex::Regex::new(r"\x1b\[[0-9;]*m").unwrap();
+    let dumped = grid.dump_screen_with_ansi(false);
+    let stripped = ansi_escape.replace_all(&dumped, "").to_string();
+
+    assert_eq!(stripped, "a   b     c");
+}

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -9147,3 +9147,20 @@ fn a_character_wider_than_two_columns_advances_the_cursor_by_its_full_width() {
     assert_eq!(row.width(), 4);
     assert_eq!(cursor_position(&grid), Some((4, 0)));
 }
+
+#[test]
+fn dump_screen_preserves_trailing_spaces_before_wrapped_continuation() {
+    let grid = create_grid_with_size_and_raw(3, 10, b"a   b     c");
+
+    assert_eq!(grid.dump_screen(false), "a   b     c");
+}
+
+#[test]
+fn dump_screen_with_ansi_preserves_trailing_spaces_before_wrapped_continuation() {
+    let grid = create_grid_with_size_and_raw(3, 10, b"\x1b[31ma   b     c\x1b[0m");
+    let ansi_escape = regex::Regex::new(r"\x1b\[[0-9;]*m").unwrap();
+    let dumped = grid.dump_screen_with_ansi(false);
+    let stripped = ansi_escape.replace_all(&dumped, "").to_string();
+
+    assert_eq!(stripped, "a   b     c");
+}


### PR DESCRIPTION
## Summary

Fixes #5259.

This fixes an issue where spaces could disappear from scrollback dump output
when a line wraps.

This affects scrollback output used by commands such as:

```bash
zellij action dump-screen
zellij action edit-scrollback
````

and their ANSI variants.

## Cause

The dump logic trimmed trailing spaces per physical row.

That behavior is correct for the final physical row of a logical line, where
trailing spaces are usually terminal padding. However, it is not correct when
the next row is a wrapped continuation row.

In that case, trailing spaces on the current row belong to the original logical
line and should not be removed.

For example, with a narrow pane, one logical line can be displayed as two
physical rows:

```text
a   b     
c
```

The spaces after `b` are part of the logical line. If they are trimmed before
appending the wrapped continuation row, the dumped output becomes:

```text
a   bc
```

instead of:

```text
a   b     c
```

## Changes

* Preserve trailing spaces when the next row is a non-canonical wrapped
  continuation row.
* Keep the existing trailing-space trimming behavior for final rows of logical
  lines.
* Apply the same behavior to both:
  * `dump_screen!`
  * `dump_screen_with_ansi!`
* Add regression tests for both plain and ANSI screen dumps.

## Tests

Added regression tests covering both dump paths:

* `dump_screen_preserves_trailing_spaces_before_wrapped_continuation`
* `dump_screen_with_ansi_preserves_trailing_spaces_before_wrapped_continuation`
