### PR TITLE
fix(route): distinguish completion sender drops from timeouts

### DIFF
--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -1612,7 +1612,7 @@ fn open_file_near_plugin(
     let _ = env.senders.send_to_pty(pty_instr);
 
     // Wait for completion
-    let result = wait_for_action_completion(completion_rx, "open_file_near_plugin", false);
+    let result = wait_for_action_completion(completion_rx, "open_file_near_plugin", false, false);
     let pane_id: OpenFileNearPluginResponse = result.affected_pane_id.map(|p| p.into());
 
     // Write response to plugin
@@ -1655,7 +1655,12 @@ fn open_file_floating_near_plugin(
     let _ = env.senders.send_to_pty(pty_instr);
 
     // Wait for completion
-    let result = wait_for_action_completion(completion_rx, "open_file_floating_near_plugin", false);
+    let result = wait_for_action_completion(
+        completion_rx,
+        "open_file_floating_near_plugin",
+        false,
+        false,
+    );
     let pane_id: OpenFileFloatingNearPluginResponse = result.affected_pane_id.map(|p| p.into());
 
     // Write response to plugin
@@ -1695,7 +1700,8 @@ fn open_file_in_place_of_plugin(
     let _ = env.senders.send_to_pty(pty_instr);
 
     // Wait for completion
-    let result = wait_for_action_completion(completion_rx, "open_file_in_place_of_plugin", false);
+    let result =
+        wait_for_action_completion(completion_rx, "open_file_in_place_of_plugin", false, false);
     let pane_id: OpenFileInPlaceOfPluginResponse = result.affected_pane_id.map(|p| p.into());
 
     // Write response to plugin
@@ -1768,7 +1774,8 @@ fn open_terminal_near_plugin(env: &PluginEnv, cwd: PathBuf) {
     ));
 
     // Wait for completion
-    let result = wait_for_action_completion(completion_rx, "open_terminal_near_plugin", false);
+    let result =
+        wait_for_action_completion(completion_rx, "open_terminal_near_plugin", false, false);
     let pane_id: OpenTerminalNearPluginResponse = result.affected_pane_id.map(|p| p.into());
 
     // Write response to plugin
@@ -1846,8 +1853,12 @@ fn open_terminal_floating_near_plugin(
     ));
 
     // Wait for completion
-    let result =
-        wait_for_action_completion(completion_rx, "open_terminal_floating_near_plugin", false);
+    let result = wait_for_action_completion(
+        completion_rx,
+        "open_terminal_floating_near_plugin",
+        false,
+        false,
+    );
     let pane_id: OpenTerminalFloatingNearPluginResponse = result.affected_pane_id.map(|p| p.into());
 
     // Write response to plugin
@@ -1922,8 +1933,12 @@ fn open_terminal_in_place_of_plugin(
         ));
 
     // Wait for completion
-    let result =
-        wait_for_action_completion(completion_rx, "open_terminal_in_place_of_plugin", false);
+    let result = wait_for_action_completion(
+        completion_rx,
+        "open_terminal_in_place_of_plugin",
+        false,
+        false,
+    );
     let pane_id: OpenTerminalInPlaceOfPluginResponse = result.affected_pane_id.map(|p| p.into());
 
     // Write response to plugin
@@ -1978,8 +1993,12 @@ fn open_command_pane_in_place_of_plugin(
         ));
 
     // Wait for completion
-    let result =
-        wait_for_action_completion(completion_rx, "open_command_pane_in_place_of_plugin", false);
+    let result = wait_for_action_completion(
+        completion_rx,
+        "open_command_pane_in_place_of_plugin",
+        false,
+        false,
+    );
     let pane_id: OpenCommandPaneInPlaceOfPluginResponse = result.affected_pane_id.map(|p| p.into());
 
     // Write response to plugin
