### PR TITLE
fix: correct floating-pane chunk clipping on right overlap

### DIFF
--- a/zellij-server/src/output/mod.rs
+++ b/zellij-server/src/output/mod.rs
@@ -795,7 +795,7 @@ impl FloatingPanesStack {
                 c_chunk.x = pane_right_edge + 1;
                 return Ok(None);
             } else if pane_left_edge >= c_chunk_left_side
-                && pane_left_edge >= c_chunk_left_side
+                && pane_left_edge < c_chunk_right_side
                 && pane_right_edge >= c_chunk_right_side
             {
                 // pane covers chunk partially to the right


### PR DESCRIPTION
The "covers chunk partially to the right" branch in `FloatingPanesStack::remove_covered_parts` checks the same condition twice, so the second operand does nothing:

```rust
} else if pane_left_edge >= c_chunk_left_side
    && pane_left_edge >= c_chunk_left_side
    && pane_right_edge >= c_chunk_right_side
```

It looks like #4678 clobbered the second operand. Before that PR it was `pane_left_edge < c_chunk_right_side`:

```diff
-            } else if pane_left_edge > c_chunk_left_side
-                && pane_left_edge < c_chunk_right_side
+            } else if pane_left_edge >= c_chunk_left_side
+                && pane_left_edge >= c_chunk_left_side
                 && pane_right_edge >= c_chunk_right_side
```

This restores `pane_left_edge < c_chunk_right_side` so the branch only matches when the pane's left edge falls within the chunk. I kept the first operand's `>` to `>=` change, which looks intentional. It also resolves a `clippy::eq_op` on the duplicated expression.

The practical effect is small (`retain_by_width` saturates, so many cases still render correctly), but the condition is a no-op as written.
