### PR TITLE
fix(kkp): handle 3-parameter Kitty CSI-u sequences

### DIFF
--- a/zellij-client/src/keyboard_parser.rs
+++ b/zellij-client/src/keyboard_parser.rs
@@ -7,6 +7,11 @@ enum KittyKeysParsingState {
     ReceivedEscapeCharacter,
     ParsingNumber,
     ParsingModifiers,
+    /// Third CSI-u parameter (after the second `;`), present when the
+    /// terminal has `REPORT_ASSOCIATED_TEXT` enabled. Holds the produced
+    /// character codepoint(s) as decimal digits, optionally separated by
+    /// `:` for multi-codepoint text.
+    ParsingAssociatedText,
     DoneParsingWithU,
     DoneParsingWithTilde,
 }
@@ -32,6 +37,7 @@ pub struct KittyKeyboardParser {
     state: KittyKeysParsingState,
     number_bytes: Vec<u8>,
     modifier_bytes: Vec<u8>,
+    associated_text_bytes: Vec<u8>,
 }
 
 /// CSI final-byte range (0x40..=0x7E), minus `u` and `~` which trigger
@@ -49,6 +55,7 @@ impl KittyKeyboardParser {
             state: KittyKeysParsingState::Ground,
             number_bytes: vec![],
             modifier_bytes: vec![],
+            associated_text_bytes: vec![],
         }
     }
 
@@ -56,6 +63,7 @@ impl KittyKeyboardParser {
         self.state = KittyKeysParsingState::Ground;
         self.number_bytes.clear();
         self.modifier_bytes.clear();
+        self.associated_text_bytes.clear();
     }
 
     /// Stateful, cross-chunk-aware entry point. Drives the same
