### PR TITLE
fix(terminal): don't log normal PTY closure as error

### DIFF
--- a/zellij-server/src/terminal_bytes.rs
+++ b/zellij-server/src/terminal_bytes.rs
@@ -54,6 +54,10 @@ impl TerminalBytes {
         loop {
             match self.async_reader.read(&mut buf).await {
                 Ok(0) => break, // EOF
+                Err(err) if is_pty_closed_error(&err) => {
+                    log::debug!("PTY closed while reading terminal bytes: {}", err);
+                    break;
+                },
                 Err(err) => {
                     log::error!("{}", err);
                     break;
@@ -105,4 +109,15 @@ impl TerminalBytes {
             .context("failed to block on sending message to screen")?;
         Ok(sent_at.elapsed())
     }
+}
+
+#[cfg(unix)]
+fn is_pty_closed_error(err: &std::io::Error) -> bool {
+    // On Unix/Linux, reading from the PTY master can return EIO when the
+    // slave side has been closed. Treat it as an EOF-like condition.
+    err.raw_os_error() == Some(libc::EIO)
+}
+#[cfg(not(unix))]
+fn is_pty_closed_error(_: &std::io::Error) -> bool {
+    false
 }


### PR DESCRIPTION
## Summary

Part of #5261.

This PR prevents a misleading ERROR log when a terminal pane exits normally.

When a pane shell exits, the terminal byte reader can receive:

```text
Input/output error (os error 5)
````

This is currently logged as an ERROR from `terminal_bytes.rs`, even though it can
happen during normal PTY closure.

## Problem

On Unix/Linux, reading from the PTY master can return `EIO` when the PTY slave
side has been closed.

This happens during normal pane termination, for example when the shell exits.

Before this change, this normal shutdown path produced an ERROR log like:

```text
ERROR |zellij_server::terminal_b| ... zellij-server/src/terminal_bytes.rs:58: Input/output error (os error 5)
```

This makes a normal pane exit look like an internal failure.

## Change
Treat `EIO` from the PTY reader as an EOF-like condition and log it at debug level instead of error level.
Other read errors are still logged as errors as before.