### PR TITLE
feat(utils): read configs from XDG_CONFIG_HOME when set before falling back to `~/.config/zellij`

### DIFF
--- a/zellij-utils/src/home_unix.rs
+++ b/zellij-utils/src/home_unix.rs
@@ -4,12 +4,16 @@ use std::path::PathBuf;
 const CONFIG_LOCATION: &str = ".config/zellij";
 
 pub(crate) fn home_config_dir() -> Option<PathBuf> {
+    if let Some(xdg_config_home) = std::env::var_os("XDG_CONFIG_HOME") {
+        if !xdg_config_home.is_empty() {
+            return Some(PathBuf::from(xdg_config_home).join("zellij"));
+        }
+    }
     BaseDirs::new().map(|dirs| dirs.home_dir().join(CONFIG_LOCATION))
 }
 
 pub(crate) fn try_create_home_config_dir() {
-    if let Some(user_dirs) = BaseDirs::new() {
-        let config_dir = user_dirs.home_dir().join(CONFIG_LOCATION);
+    if let Some(config_dir) = home_config_dir() {
         if let Err(e) = std::fs::create_dir_all(config_dir) {
             log::error!("Failed to create config dir: {:?}", e);
         }


### PR DESCRIPTION
Fixes #5199 

Note on using `BaseDirs::new().config_dir().join("zellij")`:

I originally wanted to use `config_dir` and let BaseDirs handle config locations for different platforms, but this would have been a small change for macOS users to store configs in `~/Library/Application Support/zellij`.

 Instead we just use `XDG_CONFIG_HOME` if available, otherwise fallback to `.config/zellij`