@@ -2020,6 +2039,7 @@ fn open_terminal_pane_in_place_of_pane_id(
     let result = wait_for_action_completion(
         completion_rx,
         "open_terminal_pane_in_place_of_pane_id",
+        false,
         false,
     );
     let pane_id: OpenTerminalPaneInPlaceOfPaneIdResponse =
@@ -2079,6 +2099,7 @@ fn open_command_pane_in_place_of_pane_id(
         completion_rx,
         "open_command_pane_in_place_of_pane_id",
         false,
+        false,
     );
     let pane_id: OpenCommandPaneInPlaceOfPaneIdResponse = result.affected_pane_id.map(|p| p.into());
 
@@ -2117,8 +2138,12 @@ fn open_edit_pane_in_place_of_pane_id(
     );
     let _ = env.senders.send_to_pty(pty_instr);
 
-    let result =
-        wait_for_action_completion(completion_rx, "open_edit_pane_in_place_of_pane_id", false);
+    let result = wait_for_action_completion(
+        completion_rx,
+        "open_edit_pane_in_place_of_pane_id",
+        false,
+        false,
+    );
     let pane_id: OpenEditPaneInPlaceOfPaneIdResponse = result.affected_pane_id.map(|p| p.into());
 
     let response = ProtobufOpenEditPaneInPlaceOfPaneIdResponse::from(pane_id);
@@ -2225,7 +2250,8 @@ fn open_command_pane_near_plugin(
     ));
 
     // Wait for completion
-    let result = wait_for_action_completion(completion_rx, "open_command_pane_near_plugin", false);
+    let result =
+        wait_for_action_completion(completion_rx, "open_command_pane_near_plugin", false, false);
     let pane_id: OpenCommandPaneNearPluginResponse = result.affected_pane_id.map(|p| p.into());
 
     // Write response to plugin
@@ -2335,6 +2361,7 @@ fn open_command_pane_floating_near_plugin(
         completion_rx,
         "open_command_pane_floating_near_plugin",
         false,
+        false,
     );
     let pane_id: OpenCommandPaneFloatingNearPluginResponse =
         result.affected_pane_id.map(|p| p.into());
@@ -2443,7 +2470,8 @@ fn open_command_pane_background(
     ));
 
     // Wait for completion
-    let result = wait_for_action_completion(completion_rx, "open_command_pane_background", false);
+    let result =
+        wait_for_action_completion(completion_rx, "open_command_pane_background", false, false);
     let pane_id: OpenCommandPaneBackgroundResponse = result.affected_pane_id.map(|p| p.into());
 
     // Write response to plugin
@@ -2985,7 +3013,7 @@ fn switch_session(
             ))
             .with_context(err_context)?;
         let wait_forever = false;
-        let _ = wait_for_action_completion(completion_rx, "switch_session", wait_forever);
+        let _ = wait_for_action_completion(completion_rx, "switch_session", wait_forever, false);
     }
     Ok(())
 }