@@ -76,8 +84,11 @@ impl KittyKeyboardParser {
         }
         match self.state {
             KittyKeysParsingState::DoneParsingWithU => {
-                let result =
-                    KeyWithModifier::from_bytes_with_u(&self.number_bytes, &self.modifier_bytes);
+                let result = KeyWithModifier::from_bytes_with_u(
+                    &self.number_bytes,
+                    &self.modifier_bytes,
+                    &self.associated_text_bytes,
+                );
                 self.reset();
                 match result {
                     Some(k) => KittyParseOutcome::Complete(k),
@@ -88,6 +99,7 @@ impl KittyKeyboardParser {
                 let result = KeyWithModifier::from_bytes_with_tilde(
                     &self.number_bytes,
                     &self.modifier_bytes,
+                    &self.associated_text_bytes,
                 );
                 self.reset();
                 match result {
@@ -135,6 +147,10 @@ impl KittyKeyboardParser {
                     _ => KittyParseOutcome::Incomplete,
                 }
             },
+            // Associated text never appears in letter-terminated sequences
+            // (those are pure functional keys with no produced character),
+            // so we only wait for a `u` or `~` terminator here.
+            KittyKeysParsingState::ParsingAssociatedText => KittyParseOutcome::Incomplete,
             KittyKeysParsingState::ReceivedEscapeCharacter => KittyParseOutcome::Incomplete,
             KittyKeysParsingState::Ground => KittyParseOutcome::NoMatch,
         }
@@ -156,15 +172,23 @@ impl KittyKeyboardParser {
                 }
                 self.state = KittyKeysParsingState::ParsingModifiers;
             },
+            (KittyKeysParsingState::ParsingModifiers, 59) => {
+                // second semicolon: transition to the associated-text param.
+                self.state = KittyKeysParsingState::ParsingAssociatedText;
+            },
             (
-                KittyKeysParsingState::ParsingNumber | KittyKeysParsingState::ParsingModifiers,
+                KittyKeysParsingState::ParsingNumber
+                | KittyKeysParsingState::ParsingModifiers
+                | KittyKeysParsingState::ParsingAssociatedText,
                 117,
             ) => {
                 // u
                 self.state = KittyKeysParsingState::DoneParsingWithU;
             },
             (
-                KittyKeysParsingState::ParsingNumber | KittyKeysParsingState::ParsingModifiers,
+                KittyKeysParsingState::ParsingNumber
+                | KittyKeysParsingState::ParsingModifiers
+                | KittyKeysParsingState::ParsingAssociatedText,
                 126,
             ) => {
                 // ~
@@ -175,6 +199,9 @@ impl KittyKeyboardParser {
             },
             (KittyKeysParsingState::ParsingModifiers, _) => {
                 self.modifier_bytes.push(byte);
+            },
+            (KittyKeysParsingState::ParsingAssociatedText, _) => {
+                self.associated_text_bytes.push(byte);
             },
             (_, _) => {
                 return false;
@@ -2054,4 +2081,124 @@ fn non_kitty_bytes_yield_nomatch_and_reset() {
     // immediately rather than buffering forever.
     let mut p = KittyKeyboardParser::new();
     assert!(matches!(p.feed(b"hello"), KittyParseOutcome::NoMatch));
+}
+
+// ---------------------------------------------------------------------------
+// REPORT_ASSOCIATED_TEXT (3-parameter CSI-u) coverage.
+//
+// When the terminal has flag 16 enabled, modifier + key combinations come
+// across as `\x1b[<keycode>;<modifier>;<text-codepoints>u`. The parser must
+// (a) accept the third parameter without contaminating modifier_bytes, and
+// (b) when the associated text differs from the keycode char, use the
+// produced character as the bare key with no modifiers — this is how AltGr
+// glyphs (Windows Terminal 1.25) and similar OS-keymap-resolved keystrokes
+// reach zellij correctly.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn three_param_alt_f_preserves_alt_when_text_equals_keycode() {
+    // WT 1.25, WezTerm, Alacritty all send real Alt+f as `\x1b[102;3;102u`.
+    // Text == keycode → keep Alt so the Alt+f binding still fires.
+    use zellij_utils::data::BareKey;
+    let result = parse_for_test(b"\x1b[102;3;102u").expect("parse failed");
+    assert_eq!(
+        result,
+        KeyWithModifier::new(BareKey::Char('f')).with_alt_modifier(),
+    );
+}
+
+#[test]
+fn three_param_altgr_glyph_emits_produced_char_no_modifiers() {
+    // WT 1.25 on Belgian/Hungarian AZERTY sends AltGr+6 (= '|') as
+    // `\x1b[45;3;124u`: keycode 45 ('-'), modifier 3 (Alt), text 124 ('|').
+    // Text != keycode → emit the produced char with no modifiers so the
+    // Alt+'-' binding doesn't false-fire and bash receives '|'.
+    use zellij_utils::data::BareKey;
+    let result = parse_for_test(b"\x1b[45;3;124u").expect("parse failed");
+    assert_eq!(result, KeyWithModifier::new(BareKey::Char('|')));
+}
+
+#[test]
+fn three_param_altgr_backslash_emits_backslash() {
+    // AltGr+8 → '\' on AZERTY: `\x1b[95;3;92u`.
+    use zellij_utils::data::BareKey;
+    let result = parse_for_test(b"\x1b[95;3;92u").expect("parse failed");
+    assert_eq!(result, KeyWithModifier::new(BareKey::Char('\\')));
+}
+
+#[test]
+fn three_param_with_numlock_bit_preserves_alt() {
+    // WezTerm with NumLock on: `\x1b[102;131;102u`. Modifier byte 131 has
+    // bit 128 (NumLock) set, but the existing modifier-from-bytes path
+    // already silently drops lock bits, so Alt is preserved.
+    use zellij_utils::data::BareKey;
+    let result = parse_for_test(b"\x1b[102;131;102u").expect("parse failed");
+    assert_eq!(
+        result,
+        KeyWithModifier::new(BareKey::Char('f')).with_alt_modifier(),
+    );
+}
+
+#[test]
+fn three_param_shift_f_emits_uppercase() {
+    // Shift+F: `\x1b[102;2;70u`. Text 'F' != keycode 'f' → emit 'F' with
+    // no modifiers. (zellij has no Shift+letter bindings; behaviour at the
+    // action layer is identical to legacy.)
+    use zellij_utils::data::BareKey;
+    let result = parse_for_test(b"\x1b[102;2;70u").expect("parse failed");
+    assert_eq!(result, KeyWithModifier::new(BareKey::Char('F')));
+}
+
+#[test]
+fn three_param_with_multi_codepoint_text_uses_first() {
+    // Multi-codepoint associated text (rare: combining marks, some IME
+    // outputs) is colon-separated per spec. We act on the first codepoint
+    // only — enough for binding lookup, and the rest is acceptable to drop.
+    use zellij_utils::data::BareKey;
+    let result = parse_for_test(b"\x1b[97;3;65:768u").expect("parse failed");
+    assert_eq!(result, KeyWithModifier::new(BareKey::Char('A')));
+}
+
+#[test]
+fn three_param_with_control_codepoint_falls_through() {
+    // If the associated text decodes to a control character, fall through
+    // to the modifier-preserving path so existing legacy bindings still work.
+    use zellij_utils::data::BareKey;
+    let result = parse_for_test(b"\x1b[102;5;3u").expect("parse failed");
+    assert_eq!(
+        result,
+        KeyWithModifier::new(BareKey::Char('f')).with_ctrl_modifier(),
+    );
+}
+
+#[test]
+fn two_param_form_still_parses_when_text_param_absent() {
+    // WT 1.25 sends Ctrl+f without associated text: `\x1b[102;5u`. Our
+    // changes must not break the 2-param path.
+    use zellij_utils::data::BareKey;
+    let result = parse_for_test(b"\x1b[102;5u").expect("parse failed");
+    assert_eq!(
+        result,
+        KeyWithModifier::new(BareKey::Char('f')).with_ctrl_modifier(),
+    );
+}
+
+#[test]
+fn three_param_fragmented_across_chunks() {
+    // Same handshake as `fragmented_kitty_csi_u_emits_one_event` but with
+    // a 3-param sequence split across feed() calls.
+    use zellij_utils::data::BareKey;
+    let mut p = KittyKeyboardParser::new();
+    assert!(matches!(
+        p.feed(b"\x1b[45;3"),
+        KittyParseOutcome::Incomplete
+    ));
+    assert!(matches!(p.feed(b";124"), KittyParseOutcome::Incomplete));
+    let outcome = p.feed(b"u");
+    match outcome {
+        KittyParseOutcome::Complete(k) => {
+            assert_eq!(k, KeyWithModifier::new(BareKey::Char('|')));
+        },
+        other => panic!("expected Complete, got {:?}", other),
+    }
 }

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -51,7 +51,11 @@ const EXIT_ALTERNATE_SCREEN: &str = "\u{1b}[?1049l";
 const ENABLE_BRACKETED_PASTE: &str = "\u{1b}[?2004h";
 const RESET_STYLE: &str = "\u{1b}[m";
 const SHOW_CURSOR: &str = "\u{1b}[?25h";
-const ENTER_KITTY_KEYBOARD_MODE: &str = "\u{1b}[>1u";
+// Flag 17 = DISAMBIGUATE_ESCAPE_CODES (1) | REPORT_ASSOCIATED_TEXT (16).
+// Requesting the associated-text bit lets us recover the OS-produced
+// character for AltGr glyphs and other keymap-resolved keystrokes.
+// Terminals that don't support flag 16 silently ignore it per Kitty spec.
+const ENTER_KITTY_KEYBOARD_MODE: &str = "\u{1b}[>17u";
 const EXIT_KITTY_KEYBOARD_MODE: &str = "\u{1b}[<1u";
 const CLEAR_CLIENT_TERMINAL_ATTRIBUTES: &str = "\u{1b}[?1l\u{1b}=\u{1b}[r\u{1b}[?1000l\u{1b}[?1002l\u{1b}[?1003l\u{1b}[?1005l\u{1b}[?1006l\u{1b}[?12l";
 /// Subscribe to host color-palette theme notifications (CSI 2031). Hosts

--- a/zellij-client/src/web_client/utils.rs
+++ b/zellij-client/src/web_client/utils.rs
@@ -64,7 +64,9 @@ pub fn terminal_init_messages() -> Vec<&'static str> {
     let clear_client_terminal_attributes = "\u{1b}[?1l\u{1b}=\u{1b}[r\u{1b}[?1000l\u{1b}[?1002l\u{1b}[?1003l\u{1b}[?1005l\u{1b}[?1006l\u{1b}[?12l";
     let enter_alternate_screen = "\u{1b}[?1049h";
     let bracketed_paste = "\u{1b}[?2004h";
-    let enter_kitty_keyboard_mode = "\u{1b}[>1u";
+    // Flag 17 = DISAMBIGUATE_ESCAPE_CODES (1) | REPORT_ASSOCIATED_TEXT (16);
+    // see the matching constant in zellij-client/src/lib.rs for rationale.
+    let enter_kitty_keyboard_mode = "\u{1b}[>17u";
     let enable_mouse_mode = "\u{1b}[?1000h\u{1b}[?1002h\u{1b}[?1015h\u{1b}[?1006h";
     vec![
         clear_client_terminal_attributes,

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -436,6 +436,58 @@ impl KeyModifier {
     }
 }
 
+/// Parse the first Unicode codepoint from the Kitty CSI-u `associated-text`
+/// parameter. The parameter is one or more decimal codepoints joined by `:`,
+/// representing the character(s) the OS keymap would have produced if the
+/// keystroke had not been consumed by the application. We only act on the
+/// first codepoint; multi-codepoint sequences (IME, combining marks) are
+/// rare and acceptable to truncate for binding-resolution purposes.
+fn parse_first_associated_codepoint(bytes: &[u8]) -> Option<char> {
+    if bytes.is_empty() {
+        return None;
+    }
+    let s = str::from_utf8(bytes).ok()?;
+    let first = s.split(':').next()?;
+    let n: u32 = first.parse().ok()?;
+    char::from_u32(n)
+}
+
+/// When the OS keymap produced a character different from the bare keycode
+/// (AltGr glyphs, Shift+letter → uppercase, dead-key composition, IME),
+/// terminals supporting `REPORT_ASSOCIATED_TEXT` send that produced character
+/// as the third CSI-u parameter. Returning it as the bare key with no
+/// modifiers is the right thing for zellij: bindings should never match on
+/// the underlying *physical* key when the OS has resolved the keymap and
+/// produced a textual character.
+///
+/// When the associated text matches the bare keycode char (real Alt+f sends
+/// `f` as text), or there is no associated text, or it's a control codepoint,
+/// fall through to the modifier-preserving form so Alt-bindings still fire.
+fn apply_associated_text(
+    bare_key: BareKey,
+    key_modifiers: BTreeSet<KeyModifier>,
+    associated_text_bytes: &[u8],
+) -> KeyWithModifier {
+    if let Some(text_char) = parse_first_associated_codepoint(associated_text_bytes) {
+        if !text_char.is_control() {
+            let key_char = match bare_key {
+                BareKey::Char(c) => Some(c),
+                _ => None,
+            };
+            if key_char != Some(text_char) {
+                return KeyWithModifier {
+                    bare_key: BareKey::Char(text_char),
+                    key_modifiers: BTreeSet::new(),
+                };
+            }
+        }
+    }
+    KeyWithModifier {
+        bare_key,
+        key_modifiers,
+    }
+}
+
 impl KeyWithModifier {
     pub fn new(bare_key: BareKey) -> Self {
         KeyWithModifier {
@@ -465,33 +517,33 @@ impl KeyWithModifier {
         self.key_modifiers.insert(KeyModifier::Super);
         self
     }
-    pub fn from_bytes_with_u(number_bytes: &[u8], modifier_bytes: &[u8]) -> Option<Self> {
-        // CSI number ; modifiers u
-        let bare_key = BareKey::from_bytes_with_u(number_bytes);
-        match bare_key {
-            Some(bare_key) => {
-                let key_modifiers = KeyModifier::from_bytes(modifier_bytes);
-                Some(KeyWithModifier {
-                    bare_key,
-                    key_modifiers,
-                })
-            },
-            _ => None,
-        }
+    pub fn from_bytes_with_u(
+        number_bytes: &[u8],
+        modifier_bytes: &[u8],
+        associated_text_bytes: &[u8],
+    ) -> Option<Self> {
+        // CSI number ; modifiers ; associated-text u
+        let bare_key = BareKey::from_bytes_with_u(number_bytes)?;
+        let key_modifiers = KeyModifier::from_bytes(modifier_bytes);
+        Some(apply_associated_text(
+            bare_key,
+            key_modifiers,
+            associated_text_bytes,
+        ))
     }
-    pub fn from_bytes_with_tilde(number_bytes: &[u8], modifier_bytes: &[u8]) -> Option<Self> {
-        // CSI number ; modifiers ~
-        let bare_key = BareKey::from_bytes_with_tilde(number_bytes);
-        match bare_key {
-            Some(bare_key) => {
-                let key_modifiers = KeyModifier::from_bytes(modifier_bytes);
-                Some(KeyWithModifier {
-                    bare_key,
-                    key_modifiers,
-                })
-            },
-            _ => None,
-        }
+    pub fn from_bytes_with_tilde(
+        number_bytes: &[u8],
+        modifier_bytes: &[u8],
+        associated_text_bytes: &[u8],
+    ) -> Option<Self> {
+        // CSI number ; modifiers ; associated-text ~
+        let bare_key = BareKey::from_bytes_with_tilde(number_bytes)?;
+        let key_modifiers = KeyModifier::from_bytes(modifier_bytes);
+        Some(apply_associated_text(
+            bare_key,
+            key_modifiers,
+            associated_text_bytes,
+        ))
     }
     pub fn from_bytes_with_no_ending_byte(
         number_bytes: &[u8],


### PR DESCRIPTION
Terminals supporting REPORT_ASSOCIATED_TEXT (Kitty flag 16) send the OS-produced character alongside the keycode in a third CSI-u parameter: `\e[<keycode>;<modifier>;<text>u`. The previous parser only knew the 2-parameter form, so the second `;` and the text codepoints were pushed into modifier_bytes. KeyModifier::from_bytes then failed to parse "3;124" as an integer, returning an empty modifier set and emitting the base-layer keycode (e.g. `-` for AltGr+6 instead of `|`).

Three changes:

* Bump ENTER_KITTY_KEYBOARD_MODE from `\e[>1u` to `\e[>17u` so terminals that support REPORT_ASSOCIATED_TEXT will include the produced character. Terminals that don't support the bit silently ignore it per the Kitty spec.

* Extend KittyKeyboardParser with a ParsingAssociatedText state and a third byte buffer. The second `;` transitions into the new state; both `u` and `~` terminate from it.

* KeyWithModifier::from_bytes_with_u / _tilde now take the associated text bytes and, when the produced character differs from the keycode (AltGr glyphs, Shift+letter→uppercase, dead-key composition, IME), return that character with no modifiers. When text matches the keycode (real Alt+f reporting `f` as text), modifiers are preserved so Alt-bindings still fire.

Together these fix the AltGr regression reported for Windows Terminal 1.25 in #5048 (verified on WSL + WT 1.25): AltGr+6 now produces `|`, AltGr+8 produces `\`, etc. The parser change is also load-bearing for the flag bump itself — terminals that honor REPORT_ASSOCIATED_TEXT switch all modifier+key reports to the 3-parameter form, so without the parser update, Alt+f / Ctrl+f bindings would silently break on those terminals (WezTerm, Alacritty 0.13+) instead of continuing to work.

Known limitation: on Windows native PowerShell, ConPTY strips the third parameter before bytes reach zellij, so the fix only takes effect in environments where the 3-parameter form survives the input pipeline (Linux/macOS native, WSL bash).