### PR TITLE
fix(themes): let user-defined themes override same-named built-ins

### DIFF
--- a/zellij-utils/src/input/cli_assets.rs
+++ b/zellij-utils/src/input/cli_assets.rs
@@ -4,7 +4,7 @@ use crate::pane_size::Size;
 use crate::{
     home::{find_default_config_dir, get_theme_dir},
     input::{config::Config, layout::Layout, theme::Themes},
-    setup::get_default_themes,
+    setup::{get_default_themes, themes_with_defaults},
 };
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -63,9 +63,10 @@ impl CliAssets {
             layout.recursively_add_start_suspended(Some(false));
         }
 
-        config_with_merged_layout_opts.themes = config_with_merged_layout_opts
-            .themes
-            .merge(get_default_themes());
+        config_with_merged_layout_opts.themes = themes_with_defaults(
+            get_default_themes(),
+            config_with_merged_layout_opts.themes.clone(),
+        );
 
         let user_theme_dir = self
             .configuration_options

--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -43,6 +43,14 @@ pub fn get_default_themes() -> Themes {
     Themes::default()
 }
 
+// User-defined themes (from the config) take precedence over built-in defaults of
+// the same name. `Themes::merge` lets the *argument* win, so the user themes must be
+// the argument and the defaults the receiver. (This was previously reversed, which
+// silently shadowed a user theme with a same-named built-in.)
+fn themes_with_defaults(defaults: Themes, user_themes: Themes) -> Themes {
+    defaults.merge(user_themes)
+}
+
 pub fn dump_asset(asset: &[u8]) -> std::io::Result<()> {
     std::io::stdout().write_all(asset)?;
     Ok(())
@@ -329,7 +337,7 @@ impl Setup {
                 None => config.options.clone(),
             };
 
-            config.themes = config.themes.merge(get_default_themes());
+            config.themes = themes_with_defaults(get_default_themes(), config.themes.clone());
 
             let user_theme_dir = config_options.theme_dir.clone().or_else(|| {
                 get_theme_dir(cli_args.config_dir.clone().or_else(find_default_config_dir))
@@ -684,6 +692,37 @@ mod setup_test {
     use crate::input::options::Options;
     use insta::assert_snapshot;
     use std::path::PathBuf;
+
+    #[test]
+    fn user_themes_override_default_themes_of_the_same_name() {
+        use super::themes_with_defaults;
+        use crate::data::{PaletteColor, Styling};
+        use crate::input::theme::{Theme, Themes};
+        use std::collections::HashMap;
+        let theme = |base: (u8, u8, u8)| {
+            let mut palette = Styling::default();
+            palette.text_unselected.base = PaletteColor::Rgb(base);
+            let mut m = HashMap::new();
+            m.insert(
+                "shared-name".to_string(),
+                Theme {
+                    sourced_from_external_file: false,
+                    palette,
+                },
+            );
+            Themes::from_data(m)
+        };
+        let defaults = theme((10, 10, 10)); // stands in for a same-named built-in
+        let user = theme((1, 2, 3)); // the user's version (sentinel)
+        let merged = themes_with_defaults(defaults, user);
+        assert_eq!(
+            merged
+                .get_theme("shared-name")
+                .map(|t| t.palette.text_unselected.base),
+            Some(PaletteColor::Rgb((1, 2, 3))),
+            "a user-defined theme must override a same-named default"
+        );
+    }
 
     #[test]
     fn default_config_with_no_cli_arguments() {

--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -47,7 +47,7 @@ pub fn get_default_themes() -> Themes {
 // the same name. `Themes::merge` lets the *argument* win, so the user themes must be
 // the argument and the defaults the receiver. (This was previously reversed, which
 // silently shadowed a user theme with a same-named built-in.)
-fn themes_with_defaults(defaults: Themes, user_themes: Themes) -> Themes {
+pub fn themes_with_defaults(defaults: Themes, user_themes: Themes) -> Themes {
     defaults.merge(user_themes)
 }
 


### PR DESCRIPTION
## Problem
Default (built-in) themes were merged *over* the user's config themes:

```rust
config.themes = config.themes.merge(get_default_themes());
```

`Themes::merge(&self, other)` lets the **argument** win, so the built-in defaults
overrode the user's config themes. A theme defined in the user's config with the
same name as a built-in (e.g. customizing `dracula`) was **silently shadowed** by
the built-in.

This same built-in-wins merge was duplicated across **both** theme-resolution paths:
- `setup.rs` (`apply_themes_to_config`)
- `cli_assets.rs` (config + layout resolution — runs on *every* launch, including
  plain `zellij` with the default layout)

(`theme_dir` themes were unaffected — they're merged afterwards and still win.)

## Fix
Add a `themes_with_defaults(defaults, user)` helper that makes the built-in
defaults the base and the user themes the override, and route **both** paths
through it. `theme_dir` still wins over both.

Adds a regression test. (The in-tree `get_default_themes()` is stubbed to empty
under `#[cfg(test)]` — part of why this went unnoticed — so the test drives the
helper's merge direction with explicit inputs.)

## Precedence (after)
`theme_dir`  >  user config theme  >  built-in default
