### PR TITLE
feat(themes): add optional `pane_selection` style for pane-content selection

### DIFF
--- a/zellij-client/src/web_client/control_message.rs
+++ b/zellij-client/src/web_client/control_message.rs
@@ -143,10 +143,19 @@ impl From<&Config> for SetConfigPayload {
         theme.red = web_client_theme_from_config.and_then(|theme| theme.red.clone());
         theme.selection_background = web_client_theme_from_config
             .and_then(|theme| theme.selection_background.clone())
-            .or_else(|| palette.map(|p| p.text_selected.background.as_rgb_str()));
+            .or_else(|| {
+                palette.map(|p| {
+                    p.pane_selection
+                        .unwrap_or(p.text_selected)
+                        .background
+                        .as_rgb_str()
+                })
+            });
         theme.selection_foreground = web_client_theme_from_config
             .and_then(|theme| theme.selection_foreground.clone())
-            .or_else(|| palette.map(|p| p.text_selected.base.as_rgb_str()));
+            .or_else(|| {
+                palette.map(|p| p.pane_selection.unwrap_or(p.text_selected).base.as_rgb_str())
+            });
         theme.selection_inactive_background = web_client_theme_from_config
             .and_then(|theme| theme.selection_inactive_background.clone());
         theme.white = web_client_theme_from_config.and_then(|theme| theme.white.clone());

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1583,11 +1583,17 @@ impl Grid {
                 .selection
                 .contains_row(character_chunk.y.saturating_sub(content_y))
             {
-                let background_color = match style.colors.text_selected.background {
+                // Pane-content selection uses its own `pane_selection` style when
+                // set, otherwise falls back to `text_selected` (issue #2160 POC).
+                let selection_style = style
+                    .colors
+                    .pane_selection
+                    .unwrap_or(style.colors.text_selected);
+                let background_color = match selection_style.background {
                     PaletteColor::Rgb(rgb) => AnsiCode::RgbCode(rgb),
                     PaletteColor::EightBit(col) => AnsiCode::ColorIndex(col),
                 };
-                let foreground_color = match style.colors.text_selected.base {
+                let foreground_color = match selection_style.base {
                     PaletteColor::Rgb(rgb) => AnsiCode::RgbCode(rgb),
                     PaletteColor::EightBit(col) => AnsiCode::ColorIndex(col),
                 };

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -1,4 +1,5 @@
 use super::super::Grid;
+use crate::output::HighlightSelection;
 use crate::panes::grid::SixelImageStore;
 use crate::panes::link_handler::LinkHandler;
 use insta::assert_snapshot;
@@ -7,7 +8,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use vte;
 use zellij_utils::{
-    data::{Palette, Style},
+    data::{Palette, PaletteColor, Style, StyleDeclaration},
     pane_size::SizeInPixels,
     position::Position,
 };
@@ -6100,5 +6101,95 @@ fn csi_5n_status_query_still_handled_locally() {
         grid.pending_messages_to_pty,
         vec![b"\x1b[0n".to_vec()],
         "DSR 5 must still produce its local 'all good' reply"
+    );
+}
+
+// ---- issue #2160: themeable pane-content selection (pane_selection > text_selected) ----
+
+fn grid_with_first_row_selected() -> Grid {
+    let sixel_image_store = Rc::new(RefCell::new(SixelImageStore::default()));
+    let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
+    let mut grid = Grid::new(
+        5,
+        20,
+        Rc::new(RefCell::new(Palette::default())),
+        terminal_emulator_color_codes,
+        Rc::new(RefCell::new(LinkHandler::new())),
+        Rc::new(RefCell::new(None)),
+        sixel_image_store,
+        Style::default(),
+        false,
+        true,
+        true,
+        true,
+        false,
+    );
+    let mut vte_parser = vte::Parser::new();
+    for &byte in b"hello selection test" {
+        vte_parser.advance(&mut grid, byte);
+    }
+    grid.start_selection(&Position::new(0, 0));
+    grid.end_selection(&Position::new(0, 19));
+    grid
+}
+
+fn selection_decl(base: PaletteColor, background: PaletteColor) -> StyleDeclaration {
+    StyleDeclaration {
+        base,
+        background,
+        emphasis_0: base,
+        emphasis_1: base,
+        emphasis_2: base,
+        emphasis_3: base,
+    }
+}
+
+// Render the grid and return the background color applied to the selected row.
+fn rendered_selection_bg(grid: &mut Grid, style: &Style) -> AnsiCode {
+    let (chunks, _, _) = grid
+        .render(0, 0, style)
+        .expect("render should succeed")
+        .expect("render should produce output");
+    chunks
+        .iter()
+        .flat_map(|chunk| chunk.selection_and_colors())
+        .find_map(|hs: &HighlightSelection| hs.bg)
+        .expect("a selected row should carry a highlight background")
+}
+
+#[test]
+fn pane_selection_overrides_text_selected_for_pane_content() {
+    // pane_selection=magenta, text_selected=cyan: pane-content selection must use pane_selection.
+    let mut grid = grid_with_first_row_selected();
+    let mut style = Style::default();
+    style.colors.text_selected = selection_decl(
+        PaletteColor::Rgb((255, 255, 255)),
+        PaletteColor::Rgb((0, 255, 255)),
+    );
+    style.colors.pane_selection = Some(selection_decl(
+        PaletteColor::Rgb((255, 255, 255)),
+        PaletteColor::Rgb((255, 0, 255)),
+    ));
+    assert_eq!(
+        rendered_selection_bg(&mut grid, &style),
+        AnsiCode::RgbCode((255, 0, 255)),
+        "pane_selection background should win over text_selected"
+    );
+}
+
+#[test]
+fn pane_content_selection_falls_back_to_text_selected_when_unset() {
+    // pane_selection unset -> selection falls back to text_selected (pre-#2160 behavior preserved).
+    let mut grid = grid_with_first_row_selected();
+    let mut style = Style::default();
+    style.colors.text_selected = selection_decl(
+        PaletteColor::Rgb((255, 255, 255)),
+        PaletteColor::Rgb((0, 255, 255)),
+    );
+    style.colors.pane_selection = None;
+    assert_eq!(
+        rendered_selection_bg(&mut grid, &style),
+        AnsiCode::RgbCode((0, 255, 255)),
+        "with pane_selection unset, selection should use text_selected"
     );
 }

--- a/zellij-utils/assets/prost/api.style.rs
+++ b/zellij-utils/assets/prost/api.style.rs
@@ -113,6 +113,8 @@ pub struct Styling {
     pub exit_code_error: ::prost::alloc::vec::Vec<Color>,
     #[prost(message, repeated, tag="15")]
     pub multiplayer_user_colors: ::prost::alloc::vec::Vec<Color>,
+    #[prost(message, repeated, tag="16")]
+    pub pane_selection: ::prost::alloc::vec::Vec<Color>,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -1400,6 +1400,10 @@ impl Coloration {
 pub struct Styling {
     pub text_unselected: StyleDeclaration,
     pub text_selected: StyleDeclaration,
+    /// Color of mouse-drag selection of terminal pane content.
+    /// When `None`, falls back to `text_selected` so existing themes are
+    /// byte-for-byte unchanged. (POC for issue #2160.)
+    pub pane_selection: Option<StyleDeclaration>,
     pub ribbon_unselected: StyleDeclaration,
     pub ribbon_selected: StyleDeclaration,
     pub table_title: StyleDeclaration,
@@ -1488,6 +1492,7 @@ pub const DEFAULT_STYLES: Styling = Styling {
         emphasis_3: PaletteColor::EightBit(default_colors::PURPLE),
         background: PaletteColor::EightBit(default_colors::GRAY),
     },
+    pane_selection: None,
     frame_unselected: None,
     frame_selected: StyleDeclaration {
         base: PaletteColor::EightBit(default_colors::GREEN),
@@ -1646,6 +1651,7 @@ impl From<Palette> for Styling {
                 emphasis_3: palette.purple,
                 background: Default::default(),
             },
+            pane_selection: None,
             frame_unselected: None,
             frame_selected: StyleDeclaration {
                 base: palette.green,

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__theme__theme_test__dracula_theme_from_file.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__theme__theme_test__dracula_theme_from_file.snap
@@ -94,6 +94,7 @@ expression: "format!(\"{:#?}\", theme)"
                     ),
                 ),
             },
+            pane_selection: None,
             ribbon_unselected: StyleDeclaration {
                 base: Rgb(
                     (

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -5426,6 +5426,10 @@ impl Themes {
                         "list_selected",
                     )
                     .map(|maybe_style| maybe_style.unwrap_or(DEFAULT_STYLES.list_selected))?,
+                    pane_selection: Themes::style_declaration_from_node(
+                        theme_config,
+                        "pane_selection",
+                    )?,
                     frame_unselected: Themes::style_declaration_from_node(
                         theme_config,
                         "frame_unselected",
@@ -5565,6 +5569,14 @@ impl Themes {
                     current_theme_node_children
                         .nodes_mut()
                         .push(frame_unselected_style.to_kdl("frame_unselected"));
+                },
+            }
+            match theme.palette.pane_selection {
+                None => {},
+                Some(pane_selection_style) => {
+                    current_theme_node_children
+                        .nodes_mut()
+                        .push(pane_selection_style.to_kdl("pane_selection"));
                 },
             }
             current_theme_node_children

--- a/zellij-utils/src/plugin_api/style.proto
+++ b/zellij-utils/src/plugin_api/style.proto
@@ -70,4 +70,5 @@ message Styling {
     repeated Color exit_code_success = 13;
     repeated Color exit_code_error = 14;
     repeated Color multiplayer_user_colors = 15;
+    repeated Color pane_selection = 16;
 }

--- a/zellij-utils/src/plugin_api/style.rs
+++ b/zellij-utils/src/plugin_api/style.rs
@@ -111,6 +111,12 @@ impl TryFrom<ProtobufStyling> for Styling {
             None
         };
 
+        let pane_selection = if proto.pane_selection.len() > 0 {
+            Some(color_definitions!(proto, pane_selection, 6))
+        } else {
+            None
+        };
+
         Ok(Styling {
             text_unselected: color_definitions!(proto, text_unselected, 6),
             text_selected: color_definitions!(proto, text_selected, 6),
@@ -121,6 +127,7 @@ impl TryFrom<ProtobufStyling> for Styling {
             table_cell_selected: color_definitions!(proto, table_cell_selected, 6),
             list_unselected: color_definitions!(proto, list_unselected, 6),
             list_selected: color_definitions!(proto, list_selected, 6),
+            pane_selection,
             frame_unselected,
             frame_selected: color_definitions!(proto, frame_selected, 6),
             frame_highlight: color_definitions!(proto, frame_highlight, 6),
@@ -174,6 +181,11 @@ impl TryFrom<Styling> for ProtobufStyling {
             Some(frame_unselected) => frame_unselected.try_into(),
         };
 
+        let pane_selection_vec = match style.pane_selection {
+            None => Ok(Vec::new()),
+            Some(pane_selection) => pane_selection.try_into(),
+        };
+
         Ok(ProtobufStyling {
             text_unselected: style.text_unselected.try_into()?,
             text_selected: style.text_selected.try_into()?,
@@ -184,6 +196,7 @@ impl TryFrom<Styling> for ProtobufStyling {
             table_cell_selected: style.table_cell_selected.try_into()?,
             list_unselected: style.list_unselected.try_into()?,
             list_selected: style.list_selected.try_into()?,
+            pane_selection: pane_selection_vec?,
             frame_unselected: frame_unselected_vec?,
             frame_selected: style.frame_selected.try_into()?,
             frame_highlight: style.frame_highlight.try_into()?,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
@@ -6124,6 +6124,7 @@ Config {
                         ),
                     ),
                 },
+                pane_selection: None,
                 ribbon_unselected: StyleDeclaration {
                     base: Rgb(
                         (
@@ -6714,6 +6715,7 @@ Config {
                         ),
                     ),
                 },
+                pane_selection: None,
                 ribbon_unselected: StyleDeclaration {
                     base: Rgb(
                         (
@@ -7304,6 +7306,7 @@ Config {
                         ),
                     ),
                 },
+                pane_selection: None,
                 ribbon_unselected: StyleDeclaration {
                     base: Rgb(
                         (


### PR DESCRIPTION
## What
Adds an optional `pane_selection` Styling component that colors the mouse-drag
selection of **terminal pane content**, falling back to `text_selected` when unset.

Refs #2160 (proposal — happy to adjust per the open questions below).

## Why
Since #3242, pane-content selection is already theme-driven — `grid.rs` colors it
from `text_selected.base`/`.background`. But that's the **same** component Zellij's
UI uses for selected text (the `.selected()` state of the `Text` primitive:
session-manager rows, strider results, etc.), so pane-content selection can't be
colored independently of UI selected-text. #2160 asks for control over the
pane-content selection color specifically; this gives it its own knob without
changing any existing default.

## How
- New `pane_selection: Option<StyleDeclaration>` on `Styling` (default `None`).
- Render site resolves `pane_selection.unwrap_or(text_selected)` (`grid.rs`, plus
  the web client).
- KDL de/serialization + protobuf field (and generated code) added.
- Mirrors the existing `frame_unselected: Option<StyleDeclaration>` pattern, so:
  - existing themes/configs are **byte-for-byte unchanged** (unset → fallback),
  - no churn to the bundled themes,
  - plugin back-compat preserved via the `Styling`↔`Palette` shim.

Precedence: `pane_selection` > `text_selected` > default.

```kdl
themes {
    my-theme {
        text_selected  { base 255 255 255; background 0 90 255 }   // UI selection
        pane_selection { base 255 255 255; background 56 146 233 } // pane-content selection
    }
}
```

## Tests / compatibility
- Grid-level unit tests assert the override and the `text_selected` fallback at the
  render layer (`grid_tests.rs`).
- Only `Debug`-derived theme snapshots changed (additive `pane_selection: None`);
  KDL round-trip snapshots are unchanged (`None` isn't serialized).

## Screenshots
<img width="727" height="225" alt="image" src="https://github.com/user-attachments/assets/b635f445-0bf9-4bd5-b845-d2b16bd97ebf" />


## Open questions
1. Is decoupling wanted, or is sharing `text_selected` intended (#3242 unified them)?
2. Naming — `pane_selection` / `text_selected_in_pane` / `mouse_selection`?
3. Option-with-fallback (this PR) vs. a required component added to every theme?
4. Full `StyleDeclaration` vs. just `base`+`background` (selection only uses those)?
