### PR TITLE
feat(themes): add flexoki light theme

### DIFF
--- a/zellij-utils/assets/themes/flexoki-light.kdl
+++ b/zellij-utils/assets/themes/flexoki-light.kdl
@@ -1,0 +1,129 @@
+themes {
+    flexoki-light {
+        text_unselected {
+            base 28 27 26
+            background 255 252 240
+            emphasis_0 218 112 44
+            emphasis_1 36 131 123
+            emphasis_2 102 128 11
+            emphasis_3 206 93 151
+        }
+        text_selected {
+            base 28 27 26
+            background 206 205 195
+            emphasis_0 218 112 44
+            emphasis_1 36 131 123
+            emphasis_2 102 128 11
+            emphasis_3 206 93 151
+        }
+        ribbon_selected {
+            base 255 252 240
+            background 102 128 11
+            emphasis_0 209 77 65
+            emphasis_1 218 112 44
+            emphasis_2 160 47 111
+            emphasis_3 58 169 159
+        }
+        ribbon_unselected {
+            base 87 86 83
+            background 230 228 217
+            emphasis_0 218 112 44
+            emphasis_1 183 181 172
+            emphasis_2 102 128 11
+            emphasis_3 206 93 151
+        }
+        table_title {
+            base 102 128 11
+            background 52 51 49
+            emphasis_0 218 112 44
+            emphasis_1 36 131 123
+            emphasis_2 102 128 11
+            emphasis_3 206 93 151
+        }
+        table_cell_selected {
+            base 28 27 26
+            background 206 205 195
+            emphasis_0 218 112 44
+            emphasis_1 36 131 123
+            emphasis_2 102 128 11
+            emphasis_3 206 93 151
+        }
+        table_cell_unselected {
+            base 28 27 26
+            background 255 252 240
+            emphasis_0 218 112 44
+            emphasis_1 36 131 123
+            emphasis_2 102 128 11
+            emphasis_3 206 93 151
+        }
+        list_selected {
+            base 28 27 26
+            background 206 205 195
+            emphasis_0 175 48 41
+            emphasis_1 188 82 21
+            emphasis_2 36 131 123
+            emphasis_3 160 47 111
+        }
+        list_unselected {
+            base 28 27 26
+            background 255 252 240
+            emphasis_0 175 48 41
+            emphasis_1 188 82 21
+            emphasis_2 36 131 123
+            emphasis_3 160 47 111
+        }
+        frame_selected {
+            base 102 128 11
+            background 255 252 240
+            emphasis_0 175 48 41
+            emphasis_1 188 82 21
+            emphasis_2 36 131 123
+            emphasis_3 0 0 0
+        }
+        frame_highlight {
+            base 188 82 21
+            background 255 252 240
+            emphasis_0 175 48 41
+            emphasis_1 160 47 111
+            emphasis_2 36 131 123
+            emphasis_3 32 94 166
+        }
+        frame_unselected {
+            base 183 181 172
+            background 0
+            emphasis_0 239 159 118
+            emphasis_1 153 209 219
+            emphasis_2 244 184 228
+            emphasis_3 0
+        }
+        exit_code_success {
+            base 102 128 11
+            background 255 252 240
+            emphasis_0 36 131 123
+            emphasis_1 255 252 240
+            emphasis_2 160 47 111
+            emphasis_3 32 94 166
+        }
+        exit_code_error {
+            base 175 48 41
+            background 255 252 240
+            emphasis_0 188 82 21
+            emphasis_1 0 0 0
+            emphasis_2 0 0 0
+            emphasis_3 0 0 0
+        }
+        multiplayer_user_colors {
+            player_1 160 47 111
+            player_2 32 94 166
+            player_3 36 131 123
+            player_4 188 82 21
+            player_5 102 128 11
+            player_6 94 64 157
+            player_7 175 48 41
+            player_8 173 131 1
+            player_9 0 0 0
+            player_10 0 0 0
+        }
+    }
+}
+


### PR DESCRIPTION
Based on Flexoki color system from https://github.com/kepano/flexoki
The dark theme for [Flexoki](https://stephango.com/flexoki) was added in #4555, but a light version wasn't available yet, so I added one.

<img width="1280" height="622" alt="screenshot_flexoki-light_01" src="https://github.com/user-attachments/assets/de1591a6-4d42-46e5-9f37-13ab45c0f15d" />

<img width="1920" height="1080" alt="screenshot_flexoki-light_02" src="https://github.com/user-attachments/assets/5458ac77-566e-432d-bd68-42fa956603e1" />
