### PR TITLE
build: Update Rust toolchain to 1.96.0 - cargo check becomes 8 times faster in zellij-util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ license = "MIT"
 repository = "https://github.com/zellij-org/zellij"
 version = "0.45.0"
 # NOTE: When updating this, modify `channel` in `rust-toolchain.toml` accordingly
-rust-version = "1.92"
+rust-version = "1.96"
 
 [workspace.dependencies]
 ansi_term = { version = "0.12.1", default-features = false }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # This file is updated by `update-toolchain.sh`
 [toolchain]
 # NOTE: When updating this, modify `rust-version` in `Cargo.toml` accordingly
-channel = "1.92.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]
 # NOTE: Change this with care, this is also used by the CI pipeline
 targets = ["wasm32-wasip1", "x86_64-unknown-linux-musl"]


### PR DESCRIPTION
Incremental `cargo check` in `zellij-util` crate takes 40 seconds for me even for a minor change like editing a string literal in a function body. On `1.96.0` it takes me only 5 seconds.