### PR TITLE
fix(server): avoid immediate client id reuse

### DIFF
--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -616,6 +616,16 @@ pub(crate) struct SessionState {
     /// empty synthetic reply so `Screen`'s `forward_in_flight` slot
     /// releases and the queued forwards keep moving.
     forwards_in_flight: HashMap<u32, ClientId>,
+    next_client_id: ClientId,
+}
+
+fn next_non_zero_client_id(client_id: ClientId) -> ClientId {
+    let next_client_id = client_id.wrapping_add(1);
+    if next_client_id == 0 {
+        1
+    } else {
+        next_client_id
+    }
 }
 
 impl SessionState {
@@ -626,6 +636,7 @@ impl SessionState {
             watchers: HashMap::new(),
             last_active_client: None,
             forwards_in_flight: HashMap::new(),
+            next_client_id: 1,
         }
     }
     pub fn new_client(&mut self) -> ClientId {
@@ -636,15 +647,20 @@ impl SessionState {
             .chain(self.watchers.keys().copied())
             .collect();
 
-        let mut next_client_id = 1;
+        let start_client_id = self.next_client_id;
+        let mut next_client_id = self.next_client_id;
         loop {
             if all_ids.contains(&next_client_id) {
-                next_client_id += 1;
+                next_client_id = next_non_zero_client_id(next_client_id);
+                if next_client_id == start_client_id {
+                    panic!("no available client ids");
+                }
             } else {
                 break;
             }
         }
         self.clients.insert(next_client_id, None);
+        self.next_client_id = next_non_zero_client_id(next_client_id);
         next_client_id
     }
     pub fn associate_pipe_with_client(&mut self, pipe_id: String, client_id: ClientId) {

--- a/zellij-server/src/plugins/mod.rs
+++ b/zellij-server/src/plugins/mod.rs
@@ -88,6 +88,10 @@ pub enum PluginInstruction {
     Resize(PluginId, usize, usize), // plugin_id, columns, rows
     AddClient(ClientId),
     RemoveClient(ClientId),
+    PruneDisconnectedPluginInstances {
+        plugin_id: PluginId,
+        keep_client_id: ClientId,
+    },
     NewTab(
         Option<PathBuf>,
         Option<TerminalAction>,
@@ -236,6 +240,9 @@ impl From<&PluginInstruction> for PluginContext {
             PluginInstruction::Exit => PluginContext::Exit,
             PluginInstruction::AddClient(_) => PluginContext::AddClient,
             PluginInstruction::RemoveClient(_) => PluginContext::RemoveClient,
+            PluginInstruction::PruneDisconnectedPluginInstances { .. } => {
+                PluginContext::RemoveClient
+            },
             PluginInstruction::NewTab(..) => PluginContext::NewTab,
             PluginInstruction::OverrideLayout(..) => PluginContext::OverrideLayout,
             PluginInstruction::ApplyCachedEvents { .. } => PluginContext::ApplyCachedEvents,
@@ -509,6 +516,12 @@ pub(crate) fn plugin_thread_main(
             },
             PluginInstruction::RemoveClient(client_id) => {
                 wasm_bridge.remove_client(client_id);
+            },
+            PluginInstruction::PruneDisconnectedPluginInstances {
+                plugin_id,
+                keep_client_id,
+            } => {
+                wasm_bridge.prune_disconnected_plugin_instances(plugin_id, keep_client_id)?;
             },
             PluginInstruction::NewTab(
                 cwd,

--- a/zellij-server/src/plugins/pipes.rs
+++ b/zellij-server/src/plugins/pipes.rs
@@ -82,6 +82,26 @@ impl PendingPipes {
         }
         pipe_names_to_unblock
     }
+
+    // returns a list of pipes that are no longer pending and should be unblocked
+    pub fn unload_plugin_client(
+        &mut self,
+        plugin_id: &PluginId,
+        client_id: &ClientId,
+    ) -> Vec<String> {
+        let mut pipe_names_to_unblock = vec![];
+        for (pipe_name, pending_pipe_info) in self.pipes.iter_mut() {
+            let should_unblock_this_pipe =
+                pending_pipe_info.unload_plugin_client(plugin_id, client_id);
+            if should_unblock_this_pipe {
+                pipe_names_to_unblock.push(pipe_name.to_owned());
+            }
+        }
+        for pipe_name in &pipe_names_to_unblock {
+            self.pipes.remove(pipe_name);
+        }
+        pipe_names_to_unblock
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -129,6 +149,23 @@ impl PendingPipeInfo {
     pub fn unload_plugin(&mut self, plugin_id_to_unload: &PluginId) -> bool {
         self.currently_being_processed_by
             .retain(|(plugin_id, _)| plugin_id != plugin_id_to_unload);
+        if self.currently_being_processed_by.is_empty() && !self.is_explicitly_blocked {
+            true
+        } else {
+            false
+        }
+    }
+
+    // returns true if this pipe should be unblocked
+    pub fn unload_plugin_client(
+        &mut self,
+        plugin_id_to_unload: &PluginId,
+        client_id_to_unload: &ClientId,
+    ) -> bool {
+        self.currently_being_processed_by
+            .retain(|(plugin_id, client_id)| {
+                plugin_id != plugin_id_to_unload || client_id != client_id_to_unload
+            });
         if self.currently_being_processed_by.is_empty() && !self.is_explicitly_blocked {
             true
         } else {

--- a/zellij-server/src/plugins/plugin_map.rs
+++ b/zellij-server/src/plugins/plugin_map.rs
@@ -27,35 +27,45 @@ use zellij_utils::{data::PermissionType, errors::prelude::*};
 // so when adding/removing from the map - everything is halted, that's life
 // but when cloning the internal RunningPlugin and Subscriptions atomics, we can call methods on
 // them without blocking other instances
+pub type PluginKey = (PluginId, ClientId);
+pub type PluginAssets = (
+    Arc<Mutex<RunningPlugin>>,
+    Arc<Mutex<Subscriptions>>,
+    HashMap<String, UnboundedSender<MessageToWorker>>,
+);
+pub type RemovedPluginAssets = HashMap<PluginKey, PluginAssets>;
+
 #[derive(Default)]
 pub struct PluginMap {
-    plugin_assets: HashMap<
-        (PluginId, ClientId),
-        (
-            Arc<Mutex<RunningPlugin>>,
-            Arc<Mutex<Subscriptions>>,
-            HashMap<String, UnboundedSender<MessageToWorker>>,
-        ),
-    >,
+    plugin_assets: HashMap<PluginKey, PluginAssets>,
 }
 
 impl PluginMap {
-    pub fn remove_plugins(
-        &mut self,
-        pid: PluginId,
-    ) -> HashMap<
-        (PluginId, ClientId),
-        (
-            Arc<Mutex<RunningPlugin>>,
-            Arc<Mutex<Subscriptions>>,
-            HashMap<String, UnboundedSender<MessageToWorker>>,
-        ),
-    > {
+    pub fn remove_plugins(&mut self, pid: PluginId) -> RemovedPluginAssets {
         let mut removed = HashMap::new();
-        let ids_in_plugin_map: Vec<(PluginId, ClientId)> =
-            self.plugin_assets.keys().copied().collect();
+        let ids_in_plugin_map: Vec<PluginKey> = self.plugin_assets.keys().copied().collect();
         for (plugin_id, client_id) in ids_in_plugin_map {
             if pid == plugin_id {
+                if let Some(plugin_asset) = self.plugin_assets.remove(&(plugin_id, client_id)) {
+                    removed.insert((plugin_id, client_id), plugin_asset);
+                }
+            }
+        }
+        removed
+    }
+    pub fn remove_disconnected_plugin_clients(
+        &mut self,
+        plugin_id_to_prune: PluginId,
+        keep_client_id: ClientId,
+        connected_clients: &[ClientId],
+    ) -> RemovedPluginAssets {
+        let mut removed = HashMap::new();
+        let ids_in_plugin_map: Vec<PluginKey> = self.plugin_assets.keys().copied().collect();
+        for (plugin_id, client_id) in ids_in_plugin_map {
+            if plugin_id == plugin_id_to_prune
+                && client_id != keep_client_id
+                && !connected_clients.contains(&client_id)
+            {
                 if let Some(plugin_asset) = self.plugin_assets.remove(&(plugin_id, client_id)) {
                     removed.insert((plugin_id, client_id), plugin_asset);
                 }

--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -4,7 +4,9 @@ use crate::plugins::pipes::{
     apply_pipe_message_to_plugin, pipes_to_block_or_unblock, PendingPipes, PipeStateChange,
 };
 use crate::plugins::plugin_loader::PluginLoader;
-use crate::plugins::plugin_map::{AtomicEvent, PluginEnv, PluginMap, RunningPlugin, Subscriptions};
+use crate::plugins::plugin_map::{
+    AtomicEvent, PluginEnv, PluginMap, RemovedPluginAssets, RunningPlugin, Subscriptions,
+};
 
 use crate::plugins::plugin_worker::MessageToWorker;
 use crate::plugins::watch_filesystem::watch_filesystem;
@@ -580,6 +582,78 @@ impl WasmBridge {
 
         Ok(())
     }
+    pub fn prune_disconnected_plugin_instances(
+        &mut self,
+        plugin_id_to_prune: PluginId,
+        keep_client_id: ClientId,
+    ) -> Result<()> {
+        let connected_clients = self.connected_clients.lock().unwrap().clone();
+        let plugins_to_cleanup = {
+            let mut plugin_map = self.plugin_map.lock().unwrap();
+            plugin_map.remove_disconnected_plugin_clients(
+                plugin_id_to_prune,
+                keep_client_id,
+                &connected_clients,
+            )
+        };
+
+        self.cleanup_disconnected_plugin_instances(plugins_to_cleanup)
+    }
+
+    fn cleanup_disconnected_plugin_instances(
+        &mut self,
+        plugins_to_cleanup: RemovedPluginAssets,
+    ) -> Result<()> {
+        for ((plugin_id, client_id), (running_plugin, subscriptions, workers)) in plugins_to_cleanup
+        {
+            if running_plugin.lock().unwrap().intercepting_key_presses() {
+                let _ = self
+                    .senders
+                    .send_to_screen(ScreenInstruction::ClearKeyPressesIntercepts(client_id));
+            }
+
+            for (_worker_name, worker_sender) in workers {
+                drop(worker_sender.send(MessageToWorker::Exit));
+            }
+
+            self.plugin_executor.execute_for_plugin(
+                plugin_id,
+                move |_senders, _plugin_map, _connected_clients, _plugin_cache, _engine| {
+                    let cache_dir = running_plugin
+                        .lock()
+                        .unwrap()
+                        .store
+                        .data()
+                        .plugin_own_data_dir
+                        .clone();
+                    if let Err(e) = std::fs::remove_dir_all(&cache_dir) {
+                        log::error!("Failed to remove cache dir for plugin: {:?}", e);
+                    }
+
+                    drop(running_plugin);
+                    drop(subscriptions);
+                },
+            );
+
+            let mut pipes_to_unblock = self
+                .pending_pipes
+                .unload_plugin_client(&plugin_id, &client_id);
+            for pipe_name in pipes_to_unblock.drain(..) {
+                let _ = self
+                    .senders
+                    .send_to_server(ServerInstruction::UnblockCliPipeInput(pipe_name))
+                    .context("failed to unblock input pipe");
+            }
+        }
+
+        self.cached_plugin_map.clear();
+        let plugin_list = self.plugin_map.lock().unwrap().list_plugins();
+        let _ = self
+            .senders
+            .send_to_background_jobs(BackgroundJob::ReportPluginList(plugin_list));
+        Ok(())
+    }
+
     pub fn reload_plugin_with_id(&mut self, plugin_id: u32) -> Result<()> {
         let Some(run_plugin) = self.run_plugin_of_plugin_id(plugin_id).map(|r| r.clone()) else {
             log::error!("Failed to find plugin with id: {}", plugin_id);
@@ -764,6 +838,12 @@ impl WasmBridge {
                                 plugin_ids: vec![plugin_id],
                                 done_receiving_permissions: false,
                             });
+                            let _ = senders.send_to_plugin(
+                                PluginInstruction::PruneDisconnectedPluginInstances {
+                                    plugin_id,
+                                    keep_client_id: client_id,
+                                },
+                            );
                         },
                         Err(e) => {
                             log::error!("Failed to load plugin for new client: {}", e);

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -4788,7 +4788,10 @@ impl Screen {
         }
     }
 
-    pub fn generate_and_report_tab_state(&mut self) -> Result<Vec<TabInfo>> {
+    pub fn generate_and_report_tab_state(
+        &mut self,
+        target_plugin: Option<(PluginId, ClientId)>,
+    ) -> Result<Vec<TabInfo>> {
         let mut plugin_updates = vec![];
         let mut tab_infos_for_screen_state = BTreeMap::new();
         for tab in self.tabs.values() {
@@ -4875,7 +4878,13 @@ impl Screen {
                 plugin_tab_updates.push(tab_info_for_plugins);
             }
             plugin_tab_updates.sort_by(|a, b| a.position.cmp(&b.position));
-            let target_plugin_ids = self.targeted_plugin_ids(*client_id, EventType::TabUpdate);
+            let target_plugin_ids = match target_plugin {
+                Some((plugin_id, target_client_id)) if target_client_id == *client_id => {
+                    vec![plugin_id]
+                },
+                Some(_) => vec![],
+                None => self.targeted_plugin_ids(*client_id, EventType::TabUpdate),
+            };
             for plugin_id in target_plugin_ids {
                 plugin_updates.push((
                     Some(plugin_id),
@@ -4890,7 +4899,10 @@ impl Screen {
             .context("failed to update tabs")?;
         Ok(tab_infos_for_screen_state.values().cloned().collect())
     }
-    fn generate_and_report_pane_state(&mut self) -> Result<PaneManifest> {
+    fn generate_and_report_pane_state(
+        &mut self,
+        target_plugin: Option<(PluginId, ClientId)>,
+    ) -> Result<PaneManifest> {
         let mut pane_manifest = PaneManifest::default();
         for tab in self.tabs.values() {
             pane_manifest.panes.insert(tab.position, tab.pane_infos());
@@ -4898,7 +4910,13 @@ impl Screen {
         let mut plugin_updates = vec![];
         let client_ids: Vec<ClientId> = self.active_tab_ids.keys().copied().collect();
         for client_id in client_ids {
-            let target_plugin_ids = self.targeted_plugin_ids(client_id, EventType::PaneUpdate);
+            let target_plugin_ids = match target_plugin {
+                Some((plugin_id, target_client_id)) if target_client_id == client_id => {
+                    vec![plugin_id]
+                },
+                Some(_) => vec![],
+                None => self.targeted_plugin_ids(client_id, EventType::PaneUpdate),
+            };
             for plugin_id in target_plugin_ids {
                 plugin_updates.push((
                     Some(plugin_id),
@@ -4915,6 +4933,16 @@ impl Screen {
         }
 
         Ok(pane_manifest)
+    }
+
+    fn report_pane_and_tab_state_to_plugin(
+        &mut self,
+        plugin_id: PluginId,
+        client_id: ClientId,
+    ) -> Result<()> {
+        self.generate_and_report_pane_state(Some((plugin_id, client_id)))?;
+        self.generate_and_report_tab_state(Some((plugin_id, client_id)))?;
+        Ok(())
     }
 
     fn collect_pane_list(&self, show_all: bool) -> Result<ListPanesResponse> {
@@ -4996,8 +5024,8 @@ impl Screen {
             .with_context(err_context)?;
         self.reconcile_all_single_pane_focus();
         // generate own session info
-        let pane_manifest = self.generate_and_report_pane_state()?;
-        let tab_infos = self.generate_and_report_tab_state()?;
+        let pane_manifest = self.generate_and_report_pane_state(None)?;
+        let tab_infos = self.generate_and_report_tab_state(None)?;
 
         // Lazy-load layouts on first call if cache is empty
         // After that, cache is updated by watcher via UpdateAvailableLayouts instruction
@@ -10695,8 +10723,8 @@ pub(crate) fn screen_thread_main(
                 let err_context = || "Failed to save session";
 
                 screen.update_active_pane_ids();
-                let pane_manifest = screen.generate_and_report_pane_state()?;
-                let tab_infos = screen.generate_and_report_tab_state()?;
+                let pane_manifest = screen.generate_and_report_pane_state(None)?;
+                let tab_infos = screen.generate_and_report_tab_state(None)?;
 
                 #[cfg(not(test))]
                 let (available_layouts, _layout_errors) = Layout::list_available_layouts(
@@ -11553,6 +11581,7 @@ pub(crate) fn screen_thread_main(
                     screen
                         .background_plugin_subscriptions
                         .insert((plugin_id, client_id), subscriptions);
+                    screen.report_pane_and_tab_state_to_plugin(plugin_id, client_id)?;
                 }
             },
             ScreenInstruction::ClearHintTextCache => {

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -7941,6 +7941,87 @@ pub fn background_plugin_receives_broadcasts_regardless_of_active_tab() {
 }
 
 #[test]
+pub fn background_plugin_receives_initial_tab_update_after_subscription_race() {
+    let size = Size { cols: 80, rows: 10 };
+    let mut mock_screen = MockScreen::new(size);
+    let screen_thread = mock_screen.run(None, vec![]);
+
+    let received_plugin_instructions = Arc::new(Mutex::new(vec![]));
+    let plugin_receiver = mock_screen.plugin_receiver.take().unwrap();
+    let plugin_thread = log_actions_in_thread!(
+        received_plugin_instructions,
+        PluginInstruction::Exit,
+        plugin_receiver
+    );
+
+    let mut existing_background_subscriptions = HashSet::new();
+    existing_background_subscriptions.insert(EventType::TabUpdate);
+    let _ = mock_screen
+        .to_screen
+        .send(ScreenInstruction::UpdateBackgroundPluginSubscriptions(
+            98,
+            mock_screen.main_client_id,
+            existing_background_subscriptions,
+        ));
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    // Reproduce the initial state request winning the race with subscription registration.
+    let _ = mock_screen
+        .to_screen
+        .send(ScreenInstruction::RequestStateUpdateForPlugins);
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    let count_tab_updates = |instructions: &[PluginInstruction], plugin_id: u32| {
+        instructions
+            .iter()
+            .map(|instruction| {
+                if let PluginInstruction::Update(updates) = instruction {
+                    updates
+                        .iter()
+                        .filter(|(pid, _, event)| {
+                            pid == &Some(plugin_id) && matches!(event, Event::TabUpdate(..))
+                        })
+                        .count()
+                } else {
+                    0
+                }
+            })
+            .sum::<usize>()
+    };
+    let existing_plugin_tab_updates_before_new_subscription = {
+        let instructions = received_plugin_instructions.lock().unwrap();
+        count_tab_updates(&instructions, 98)
+    };
+
+    let mut background_subscriptions = HashSet::new();
+    background_subscriptions.insert(EventType::TabUpdate);
+    let _ = mock_screen
+        .to_screen
+        .send(ScreenInstruction::UpdateBackgroundPluginSubscriptions(
+            99,
+            mock_screen.main_client_id,
+            background_subscriptions,
+        ));
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    mock_screen.teardown(vec![plugin_thread, screen_thread]);
+
+    let received_plugin_instructions = received_plugin_instructions.lock().unwrap();
+    let received_initial_tab_update = count_tab_updates(&received_plugin_instructions, 99) > 0;
+    assert!(
+        received_initial_tab_update,
+        "Background plugin should receive TabUpdate after subscription registration: {:?}",
+        *received_plugin_instructions
+    );
+    assert_eq!(
+        count_tab_updates(&received_plugin_instructions, 98),
+        existing_plugin_tab_updates_before_new_subscription,
+        "Existing background plugins should not receive duplicate TabUpdates: {:?}",
+        *received_plugin_instructions
+    );
+}
+
+#[test]
 pub fn tab_switch_only_updates_active_tab_plugins() {
     // Tab 0: plugin pane 2 (from new_tab_with_plugins)
     // Tab 1: plugin pane 3 (from new_tab_with_plugins)


### PR DESCRIPTION
## Summary

Part of #5270.

This PR avoids immediate reuse of `client_id` values for short-lived clients.

Previously, new clients were allocated by starting from the lowest available
client id. Under heavy concurrent CLI activity, this meant the same `client_id`
could be reused almost immediately after being removed.

This is fragile because some server instructions are queued asynchronously and
refer to clients only by `client_id`. If an old instruction is processed after
that `client_id` has already been reused, it can affect a newer, unrelated
client.

## Problem

The issue was observed while investigating intermittent failures where
concurrent `zellij pipe` commands could report:

```text
There is no active session!
```

even though the session was still active.

One observed stale instruction path involved `ConnStatus`, which is used by
`assert_socket()` as a short-lived session socket probe.

That path can issue cleanup for the probe client more than once: the server
handles `ServerInstruction::ConnStatus(client_id)` by sending `Connected` and
removing the temporary probe client, while the route thread can also send its
generic cleanup for the same `client_id` when the route loop exits.

This PR does not try to audit or fix every duplicate cleanup path. Instead, it
mitigates the broader issue by avoiding immediate `client_id` reuse, so stale
client-id based instructions are much less likely to affect newly created
clients.

## Change

Track the next client id to try in `SessionState`.

Instead of always starting allocation from the lowest available id, client id
allocation now continues from the previously issued id and wraps around when
needed.

This makes immediate `client_id` reuse much less likely.

## Limitations

This is a mitigation rather than a complete correctness guarantee.

Client ids can still wrap around eventually, so a stale instruction could
theoretically still affect a later client after wraparound.

A more complete long-term fix would be to use generation-aware client handles,
so stale client-id based instructions can be detected and ignored explicitly.
