### PR TITLE
fix(route): distinguish client IO errors from malformed messages

### DIFF
--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -28,7 +28,10 @@ use zellij_utils::{
         actions::{Action, SearchDirection, SearchOption},
         command::TerminalAction,
     },
-    ipc::{ClientToServerMsg, ExitReason, IpcReceiverWithContext, ResizeCause, ServerToClientMsg},
+    ipc::{
+        ClientToServerMsg, ExitReason, IpcReceiverWithContext, RecvClientMsg, ResizeCause,
+        ServerToClientMsg,
+    },
 };
 
 use crate::ClientId;
@@ -2163,7 +2166,7 @@ pub(crate) fn route_thread_main(
     let mut consecutive_unknown_messages_received = 0;
     'route_loop: loop {
         match receiver.recv_client_msg() {
-            Some((instruction, err_ctx)) => {
+            RecvClientMsg::Message(instruction, err_ctx) => {
                 consecutive_unknown_messages_received = 0;
                 err_ctx.update_thread_ctx();
                 let mut handle_instruction = |instruction: ClientToServerMsg,
@@ -2688,7 +2691,10 @@ pub(crate) fn route_thread_main(
                     break 'route_loop;
                 }
             },
-            None => {
+            RecvClientMsg::IoError => {
+                break 'route_loop;
+            },
+            RecvClientMsg::Malformed => {
                 consecutive_unknown_messages_received += 1;
                 if consecutive_unknown_messages_received == 1 {
                     log::error!("Received unknown message from client.");

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -28,7 +28,9 @@ use zellij_utils::{
         actions::{Action, SearchDirection, SearchOption},
         command::TerminalAction,
     },
-    ipc::{ClientToServerMsg, ExitReason, IpcReceiverWithContext, ServerToClientMsg},
+    ipc::{
+        ClientToServerMsg, ExitReason, IpcReceiverWithContext, RecvClientMsg, ServerToClientMsg,
+    },
 };
 
 use crate::ClientId;
@@ -2230,7 +2232,7 @@ pub(crate) fn route_thread_main(
     let mut consecutive_unknown_messages_received = 0;
     'route_loop: loop {
         match receiver.recv_client_msg() {
-            Some((instruction, err_ctx)) => {
+            RecvClientMsg::Message(instruction, err_ctx) => {
                 consecutive_unknown_messages_received = 0;
                 err_ctx.update_thread_ctx();
                 let mut handle_instruction = |instruction: ClientToServerMsg,
@@ -2869,7 +2871,10 @@ pub(crate) fn route_thread_main(
                 // retry on loop around
                 retry_queue = deferred_instructions;
             },
-            None => {
+            RecvClientMsg::IoError => {
+                break 'route_loop;
+            },
+            RecvClientMsg::Malformed => {
                 consecutive_unknown_messages_received += 1;
                 if consecutive_unknown_messages_received == 1 {
                     log::error!("Received unknown message from client.");

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -342,6 +342,13 @@ pub struct IpcReceiverWithContext<T> {
     _phantom: PhantomData<T>,
 }
 
+#[derive(Debug)]
+pub enum RecvClientMsg {
+    Message(ClientToServerMsg, ErrorContext),
+    IoError,
+    Malformed,
+}
+
 impl<T> IpcReceiverWithContext<T>
 where
     T: for<'de> Deserialize<'de> + Serialize,
@@ -361,16 +368,22 @@ where
         }
     }
 
-    pub fn recv_client_msg(&mut self) -> Option<(ClientToServerMsg, ErrorContext)> {
+    pub fn recv_client_msg(&mut self) -> RecvClientMsg {
         match read_protobuf_message::<ProtoClientToServerMsg>(&mut self.receiver) {
             Ok(proto_msg) => match proto_msg.try_into() {
-                Ok(rust_msg) => Some((rust_msg, ErrorContext::default())),
+                Ok(rust_msg) => RecvClientMsg::Message(rust_msg, ErrorContext::default()),
                 Err(e) => {
                     warn!("Error converting protobuf to ClientToServerMsg: {:?}", e);
-                    None
+                    RecvClientMsg::Malformed
                 },
             },
-            Err(_e) => None,
+            Err(e) => {
+                if e.downcast_ref::<std::io::Error>().is_some() {
+                    RecvClientMsg::IoError
+                } else {
+                    RecvClientMsg::Malformed
+                }
+            },
         }
     }
 

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -413,6 +413,13 @@ pub struct IpcReceiverWithContext<T> {
     _phantom: PhantomData<T>,
 }
 
+#[derive(Debug)]
+pub enum RecvClientMsg {
+    Message(ClientToServerMsg, ErrorContext),
+    IoError,
+    Malformed,
+}
+
 impl<T> IpcReceiverWithContext<T>
 where
     T: for<'de> Deserialize<'de> + Serialize,
@@ -432,16 +439,22 @@ where
         }
     }
 
-    pub fn recv_client_msg(&mut self) -> Option<(ClientToServerMsg, ErrorContext)> {
+    pub fn recv_client_msg(&mut self) -> RecvClientMsg {
         match read_protobuf_message::<ProtoClientToServerMsg>(&mut self.receiver) {
             Ok(proto_msg) => match proto_msg.try_into() {
-                Ok(rust_msg) => Some((rust_msg, ErrorContext::default())),
+                Ok(rust_msg) => RecvClientMsg::Message(rust_msg, ErrorContext::default()),
                 Err(e) => {
                     warn!("Error converting protobuf to ClientToServerMsg: {:?}", e);
-                    None
+                    RecvClientMsg::Malformed
                 },
             },
-            Err(_e) => None,
+            Err(e) => {
+                if e.downcast_ref::<std::io::Error>().is_some() {
+                    RecvClientMsg::IoError
+                } else {
+                    RecvClientMsg::Malformed
+                }
+            },
         }
     }
 

--- a/zellij-utils/src/ipc/tests/socket_tests.rs
+++ b/zellij-utils/src/ipc/tests/socket_tests.rs
@@ -1,5 +1,6 @@
 use crate::ipc::{
-    ClientToServerMsg, IpcReceiverWithContext, IpcSenderWithContext, ServerToClientMsg,
+    ClientToServerMsg, IpcReceiverWithContext, IpcSenderWithContext, RecvClientMsg,
+    ServerToClientMsg,
 };
 use crate::pane_size::Size;
 use interprocess::local_socket::{prelude::*, ListenerOptions};
@@ -7,6 +8,14 @@ use interprocess::local_socket::{prelude::*, ListenerOptions};
 use std::sync::atomic::{AtomicU32, Ordering};
 
 static IPC_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn unwrap_client_message(message: RecvClientMsg) -> ClientToServerMsg {
+    match message {
+        RecvClientMsg::Message(message, _) => message,
+        RecvClientMsg::IoError => panic!("failed to receive client message: I/O error"),
+        RecvClientMsg::Malformed => panic!("failed to receive client message: malformed message"),
+    }
+}
 
 // --- Cross-platform IPC helpers ---
 // On Unix: use filesystem-based sockets (TempDir + PathBuf + GenericFilePath)
@@ -112,9 +121,7 @@ fn client_to_server_message_over_socket() {
     let mut receiver: IpcReceiverWithContext<ClientToServerMsg> =
         IpcReceiverWithContext::new(stream);
 
-    let msg = receiver.recv_client_msg();
-    assert!(msg.is_some(), "should receive a message");
-    let (msg, _ctx) = msg.unwrap();
+    let msg = unwrap_client_message(receiver.recv_client_msg());
     assert!(
         matches!(msg, ClientToServerMsg::ConnStatus),
         "should be ConnStatus, got: {:?}",
@@ -167,9 +174,7 @@ fn bidirectional_communication_via_fd_duplication() {
             .send_server_msg(ServerToClientMsg::Connected)
             .expect("send failed");
 
-        let msg = receiver.recv_client_msg();
-        assert!(msg.is_some(), "server should receive client message");
-        let (msg, _) = msg.unwrap();
+        let msg = unwrap_client_message(receiver.recv_client_msg());
         assert!(
             matches!(msg, ClientToServerMsg::ConnStatus),
             "should be ConnStatus"
@@ -229,10 +234,10 @@ fn multiple_messages_in_sequence() {
     let mut receiver: IpcReceiverWithContext<ClientToServerMsg> =
         IpcReceiverWithContext::new(stream);
 
-    let (msg1, _) = receiver.recv_client_msg().expect("missing message 1");
+    let msg1 = unwrap_client_message(receiver.recv_client_msg());
     assert!(matches!(msg1, ClientToServerMsg::ConnStatus));
 
-    let (msg2, _) = receiver.recv_client_msg().expect("missing message 2");
+    let msg2 = unwrap_client_message(receiver.recv_client_msg());
     match msg2 {
         ClientToServerMsg::TerminalResize { new_size } => {
             assert_eq!(new_size.rows, 50);
@@ -241,7 +246,7 @@ fn multiple_messages_in_sequence() {
         other => panic!("expected TerminalResize, got: {:?}", other),
     }
 
-    let (msg3, _) = receiver.recv_client_msg().expect("missing message 3");
+    let msg3 = unwrap_client_message(receiver.recv_client_msg());
     assert!(matches!(msg3, ClientToServerMsg::KillSession));
 
     client.join().expect("client thread panicked");
@@ -270,11 +275,11 @@ fn receiver_returns_none_on_closed_connection() {
 
     client.join().expect("client thread panicked");
 
-    let msg = receiver.recv_client_msg();
-    assert!(msg.is_some(), "should receive the sent message");
+    let msg = unwrap_client_message(receiver.recv_client_msg());
+    assert!(matches!(msg, ClientToServerMsg::ConnStatus));
 
     let msg = receiver.recv_client_msg();
-    assert!(msg.is_none(), "should return None after connection closed");
+    assert!(matches!(msg, RecvClientMsg::IoError));
 }
 
 #[cfg(unix)]
@@ -318,7 +323,10 @@ fn session_probe_accepts_responding_socket() {
         let mut sender: IpcSenderWithContext<ServerToClientMsg> = receiver.get_sender();
 
         let msg = receiver.recv_client_msg();
-        assert!(matches!(msg, Some((ClientToServerMsg::ConnStatus, _))));
+        assert!(matches!(
+            msg,
+            RecvClientMsg::Message(ClientToServerMsg::ConnStatus, _)
+        ));
 
         sender
             .send_server_msg(ServerToClientMsg::Connected)


### PR DESCRIPTION
## Summary

Part of #5261.

This PR fixes a misleading route error that can happen with `zellij pipe`.

When the server fails to read a client message, the route thread previously
treated that failure the same way as a malformed or unknown message. This could
cause the route loop to keep counting consecutive unknown messages until it hit
the 1000-message guard.

This could produce an error like:

```text
Client sent over 1000 consecutive unknown messages, this is probably an infinite loop, logging client out
````

even though the client did not actually send 1000 unknown messages.

## Problem

`recv_client_msg()` previously returned `None` for multiple different cases:

* the client message was read successfully but could not be converted into
  `ClientToServerMsg`
* reading the client protobuf message failed
* the client disconnected or the client stream could no longer be read

`route.rs` treated `None` as an unknown message.

As a result, IO/read failures could be counted as malformed or unknown messages.
In the `zellij pipe` case, this could cause the route loop to keep reading and
eventually hit the 1000-message guard.

## Change

Introduce an explicit result type for receiving client messages:

* `Message(ClientToServerMsg, ErrorContext)`
* `IoError`
* `Malformed`

`IoError` is returned when reading the client protobuf message fails with an IO
error. The route loop exits for that client in this case.

`Malformed` is returned when a protobuf message cannot be converted into a valid
`ClientToServerMsg`.
Malformed messages still use the existing unknown-message counter and
1000-message guard.

## Why this is correct

An IO/read failure is different from receiving a malformed or unknown client
message.

If the client stream cannot be read, continuing to read from the same route loop
is not useful and can lead to misleading repeated unknown-message logs.

Malformed messages are still counted by the existing guard, because after a
malformed message the stream may still be usable and a later message may be
valid.