### PR TITLE
feat(themes): foreground-preserving and alpha-composited pane selection

### DIFF
--- a/zellij-client/src/web_client/control_message.rs
+++ b/zellij-client/src/web_client/control_message.rs
@@ -154,7 +154,15 @@ impl From<&Config> for SetConfigPayload {
         theme.selection_foreground = web_client_theme_from_config
             .and_then(|theme| theme.selection_foreground.clone())
             .or_else(|| {
-                palette.map(|p| p.pane_selection.unwrap_or(p.text_selected).base.as_rgb_str())
+                palette.and_then(|p| {
+                    if p.pane_selection_keep_foreground {
+                        // Preserve each cell's own foreground (terminal-native
+                        // selection) — leave xterm.js' selectionForeground unset.
+                        None
+                    } else {
+                        Some(p.pane_selection.unwrap_or(p.text_selected).base.as_rgb_str())
+                    }
+                })
             });
         theme.selection_inactive_background = web_client_theme_from_config
             .and_then(|theme| theme.selection_inactive_background.clone());

--- a/zellij-client/src/web_client/control_message.rs
+++ b/zellij-client/src/web_client/control_message.rs
@@ -143,10 +143,19 @@ impl From<&Config> for SetConfigPayload {
         theme.red = web_client_theme_from_config.and_then(|theme| theme.red.clone());
         theme.selection_background = web_client_theme_from_config
             .and_then(|theme| theme.selection_background.clone())
-            .or_else(|| palette.map(|p| p.text_selected.background.as_rgb_str()));
+            .or_else(|| {
+                palette.map(|p| {
+                    p.pane_selection
+                        .unwrap_or(p.text_selected)
+                        .background
+                        .as_rgb_str()
+                })
+            });
         theme.selection_foreground = web_client_theme_from_config
             .and_then(|theme| theme.selection_foreground.clone())
-            .or_else(|| palette.map(|p| p.text_selected.base.as_rgb_str()));
+            .or_else(|| {
+                palette.map(|p| p.pane_selection.unwrap_or(p.text_selected).base.as_rgb_str())
+            });
         theme.selection_inactive_background = web_client_theme_from_config
             .and_then(|theme| theme.selection_inactive_background.clone());
         theme.white = web_client_theme_from_config.and_then(|theme| theme.white.clone());

--- a/zellij-server/src/output/mod.rs
+++ b/zellij-server/src/output/mod.rs
@@ -18,6 +18,7 @@ use std::{
 };
 use zellij_utils::data::{HighlightLayer, PaneContents, PaneRenderReport};
 use zellij_utils::errors::prelude::*;
+use zellij_utils::shared::eightbit_to_rgb;
 use zellij_utils::pane_size::SizeInPixels;
 use zellij_utils::pane_size::{PaneGeom, Size};
 
@@ -46,10 +47,39 @@ pub struct HighlightSelection {
     pub selection: Selection,
     pub bg: Option<AnsiCode>,
     pub fg: Option<AnsiCode>,
+    /// When set, `bg` is the selection color to alpha-composite over each
+    /// cell's own foreground and background by this weight (0–255), instead
+    /// of overriding them. Preserves contrast so same-colored text survives.
+    pub alpha: Option<u8>,
     pub bold: bool,
     pub italic: bool,
     pub underline: bool,
     pub layer: HighlightLayer,
+}
+
+/// Resolve an `AnsiCode` color to RGB, mapping indexed and named colors
+/// through the 256-color palette. Returns `None` for non-color codes.
+fn ansi_code_to_rgb(code: AnsiCode) -> Option<(u8, u8, u8)> {
+    match code {
+        AnsiCode::RgbCode(rgb) => Some(rgb),
+        AnsiCode::ColorIndex(index) => Some(eightbit_to_rgb(index)),
+        // `NamedColor` is declared in ANSI order (Black = 0 .. BrightWhite = 15),
+        // matching the first 16 entries of the 256-color palette.
+        AnsiCode::NamedColor(named) => Some(eightbit_to_rgb(named as u8)),
+        _ => None,
+    }
+}
+
+/// Linear blend of `cell` toward `selection` by `alpha` (0 = none, 255 = full).
+fn blend_rgb(cell: (u8, u8, u8), selection: (u8, u8, u8), alpha: u8) -> (u8, u8, u8) {
+    let a = alpha as u16;
+    let inv = 255 - a;
+    let mix = |c: u8, s: u8| (((c as u16) * inv + (s as u16) * a) / 255) as u8;
+    (
+        mix(cell.0, selection.0),
+        mix(cell.1, selection.1),
+        mix(cell.2, selection.2),
+    )
 }
 
 fn adjust_styles_for_possible_selection(
@@ -57,17 +87,49 @@ fn adjust_styles_for_possible_selection(
     character_styles: CharacterStyles,
     chunk_y: usize,
     chunk_width: usize,
+    pane_default_fg: Option<AnsiCode>,
+    pane_default_bg: Option<AnsiCode>,
 ) -> CharacterStyles {
     chunk_selection_and_colors
         .iter()
         .find(|hs| hs.selection.contains(chunk_y, chunk_width))
         .map(|hs| {
             let mut styles = character_styles;
-            if let Some(bg) = hs.bg {
-                styles = styles.background(Some(bg));
-            }
-            if let Some(fg) = hs.fg {
-                styles = styles.foreground(Some(fg));
+            match hs.alpha {
+                Some(alpha) => {
+                    // Alpha-composite the selection color (`hs.bg`) over the cell's
+                    // own foreground AND background. Because both shift toward the
+                    // selection color by the same weight, their relative contrast is
+                    // preserved, so text matching the selection color isn't erased
+                    // (mirrors macOS Terminal's translucent selection layer).
+                    if let Some(selection) = hs.bg.and_then(ansi_code_to_rgb) {
+                        let cell_bg = styles
+                            .background
+                            .or(pane_default_bg)
+                            .and_then(ansi_code_to_rgb)
+                            .unwrap_or((0, 0, 0));
+                        styles = styles.background(Some(AnsiCode::RgbCode(blend_rgb(
+                            cell_bg, selection, alpha,
+                        ))));
+                        if let Some(cell_fg) = styles
+                            .foreground
+                            .or(pane_default_fg)
+                            .and_then(ansi_code_to_rgb)
+                        {
+                            styles = styles.foreground(Some(AnsiCode::RgbCode(blend_rgb(
+                                cell_fg, selection, alpha,
+                            ))));
+                        }
+                    }
+                },
+                None => {
+                    if let Some(bg) = hs.bg {
+                        styles = styles.background(Some(bg));
+                    }
+                    if let Some(fg) = hs.fg {
+                        styles = styles.foreground(Some(fg));
+                    }
+                },
             }
             if hs.bold {
                 styles = styles.bold(Some(AnsiCode::On));
@@ -175,6 +237,8 @@ fn serialize_chunks_with_newlines(
                     *t_character.styles,
                     character_chunk.y,
                     chunk_width,
+                    pane_default_fg,
+                    pane_default_bg,
                 ),
                 pane_default_fg,
                 pane_default_bg,
@@ -240,6 +304,8 @@ fn serialize_chunks(
                     *t_character.styles,
                     character_chunk.y,
                     chunk_width,
+                    pane_default_fg,
+                    pane_default_bg,
                 ),
                 pane_default_fg,
                 pane_default_bg,

--- a/zellij-server/src/output/unit/output_tests.rs
+++ b/zellij-server/src/output/unit/output_tests.rs
@@ -1111,3 +1111,72 @@ fn test_pane_defaults_preserved_when_right_covered() {
         "Remaining chunk should preserve pane_default_bg"
     );
 }
+
+// ---- alpha-composited pane-content selection (issue #2160) ----
+
+#[test]
+fn blend_rgb_mixes_cell_toward_selection() {
+    use super::super::blend_rgb;
+    // alpha 0 -> unchanged cell color
+    assert_eq!(blend_rgb((10, 20, 30), (200, 100, 50), 0), (10, 20, 30));
+    // alpha 255 -> fully the selection color
+    assert_eq!(blend_rgb((10, 20, 30), (200, 100, 50), 255), (200, 100, 50));
+    // alpha 128 -> ~halfway
+    assert_eq!(blend_rgb((0, 0, 0), (255, 255, 255), 128), (128, 128, 128));
+}
+
+#[test]
+fn ansi_code_to_rgb_resolves_colors() {
+    use super::super::ansi_code_to_rgb;
+    use crate::panes::terminal_character::{AnsiCode, NamedColor};
+    assert_eq!(ansi_code_to_rgb(AnsiCode::RgbCode((1, 2, 3))), Some((1, 2, 3)));
+    assert!(ansi_code_to_rgb(AnsiCode::ColorIndex(4)).is_some());
+    assert!(ansi_code_to_rgb(AnsiCode::NamedColor(NamedColor::Blue)).is_some());
+    assert_eq!(ansi_code_to_rgb(AnsiCode::Reset), None);
+}
+
+#[test]
+fn alpha_selection_composites_over_cell_fg_and_bg() {
+    use super::super::{adjust_styles_for_possible_selection, blend_rgb, HighlightSelection};
+    use crate::panes::terminal_character::DEFAULT_STYLES;
+    use crate::panes::Selection;
+    use zellij_utils::data::HighlightLayer;
+    use zellij_utils::position::Position;
+
+    let cell_fg = (220, 220, 220);
+    let cell_bg = (10, 10, 10);
+    let selection_color = (56, 146, 233);
+    let alpha = 128u8;
+
+    let mut sel = Selection::default();
+    sel.set_start_and_end_positions(Position::new(0, 0), Position::new(0, 5));
+
+    let styles = DEFAULT_STYLES
+        .foreground(Some(AnsiCode::RgbCode(cell_fg)))
+        .background(Some(AnsiCode::RgbCode(cell_bg)));
+
+    let hs = HighlightSelection {
+        selection: sel,
+        bg: Some(AnsiCode::RgbCode(selection_color)),
+        fg: None,
+        alpha: Some(alpha),
+        bold: false,
+        italic: false,
+        underline: false,
+        layer: HighlightLayer::ActionFeedback,
+    };
+
+    let out = adjust_styles_for_possible_selection(&[hs], styles, 0, 0, None, None);
+    assert_eq!(
+        out.foreground,
+        Some(AnsiCode::RgbCode(blend_rgb(cell_fg, selection_color, alpha))),
+        "foreground should be blended toward the selection color, not erased"
+    );
+    assert_eq!(
+        out.background,
+        Some(AnsiCode::RgbCode(blend_rgb(cell_bg, selection_color, alpha))),
+        "background should be blended toward the selection color"
+    );
+    // The blended fg and bg still differ, so text remains visible.
+    assert_ne!(out.foreground, out.background);
+}

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1583,11 +1583,17 @@ impl Grid {
                 .selection
                 .contains_row(character_chunk.y.saturating_sub(content_y))
             {
-                let background_color = match style.colors.text_selected.background {
+                // Pane-content selection uses its own `pane_selection` style when
+                // set, otherwise falls back to `text_selected` (issue #2160 POC).
+                let selection_style = style
+                    .colors
+                    .pane_selection
+                    .unwrap_or(style.colors.text_selected);
+                let background_color = match selection_style.background {
                     PaletteColor::Rgb(rgb) => AnsiCode::RgbCode(rgb),
                     PaletteColor::EightBit(col) => AnsiCode::ColorIndex(col),
                 };
-                let foreground_color = match style.colors.text_selected.base {
+                let foreground_color = match selection_style.base {
                     PaletteColor::Rgb(rgb) => AnsiCode::RgbCode(rgb),
                     PaletteColor::EightBit(col) => AnsiCode::ColorIndex(col),
                 };

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1593,16 +1593,30 @@ impl Grid {
                     PaletteColor::Rgb(rgb) => AnsiCode::RgbCode(rgb),
                     PaletteColor::EightBit(col) => AnsiCode::ColorIndex(col),
                 };
-                let foreground_color = match selection_style.base {
-                    PaletteColor::Rgb(rgb) => AnsiCode::RgbCode(rgb),
-                    PaletteColor::EightBit(col) => AnsiCode::ColorIndex(col),
+                let selection_alpha = style.colors.pane_selection_alpha;
+                // With `alpha`, the selection color is composited over each cell
+                // (both fg and bg) in the output layer, so we leave the foreground
+                // for that blend. Without `alpha`, `keep_foreground` preserves the
+                // cell's own foreground and only recolors the background (like macOS
+                // Terminal). Either is only ever set when `pane_selection` is `Some`,
+                // so the `text_selected` fallback above is unaffected.
+                let foreground_color = if selection_alpha.is_some()
+                    || style.colors.pane_selection_keep_foreground
+                {
+                    None
+                } else {
+                    Some(match selection_style.base {
+                        PaletteColor::Rgb(rgb) => AnsiCode::RgbCode(rgb),
+                        PaletteColor::EightBit(col) => AnsiCode::ColorIndex(col),
+                    })
                 };
 
                 character_chunk.add_selection_and_colors(
                     HighlightSelection {
                         selection: self.selection,
                         bg: Some(background_color),
-                        fg: Some(foreground_color),
+                        fg: foreground_color,
+                        alpha: selection_alpha,
                         bold: false,
                         italic: false,
                         underline: false,
@@ -1639,6 +1653,7 @@ impl Grid {
                                 selection: *res,
                                 bg: Some(background_color),
                                 fg: Some(foreground_color),
+                                alpha: None,
                                 bold: false,
                                 italic: false,
                                 underline: false,
@@ -2560,6 +2575,7 @@ impl Grid {
                                                 selection: sel,
                                                 bg: compiled.bg,
                                                 fg: compiled.fg,
+                                                alpha: None,
                                                 bold: compiled.bold,
                                                 italic: compiled.italic,
                                                 underline: compiled.underline,
@@ -2593,6 +2609,7 @@ impl Grid {
                                 selection: sel,
                                 bg: compiled.bg,
                                 fg: compiled.fg,
+                                alpha: None,
                                 bold: compiled.bold,
                                 italic: compiled.italic,
                                 underline: compiled.underline,

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -6193,3 +6193,82 @@ fn pane_content_selection_falls_back_to_text_selected_when_unset() {
         "with pane_selection unset, selection should use text_selected"
     );
 }
+
+// Render the grid and return (foreground, background) applied to the selected row.
+fn rendered_selection_colors(
+    grid: &mut Grid,
+    style: &Style,
+) -> (Option<AnsiCode>, Option<AnsiCode>) {
+    let (chunks, _, _) = grid
+        .render(0, 0, style)
+        .expect("render should succeed")
+        .expect("render should produce output");
+    chunks
+        .iter()
+        .flat_map(|chunk| chunk.selection_and_colors())
+        .next()
+        .map(|hs: &HighlightSelection| (hs.fg, hs.bg))
+        .expect("a selected row should carry a highlight")
+}
+
+#[test]
+fn pane_selection_keep_foreground_preserves_cell_foreground() {
+    // pane_selection set with keep_foreground -> only the background is recolored,
+    // each cell keeps its own foreground (terminal-native selection, like macOS Terminal).
+    let mut grid = grid_with_first_row_selected();
+    let mut style = Style::default();
+    style.colors.pane_selection = Some(selection_decl(
+        PaletteColor::Rgb((255, 255, 255)), // base present but must be ignored
+        PaletteColor::Rgb((56, 146, 233)),  // blue background
+    ));
+    style.colors.pane_selection_keep_foreground = true;
+    let (fg, bg) = rendered_selection_colors(&mut grid, &style);
+    assert_eq!(
+        bg,
+        Some(AnsiCode::RgbCode((56, 146, 233))),
+        "background should be recolored from pane_selection"
+    );
+    assert_eq!(
+        fg, None,
+        "foreground should be preserved (not overridden) when keep_foreground is set"
+    );
+}
+
+// Render the grid and return the first HighlightSelection on the selected row.
+fn rendered_selection(grid: &mut Grid, style: &Style) -> HighlightSelection {
+    let (chunks, _, _) = grid
+        .render(0, 0, style)
+        .expect("render should succeed")
+        .expect("render should produce output");
+    chunks
+        .iter()
+        .flat_map(|chunk| chunk.selection_and_colors())
+        .next()
+        .copied()
+        .expect("a selected row should carry a highlight")
+}
+
+#[test]
+fn pane_selection_alpha_marks_highlight_for_compositing() {
+    // With pane_selection_alpha set, the highlight carries the selection color as
+    // `bg`, no `fg` (left to the blend), and the alpha weight for the output layer.
+    let mut grid = grid_with_first_row_selected();
+    let mut style = Style::default();
+    style.colors.pane_selection = Some(selection_decl(
+        PaletteColor::Rgb((255, 255, 255)),
+        PaletteColor::Rgb((56, 146, 233)),
+    ));
+    style.colors.pane_selection_alpha = Some(128);
+    let hs = rendered_selection(&mut grid, &style);
+    assert_eq!(
+        hs.alpha,
+        Some(128),
+        "alpha should be carried to the highlight for compositing"
+    );
+    assert_eq!(
+        hs.bg,
+        Some(AnsiCode::RgbCode((56, 146, 233))),
+        "bg should be the selection color to composite"
+    );
+    assert_eq!(hs.fg, None, "fg is left to the composite blend");
+}

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -1,4 +1,5 @@
 use super::super::Grid;
+use crate::output::HighlightSelection;
 use crate::panes::grid::SixelImageStore;
 use crate::panes::link_handler::LinkHandler;
 use insta::assert_snapshot;
@@ -7,7 +8,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use vte;
 use zellij_utils::{
-    data::{Palette, Style},
+    data::{Palette, PaletteColor, Style, StyleDeclaration},
     pane_size::SizeInPixels,
     position::Position,
 };
@@ -6100,5 +6101,95 @@ fn csi_5n_status_query_still_handled_locally() {
         grid.pending_messages_to_pty,
         vec![b"\x1b[0n".to_vec()],
         "DSR 5 must still produce its local 'all good' reply"
+    );
+}
+
+// ---- issue #2160: themeable pane-content selection (pane_selection > text_selected) ----
+
+fn grid_with_first_row_selected() -> Grid {
+    let sixel_image_store = Rc::new(RefCell::new(SixelImageStore::default()));
+    let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
+    let mut grid = Grid::new(
+        5,
+        20,
+        Rc::new(RefCell::new(Palette::default())),
+        terminal_emulator_color_codes,
+        Rc::new(RefCell::new(LinkHandler::new())),
+        Rc::new(RefCell::new(None)),
+        sixel_image_store,
+        Style::default(),
+        false,
+        true,
+        true,
+        true,
+        false,
+    );
+    let mut vte_parser = vte::Parser::new();
+    for &byte in b"hello selection test" {
+        vte_parser.advance(&mut grid, byte);
+    }
+    grid.start_selection(&Position::new(0, 0));
+    grid.end_selection(&Position::new(0, 19));
+    grid
+}
+
+fn selection_decl(base: PaletteColor, background: PaletteColor) -> StyleDeclaration {
+    StyleDeclaration {
+        base,
+        background,
+        emphasis_0: base,
+        emphasis_1: base,
+        emphasis_2: base,
+        emphasis_3: base,
+    }
+}
+
+// Render the grid and return the background color applied to the selected row.
+fn rendered_selection_bg(grid: &mut Grid, style: &Style) -> AnsiCode {
+    let (chunks, _, _) = grid
+        .render(0, 0, style)
+        .expect("render should succeed")
+        .expect("render should produce output");
+    chunks
+        .iter()
+        .flat_map(|chunk| chunk.selection_and_colors())
+        .find_map(|hs: &HighlightSelection| hs.bg)
+        .expect("a selected row should carry a highlight background")
+}
+
+#[test]
+fn pane_selection_overrides_text_selected_for_pane_content() {
+    // pane_selection=magenta, text_selected=cyan: pane-content selection must use pane_selection.
+    let mut grid = grid_with_first_row_selected();
+    let mut style = Style::default();
+    style.colors.text_selected = selection_decl(
+        PaletteColor::Rgb((255, 255, 255)),
+        PaletteColor::Rgb((0, 255, 255)),
+    );
+    style.colors.pane_selection = Some(selection_decl(
+        PaletteColor::Rgb((255, 255, 255)),
+        PaletteColor::Rgb((255, 0, 255)),
+    ));
+    assert_eq!(
+        rendered_selection_bg(&mut grid, &style),
+        AnsiCode::RgbCode((255, 0, 255)),
+        "pane_selection background should win over text_selected"
+    );
+}
+
+#[test]
+fn pane_content_selection_falls_back_to_text_selected_when_unset() {
+    // pane_selection unset -> selection falls back to text_selected (pre-#2160 behavior preserved).
+    let mut grid = grid_with_first_row_selected();
+    let mut style = Style::default();
+    style.colors.text_selected = selection_decl(
+        PaletteColor::Rgb((255, 255, 255)),
+        PaletteColor::Rgb((0, 255, 255)),
+    );
+    style.colors.pane_selection = None;
+    assert_eq!(
+        rendered_selection_bg(&mut grid, &style),
+        AnsiCode::RgbCode((0, 255, 255)),
+        "with pane_selection unset, selection should use text_selected"
     );
 }

--- a/zellij-utils/assets/prost/api.style.rs
+++ b/zellij-utils/assets/prost/api.style.rs
@@ -113,6 +113,8 @@ pub struct Styling {
     pub exit_code_error: ::prost::alloc::vec::Vec<Color>,
     #[prost(message, repeated, tag="15")]
     pub multiplayer_user_colors: ::prost::alloc::vec::Vec<Color>,
+    #[prost(message, repeated, tag="16")]
+    pub pane_selection: ::prost::alloc::vec::Vec<Color>,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -1404,6 +1404,18 @@ pub struct Styling {
     /// When `None`, falls back to `text_selected` so existing themes are
     /// byte-for-byte unchanged. (POC for issue #2160.)
     pub pane_selection: Option<StyleDeclaration>,
+    /// When a `pane_selection` style is given without a `base` (foreground),
+    /// preserve each cell's own foreground and only recolor the background —
+    /// a terminal-native selection (like macOS Terminal). Only ever `true`
+    /// when `pane_selection` is `Some`.
+    pub pane_selection_keep_foreground: bool,
+    /// When set, the `pane_selection` background color is alpha-composited over
+    /// each selected cell's own foreground AND background by this weight
+    /// (0 = none, 255 = fully opaque). Because fg and bg shift toward the
+    /// selection color equally, relative contrast is preserved, so text that
+    /// matches the selection color isn't erased (mirrors macOS Terminal's
+    /// translucent selection). Only ever `Some` when `pane_selection` is `Some`.
+    pub pane_selection_alpha: Option<u8>,
     pub ribbon_unselected: StyleDeclaration,
     pub ribbon_selected: StyleDeclaration,
     pub table_title: StyleDeclaration,
@@ -1493,6 +1505,8 @@ pub const DEFAULT_STYLES: Styling = Styling {
         background: PaletteColor::EightBit(default_colors::GRAY),
     },
     pane_selection: None,
+    pane_selection_keep_foreground: false,
+    pane_selection_alpha: None,
     frame_unselected: None,
     frame_selected: StyleDeclaration {
         base: PaletteColor::EightBit(default_colors::GREEN),
@@ -1652,6 +1666,8 @@ impl From<Palette> for Styling {
                 background: Default::default(),
             },
             pane_selection: None,
+            pane_selection_keep_foreground: false,
+            pane_selection_alpha: None,
             frame_unselected: None,
             frame_selected: StyleDeclaration {
                 base: palette.green,

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -1400,6 +1400,10 @@ impl Coloration {
 pub struct Styling {
     pub text_unselected: StyleDeclaration,
     pub text_selected: StyleDeclaration,
+    /// Color of mouse-drag selection of terminal pane content.
+    /// When `None`, falls back to `text_selected` so existing themes are
+    /// byte-for-byte unchanged. (POC for issue #2160.)
+    pub pane_selection: Option<StyleDeclaration>,
     pub ribbon_unselected: StyleDeclaration,
     pub ribbon_selected: StyleDeclaration,
     pub table_title: StyleDeclaration,
@@ -1488,6 +1492,7 @@ pub const DEFAULT_STYLES: Styling = Styling {
         emphasis_3: PaletteColor::EightBit(default_colors::PURPLE),
         background: PaletteColor::EightBit(default_colors::GRAY),
     },
+    pane_selection: None,
     frame_unselected: None,
     frame_selected: StyleDeclaration {
         base: PaletteColor::EightBit(default_colors::GREEN),
@@ -1646,6 +1651,7 @@ impl From<Palette> for Styling {
                 emphasis_3: palette.purple,
                 background: Default::default(),
             },
+            pane_selection: None,
             frame_unselected: None,
             frame_selected: StyleDeclaration {
                 base: palette.green,

--- a/zellij-utils/src/input/config.rs
+++ b/zellij-utils/src/input/config.rs
@@ -1169,6 +1169,74 @@ mod config_test {
     }
 
     #[test]
+    fn pane_selection_without_base_keeps_foreground() {
+        // A `pane_selection` with only a `background` (no `base`) preserves each
+        // cell's own foreground: only the background is recolored.
+        let config_contents = r##"
+            themes {
+                t {
+                    pane_selection {
+                        background "#3892E9"
+                    }
+                }
+            }
+        "##;
+        let config = Config::from_kdl(config_contents, None).unwrap();
+        let theme = config.themes.get_theme("t").expect("theme t should parse");
+        assert!(
+            theme.palette.pane_selection_keep_foreground,
+            "omitting `base` should set keep_foreground"
+        );
+        assert_eq!(
+            theme.palette.pane_selection.unwrap().background,
+            PaletteColor::Rgb((0x38, 0x92, 0xE9)),
+        );
+    }
+
+    #[test]
+    fn pane_selection_with_base_overrides_foreground() {
+        // A `pane_selection` with an explicit `base` overrides the foreground
+        // (no preservation) — the pre-existing behavior.
+        let config_contents = r##"
+            themes {
+                t {
+                    pane_selection {
+                        base "#FFFFFF"
+                        background "#3892E9"
+                    }
+                }
+            }
+        "##;
+        let config = Config::from_kdl(config_contents, None).unwrap();
+        let theme = config.themes.get_theme("t").expect("theme t should parse");
+        assert!(
+            !theme.palette.pane_selection_keep_foreground,
+            "providing `base` should not preserve the foreground"
+        );
+        let decl = theme.palette.pane_selection.unwrap();
+        assert_eq!(decl.base, PaletteColor::Rgb((0xFF, 0xFF, 0xFF)));
+        assert_eq!(decl.background, PaletteColor::Rgb((0x38, 0x92, 0xE9)));
+    }
+
+    #[test]
+    fn pane_selection_alpha_is_parsed() {
+        // `alpha 0.5` (0.0–1.0) -> stored as ~128 (0–255 weight).
+        let config_contents = r##"
+            themes {
+                t {
+                    pane_selection {
+                        background "#3892E9"
+                        alpha 0.5
+                    }
+                }
+            }
+        "##;
+        let config = Config::from_kdl(config_contents, None).unwrap();
+        let theme = config.themes.get_theme("t").expect("theme t should parse");
+        assert_eq!(theme.palette.pane_selection_alpha, Some(128));
+    }
+
+    #[test]
     fn omitting_required_style_errors() {
         let config_contents = r##"
             themes {

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__theme__theme_test__dracula_theme_from_file.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__theme__theme_test__dracula_theme_from_file.snap
@@ -94,6 +94,7 @@ expression: "format!(\"{:#?}\", theme)"
                     ),
                 ),
             },
+            pane_selection: None,
             ribbon_unselected: StyleDeclaration {
                 base: Rgb(
                     (

--- a/zellij-utils/src/input/unit/snapshots/zellij_utils__input__theme__theme_test__dracula_theme_from_file.snap
+++ b/zellij-utils/src/input/unit/snapshots/zellij_utils__input__theme__theme_test__dracula_theme_from_file.snap
@@ -95,6 +95,8 @@ expression: "format!(\"{:#?}\", theme)"
                 ),
             },
             pane_selection: None,
+            pane_selection_keep_foreground: false,
+            pane_selection_alpha: None,
             ribbon_unselected: StyleDeclaration {
                 base: Rgb(
                     (

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -5426,6 +5426,10 @@ impl Themes {
                         "list_selected",
                     )
                     .map(|maybe_style| maybe_style.unwrap_or(DEFAULT_STYLES.list_selected))?,
+                    pane_selection: Themes::style_declaration_from_node(
+                        theme_config,
+                        "pane_selection",
+                    )?,
                     frame_unselected: Themes::style_declaration_from_node(
                         theme_config,
                         "frame_unselected",
@@ -5565,6 +5569,14 @@ impl Themes {
                     current_theme_node_children
                         .nodes_mut()
                         .push(frame_unselected_style.to_kdl("frame_unselected"));
+                },
+            }
+            match theme.palette.pane_selection {
+                None => {},
+                Some(pane_selection_style) => {
+                    current_theme_node_children
+                        .nodes_mut()
+                        .push(pane_selection_style.to_kdl("pane_selection"));
                 },
             }
             current_theme_node_children

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -5306,6 +5306,63 @@ impl Themes {
         }
     }
 
+    /// Parse the `pane_selection` style. Unlike other components, its `base`
+    /// (foreground) is optional: when omitted, each cell keeps its own
+    /// foreground and only the background is recolored — a terminal-native
+    /// selection (like macOS Terminal). An optional `alpha` (0.0–1.0) instead
+    /// alpha-composites the `background` color over each cell. Returns the
+    /// style, a flag marking whether the foreground should be preserved, and
+    /// the parsed alpha (as 0–255).
+    fn pane_selection_from_node(
+        style_node: &KdlNode,
+    ) -> Result<(Option<StyleDeclaration>, bool, Option<u8>), ConfigError> {
+        let descriptor_node = kdl_child_with_name!(style_node, "pane_selection");
+        match descriptor_node {
+            None => Ok((None, false, None)),
+            Some(descriptor) => {
+                let colors = kdl_children_or_error!(
+                    descriptor,
+                    "Missing colors for pane_selection"
+                );
+                let parsed_base = PaletteColor::try_from(("base", colors)).ok();
+                let keep_foreground = parsed_base.is_none();
+                let background =
+                    PaletteColor::try_from(("background", colors)).unwrap_or_default();
+                // `alpha` (0.0–1.0) -> 0–255 weight of the selection color in the
+                // composite. Integers (e.g. `alpha 0` / `alpha 1`) are accepted too.
+                let alpha = colors
+                    .get("alpha")
+                    .and_then(|n| n.entries().first())
+                    .and_then(|e| {
+                        e.value()
+                            .as_f64()
+                            .or_else(|| e.value().as_i64().map(|i| i as f64))
+                    })
+                    .map(|f| (f.clamp(0.0, 1.0) * 255.0).round() as u8);
+                // Selection only renders base+background; default the (unused)
+                // emphases. With no `base`, fold it onto `background` as a
+                // harmless placeholder — render ignores it when keeping fg.
+                let base = parsed_base.unwrap_or(background);
+                Ok((
+                    Some(StyleDeclaration {
+                        base,
+                        background,
+                        emphasis_0: PaletteColor::try_from(("emphasis_0", colors))
+                            .unwrap_or(base),
+                        emphasis_1: PaletteColor::try_from(("emphasis_1", colors))
+                            .unwrap_or(base),
+                        emphasis_2: PaletteColor::try_from(("emphasis_2", colors))
+                            .unwrap_or(base),
+                        emphasis_3: PaletteColor::try_from(("emphasis_3", colors))
+                            .unwrap_or(base),
+                    }),
+                    keep_foreground,
+                    alpha,
+                ))
+            },
+        }
+    }
+
     fn multiplayer_colors(style_node: &KdlNode) -> Result<MultiplayerColors, ConfigError> {
         let descriptor_node = kdl_child_with_name!(style_node, "multiplayer_user_colors");
         match descriptor_node {
@@ -5379,6 +5436,8 @@ impl Themes {
                 }
             } else {
                 // Newer theme definition with named styles
+                let (pane_selection, pane_selection_keep_foreground, pane_selection_alpha) =
+                    Themes::pane_selection_from_node(theme_config)?;
                 let s = Styling {
                     text_unselected: Themes::style_declaration_from_node(
                         theme_config,
@@ -5426,10 +5485,9 @@ impl Themes {
                         "list_selected",
                     )
                     .map(|maybe_style| maybe_style.unwrap_or(DEFAULT_STYLES.list_selected))?,
-                    pane_selection: Themes::style_declaration_from_node(
-                        theme_config,
-                        "pane_selection",
-                    )?,
+                    pane_selection,
+                    pane_selection_keep_foreground,
+                    pane_selection_alpha,
                     frame_unselected: Themes::style_declaration_from_node(
                         theme_config,
                         "frame_unselected",
@@ -5574,9 +5632,26 @@ impl Themes {
             match theme.palette.pane_selection {
                 None => {},
                 Some(pane_selection_style) => {
-                    current_theme_node_children
-                        .nodes_mut()
-                        .push(pane_selection_style.to_kdl("pane_selection"));
+                    let mut node = if theme.palette.pane_selection_keep_foreground {
+                        // Foreground-preserving selection: emit only `background`
+                        // (no `base`) so it round-trips back to keep_foreground.
+                        let mut node = KdlNode::new("pane_selection");
+                        let mut doc = KdlDocument::new();
+                        doc.nodes_mut()
+                            .push(pane_selection_style.background.to_kdl("background"));
+                        node.set_children(doc);
+                        node
+                    } else {
+                        pane_selection_style.to_kdl("pane_selection")
+                    };
+                    if let Some(alpha) = theme.palette.pane_selection_alpha {
+                        let mut alpha_node = KdlNode::new("alpha");
+                        alpha_node.push(KdlValue::from(alpha as f64 / 255.0));
+                        if let Some(children) = node.children_mut() {
+                            children.nodes_mut().push(alpha_node);
+                        }
+                    }
+                    current_theme_node_children.nodes_mut().push(node);
                 },
             }
             current_theme_node_children

--- a/zellij-utils/src/plugin_api/style.proto
+++ b/zellij-utils/src/plugin_api/style.proto
@@ -70,4 +70,5 @@ message Styling {
     repeated Color exit_code_success = 13;
     repeated Color exit_code_error = 14;
     repeated Color multiplayer_user_colors = 15;
+    repeated Color pane_selection = 16;
 }

--- a/zellij-utils/src/plugin_api/style.rs
+++ b/zellij-utils/src/plugin_api/style.rs
@@ -128,6 +128,11 @@ impl TryFrom<ProtobufStyling> for Styling {
             list_unselected: color_definitions!(proto, list_unselected, 6),
             list_selected: color_definitions!(proto, list_selected, 6),
             pane_selection,
+            // Pane-content selection is drawn only by the server/web-client (never by
+            // plugins), so these render-time settings are intentionally not part of the
+            // plugin theme protobuf; they are resolved from the in-process config style.
+            pane_selection_keep_foreground: false,
+            pane_selection_alpha: None,
             frame_unselected,
             frame_selected: color_definitions!(proto, frame_selected, 6),
             frame_highlight: color_definitions!(proto, frame_highlight, 6),

--- a/zellij-utils/src/plugin_api/style.rs
+++ b/zellij-utils/src/plugin_api/style.rs
@@ -111,6 +111,12 @@ impl TryFrom<ProtobufStyling> for Styling {
             None
         };
 
+        let pane_selection = if proto.pane_selection.len() > 0 {
+            Some(color_definitions!(proto, pane_selection, 6))
+        } else {
+            None
+        };
+
         Ok(Styling {
             text_unselected: color_definitions!(proto, text_unselected, 6),
             text_selected: color_definitions!(proto, text_selected, 6),
@@ -121,6 +127,7 @@ impl TryFrom<ProtobufStyling> for Styling {
             table_cell_selected: color_definitions!(proto, table_cell_selected, 6),
             list_unselected: color_definitions!(proto, list_unselected, 6),
             list_selected: color_definitions!(proto, list_selected, 6),
+            pane_selection,
             frame_unselected,
             frame_selected: color_definitions!(proto, frame_selected, 6),
             frame_highlight: color_definitions!(proto, frame_highlight, 6),
@@ -174,6 +181,11 @@ impl TryFrom<Styling> for ProtobufStyling {
             Some(frame_unselected) => frame_unselected.try_into(),
         };
 
+        let pane_selection_vec = match style.pane_selection {
+            None => Ok(Vec::new()),
+            Some(pane_selection) => pane_selection.try_into(),
+        };
+
         Ok(ProtobufStyling {
             text_unselected: style.text_unselected.try_into()?,
             text_selected: style.text_selected.try_into()?,
@@ -184,6 +196,7 @@ impl TryFrom<Styling> for ProtobufStyling {
             table_cell_selected: style.table_cell_selected.try_into()?,
             list_unselected: style.list_unselected.try_into()?,
             list_selected: style.list_selected.try_into()?,
+            pane_selection: pane_selection_vec?,
             frame_unselected: frame_unselected_vec?,
             frame_selected: style.frame_selected.try_into()?,
             frame_highlight: style.frame_highlight.try_into()?,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
@@ -6124,6 +6124,7 @@ Config {
                         ),
                     ),
                 },
+                pane_selection: None,
                 ribbon_unselected: StyleDeclaration {
                     base: Rgb(
                         (
@@ -6714,6 +6715,7 @@ Config {
                         ),
                     ),
                 },
+                pane_selection: None,
                 ribbon_unselected: StyleDeclaration {
                     base: Rgb(
                         (
@@ -7304,6 +7306,7 @@ Config {
                         ),
                     ),
                 },
+                pane_selection: None,
                 ribbon_unselected: StyleDeclaration {
                     base: Rgb(
                         (

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
@@ -6125,6 +6125,8 @@ Config {
                     ),
                 },
                 pane_selection: None,
+                pane_selection_keep_foreground: false,
+                pane_selection_alpha: None,
                 ribbon_unselected: StyleDeclaration {
                     base: Rgb(
                         (
@@ -6716,6 +6718,8 @@ Config {
                     ),
                 },
                 pane_selection: None,
+                pane_selection_keep_foreground: false,
+                pane_selection_alpha: None,
                 ribbon_unselected: StyleDeclaration {
                     base: Rgb(
                         (
@@ -7307,6 +7311,8 @@ Config {
                     ),
                 },
                 pane_selection: None,
+                pane_selection_keep_foreground: false,
+                pane_selection_alpha: None,
                 ribbon_unselected: StyleDeclaration {
                     base: Rgb(
                         (


### PR DESCRIPTION
> **Builds on #5282.** Until that merges, this PR's diff also shows #5282's
> `pane_selection` commit — review the commit
> `feat(themes): foreground-preserving and alpha-composited pane selection`
> (or this PR after #5282 lands). Targets `main` for the same reason.

Follow-up to #5282 (and issue #2160). #5282 added an optional `pane_selection`
style that overrides both foreground and background of a pane-content
selection. This adds two opt-in ways to get a **terminal-native** selection,
where text keeps its colors instead of being repainted.

## Motivation
With a solid `pane_selection`, text whose color matches the selection
background disappears (e.g. blue `ls` directory names under a blue selection).
macOS Terminal avoids this by compositing the selection as a translucent
layer, so foreground and background shift together and stay distinguishable.

## What's added
Two optional keys on `pane_selection`:

```kdl
// 1. Preserve foreground: omit `base` -> only the background is recolored
pane_selection {
    background "#3892E9"
}

// 2. Alpha-composite: blend the selection color over each cell's fg AND bg
pane_selection {
    background "#3892E9"
    alpha 0.6            // 0.0–1.0
}
```

| config | behavior |
|---|---|
| `base` + `background` | solid override (existing #5282 behavior) |
| `background` only | preserve each cell's own foreground, solid background |
| `background` + `alpha` | alpha-composite the selection color over fg **and** bg |

For `alpha`, because fg and bg shift toward the selection color by the same
weight, their relative contrast is preserved (`fg − bg → (1−α)·(fg − bg)`,
never zero), so same-colored text isn't erased. Indexed and named cell colors
are resolved to RGB via the 256-color palette before blending, so colored
program output composites correctly. The blend runs in the output layer
(`adjust_styles_for_possible_selection`) where each cell's resolved fg/bg are
known.

## Notes
- Fully backward compatible: default `pane_selection: None` falls back to
  `text_selected`; existing `base`+`background` themes are unchanged.
- These are render-time settings resolved from the in-process config style and
  are intentionally **not** part of the plugin theme protobuf — plugins never
  draw pane-content selection. The web client mirrors the same behavior.
- Round-trips through `to_kdl`.

## Tests
Blend math, `AnsiCode`→RGB resolution, the output-layer composite (asserts
blended fg ≠ bg), KDL parsing (with/without `base`, and `alpha`), and grid
wiring. Updates the two `Styling` Debug snapshots.
