### PR TITLE
feat(action): break-pane to an adjacent tab preserves the pane's column

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -4738,56 +4738,38 @@ impl Screen {
         ))?;
         Ok(tab_index)
     }
+    // The distinct tiled-column x-positions of a tab, left to right. A stacked column's
+    // panes all share one x, so this is effectively "the columns of the tab".
+    fn tiled_column_xs(tab: &Tab) -> Vec<usize> {
+        let mut xs: Vec<usize> = tab.get_tiled_panes().map(|(_, p)| p.x()).collect();
+        xs.sort_unstable();
+        xs.dedup();
+        xs
+    }
+    // The column "rank" (0 = leftmost) of a pane within its tab.
+    fn column_rank_of(tab: &Tab, pane_id: &PaneId) -> Option<usize> {
+        let target_x = tab
+            .get_tiled_panes()
+            .find(|(pid, _)| *pid == pane_id)
+            .map(|(_, p)| p.x())?;
+        Self::tiled_column_xs(tab)
+            .iter()
+            .position(|&x| x == target_x)
+    }
+    // A pane in the tab's column at the given rank (to anchor a stack onto).
+    fn pane_at_column_rank(tab: &Tab, rank: usize) -> Option<PaneId> {
+        let x = *Self::tiled_column_xs(tab).get(rank)?;
+        tab.get_tiled_panes()
+            .find(|(_, p)| p.x() == x)
+            .map(|(pid, _)| *pid)
+    }
     pub fn break_pane_to_new_tab(
         &mut self,
         direction: Direction,
         client_id: ClientId,
     ) -> Result<()> {
         let err_context = || "failed break pane out of tab".to_string();
-        if self.tabs.len() > 1 {
-            let (active_pane_id, active_pane, pane_to_break_is_floating) = {
-                let active_tab = self.get_active_tab_mut(client_id)?;
-                let active_pane_id = active_tab
-                    .get_active_pane_id(client_id)
-                    .with_context(err_context)?;
-                let pane_to_break_is_floating = active_tab.are_floating_panes_visible();
-                let active_pane = active_tab
-                    .extract_pane(active_pane_id, false)
-                    .with_context(err_context)?;
-                (active_pane_id, active_pane, pane_to_break_is_floating)
-            };
-            let update_mode_infos = false;
-            match direction {
-                Direction::Right | Direction::Down => {
-                    self.switch_tab_next(None, update_mode_infos, client_id)?;
-                },
-                Direction::Left | Direction::Up => {
-                    self.switch_tab_prev(None, update_mode_infos, client_id)?;
-                },
-            };
-            let new_active_tab = self.get_active_tab_mut(client_id)?;
-
-            if pane_to_break_is_floating {
-                new_active_tab.show_floating_panes();
-                new_active_tab.add_floating_pane(
-                    active_pane,
-                    active_pane_id,
-                    None,
-                    true,
-                    Some(client_id),
-                )?;
-            } else {
-                new_active_tab.hide_floating_panes();
-                new_active_tab.add_tiled_pane(
-                    active_pane,
-                    active_pane_id,
-                    false,
-                    Some(client_id),
-                )?;
-            }
-
-            self.log_and_report_session_state()?;
-        } else {
+        if self.tabs.len() <= 1 {
             let active_pane_id = {
                 let active_tab = self.get_active_tab_mut(client_id)?;
                 active_tab
@@ -4801,7 +4783,87 @@ impl Screen {
                     "No other tabs to add pane to!".into(),
                 ))
                 .with_context(err_context)?;
+            self.render(None)?;
+            return Ok(());
         }
+
+        // Column-preserving fast path: move the focused *tiled* pane into the matching
+        // column (left->left, middle->middle, right->right) of the adjacent tab and stack
+        // it onto whatever is already there. Reuses stack_panes, which moves the pane
+        // across tabs and follows focus. Falls through to the default break behavior for
+        // floating panes or when the destination column has no pane to anchor onto.
+        let (active_pos, active_pane_id, is_floating, col_rank) = {
+            let active_tab = self.get_active_tab(client_id)?;
+            let active_pane_id = active_tab
+                .get_active_pane_id(client_id)
+                .with_context(err_context)?;
+            let is_floating = active_tab.are_floating_panes_visible();
+            let col_rank = if is_floating {
+                None
+            } else {
+                Self::column_rank_of(active_tab, &active_pane_id)
+            };
+            (active_tab.position, active_pane_id, is_floating, col_rank)
+        };
+        if !is_floating {
+            if let Some(rank) = col_rank {
+                let n = self.tabs.len();
+                let dest_pos = match direction {
+                    Direction::Right | Direction::Down => (active_pos + 1) % n,
+                    Direction::Left | Direction::Up => (active_pos + n - 1) % n,
+                };
+                let dest_root = self
+                    .tabs
+                    .values()
+                    .find(|t| t.position == dest_pos)
+                    .and_then(|t| Self::pane_at_column_rank(t, rank));
+                if let Some(root) = dest_root {
+                    self.stack_panes(vec![root, active_pane_id]);
+                    let _ =
+                        self.focus_pane_with_id(active_pane_id, false, false, client_id);
+                    self.log_and_report_session_state()?;
+                    self.render(None)?;
+                    return Ok(());
+                }
+            }
+        }
+
+        // Default behavior: extract the pane, switch to the adjacent tab, and add it.
+        let (active_pane_id, active_pane, pane_to_break_is_floating) = {
+            let active_tab = self.get_active_tab_mut(client_id)?;
+            let active_pane_id = active_tab
+                .get_active_pane_id(client_id)
+                .with_context(err_context)?;
+            let pane_to_break_is_floating = active_tab.are_floating_panes_visible();
+            let active_pane = active_tab
+                .extract_pane(active_pane_id, false)
+                .with_context(err_context)?;
+            (active_pane_id, active_pane, pane_to_break_is_floating)
+        };
+        let update_mode_infos = false;
+        match direction {
+            Direction::Right | Direction::Down => {
+                self.switch_tab_next(None, update_mode_infos, client_id)?;
+            },
+            Direction::Left | Direction::Up => {
+                self.switch_tab_prev(None, update_mode_infos, client_id)?;
+            },
+        };
+        let new_active_tab = self.get_active_tab_mut(client_id)?;
+        if pane_to_break_is_floating {
+            new_active_tab.show_floating_panes();
+            new_active_tab.add_floating_pane(
+                active_pane,
+                active_pane_id,
+                None,
+                true,
+                Some(client_id),
+            )?;
+        } else {
+            new_active_tab.hide_floating_panes();
+            new_active_tab.add_tiled_pane(active_pane, active_pane_id, false, Some(client_id))?;
+        }
+        self.log_and_report_session_state()?;
         self.render(None)?;
         Ok(())
     }


### PR DESCRIPTION
## What

`BreakPaneRight` / `BreakPaneLeft` move the focused pane to the adjacent tab. Previously the destination tab's tiling placed the incoming pane wherever the algorithm chose. This makes the move **column-preserving**: a tiled pane lands in the **same column position** (left→left, middle→middle, right→right) as it had in the source tab, stacking onto whatever is already in that column there.

## Why

When you keep a consistent multi-column arrangement across tabs (e.g. one tab per git worktree, each with the same left/middle/right columns), moving a pane to another tab and having it dropped into an arbitrary slot scrambles the destination layout. Preserving the column makes "send this pane to the same spot in the next tab" predictable — you can shuttle panes between tabs without re-tidying.

## How

- Reuses the existing `Screen::stack_panes`, which already moves a pane across tabs onto a root pane and follows focus — so this is a single in-process operation, no extra machinery.
- The source pane's **column** is identified by *rank*: the index of its `x` among the tab's distinct, left-to-right tiled-column x-positions (a stacked column's panes all share one `x`, so this is "which column"). The destination anchor is the pane occupying the same rank in the adjacent tab. Rank-matching means it works even when the two tabs' columns aren't at pixel-identical `x`.
- **Fallbacks to the previous behavior** (extract → switch tab → add) when the pane is floating, or when the destination column has no pane to anchor onto — so nothing regresses for those cases.
- Edge tabs wrap (as `BreakPane` already does via `switch_tab_next`/`prev`).

## Testing

- `cargo check` clean.
- Exercised end-to-end in a 3-tab × 3-column session: moving a pane right/left from every column of every tab lands it in the matching column of the adjacent tab, stacked, with focus following — and floating panes / empty destination columns still use the original path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
