### PR TITLE
fix(plugins): ensure get_session_list includes current session

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -90,7 +90,7 @@ pub(crate) fn delete_all_sessions(yes: bool, force: bool) {
         .map(|s| s.0.clone())
         .collect();
     let (_live_sessions, resurrectable_map) =
-        scan_session_list_default_dirs(&String::new(), &[], &BTreeMap::new());
+        scan_session_list_default_dirs(&String::new(), None, &BTreeMap::new());
     let mut resurrectable_sessions: Vec<(String, Duration)> =
         resurrectable_map.into_iter().collect();
     if force {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -86,7 +86,7 @@ pub(crate) fn delete_all_sessions(yes: bool, force: bool) {
         .map(|s| s.0.clone())
         .collect();
     let (_live_sessions, resurrectable_map) =
-        scan_session_list_default_dirs(&String::new(), &[], &BTreeMap::new());
+        scan_session_list_default_dirs(&String::new(), None, &BTreeMap::new());
     let mut resurrectable_sessions: Vec<(String, Duration)> =
         resurrectable_map.into_iter().collect();
     if force {

--- a/zellij-server/src/background_jobs.rs
+++ b/zellij-server/src/background_jobs.rs
@@ -721,17 +721,24 @@ pub fn write_session_state_to_disk(
 
 pub fn scan_session_list(
     current_session_name: &str,
-    available_layouts: &[LayoutInfo],
+    current_session_info: Option<&SessionInfo>,
     current_session_plugin_list: &BTreeMap<PluginId, RunPlugin>,
     sock_dir: &Path,
     session_info_cache_dir: &Path,
 ) -> (BTreeMap<String, SessionInfo>, BTreeMap<String, Duration>) {
     let mut session_infos_on_machine =
         read_other_live_session_states(current_session_name, sock_dir, session_info_cache_dir);
-    for (name, info) in session_infos_on_machine.iter_mut() {
-        if name == current_session_name {
+    if let Some(current_session_info) = current_session_info {
+        if let Some(info) = session_infos_on_machine.get_mut(current_session_name) {
             info.populate_plugin_list(current_session_plugin_list.clone());
-            info.available_layouts = available_layouts.to_vec();
+            info.available_layouts = current_session_info.available_layouts.clone();
+        } else {
+            // The session info cache can briefly lag behind right after startup. The
+            // current session info is already available in memory, so ensure it is
+            // included even if the scan did not find it yet.
+            let mut current_session_info = current_session_info.clone();
+            current_session_info.populate_plugin_list(current_session_plugin_list.clone());
+            session_infos_on_machine.insert(current_session_name.to_owned(), current_session_info);
         }
     }
     let resurrectable_sessions =
@@ -741,12 +748,12 @@ pub fn scan_session_list(
 
 pub fn scan_session_list_default_dirs(
     current_session_name: &str,
-    available_layouts: &[LayoutInfo],
+    current_session_info: Option<&SessionInfo>,
     current_session_plugin_list: &BTreeMap<PluginId, RunPlugin>,
 ) -> (BTreeMap<String, SessionInfo>, BTreeMap<String, Duration>) {
     scan_session_list(
         current_session_name,
-        available_layouts,
+        current_session_info,
         current_session_plugin_list,
         &*ZELLIJ_SOCK_DIR,
         &*ZELLIJ_SESSION_INFO_CACHE_DIR,
@@ -909,7 +916,7 @@ mod tests {
         let info_dir = tempdir().unwrap();
         let (live, resurrectable) = scan_session_list(
             "me",
-            &[],
+            None,
             &BTreeMap::new(),
             sock_dir.path(),
             info_dir.path(),
@@ -928,7 +935,7 @@ mod tests {
 
         let (live, resurrectable) = scan_session_list(
             "me",
-            &[],
+            None,
             &BTreeMap::new(),
             sock_dir.path(),
             info_dir.path(),
@@ -946,7 +953,7 @@ mod tests {
 
         let (live, resurrectable) = scan_session_list(
             "me",
-            &[],
+            None,
             &BTreeMap::new(),
             sock_dir.path(),
             info_dir.path(),
@@ -954,6 +961,25 @@ mod tests {
         assert!(live.is_empty());
         assert_eq!(resurrectable.len(), 1);
         assert!(resurrectable.contains_key("dead-beta"));
+    }
+
+    #[test]
+    fn scan_session_list_includes_current_session_when_scan_misses_it() {
+        let sock_dir = tempdir().unwrap();
+        let info_dir = tempdir().unwrap();
+        let current_session_info = SessionInfo::new("me".to_string());
+
+        let (live, resurrectable) = scan_session_list(
+            "me",
+            Some(&current_session_info),
+            &BTreeMap::new(),
+            sock_dir.path(),
+            info_dir.path(),
+        );
+
+        assert_eq!(live.len(), 1);
+        assert!(live.contains_key("me"));
+        assert!(resurrectable.is_empty());
     }
 
     #[test]
@@ -971,7 +997,7 @@ mod tests {
 
         let (live, resurrectable) = scan_session_list(
             "me",
-            &[],
+            None,
             &BTreeMap::new(),
             sock_dir.path(),
             info_dir.path(),

--- a/zellij-server/src/background_jobs.rs
+++ b/zellij-server/src/background_jobs.rs
@@ -736,7 +736,7 @@ pub fn write_session_state_to_disk(
 
 pub fn scan_session_list(
     current_session_name: &str,
-    available_layouts: &[LayoutInfo],
+    current_session_info: Option<&SessionInfo>,
     current_session_plugin_list: &BTreeMap<PluginId, RunPlugin>,
     sock_dir: &Path,
     session_info_cache_dir: &Path,
@@ -746,10 +746,17 @@ pub fn scan_session_list(
         sock_dir,
         session_info_cache_dir,
     );
-    for (name, info) in session_infos_on_machine.iter_mut() {
-        if name == current_session_name {
+    if let Some(current_session_info) = current_session_info {
+        if let Some(info) = session_infos_on_machine.get_mut(current_session_name) {
             info.populate_plugin_list(current_session_plugin_list.clone());
-            info.available_layouts = available_layouts.to_vec();
+            info.available_layouts = current_session_info.available_layouts.clone();
+        } else {
+            // The session info cache can briefly lag behind right after startup. The
+            // current session info is already available in memory, so ensure it is
+            // included even if the scan did not find it yet.
+            let mut current_session_info = current_session_info.clone();
+            current_session_info.populate_plugin_list(current_session_plugin_list.clone());
+            session_infos_on_machine.insert(current_session_name.to_owned(), current_session_info);
         }
     }
     let resurrectable_sessions =
@@ -759,12 +766,12 @@ pub fn scan_session_list(
 
 pub fn scan_session_list_default_dirs(
     current_session_name: &str,
-    available_layouts: &[LayoutInfo],
+    current_session_info: Option<&SessionInfo>,
     current_session_plugin_list: &BTreeMap<PluginId, RunPlugin>,
 ) -> (BTreeMap<String, SessionInfo>, BTreeMap<String, Duration>) {
     scan_session_list(
         current_session_name,
-        available_layouts,
+        current_session_info,
         current_session_plugin_list,
         &*ZELLIJ_SOCK_DIR,
         &*ZELLIJ_SESSION_INFO_CACHE_DIR,
@@ -885,7 +892,7 @@ mod tests {
         let info_dir = tempdir().unwrap();
         let (live, resurrectable) = scan_session_list(
             "me",
-            &[],
+            None,
             &BTreeMap::new(),
             sock_dir.path(),
             info_dir.path(),
@@ -904,7 +911,7 @@ mod tests {
 
         let (live, resurrectable) = scan_session_list(
             "me",
-            &[],
+            None,
             &BTreeMap::new(),
             sock_dir.path(),
             info_dir.path(),
@@ -922,7 +929,7 @@ mod tests {
 
         let (live, resurrectable) = scan_session_list(
             "me",
-            &[],
+            None,
             &BTreeMap::new(),
             sock_dir.path(),
             info_dir.path(),
@@ -930,6 +937,25 @@ mod tests {
         assert!(live.is_empty());
         assert_eq!(resurrectable.len(), 1);
         assert!(resurrectable.contains_key("dead-beta"));
+    }
+
+    #[test]
+    fn scan_session_list_includes_current_session_when_scan_misses_it() {
+        let sock_dir = tempdir().unwrap();
+        let info_dir = tempdir().unwrap();
+        let current_session_info = SessionInfo::new("me".to_string());
+
+        let (live, resurrectable) = scan_session_list(
+            "me",
+            Some(&current_session_info),
+            &BTreeMap::new(),
+            sock_dir.path(),
+            info_dir.path(),
+        );
+
+        assert_eq!(live.len(), 1);
+        assert!(live.contains_key("me"));
+        assert!(resurrectable.is_empty());
     }
 
     #[test]
@@ -947,7 +973,7 @@ mod tests {
 
         let (live, resurrectable) = scan_session_list(
             "me",
-            &[],
+            None,
             &BTreeMap::new(),
             sock_dir.path(),
             info_dir.path(),

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -4305,15 +4305,18 @@ fn get_session_list(env: &PluginEnv) {
 
     let response = match session_scan_state() {
         Some(state) => {
-            let (session_name, available_layouts, plugin_list) = {
+            let (session_name, current_session_info, plugin_list) = {
                 let name = state.current_session_name.lock().unwrap().clone();
                 let info = state.current_session_info.lock().unwrap().clone();
                 let plugins = state.current_session_plugin_list.lock().unwrap().clone();
-                (name, info.available_layouts, plugins)
+                (name, info, plugins)
             };
 
-            let (live_sessions_map, resurrectable_sessions_map) =
-                scan_session_list_default_dirs(&session_name, &available_layouts, &plugin_list);
+            let (live_sessions_map, resurrectable_sessions_map) = scan_session_list_default_dirs(
+                &session_name,
+                Some(&current_session_info),
+                &plugin_list,
+            );
 
             let _ = env
                 .senders

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -4323,15 +4323,18 @@ fn get_session_list(env: &PluginEnv) {
 
     let response = match session_scan_state() {
         Some(state) => {
-            let (session_name, available_layouts, plugin_list) = {
+            let (session_name, current_session_info, plugin_list) = {
                 let name = state.current_session_name.lock().unwrap().clone();
                 let info = state.current_session_info.lock().unwrap().clone();
                 let plugins = state.current_session_plugin_list.lock().unwrap().clone();
-                (name, info.available_layouts, plugins)
+                (name, info, plugins)
             };
 
-            let (live_sessions_map, resurrectable_sessions_map) =
-                scan_session_list_default_dirs(&session_name, &available_layouts, &plugin_list);
+            let (live_sessions_map, resurrectable_sessions_map) = scan_session_list_default_dirs(
+                &session_name,
+                Some(&current_session_info),
+                &plugin_list,
+            );
 
             let _ = env
                 .senders

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -2798,7 +2798,7 @@ pub(crate) fn route_thread_main(
                                 if let Some(scan_state) =
                                     crate::background_jobs::session_scan_state()
                                 {
-                                    let (session_name, available_layouts, plugin_list) = {
+                                    let (session_name, session_info, plugin_list) = {
                                         let name =
                                             scan_state.current_session_name.lock().unwrap().clone();
                                         let info =
@@ -2808,12 +2808,12 @@ pub(crate) fn route_thread_main(
                                             .lock()
                                             .unwrap()
                                             .clone();
-                                        (name, info.available_layouts, plugins)
+                                        (name, info, plugins)
                                     };
                                     let (live_sessions_map, resurrectable_sessions_map) =
                                         crate::background_jobs::scan_session_list_default_dirs(
                                             &session_name,
-                                            &available_layouts,
+                                            Some(&session_info),
                                             &plugin_list,
                                         );
                                     let _ = senders.send_to_screen(


### PR DESCRIPTION
Fixes #5278.

## Summary

This PR ensures that plugin API `get_session_list()` always includes the current
session in the returned live session list.

Right after startup, the session info cache / scan result can briefly lag behind.
If a plugin calls `get_session_list()` during that window, the scan can miss the
current session even though the current session info is already available in
memory.

## Problem

`get_session_list()` builds its response from the scanned live session list.

The existing code already handled the current session specially when it was
present in the scan result: it updated the current session entry with the current
plugin list and available layouts.

However, this only worked if the scan had already found the current session.

If the scan missed the current session shortly after startup, the current session
was not added to the response.

## Change

Pass the current session info into:

- `scan_session_list()`
- `scan_session_list_default_dirs()`

When the scanned live session map already contains the current session, keep the
scanned entry and update the current-session specific fields.

When the scan does not contain the current session, insert the in-memory current
session info into the live session map.
