### PR TITLE
perf: foreground pane-command discovery without scanning the whole process table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * feat: new title-frames UI (https://github.com/zellij-org/zellij/pull/5318)
 * chore: upgrade wasmi to 1.1.0 (https://github.com/zellij-org/zellij/pull/5319)
 * fix: fragmented STDIN causing "garbage" input on slow SSH connections (https://github.com/zellij-org/zellij/pull/5320)
+* build(deps): bump sysinfo to 0.37 for scan-free targeted process refresh (https://github.com/zellij-org/zellij/pull/5324)
 
 ## [0.44.3] - 2026-05-13
 * fix(windows): bump windows-sys to 0.59 to align manifest with code, fixing source builds via `cargo install`/`cargo binstall` (https://github.com/zellij-org/zellij/pull/5139)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * chore: upgrade wasmi to 1.1.0 (https://github.com/zellij-org/zellij/pull/5319)
 * fix: fragmented STDIN causing "garbage" input on slow SSH connections (https://github.com/zellij-org/zellij/pull/5320)
 * build(deps): bump sysinfo to 0.37 for scan-free targeted process refresh (https://github.com/zellij-org/zellij/pull/5324)
+* perf: discover foreground pane commands without scanning the whole process table (https://github.com/zellij-org/zellij/pull/5324)
 
 ## [0.44.3] - 2026-05-13
 * fix(windows): bump windows-sys to 0.59 to align manifest with code, fixing source builds via `cargo install`/`cargo binstall` (https://github.com/zellij-org/zellij/pull/5139)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * feat: new title-frames UI (https://github.com/zellij-org/zellij/pull/5318)
 * chore: upgrade wasmi to 1.1.0 (https://github.com/zellij-org/zellij/pull/5319)
 * fix: fragmented STDIN causing "garbage" input on slow SSH connections (https://github.com/zellij-org/zellij/pull/5320)
-* build(deps): bump sysinfo to 0.37 for scan-free targeted process refresh (https://github.com/zellij-org/zellij/pull/5324)
-* perf: discover foreground pane commands without scanning the whole process table (https://github.com/zellij-org/zellij/pull/5324)
 
 ## [0.44.3] - 2026-05-13
 * fix(windows): bump windows-sys to 0.59 to align manifest with code, fixing source builds via `cargo install`/`cargo binstall` (https://github.com/zellij-org/zellij/pull/5139)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2304,6 +2304,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.28.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2861,7 +2880,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3502,14 +3521,15 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.33.1"
+version = "0.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
 dependencies = [
- "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
  "windows",
 ]
 
@@ -4437,12 +4457,24 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.57.0"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4456,21 +4488,33 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.57.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
+ "windows-link 0.1.3",
  "windows-result",
- "windows-targets 0.52.6",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.57.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4479,9 +4523,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.57.0"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4490,17 +4534,42 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-result"
-version = "0.1.2"
+name = "windows-numerics"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4576,7 +4645,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -4585,6 +4654,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/zellij-server/Cargo.toml
+++ b/zellij-server/Cargo.toml
@@ -33,7 +33,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sixel-image = { version = "0.2.1", default-features = false }
 sixel-tokenizer = { version = "0.1.0", default-features = false }
-sysinfo = { version = "0.33", default-features = false, features = ["system"] }
+sysinfo = { version = "0.37", default-features = false, features = ["system"] }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 typetag = { version = "0.1.7", default-features = false }

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -574,27 +574,7 @@ impl ServerOsApi for ServerOsInputOutput {
                 if command.is_empty() {
                     continue;
                 }
-                match post_hook {
-                    Some(post_hook) => {
-                        let stringified = command.join(" ");
-                        let cmd = match run_command_hook(&stringified, post_hook) {
-                            Ok(command) => command,
-                            Err(e) => {
-                                log::error!("Post command hook failed to run: {}", e);
-                                stringified.to_owned()
-                            },
-                        };
-                        let line_parts: Vec<String> = cmd
-                            .trim()
-                            .split_ascii_whitespace()
-                            .map(|p| p.to_owned())
-                            .collect();
-                        cmds.insert(ppid_str, line_parts);
-                    },
-                    None => {
-                        cmds.insert(ppid_str, command);
-                    },
-                }
+                cmds.insert(ppid_str, apply_post_command_hook(command, post_hook));
             }
         }
         cmds
@@ -649,23 +629,7 @@ impl ServerOsApi for ServerOsInputOutput {
             if command.is_empty() {
                 continue;
             }
-            let command = match post_hook {
-                Some(post_hook) => {
-                    let stringified = command.join(" ");
-                    let cmd = match run_command_hook(&stringified, post_hook) {
-                        Ok(command) => command,
-                        Err(e) => {
-                            log::error!("Post command hook failed to run: {}", e);
-                            stringified
-                        },
-                    };
-                    cmd.trim()
-                        .split_ascii_whitespace()
-                        .map(|p| p.to_owned())
-                        .collect()
-                },
-                None => command,
-            };
+            let command = apply_post_command_hook(command, post_hook);
             cmds.insert(terminal_id, command);
         }
         cmds
@@ -777,6 +741,26 @@ impl Drop for ResizeCache {
                 log::error!("Failed to apply cached resizes: {}", e);
             });
     }
+}
+
+/// Apply the post-command-discovery `post_hook` to a discovered command, returning the
+/// (possibly rewritten) command in argv form. With no hook the command is returned unchanged.
+fn apply_post_command_hook(command: Vec<String>, post_hook: &Option<String>) -> Vec<String> {
+    let Some(post_hook) = post_hook else {
+        return command;
+    };
+    let stringified = command.join(" ");
+    let cmd = match run_command_hook(&stringified, post_hook) {
+        Ok(command) => command,
+        Err(e) => {
+            Err::<(), _>(anyhow!("post command discovery hook failed to run: {e}")).non_fatal();
+            stringified
+        },
+    };
+    cmd.trim()
+        .split_ascii_whitespace()
+        .map(|p| p.to_owned())
+        .collect()
 }
 
 #[cfg(not(windows))]

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -348,6 +348,18 @@ pub trait ServerOsApi: Send + Sync {
     fn get_all_cmds_by_ppid(&self, _post_hook: &Option<String>) -> HashMap<String, Vec<String>> {
         HashMap::new()
     }
+    /// For each `(terminal_id, shell_pid)` pane, return the foreground command running in its
+    /// controlling terminal, keyed by `terminal_id`. This is `O(panes)` and performs no full
+    /// process-table scan. Panes whose foreground process group is led by the shell itself
+    /// (idle prompt, or a command sharing the shell's group without job control) are omitted,
+    /// so the caller falls back to reporting the shell.
+    fn get_foreground_cmds(
+        &self,
+        _panes: &[(u32, u32)],
+        _post_hook: &Option<String>,
+    ) -> HashMap<u32, Vec<String>> {
+        HashMap::new()
+    }
     /// Writes the given buffer to a string
     fn write_to_file(&mut self, buf: String, file: Option<String>) -> Result<()>;
 
@@ -545,54 +557,6 @@ impl ServerOsApi for ServerOsInputOutput {
 
         (cwds, cmds)
     }
-    #[cfg(unix)]
-    fn get_all_cmds_by_ppid(&self, post_hook: &Option<String>) -> HashMap<String, Vec<String>> {
-        // the key is the stringified ppid
-        let mut cmds = HashMap::new();
-        if let Some(output) = Command::new("ps")
-            .args(vec!["-ao", "ppid,args"])
-            .output()
-            .ok()
-        {
-            let output = String::from_utf8(output.stdout.clone())
-                .unwrap_or_else(|_| String::from_utf8_lossy(&output.stdout).to_string());
-            for line in output.lines() {
-                let line_parts: Vec<String> = line
-                    .trim()
-                    .split_ascii_whitespace()
-                    .map(|p| p.to_owned())
-                    .collect();
-                let mut line_parts = line_parts.into_iter();
-                let ppid = line_parts.next();
-                if let Some(ppid) = ppid {
-                    match &post_hook {
-                        Some(post_hook) => {
-                            let command: Vec<String> = line_parts.clone().collect();
-                            let stringified = command.join(" ");
-                            let cmd = match run_command_hook(&stringified, post_hook) {
-                                Ok(command) => command,
-                                Err(e) => {
-                                    log::error!("Post command hook failed to run: {}", e);
-                                    stringified.to_owned()
-                                },
-                            };
-                            let line_parts: Vec<String> = cmd
-                                .trim()
-                                .split_ascii_whitespace()
-                                .map(|p| p.to_owned())
-                                .collect();
-                            cmds.insert(ppid.into(), line_parts);
-                        },
-                        None => {
-                            cmds.insert(ppid.into(), line_parts.collect());
-                        },
-                    }
-                }
-            }
-        }
-        cmds
-    }
-
     #[cfg(not(unix))]
     fn get_all_cmds_by_ppid(&self, post_hook: &Option<String>) -> HashMap<String, Vec<String>> {
         let mut system_info = System::new();
@@ -631,6 +595,95 @@ impl ServerOsApi for ServerOsInputOutput {
                         cmds.insert(ppid_str, command);
                     },
                 }
+            }
+        }
+        cmds
+    }
+
+    #[cfg(unix)]
+    fn get_foreground_cmds(
+        &self,
+        panes: &[(u32, u32)],
+        post_hook: &Option<String>,
+    ) -> HashMap<u32, Vec<String>> {
+        // Resolve each pane's foreground command via `tcgetpgrp` on the pty master: the
+        // foreground process group leader has `pid == pgid`, so the returned pgid is the pid we
+        // want. When it equals the shell's pid the shell itself is in the foreground (idle, or a
+        // command sharing the shell's group without job control) and we omit the pane so the
+        // caller falls back to the shell command. No full process-table scan.
+        let mut terminal_to_fg_pid: HashMap<u32, u32> = HashMap::new();
+        for &(terminal_id, shell_pid) in panes {
+            if let Some(fpgid) = self.pty_backend.tcgetpgrp(terminal_id) {
+                if fpgid > 0 && fpgid as u32 != shell_pid {
+                    terminal_to_fg_pid.insert(terminal_id, fpgid as u32);
+                }
+            }
+        }
+        if terminal_to_fg_pid.is_empty() {
+            return HashMap::new();
+        }
+
+        // Refresh the foreground pids.
+        let sysinfo_pids: Vec<sysinfo::Pid> = terminal_to_fg_pid
+            .values()
+            .map(|&p| sysinfo::Pid::from_u32(p))
+            .collect();
+        let mut system_info = System::new();
+        let refresh_kind = ProcessRefreshKind::nothing().with_cmd(UpdateKind::Always);
+        system_info.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&sysinfo_pids),
+            false,
+            refresh_kind,
+        );
+
+        let mut cmds = HashMap::new();
+        for (terminal_id, fg_pid) in terminal_to_fg_pid {
+            let Some(process) = system_info.process(sysinfo::Pid::from_u32(fg_pid)) else {
+                continue;
+            };
+            let command: Vec<String> = process
+                .cmd()
+                .iter()
+                .map(|s| s.to_string_lossy().into_owned())
+                .collect();
+            if command.is_empty() {
+                continue;
+            }
+            let command = match post_hook {
+                Some(post_hook) => {
+                    let stringified = command.join(" ");
+                    let cmd = match run_command_hook(&stringified, post_hook) {
+                        Ok(command) => command,
+                        Err(e) => {
+                            log::error!("Post command hook failed to run: {}", e);
+                            stringified
+                        },
+                    };
+                    cmd.trim()
+                        .split_ascii_whitespace()
+                        .map(|p| p.to_owned())
+                        .collect()
+                },
+                None => command,
+            };
+            cmds.insert(terminal_id, command);
+        }
+        cmds
+    }
+
+    #[cfg(not(unix))]
+    fn get_foreground_cmds(
+        &self,
+        panes: &[(u32, u32)],
+        post_hook: &Option<String>,
+    ) -> HashMap<u32, Vec<String>> {
+        // Use ppid-based discovery on Windows, because it has no controlling-terminal
+        // foreground group.
+        let ppids_to_cmds = self.get_all_cmds_by_ppid(post_hook);
+        let mut cmds = HashMap::new();
+        for &(terminal_id, shell_pid) in panes {
+            if let Some(cmd) = ppids_to_cmds.get(&shell_pid.to_string()) {
+                cmds.insert(terminal_id, cmd.clone());
             }
         }
         cmds

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -349,10 +349,7 @@ pub trait ServerOsApi: Send + Sync {
         HashMap::new()
     }
     /// For each `(terminal_id, shell_pid)` pane, return the foreground command running in its
-    /// controlling terminal, keyed by `terminal_id`. This is `O(panes)` and performs no full
-    /// process-table scan. Panes whose foreground process group is led by the shell itself
-    /// (idle prompt, or a command sharing the shell's group without job control) are omitted,
-    /// so the caller falls back to reporting the shell.
+    /// controlling terminal, keyed by `terminal_id`.
     fn get_foreground_cmds(
         &self,
         _panes: &[(u32, u32)],
@@ -586,11 +583,6 @@ impl ServerOsApi for ServerOsInputOutput {
         panes: &[(u32, u32)],
         post_hook: &Option<String>,
     ) -> HashMap<u32, Vec<String>> {
-        // Resolve each pane's foreground command via `tcgetpgrp` on the pty master: the
-        // foreground process group leader has `pid == pgid`, so the returned pgid is the pid we
-        // want. When it equals the shell's pid the shell itself is in the foreground (idle, or a
-        // command sharing the shell's group without job control) and we omit the pane so the
-        // caller falls back to the shell command. No full process-table scan.
         let mut terminal_to_fg_pid: HashMap<u32, u32> = HashMap::new();
         for &(terminal_id, shell_pid) in panes {
             if let Some(fpgid) = self.pty_backend.tcgetpgrp(terminal_id) {
@@ -603,7 +595,6 @@ impl ServerOsApi for ServerOsInputOutput {
             return HashMap::new();
         }
 
-        // Refresh the foreground pids.
         let sysinfo_pids: Vec<sysinfo::Pid> = terminal_to_fg_pid
             .values()
             .map(|&p| sysinfo::Pid::from_u32(p))
@@ -743,8 +734,6 @@ impl Drop for ResizeCache {
     }
 }
 
-/// Apply the post-command-discovery `post_hook` to a discovered command, returning the
-/// (possibly rewritten) command in argv form. With no hook the command is returned unchanged.
 fn apply_post_command_hook(command: Vec<String>, post_hook: &Option<String>) -> Vec<String> {
     let Some(post_hook) = post_hook else {
         return command;

--- a/zellij-server/src/os_input_output_unix.rs
+++ b/zellij-server/src/os_input_output_unix.rs
@@ -414,6 +414,25 @@ impl UnixPtyBackend {
         }
     }
 
+    /// Return the foreground process group of the controlling terminal behind
+    /// `terminal_id` (i.e. `tcgetpgrp` on the pty master). A process group's leader
+    /// has `pid == pgid`, so the returned value is also the pid of the foreground
+    /// group leader. Returns `None` if the fd is unknown or the syscall fails.
+    pub fn tcgetpgrp(&self, terminal_id: u32) -> Option<i32> {
+        let guard = self.terminal_id_to_raw_fd.lock().ok()?;
+        let fd = match guard.get(&terminal_id) {
+            Some(Some(fd)) => *fd,
+            _ => return None,
+        };
+        // Release the lock before the syscall (as `write_to_tty_stdin` does) rather than hold it
+        // across `tcgetpgrp`. This opens a small TOCTOU window: if the pane is torn down here the
+        // fd could be closed (or reused) before the syscall runs, giving a stale/wrong result.
+        // The syscall is non-blocking and the worst case is a momentarily wrong or missing
+        // foreground command, so we accept the race instead of serializing pty I/O on this lookup.
+        drop(guard);
+        unistd::tcgetpgrp(fd).ok().map(|pgid| pgid.as_raw())
+    }
+
     pub fn kill(&self, pid: u32) -> Result<()> {
         let _ = kill(unistd::Pid::from_raw(pid as i32), Some(Signal::SIGHUP));
         Ok(())

--- a/zellij-server/src/os_input_output_unix.rs
+++ b/zellij-server/src/os_input_output_unix.rs
@@ -414,23 +414,11 @@ impl UnixPtyBackend {
         }
     }
 
-    /// Return the foreground process group of the controlling terminal behind
-    /// `terminal_id` (i.e. `tcgetpgrp` on the pty master). A process group's leader
-    /// has `pid == pgid`, so the returned value is also the pid of the foreground
-    /// group leader. Returns `None` if the fd is unknown or the syscall fails.
     pub fn tcgetpgrp(&self, terminal_id: u32) -> Option<i32> {
-        let guard = self.terminal_id_to_raw_fd.lock().ok()?;
-        let fd = match guard.get(&terminal_id) {
-            Some(Some(fd)) => *fd,
-            _ => return None,
-        };
-        // Release the lock before the syscall (as `write_to_tty_stdin` does) rather than hold it
-        // across `tcgetpgrp`. This opens a small TOCTOU window: if the pane is torn down here the
-        // fd could be closed (or reused) before the syscall runs, giving a stale/wrong result.
-        // The syscall is non-blocking and the worst case is a momentarily wrong or missing
-        // foreground command, so we accept the race instead of serializing pty I/O on this lookup.
-        drop(guard);
-        unistd::tcgetpgrp(fd).ok().map(|pgid| pgid.as_raw())
+        match self.terminal_id_to_raw_fd.lock().ok()?.get(&terminal_id) {
+            Some(Some(fd)) => unistd::tcgetpgrp(*fd).ok().map(|pgid| pgid.as_raw()),
+            _ => None,
+        }
     }
 
     pub fn kill(&self, pid: u32) -> Result<()> {

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -1959,19 +1959,23 @@ impl Pty {
             .as_ref()
             .map(|os_input| os_input.get_cwds(pids))
             .unwrap_or_default();
-        let ppids_to_cmds = self
+        let panes: Vec<(u32, u32)> = terminal_ids
+            .iter()
+            .filter_map(|id| self.id_to_child_pid.get(id).map(|pid| (*id, *pid)))
+            .collect();
+        let foreground_cmds = self
             .bus
             .os_input
             .as_ref()
-            .map(|os_input| os_input.get_all_cmds_by_ppid(&self.post_command_discovery_hook))
+            .map(|os_input| os_input.get_foreground_cmds(&panes, &self.post_command_discovery_hook))
             .unwrap_or_default();
 
         for terminal_id in terminal_ids {
             let process_id = self.id_to_child_pid.get(&terminal_id);
             let cwd = process_id.and_then(|pid| pids_to_cwds.get(pid));
             let cmd_sysinfo = process_id.and_then(|pid| pids_to_cmds.get(pid));
-            let cmd_ps = process_id.and_then(|pid| ppids_to_cmds.get(&format!("{}", pid)));
-            if let Some(cmd) = cmd_ps {
+            let cmd_foreground = foreground_cmds.get(&terminal_id);
+            if let Some(cmd) = cmd_foreground {
                 terminal_ids_to_commands.insert(terminal_id, cmd.clone());
             } else if let Some(cmd) = cmd_sysinfo {
                 terminal_ids_to_commands.insert(terminal_id, cmd.clone());
@@ -2126,17 +2130,20 @@ impl Pty {
             }
         }
 
-        let ppids_to_cmds = self
+        let panes: Vec<(u32, u32)> = active_terminal_ids
+            .iter()
+            .filter_map(|id| self.id_to_child_pid.get(id).map(|pid| (*id, *pid)))
+            .collect();
+        let foreground_cmds = self
             .bus
             .os_input
             .as_ref()
-            .map(|os_input| os_input.get_all_cmds_by_ppid(&self.post_command_discovery_hook))
+            .map(|os_input| os_input.get_foreground_cmds(&panes, &self.post_command_discovery_hook))
             .unwrap_or_default();
 
         for terminal_id in &active_terminal_ids {
-            let process_id = self.id_to_child_pid.get(terminal_id);
-            let foreground_cmd: Vec<String> = process_id
-                .and_then(|pid| ppids_to_cmds.get(&pid.to_string()))
+            let foreground_cmd: Vec<String> = foreground_cmds
+                .get(terminal_id)
                 .cloned()
                 .unwrap_or_default();
 
@@ -2281,16 +2288,18 @@ impl Pty {
                 if let Some(&child_pid) = self.id_to_child_pid.get(&terminal_id) {
                     // Query OS for current running command
                     if let Some(os_input) = self.bus.os_input.as_ref() {
-                        // First, try to get child process command (e.g., nvim running in bash)
-                        let ppids_to_cmds =
-                            os_input.get_all_cmds_by_ppid(&self.post_command_discovery_hook);
-                        let cmd_ps = ppids_to_cmds.get(&format!("{}", child_pid));
+                        // First, try to get the foreground command (e.g., nvim running in bash)
+                        let foreground_cmds = os_input.get_foreground_cmds(
+                            &[(terminal_id, child_pid)],
+                            &self.post_command_discovery_hook,
+                        );
+                        let cmd_foreground = foreground_cmds.get(&terminal_id);
 
-                        // If no child process, fall back to parent process (e.g., the shell itself)
+                        // If no foreground command, fall back to the shell itself
                         let (_cwds, cmds) = os_input.get_cwds(vec![child_pid]);
                         let cmd_sysinfo = cmds.get(&child_pid);
 
-                        if let Some(command_args) = cmd_ps {
+                        if let Some(command_args) = cmd_foreground {
                             GetPaneRunningCommandResponse::Ok(command_args.clone())
                         } else if let Some(command_args) = cmd_sysinfo {
                             GetPaneRunningCommandResponse::Ok(command_args.clone())

--- a/zellij-server/src/unit/os_input_output_tests.rs
+++ b/zellij-server/src/unit/os_input_output_tests.rs
@@ -201,3 +201,60 @@ fn spawn_and_read_output() {
         output_str
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn tcgetpgrp_returns_foreground_group() {
+    use crate::panes::PaneId;
+    use zellij_utils::input::command::TerminalAction;
+
+    let server = make_server();
+
+    // Spawn a long-running command directly in the pty. `login_tty` (in the child's pre_exec)
+    // calls setsid + TIOCSCTTY, so the spawned process leads its own session/process group and
+    // becomes the controlling terminal's foreground group. Hence tcgetpgrp(master) == child_pid.
+    let cmd = RunCommand {
+        command: PathBuf::from("sleep"),
+        args: vec!["60".to_string()],
+        ..Default::default()
+    };
+    let quit_cb: Box<dyn Fn(PaneId, Option<i32>, RunCommand) + Send> = Box::new(|_, _, _| {});
+    let (terminal_id, _reader, child_pid) = server
+        .spawn_terminal(TerminalAction::RunCommand(cmd), quit_cb, None)
+        .expect("spawn_terminal should succeed");
+
+    // Poll (rather than sleep a fixed duration) for the child to finish setting up its
+    // controlling terminal: once login_tty runs, tcgetpgrp(master) returns the child's own pgid.
+    // Bounded to ~2s so a stuck child fails the test rather than hanging.
+    let mut fpgid = None;
+    for _ in 0..100 {
+        fpgid = server.pty_backend.tcgetpgrp(terminal_id);
+        let ready = match (fpgid, child_pid) {
+            (Some(p), Some(child_pid)) => p > 0 && p as u32 == child_pid,
+            (Some(p), None) => p > 0,
+            _ => false,
+        };
+        if ready {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    assert!(
+        matches!(fpgid, Some(p) if p > 0),
+        "tcgetpgrp should return the foreground process group, got {:?}",
+        fpgid
+    );
+    if let (Some(fpgid), Some(child_pid)) = (fpgid, child_pid) {
+        assert_eq!(
+            fpgid as u32, child_pid,
+            "the spawned command leads its own foreground group"
+        );
+    }
+
+    // An unknown terminal id has no fd and must not panic.
+    assert_eq!(server.pty_backend.tcgetpgrp(u32::MAX), None);
+
+    if let Some(child_pid) = child_pid {
+        let _ = server.force_kill(child_pid);
+    }
+}

--- a/zellij-server/src/unit/os_input_output_tests.rs
+++ b/zellij-server/src/unit/os_input_output_tests.rs
@@ -210,9 +210,8 @@ fn tcgetpgrp_returns_foreground_group() {
 
     let server = make_server();
 
-    // Spawn a long-running command directly in the pty. `login_tty` (in the child's pre_exec)
-    // calls setsid + TIOCSCTTY, so the spawned process leads its own session/process group and
-    // becomes the controlling terminal's foreground group. Hence tcgetpgrp(master) == child_pid.
+    // `login_tty` in the child makes the spawned command the controlling terminal's
+    // foreground process group, so tcgetpgrp(master) should return its pid
     let cmd = RunCommand {
         command: PathBuf::from("sleep"),
         args: vec!["60".to_string()],
@@ -223,9 +222,7 @@ fn tcgetpgrp_returns_foreground_group() {
         .spawn_terminal(TerminalAction::RunCommand(cmd), quit_cb, None)
         .expect("spawn_terminal should succeed");
 
-    // Poll (rather than sleep a fixed duration) for the child to finish setting up its
-    // controlling terminal: once login_tty runs, tcgetpgrp(master) returns the child's own pgid.
-    // Bounded to ~2s so a stuck child fails the test rather than hanging.
+    // poll (bounded to ~2s) for the child to finish setting up its controlling terminal
     let mut fpgid = None;
     for _ in 0..100 {
         fpgid = server.pty_backend.tcgetpgrp(terminal_id);

--- a/zellij-server/src/unit/pty_tests.rs
+++ b/zellij-server/src/unit/pty_tests.rs
@@ -125,6 +125,21 @@ impl ServerOsApi for MockOsApi {
     fn get_all_cmds_by_ppid(&self, _: &Option<String>) -> HashMap<String, Vec<String>> {
         self.cmds_by_ppid.lock().unwrap().clone()
     }
+    fn get_foreground_cmds(
+        &self,
+        panes: &[(u32, u32)],
+        _: &Option<String>,
+    ) -> HashMap<u32, Vec<String>> {
+        let cmds_by_ppid = self.cmds_by_ppid.lock().unwrap();
+        panes
+            .iter()
+            .filter_map(|(terminal_id, shell_pid)| {
+                cmds_by_ppid
+                    .get(&shell_pid.to_string())
+                    .map(|cmd| (*terminal_id, cmd.clone()))
+            })
+            .collect()
+    }
     fn write_to_file(&mut self, _: String, _: Option<String>) -> anyhow::Result<()> {
         Ok(())
     }


### PR DESCRIPTION
## What

Foreground command discovery was reading information about every process on the host, on each pane/tab creation and on every periodic poll. On hosts with many processes (eg, 50k) this stalled pane creation for tens of seconds and overran the action-completion timeout.

This replaces the `O(host processes)` lookup with an `O(panes)` one:

- `tcgetpgrp()` on each pane's pty master yields the foreground process-group
  leader's pid.
- argv comes from a single targeted `sysinfo` refresh of just those pids
  (scan-free on Linux thanks to sysinfo 0.37's `ProcessesToUpdate::Some`).
- When the foreground group is the shell itself (idle prompt, or a command
  sharing the shell's group without job control) the pane is omitted and the
  caller falls back to the shell command — matching prior behavior. With job
  control on, it now reports the true foreground job instead of possibly a
  background one.
- Linux, macOS, and BSD take the new path; Windows keeps the existing
  ppid-based path.

## Commits

- `build(deps): bump sysinfo to 0.37`: enables the scan-free
  `ProcessesToUpdate::Some` targeted refresh.
- `perf: discover foreground pane commands w/o scanning all processes`: the
  core change.
- `refactor(os_input): extract apply_post_command_hook helper`: de-duplicates
  the post-command-hook application.

## Fixes

Fixes #5304
Fixes #5305

## Testing

- `cargo fmt` clean; `cargo test -p zellij-server` passing, including new tests
  `tcgetpgrp_returns_foreground_group` and the `pty_tests` foreground-discovery
  cases (`foreground_command_emitted_with_is_foreground_true`,
  `empty_foreground_falls_back_to_shell_command`, …).
- **Manually confirmed on a test host with ~50k processes**: new-pane/tab
  creation no longer stalls (no multi-second delay, no `ps`/`/proc` scan),
  resolving both #5304 and #5305.
