### PR TITLE
fix(pty): report a pane's own command, not a subprocess it spawned

### DIFF
--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -1971,9 +1971,16 @@ impl Pty {
             let cwd = process_id.and_then(|pid| pids_to_cwds.get(pid));
             let cmd_sysinfo = process_id.and_then(|pid| pids_to_cmds.get(pid));
             let cmd_ps = process_id.and_then(|pid| ppids_to_cmds.get(&format!("{}", pid)));
-            if let Some(cmd) = cmd_ps {
-                terminal_ids_to_commands.insert(terminal_id, cmd.clone());
-            } else if let Some(cmd) = cmd_sysinfo {
+            // Only "see through" to a child process when the pane's own process is a
+            // shell (e.g. nvim in bash). Otherwise report the pane process itself, so a
+            // command pane (e.g. `claude`) isn't masked by a subprocess it spawned.
+            let child_is_shell = cmd_sysinfo.map(|c| cmd_is_shell(c)).unwrap_or(false);
+            let chosen = if child_is_shell {
+                cmd_ps.or(cmd_sysinfo)
+            } else {
+                cmd_sysinfo.or(cmd_ps)
+            };
+            if let Some(cmd) = chosen {
                 terminal_ids_to_commands.insert(terminal_id, cmd.clone());
             }
             if let Some(cwd) = cwd {
@@ -2290,9 +2297,18 @@ impl Pty {
                         let (_cwds, cmds) = os_input.get_cwds(vec![child_pid]);
                         let cmd_sysinfo = cmds.get(&child_pid);
 
-                        if let Some(command_args) = cmd_ps {
-                            GetPaneRunningCommandResponse::Ok(command_args.clone())
-                        } else if let Some(command_args) = cmd_sysinfo {
+                        // Only "see through" to a child process when the pane's own
+                        // process is a shell (e.g. nvim in bash); otherwise report the
+                        // pane process itself, so a command pane (e.g. `claude`) isn't
+                        // masked by a subprocess it spawned (an MCP server, etc).
+                        let child_is_shell =
+                            cmd_sysinfo.map(|c| cmd_is_shell(c)).unwrap_or(false);
+                        let chosen = if child_is_shell {
+                            cmd_ps.or(cmd_sysinfo)
+                        } else {
+                            cmd_sysinfo.or(cmd_ps)
+                        };
+                        if let Some(command_args) = chosen {
                             GetPaneRunningCommandResponse::Ok(command_args.clone())
                         } else {
                             GetPaneRunningCommandResponse::Err(format!(
@@ -2381,6 +2397,28 @@ fn send_command_not_found_to_screen(
         ))
         .with_context(err_context)?;
     Ok(())
+}
+
+// True when this command line is a shell. Used to decide whether to "see through"
+// a pane's process to a child it spawned: we only do that for shells (e.g. nvim
+// running in bash). A command pane (e.g. `claude`) should report itself, not a
+// subprocess it launched (an MCP server, caffeinate, ...).
+fn cmd_is_shell(cmd: &[String]) -> bool {
+    let first = match cmd.first() {
+        Some(f) => f,
+        None => return false,
+    };
+    let base = first
+        .rsplit(|c| c == '/' || c == '\\')
+        .next()
+        .unwrap_or(first.as_str())
+        .trim_start_matches('-'); // login shells set argv[0] to e.g. "-zsh"
+    matches!(
+        base,
+        "sh" | "bash" | "zsh" | "fish" | "dash" | "ksh" | "ksh93" | "mksh"
+            | "tcsh" | "csh" | "ash" | "nu" | "xonsh" | "elvish"
+            | "pwsh" | "pwsh.exe" | "powershell" | "powershell.exe"
+    )
 }
 
 #[cfg(not(windows))]

--- a/zellij-server/src/unit/pty_tests.rs
+++ b/zellij-server/src/unit/pty_tests.rs
@@ -477,3 +477,27 @@ fn osc7_then_poll_skips_terminal() {
         "poll after osc7 should skip terminal since flag was cleared"
     );
 }
+
+#[test]
+fn cmd_is_shell_distinguishes_shells_from_command_panes() {
+    let s = |v: &[&str]| v.iter().map(|x| x.to_string()).collect::<Vec<_>>();
+    // Shells (incl. absolute paths and login-shell argv[0]) — we DO see through
+    // these to the program running in them.
+    assert!(cmd_is_shell(&s(&["zsh"])));
+    assert!(cmd_is_shell(&s(&["/bin/bash", "-l"])));
+    assert!(cmd_is_shell(&s(&["-zsh"])));
+    assert!(cmd_is_shell(&s(&["/usr/bin/fish"])));
+    assert!(cmd_is_shell(&s(&["dash"])));
+    // Command panes / programs — must NOT be treated as shells, so they aren't
+    // "seen through" to a spawned subprocess (the #2160 dump-layout masking bug).
+    assert!(!cmd_is_shell(&s(&[
+        "claude",
+        "--dangerously-skip-permissions",
+        "--resume",
+        "x"
+    ])));
+    assert!(!cmd_is_shell(&s(&["npm", "exec", "@playwright/mcp@latest"])));
+    assert!(!cmd_is_shell(&s(&["caffeinate"])));
+    assert!(!cmd_is_shell(&s(&["nvim"])));
+    assert!(!cmd_is_shell(&s(&[])));
+}


### PR DESCRIPTION
## Problem
A pane's running command (used by `dump-layout` and `list-clients`) is derived
from `get_all_cmds_by_ppid(child_pid)` — the command of *a child* of the pane's
process. That correctly "sees through" a shell to the program running in it
(e.g. `nvim` in `bash`), but for a **command pane** it surfaces a subprocess the
command spawned instead of the command itself.

Concretely: a pane running `claude` (which spawns an MCP server) is reported as
`npm exec @playwright/mcp@latest`; a pane whose program spawned `caffeinate` is
reported as `caffeinate`. This breaks layout snapshot / resurrection tooling,
which can no longer tell the pane is running `claude`.  

I was using this in a script I published at https://github.com/dchersey/claude-zellij-restore and that surfaced the inconsistency.  The script manages around it but this fix seems cleaner. 

## Fix
Only see through to a child process when the pane's own process is actually a
**shell**; otherwise report the pane process itself. Adds a `cmd_is_shell`
helper (+ unit test) and applies the rule in both affected paths:
- `fill_layout_metadata` (dump-layout)
- `get_pane_running_command` (list-clients / queries)

## Behavior
| pane | before | after |
|---|---|---|
| `bash` running `nvim` | `nvim` | `nvim` (unchanged) |
| `bash` at prompt | `bash` | `bash` (unchanged) |
| `claude` (spawns MCP server) | `npm exec @playwright/mcp@latest` | `claude …` |
| `npm run dev` (spawns node) | a node subprocess | `npm run dev` |

No config or format changes — it purely corrects the reported command.
