### PR TITLE
feat: add install.sh interactive n easier installer with SHA256 verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,17 +55,29 @@ For more details about our future plans, read about upcoming features in our [ro
 
 ## How do I install it?
 
-The easiest way to install Zellij is through a [package for your OS](./docs/THIRD_PARTY_INSTALL.md).
+### Linux & macOS
 
-If one is not available for your OS, you could download a prebuilt binary from the [latest release](https://github.com/zellij-org/zellij/releases/latest) and place it in your `$PATH`. If you'd like, we could [automatically choose one for you](#try-zellij-without-installing).
+Run the installer in a terminal:
 
-You can also install (compile) with `cargo`:
+```bash
+curl -fsSL https://raw.githubusercontent.com/zellij-org/zellij/main/install.sh | bash
+```
+
+### Windows
+
+Download and run the `.msi` installer from the [latest release](https://github.com/zellij-org/zellij/releases/latest).
+
+### Other installation methods
+
+You can also use a [third-party package for your OS](./docs/THIRD_PARTY_INSTALL.md), or download a prebuilt binary from the [latest release](https://github.com/zellij-org/zellij/releases/latest) and place it in your `$PATH`.
+
+You can also install from source with `cargo`:
 
 ```
 cargo install --locked zellij
 ```
 
-#### Try Zellij without installing
+### Try Zellij without installing
 
 bash/zsh:
 ```bash
@@ -76,7 +88,7 @@ fish/xonsh:
 bash -c 'bash <(curl -L https://zellij.dev/launch)'
 ```
 
-#### Installing from `main`
+### Installing from `main`
 Installing Zellij from the `main` branch is not recommended. This branch represents pre-release code, is constantly being worked on and may contain broken or unusable features. In addition, using it may corrupt the cache for future versions, forcing users to clear it before they can use the officially released version.
 
 That being said - no-one will stop you from using it (and bug reports involving new features are greatly appreciated), but please consider using the latest release instead as detailed at the top of this section.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,17 @@ For more details about our future plans, read about upcoming features in our [ro
 
 The easiest way to install Zellij is through a [package for your OS](./docs/THIRD_PARTY_INSTALL.md).
 
-If one is not available for your OS, you could download a prebuilt binary from the [latest release](https://github.com/zellij-org/zellij/releases/latest) and place it in your `$PATH`. If you'd like, we could [automatically choose one for you](#try-zellij-without-installing).
+#### Install script
+
+If a package is not available for your OS, use the install script to automatically download and install a prebuilt binary:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/zellij-org/zellij/main/install.sh)
+```
+
+The script will ask which variant to install (full or no-web) and where to place the binary.
+
+You can also download a prebuilt binary manually from the [latest release](https://github.com/zellij-org/zellij/releases/latest) and place it in your `$PATH`.
 
 You can also install (compile) with `cargo`:
 

--- a/README.md
+++ b/README.md
@@ -55,33 +55,13 @@ For more details about our future plans, read about upcoming features in our [ro
 
 ## How do I install it?
 
-#### Linux / macOS
+The easiest way to install Zellij is through a [package for your OS](./docs/THIRD_PARTY_INSTALL.md).
 
-**Package manager** — see [third-party packages](./docs/THIRD_PARTY_INSTALL.md) (recommended if available for your distro/OS).
+If one is not available for your OS, you could download a prebuilt binary from the [latest release](https://github.com/zellij-org/zellij/releases/latest) and place it in your `$PATH`. If you'd like, we could [automatically choose one for you](#try-zellij-without-installing).
 
-**Install script** — no account or registration required, only `curl` and `tar`:
+You can also install (compile) with `cargo`:
 
-```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/zellij-org/zellij/main/install.sh)
-# or
-curl -fsSL https://raw.githubusercontent.com/zellij-org/zellij/main/install.sh | bash
 ```
-
-**Prebuilt binary** — download from [latest release](https://github.com/zellij-org/zellij/releases/latest) and place in your `$PATH`.
-
-**From source** — requires [Rust](https://rustup.rs/):
-
-```bash
-cargo install --locked zellij
-```
-
-#### Windows
-
-**MSI installer** — download from [latest release](https://github.com/zellij-org/zellij/releases/latest).
-
-**From source** — requires [Rust](https://rustup.rs/):
-
-```bash
 cargo install --locked zellij
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,23 +55,33 @@ For more details about our future plans, read about upcoming features in our [ro
 
 ## How do I install it?
 
-The easiest way to install Zellij is through a [package for your OS](./docs/THIRD_PARTY_INSTALL.md).
+#### Linux / macOS
 
-#### Install script
+**Package manager** — see [third-party packages](./docs/THIRD_PARTY_INSTALL.md) (recommended if available for your distro/OS).
 
-If a package is not available for your OS, use the install script to automatically download and install a prebuilt binary:
+**Install script** — no account or registration required, only `curl` and `tar`:
 
 ```bash
 bash <(curl -fsSL https://raw.githubusercontent.com/zellij-org/zellij/main/install.sh)
+# or
+curl -fsSL https://raw.githubusercontent.com/zellij-org/zellij/main/install.sh | bash
 ```
 
-The script will ask which variant to install (full or no-web) and where to place the binary.
+**Prebuilt binary** — download from [latest release](https://github.com/zellij-org/zellij/releases/latest) and place in your `$PATH`.
 
-You can also download a prebuilt binary manually from the [latest release](https://github.com/zellij-org/zellij/releases/latest) and place it in your `$PATH`.
+**From source** — requires [Rust](https://rustup.rs/):
 
-You can also install (compile) with `cargo`:
-
+```bash
+cargo install --locked zellij
 ```
+
+#### Windows
+
+**MSI installer** — download from [latest release](https://github.com/zellij-org/zellij/releases/latest).
+
+**From source** — requires [Rust](https://rustup.rs/):
+
+```bash
 cargo install --locked zellij
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="zellij-org/zellij"
+INSTALL_DIR=""
+NO_WEB=false
+TMPDIR_WORK=""
+
+die() { echo "Error: $1" >&2; exit 1; }
+
+detect_target() {
+    local arch sys
+    case "$(uname -m)" in
+        x86_64)          arch="x86_64" ;;
+        aarch64 | arm64) arch="aarch64" ;;
+        *) die "Unsupported architecture: $(uname -m)" ;;
+    esac
+    case "$(uname -s)" in
+        Linux)  sys="unknown-linux-musl" ;;
+        Darwin) sys="apple-darwin" ;;
+        *) die "Unsupported OS: $(uname -s)" ;;
+    esac
+    echo "${arch}-${sys}"
+}
+
+pick_install_dir() {
+    if [ -w /usr/local/bin ]; then
+        echo /usr/local/bin
+    else
+        echo "$HOME/.local/bin"
+    fi
+}
+
+prompt_no_web() {
+    local answer
+    printf "Install variant:\n"
+    printf "  [1] Full (with web plugins) [default]\n"
+    printf "  [2] No-web (lighter, no WebAssembly plugin support)\n"
+    printf "Choice [1/2]: "
+    read -r answer </dev/tty
+    case "$answer" in
+        2) NO_WEB=true ;;
+        *) NO_WEB=false ;;
+    esac
+}
+
+prompt_install_dir() {
+    local default_dir answer
+    default_dir="$(pick_install_dir)"
+    printf "Install directory [%s]: " "$default_dir"
+    read -r answer </dev/tty
+    if [ -z "$answer" ]; then
+        INSTALL_DIR="$default_dir"
+    else
+        INSTALL_DIR="$answer"
+    fi
+}
+
+verify_sha256() {
+    local file="$1" expected="$2"
+    local actual
+    if command -v sha256sum &>/dev/null; then
+        actual="$(sha256sum "$file" | awk '{print $1}')"
+    elif command -v shasum &>/dev/null; then
+        actual="$(shasum -a 256 "$file" | awk '{print $1}')"
+    else
+        die "sha256sum / shasum not found"
+    fi
+    [ "$actual" = "$expected" ] || die "SHA256 mismatch!\n  expected: $expected\n  got:      $actual"
+}
+
+main() {
+    local target version prefix asset checksum_file asset_url checksum_url expected_hash
+
+    target="$(detect_target)"
+
+    echo "=== Zellij Installer ==="
+    echo "Detected target: $target"
+    echo ""
+
+    prompt_no_web
+    prompt_install_dir
+
+    echo ""
+    echo "Fetching latest release..."
+    version="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+        | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
+    [ -n "$version" ] || die "Could not determine latest version"
+    echo "Version: $version"
+
+    prefix=""
+    "$NO_WEB" && prefix="no-web-"
+
+    asset="zellij-${prefix}${target}.tar.gz"
+    checksum_file="zellij-${prefix}${target}.sha256sum"
+    asset_url="https://github.com/${REPO}/releases/download/${version}/${asset}"
+    checksum_url="https://github.com/${REPO}/releases/download/${version}/${checksum_file}"
+
+    TMPDIR_WORK="$(mktemp -d)"
+    trap 'rm -rf "$TMPDIR_WORK"' EXIT
+
+    echo "Downloading ${asset}..."
+    curl -fSL --progress-bar "$asset_url" -o "$TMPDIR_WORK/$asset"
+
+    echo "Extracting..."
+    tar -C "$TMPDIR_WORK" -xzf "$TMPDIR_WORK/$asset"
+
+    echo "Verifying checksum..."
+    expected_hash="$(curl -fsSL "$checksum_url" | awk '{print $1}')"
+    verify_sha256 "$TMPDIR_WORK/zellij" "$expected_hash"
+    echo "Checksum OK"
+
+    mkdir -p "$INSTALL_DIR"
+    mv "$TMPDIR_WORK/zellij" "$INSTALL_DIR/zellij"
+    chmod +x "$INSTALL_DIR/zellij"
+
+    echo ""
+    echo "Installed: $INSTALL_DIR/zellij"
+
+    case ":$PATH:" in
+        *":$INSTALL_DIR:"*) ;;
+        *) echo "Warning: $INSTALL_DIR is not in \$PATH" ;;
+    esac
+
+    echo "Done. Run: zellij"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

* Add `install.sh`, an interactive installer for prebuilt Zellij binaries on Linux and macOS
* Update `README.md` with installation instructions
* Closes #3473

## What this does

Unlike `zellij.dev/launch`, which downloads and runs Zellij temporarily from `/tmp`, `install.sh` installs the binary into a directory intended to be on the user's `$PATH`.

The installer:

* Detects the operating system and CPU architecture automatically
* Prompts for the binary variant:

  * **Full**: includes web plugins and is selected by default
  * **No-web**: smaller build without web plugins
* Prompts for an installation directory

  * Defaults to `/usr/local/bin`
  * Falls back to `~/.local/bin` when appropriate
* Retrieves the latest release version through the GitHub API
* Downloads the corresponding prebuilt binary from GitHub Releases
* Extracts the binary and verifies its SHA-256 checksum against the upstream `.sha256sum` file
* Warns when the selected installation directory is not included in `$PATH`

## Usage

```bash
curl -fsSL https://raw.githubusercontent.com/zellij-org/zellij/main/install.sh | bash
```

Alternatively, in Bash or Zsh:

```bash
bash <(curl -fsSL https://raw.githubusercontent.com/zellij-org/zellij/main/install.sh)
```

<img width="772" height="444" alt="Zellij installer prompts" src="https://github.com/user-attachments/assets/376e50b5-d3bc-4b68-a8fd-d847b78d1459" />

## Notes

The `.sha256sum` files attached to Zellij releases contain checksums for the extracted binaries rather than the downloaded archives. The installer therefore extracts the archive before verifying the checksum, matching the existing upstream checksum convention.