@@ -3574,7 +3602,8 @@ fn save_session(env: &PluginEnv) {
         }
     } else {
         let wait_forever = false;
-        let _result = wait_for_action_completion(completion_rx, "save_session", wait_forever);
+        let _result =
+            wait_for_action_completion(completion_rx, "save_session", wait_forever, false);
         ProtobufSaveSessionResponse {
             result: Some(SaveSessionResult::Success(true)),
         }
@@ -3598,7 +3627,7 @@ fn show_floating_panes(env: &PluginEnv, tab_id: Option<usize>) {
             result: Some(ShowResult::Error(format!("{}", e))),
         }
     } else {
-        let result = wait_for_action_completion(completion_rx, "show_floating_panes", false);
+        let result = wait_for_action_completion(completion_rx, "show_floating_panes", false, false);
         match result.exit_status {
             Some(0) => ProtobufShowFloatingPanesResponse {
                 result: Some(ShowResult::Success(true)),
@@ -3629,7 +3658,7 @@ fn hide_floating_panes(env: &PluginEnv, tab_id: Option<usize>) {
             result: Some(HideResult::Error(format!("{}", e))),
         }
     } else {
-        let result = wait_for_action_completion(completion_rx, "hide_floating_panes", false);
+        let result = wait_for_action_completion(completion_rx, "hide_floating_panes", false, false);
         match result.exit_status {
             Some(0) => ProtobufHideFloatingPanesResponse {
                 result: Some(HideResult::Success(true)),
@@ -4187,7 +4216,7 @@ fn write_to_pane_id(env: &PluginEnv, bytes: Vec<u8>, pane_id: PaneId) {
     ));
     if send_result.is_ok() {
         let wait_forever = false;
-        let _ = wait_for_action_completion(completion_rx, "write_to_pane_id", wait_forever);
+        let _ = wait_for_action_completion(completion_rx, "write_to_pane_id", wait_forever, false);
     }
 }
 
@@ -4201,7 +4230,12 @@ fn write_chars_to_pane_id(env: &PluginEnv, chars: String, pane_id: PaneId) {
     ));
     if send_result.is_ok() {
         let wait_forever = false;
-        let _ = wait_for_action_completion(completion_rx, "write_chars_to_pane_id", wait_forever);
+        let _ = wait_for_action_completion(
+            completion_rx,
+            "write_chars_to_pane_id",
+            wait_forever,
+            false,
+        );
     }
 }
 
@@ -4852,7 +4886,7 @@ fn break_panes_to_new_tab(
         });
 
     let tab_id: BreakPanesToNewTabResponse = if result.is_ok() {
-        wait_for_action_completion(rx, "break_panes_to_new_tab", false).affected_tab_id
+        wait_for_action_completion(rx, "break_panes_to_new_tab", false, false).affected_tab_id
     } else {
         None
     };
@@ -4882,7 +4916,8 @@ fn break_panes_to_tab_with_index(
         });
 
     let tab_id: BreakPanesToTabWithIndexResponse = if result.is_ok() {
-        wait_for_action_completion(rx, "break_panes_to_tab_with_index", false).affected_tab_id
+        wait_for_action_completion(rx, "break_panes_to_tab_with_index", false, false)
+            .affected_tab_id
     } else {
         None
     };
@@ -4961,7 +4996,7 @@ fn break_panes_to_tab_with_id(
         });
 
     let result_tab_id: BreakPanesToTabWithIdResponse = if result.is_ok() {
-        wait_for_action_completion(rx, "break_panes_to_tab_with_id", false).affected_tab_id
+        wait_for_action_completion(rx, "break_panes_to_tab_with_id", false, false).affected_tab_id
     } else {
         None
     };
@@ -5299,7 +5334,12 @@ fn replace_pane_with_existing_pane(
             suppress_replaced_pane,
             Some(NotificationEnd::new(completion_tx)),
         ));
