### PR TITLE
fix(cli): prevent CLI pipe responses from breaking session detection

### DIFF
--- a/zellij-client/src/cli_client.rs
+++ b/zellij-client/src/cli_client.rs
@@ -130,6 +130,8 @@ fn pipe_client(
     };
     let is_piped = !os_input.stdin_is_terminal();
     loop {
+        let mut reached_stdin_eof = false;
+
         if let Some(payload) = payload.take() {
             let msg = create_msg(Some(payload));
             os_input.send_to_server(msg);
@@ -144,9 +146,13 @@ fn pipe_client(
             let mut buffer = String::new();
             let _ = stdin.read_line(&mut buffer);
             if buffer.is_empty() {
+                // EOF on piped STDIN. We still send an empty message to trigger the plugin,
+                // then wait for the corresponding UnblockCliPipeInput before exiting.
+                // Otherwise the CLI client would exit immediately, the server would remove its
+                // pipe association, and a later unblock could no longer be routed to this client.
+                reached_stdin_eof = true;
                 let msg = create_msg(None);
                 os_input.send_to_server(msg);
-                break;
             } else {
                 // we've got data! send it down the pipe (most common)
                 let msg = create_msg(Some(buffer));
@@ -160,9 +166,9 @@ fn pipe_client(
                     // unblock this pipe, meaning we need to stop waiting for a response and read
                     // once more from STDIN
                     if pipe_name == pipe_id {
-                        if !is_piped {
-                            // if this client is not piped, we need to exit the process completely
-                            // rather than wait for more data
+                        if !is_piped || reached_stdin_eof {
+                            // if this client is not piped, or if piped STDIN reached EOF, we need
+                            // to exit the process completely rather than wait for more data
                             process::exit(0);
                         } else {
                             break;

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -1248,19 +1248,15 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                         );
                     },
                     None => {
-                        // send to all clients, this pipe might not have been associated yet
-                        let client_ids = session_state.read().unwrap().client_ids();
-                        for client_id in client_ids {
-                            send_to_client!(
-                                client_id,
-                                os_input,
-                                ServerToClientMsg::UnblockCliPipeInput {
-                                    pipe_name: pipe_name.clone()
-                                },
-                                session_state,
-                                session_data
-                            );
-                        }
+                        // `UnblockCliPipeInput` is a response for one CLI pipe client, identified
+                        // by `pipe_name`. If the pipe is no longer associated with a client, the
+                        // original CLI client has already disconnected or its association has been
+                        // cleaned up. Broadcasting this response to all clients can leak unrelated
+                        // pipe messages to ordinary/probe clients (eg. assert_socket), so drop it.
+                        log::warn!(
+                            "Dropping UnblockCliPipeInput for unassociated pipe: {}",
+                            pipe_name
+                        );
                     },
                 }
             },
@@ -1280,20 +1276,12 @@ pub fn start_server(mut os_input: Box<dyn ServerOsApi>, socket_path: PathBuf) {
                         );
                     },
                     None => {
-                        // send to all clients, this pipe might not have been associated yet
-                        let client_ids = session_state.read().unwrap().client_ids();
-                        for client_id in client_ids {
-                            send_to_client!(
-                                client_id,
-                                os_input,
-                                ServerToClientMsg::CliPipeOutput {
-                                    pipe_name: pipe_name.clone(),
-                                    output: output.clone()
-                                },
-                                session_state,
-                                session_data
-                            );
-                        }
+                        // `CliPipeOutput` is also addressed to the CLI client associated with this
+                        // pipe. If no association exists, there is no correct recipient.
+                        log::warn!(
+                            "Dropping CliPipeOutput for unassociated pipe: {}",
+                            pipe_name
+                        );
                     },
                 }
             },

--- a/zellij-utils/src/sessions.rs
+++ b/zellij-utils/src/sessions.rs
@@ -152,9 +152,18 @@ fn assert_socket(name: &str) -> bool {
                 IpcSenderWithContext::new(stream);
             let _ = sender.send_client_msg(ClientToServerMsg::ConnStatus);
             let mut receiver: IpcReceiverWithContext<ServerToClientMsg> = sender.get_receiver();
-            match receiver.recv_server_msg() {
-                Some((ServerToClientMsg::Connected, _)) => true,
-                None | Some((_, _)) => false,
+            loop {
+                match receiver.recv_server_msg() {
+                    Some((ServerToClientMsg::Connected, _)) => return true,
+                    Some((_unrelated_message, _)) => {
+                        // `assert_socket` is only probing whether this socket belongs to a live
+                        // Zellij server. While waiting for the ConnStatus response, this temporary
+                        // client can receive other server-to-client messages. These are not the
+                        // response to our probe, so ignore them and keep waiting.
+                        continue;
+                    },
+                    None => return false,
+                }
             }
         },
         Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => {


### PR DESCRIPTION
## Summary

Part of #5270.

This PR fixes one of the races that can make `zellij pipe` incorrectly report:

```text
There is no active session!
````

The issue can happen when short-lived CLI pipe clients are run concurrently with
piped stdin.

This PR addresses the CLI pipe response / socket probing side of the issue.

## Problem

A `zellij pipe` client with non-terminal stdin can reach EOF, send the final
empty pipe message, and exit before the corresponding `UnblockCliPipeInput` is
produced.

When that happens, the server can remove the pipe association for that client.
If a later `UnblockCliPipeInput` or `CliPipeOutput` is produced for the same
pipe, there is no longer an associated CLI client.

Previously, the server handled this case by broadcasting the pipe response to
all clients.

That broadcast is not correct for CLI pipe responses. `UnblockCliPipeInput` and
`CliPipeOutput` are addressed to the specific CLI pipe client associated with
the pipe. If there is no associated client when the response is handled, there
is no correct recipient.

Broadcasting such responses can also interfere with temporary clients used by
`assert_socket()` while probing active sessions. If such a probe receives an
unrelated server-to-client message instead of the expected `Connected` response,
session detection can incorrectly fail.

## Changes

This PR fixes the issue in three places:

### 1. Keep piped CLI pipe clients alive until unblock

When piped stdin reaches EOF, the CLI pipe client still sends an empty pipe
message to trigger plugins.

Instead of exiting immediately after sending that message, it now waits for the
matching `UnblockCliPipeInput` before exiting.

This keeps the pipe association alive long enough for the server to route the
response back to the correct client.

### 2. Do not broadcast unassociated CLI pipe responses

If `UnblockCliPipeInput` or `CliPipeOutput` is produced for a pipe that no
longer has an associated client, the response is now dropped instead of
broadcast to all clients.

There is no valid case where broadcasting an unassociated CLI pipe response can
deliver it to the correct client. If no association exists at response time,
there is no correct recipient.

### 3. Ignore unrelated messages in `assert_socket()`

`assert_socket()` sends `ConnStatus` and waits for `Connected`.

It now ignores unrelated server-to-client messages while waiting for the
`Connected` response, instead of treating the first non-`Connected` message as a
failed probe.

## Notes

This PR addresses the first cause described in #5270.