### PR TITLE
fix(keybinds): apply every top-level `unbind` node, not just the first

### DIFF
--- a/zellij-utils/src/input/unit/keybinds_test.rs
+++ b/zellij-utils/src/input/unit/keybinds_test.rs
@@ -399,6 +399,43 @@ fn can_unbind_multiple_keys_globally() {
 }
 
 #[test]
+fn can_unbind_keys_across_multiple_global_unbind_nodes() {
+    // Regression: `KdlDocument::get("unbind")` returns only the first `unbind` node,
+    // so multiple top-level `unbind` lines used to silently drop all but the first.
+    let default_config_contents = r#"
+        keybinds {
+            normal {
+                bind "Ctrl g" { SwitchToMode "Locked"; }
+                bind "z" { TogglePaneFrames; }
+                bind "r" { TogglePaneFrames; }
+            }
+        }
+    "#;
+    let config_contents = r#"
+        keybinds {
+            unbind "Ctrl g"
+            unbind "z"
+            unbind "r"
+        }
+    "#;
+    let default_config = Config::from_kdl(default_config_contents, None).unwrap();
+    let config = Config::from_kdl(config_contents, Some(default_config)).unwrap();
+    let ctrl_g = config.keybinds.get_actions_for_key_in_mode(
+        &InputMode::Normal,
+        &KeyWithModifier::new(BareKey::Char('g')).with_ctrl_modifier(),
+    );
+    let z = config
+        .keybinds
+        .get_actions_for_key_in_mode(&InputMode::Normal, &KeyWithModifier::new(BareKey::Char('z')));
+    let r = config
+        .keybinds
+        .get_actions_for_key_in_mode(&InputMode::Normal, &KeyWithModifier::new(BareKey::Char('r')));
+    assert_eq!(ctrl_g, None, "first unbind node applied");
+    assert_eq!(z, None, "second unbind node applied (previously silently dropped)");
+    assert_eq!(r, None, "third unbind node applied (previously silently dropped)");
+}
+
+#[test]
 fn can_unbind_multiple_keys_per_single_mode() {
     let default_config_contents = r#"
         keybinds {

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -4735,9 +4735,14 @@ impl Keybinds {
                 Keybinds::input_mode_keybindings(mode, &mut keybinds_from_config)?;
             Keybinds::bind_keys_in_block(mode, &mut input_mode_keybinds, config_options)?;
         }
-        if let Some(global_unbind) = kdl_keybinds.children().and_then(|c| c.get("unbind")) {
-            Keybinds::unbind_keys_in_all_modes(global_unbind, &mut keybinds_from_config)?;
-        };
+        // Apply *every* top-level `unbind` node, not just the first. `KdlDocument::get`
+        // returns only the first node of a given name, so previously a second/third
+        // `unbind` line was silently dropped.
+        if let Some(children) = kdl_keybinds.children() {
+            for global_unbind in children.nodes().iter().filter(|n| kdl_name!(n) == "unbind") {
+                Keybinds::unbind_keys_in_all_modes(global_unbind, &mut keybinds_from_config)?;
+            }
+        }
         Ok(keybinds_from_config)
     }
     fn bind_actions_for_each_key(


### PR DESCRIPTION
## Problem
A `keybinds {}` block may contain multiple top-level `unbind` nodes:

```kdl
keybinds {
    unbind "Ctrl g"
    unbind "Alt f"
}
```

But the parser used `KdlDocument::get("unbind")`, which returns only the **first**
node of a given name — so every `unbind` line after the first was silently
dropped and those keys stayed bound. The only working form was to combine them
onto one line (`unbind "Ctrl g" "Alt f"`), with nothing to indicate the others
were ignored.

## Fix
Iterate **all** top-level `unbind` nodes (mirroring the per-mode unbind handling
already present in the file) and apply each. Adds a regression test that parses
three separate `unbind` lines and asserts all three keys are unbound.

No behavior change for single-node configs.