-    let _ = wait_for_action_completion(completion_rx, "replace_pane_with_existing_pane", false);
+    let _ = wait_for_action_completion(
+        completion_rx,
+        "replace_pane_with_existing_pane",
+        false,
+        false,
+    );
 }
 
 fn override_layout(

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -48,6 +48,7 @@ pub fn wait_for_action_completion(
     receiver: oneshot::Receiver<ActionCompletionResult>,
     action_name: &str,
     wait_forever: bool,
+    completion_sender_drop_expected: bool,
 ) -> ActionCompletionResult {
     let runtime = get_tokio_runtime();
     if wait_forever {
@@ -71,12 +72,32 @@ pub fn wait_for_action_completion(
             .block_on(async { tokio::time::timeout(ACTION_COMPLETION_TIMEOUT, receiver).await })
         {
             Ok(Ok(result)) => result,
-            Err(_) | Ok(Err(_)) => {
+            Err(_) => {
                 log::error!(
                     "Action {} did not complete within {:?} timeout",
                     action_name,
                     ACTION_COMPLETION_TIMEOUT
                 );
+                ActionCompletionResult {
+                    exit_status: None,
+                    affected_pane_id: None,
+                    affected_tab_id: None,
+                    error_message: None,
+                    stdout_message: None,
+                }
+            },
+
+            Ok(Err(e)) => {
+                // This is not a timeout: the completion sender was dropped before
+                // sending a result. Some actions do this intentionally, while unexpected
+                // sender drops are logged for diagnostics.
+                if !completion_sender_drop_expected {
+                    log::warn!(
+                        "Action {} completion sender dropped before sending result: {}",
+                        action_name,
+                        e
+                    );
+                }
                 ActionCompletionResult {
                     exit_status: None,
                     affected_pane_id: None,
@@ -228,6 +249,7 @@ pub(crate) fn route_action(
     let (completion_tx, completion_rx) = oneshot::channel();
 
     let mut wait_forever = false;
+    let mut completion_sender_drop_expected = false;
 
     match action {
         Action::ToggleTab => {
@@ -1171,6 +1193,7 @@ pub(crate) fn route_action(
                     .with_context(err_context)?;
                 should_break = true;
             } else {
+                completion_sender_drop_expected = true;
                 drop(completion_tx); // no need to wait, this is a no-op
             }
         },
@@ -1202,6 +1225,7 @@ pub(crate) fn route_action(
         #[allow(clippy::single_match)]
         Action::SkipConfirm { action } => match *action {
             Action::Quit => {
+                completion_sender_drop_expected = true;
                 drop(completion_tx);
                 senders
                     .send_to_server(ServerInstruction::ClientExit(client_id, None))
@@ -1211,6 +1235,7 @@ pub(crate) fn route_action(
             _ => {},
         },
         Action::NoOp => {
+            completion_sender_drop_expected = true;
             drop(completion_tx);
         },
         Action::SearchInput { input } => {
@@ -1567,6 +1592,7 @@ pub(crate) fn route_action(
             pane_title,
             ..
         } => {
+            completion_sender_drop_expected = true;
             drop(completion_tx); // releasing pipes is handled by the plugins, so we don't want
                                  // this to block additionallu
             if let Some(seen_cli_pipes) = seen_cli_pipes.as_mut() {
@@ -2069,7 +2095,12 @@ pub(crate) fn route_action(
                 .with_context(err_context)?;
         },
     }
-    let result = wait_for_action_completion(completion_rx, &action_name, wait_forever);
+    let result = wait_for_action_completion(
+        completion_rx,
+        &action_name,
+        wait_forever,
+        completion_sender_drop_expected,
+    );
     if let Some(error_message) = &result.error_message {
         if let Some(cli_client_id) = cli_client_id {
             if let Some(ref os_input) = os_input {


### PR DESCRIPTION
## Summary

Part of #5261.

This PR fixes a misleading action completion timeout log.

Previously, `wait_for_action_completion()` handled both of the following cases
as the same timeout error:

- the action actually timed out
- the oneshot completion sender was dropped before sending a result

This could produce logs such as:

```text
Action CliPipe did not complete within 1s timeout
````

even though the timeout did not actually elapse.

## Problem

`tokio::time::timeout(receiver).await` returns a nested result:

* `Err(_)`: the timeout elapsed
* `Ok(Err(_))`: the completion sender was dropped before sending a result

Previously, both cases were logged as:

```text
Action ... did not complete within 1s timeout
```

This is misleading because a dropped completion sender is not the same thing as
a timeout.

Some actions intentionally drop the completion sender. For example:

* `CliPipe` does this because pipe release is handled by plugins instead of the
  normal action completion mechanism.
* Switching to the current session is a no-op and does not need to wait for
  action completion.

## Change

Add a `completion_sender_drop_expected` flag to `wait_for_action_completion()`.

With this change:

* real timeouts are still logged as errors
* expected completion sender drops are not logged as timeout errors
* unexpected completion sender drops are logged as warnings for diagnostics

This keeps real timeout diagnostics intact while avoiding misleading ERROR logs
for expected sender-drop paths.