### PR TITLE
fix(server): break panes to the correct tab after closing tabs

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -9744,27 +9744,33 @@ pub(crate) fn screen_thread_main(
                 client_id,
                 mut completion_tx,
             } => {
-                // tab_index is the target tab ID
-                screen.break_multiple_panes_to_tab_with_index(
-                    pane_ids,
-                    tab_index,
-                    should_change_focus_to_new_tab,
-                    client_id,
-                )?;
-                // Set affected tab ID (tab_index is the ID here)
-                completion_tx
-                    .as_mut()
-                    .map(|c| c.set_affected_tab_id(tab_index));
-                let pane_group = screen.get_client_pane_group(&client_id);
-                if !pane_group.is_empty() {
-                    let _ = screen.bus.senders.send_to_background_jobs(
-                        BackgroundJob::HighlightPanesWithMessage(
-                            pane_group.iter().copied().collect(),
-                            "BROKEN OUT".to_owned(),
-                        ),
-                    );
+                match screen.get_tab_id_at_position(tab_index) {
+                    Some(tab_id) => {
+                        // tab_index is the target tab position
+                        screen.break_multiple_panes_to_tab_with_index(
+                            pane_ids,
+                            tab_index,
+                            should_change_focus_to_new_tab,
+                            client_id,
+                        )?;
+                        // affected_tab_id is the stable tab id at this display position
+                        completion_tx
+                            .as_mut()
+                            .map(|c| c.set_affected_tab_id(tab_id));
+                        let pane_group = screen.get_client_pane_group(&client_id);
+                        if !pane_group.is_empty() {
+                            let _ = screen.bus.senders.send_to_background_jobs(
+                                BackgroundJob::HighlightPanesWithMessage(
+                                    pane_group.iter().copied().collect(),
+                                    "BROKEN OUT".to_owned(),
+                                ),
+                            );
+                        }
+                        screen.clear_pane_group(&client_id);
+                    },
+                    // Don't set affected_tab_id, it will remain None to signal failure
+                    None => log::error!("Cannot find tab with index: {tab_index}"),
                 }
-                screen.clear_pane_group(&client_id);
             },
             ScreenInstruction::TogglePanePinned(
                 client_id,

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -9112,32 +9112,32 @@ pub(crate) fn screen_thread_main(
                 client_id,
                 mut completion_tx,
             } => {
-                // Verify tab exists
-                if screen.get_tab_by_id(tab_id).is_none() {
-                    log::error!("Tab with ID {} not found", tab_id);
+                match screen.get_tab_position_by_id(tab_id) {
+                    Some(position) => {
+                        // The helper takes a display position, not a tab id
+                        screen.break_multiple_panes_to_tab_with_index(
+                            pane_ids,
+                            position,
+                            should_change_focus_to_target_tab,
+                            client_id,
+                        )?;
+                        // Set affected tab ID (tab_id is the ID here)
+                        completion_tx
+                            .as_mut()
+                            .map(|c| c.set_affected_tab_id(tab_id));
+                        let pane_group = screen.get_client_pane_group(&client_id);
+                        if !pane_group.is_empty() {
+                            let _ = screen.bus.senders.send_to_background_jobs(
+                                BackgroundJob::HighlightPanesWithMessage(
+                                    pane_group.iter().copied().collect(),
+                                    "BROKEN OUT".to_owned(),
+                                ),
+                            );
+                        }
+                        screen.clear_pane_group(&client_id);
+                    },
                     // Don't set affected_tab_id, it will remain None to signal failure
-                } else {
-                    // break_multiple_panes_to_tab_with_index uses tab ID
-                    screen.break_multiple_panes_to_tab_with_index(
-                        pane_ids,
-                        tab_id,
-                        should_change_focus_to_target_tab,
-                        client_id,
-                    )?;
-                    // Set affected tab ID (tab_id is the ID here)
-                    completion_tx
-                        .as_mut()
-                        .map(|c| c.set_affected_tab_id(tab_id));
-                    let pane_group = screen.get_client_pane_group(&client_id);
-                    if !pane_group.is_empty() {
-                        let _ = screen.bus.senders.send_to_background_jobs(
-                            BackgroundJob::HighlightPanesWithMessage(
-                                pane_group.iter().copied().collect(),
-                                "BROKEN OUT".to_owned(),
-                            ),
-                        );
-                    }
-                    screen.clear_pane_group(&client_id);
+                    None => log::error!("Tab with ID {} not found", tab_id),
                 }
             },
             ScreenInstruction::RequestPluginPermissions(plugin_id, plugin_permission) => {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -4845,7 +4845,7 @@ impl Screen {
             return Ok(());
         }
         let screen_size = self.size;
-        if let Some(new_active_tab) = self.get_indexed_tab_mut(tab_index) {
+        if let Some(new_active_tab) = self.get_tab_by_position_mut(tab_index) {
             for (pane_was_floating, mut pane) in extracted_panes {
                 let pane_id = pane.pid();
                 if pane_was_floating {

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -9834,6 +9834,66 @@ fn moving_panes_between_tabs_with_focus_change_recomputes_both() {
 }
 
 #[test]
+fn break_pane_to_tab_after_closing_middle_tab() {
+    // Regression test: `break_multiple_panes_to_tab_with_index` resolved its
+    // destination by tab id (the `BTreeMap` key) instead of display position.
+    // Once a middle tab is closed, position and id diverge, so the destination
+    // lookup hit an empty id slot and the extracted pane was silently dropped.
+    let size = Size { cols: 80, rows: 20 };
+    let mut screen = create_new_screen(size, true, true);
+
+    // Three tabs (ids 0/1/2, positions 0/1/2)
+    new_tab(&mut screen, 1, 0);
+    new_tab(&mut screen, 2, 1);
+    new_tab(&mut screen, 3, 2);
+
+    // Close the middle tab (id 1)
+    // Remaining tabs (ids 0/2, positions 0/1)
+    screen.go_to_tab(2, 1).expect("TEST"); // focus position 2 (1-based) = middle
+    screen.close_tab(1).expect("TEST");
+    assert_eq!(
+        screen.tabs.len(),
+        2,
+        "Two tabs left after closing the middle one"
+    );
+
+    // Put a pane on the first tab
+    let pane_to_move = PaneId::Terminal(42);
+    screen.go_to_tab(1, 1).expect("TEST"); // focus position 1 (1-based) = first tab
+    {
+        let active_tab = screen.get_active_tab_mut(1).unwrap();
+        active_tab
+            .new_pane(
+                pane_to_move,
+                None,
+                None,
+                false,
+                true,
+                NewPanePlacement::default(),
+                Some(1),
+                None,
+            )
+            .unwrap();
+    }
+
+    // Break the pane to display position 1 (0-based) = last tab
+    screen
+        .break_multiple_panes_to_tab_with_index(vec![pane_to_move], 1, false, 1)
+        .expect("TEST");
+
+    // The pane must land on the tab at display position 1 (id 2), not be dropped.
+    let dest = screen
+        .tabs
+        .values()
+        .find(|t| t.position == 1)
+        .expect("a tab at display position 1");
+    assert!(
+        dest.has_pane_with_pid(&pane_to_move),
+        "pane should move to the tab at display position 1, not be dropped"
+    );
+}
+
+#[test]
 fn detaching_client_grows_vacated_tab_back() {
     let initial_size = Size {
         cols: 200,


### PR DESCRIPTION
Fixes #5329.

`break_multiple_panes_to_tab_with_index` extracted panes by `Tab::position` but resolved the destination via `get_indexed_tab_mut`, which indexes the tab map by **id**.
Once position and id diverge (after a tab is closed), the destination lookup returned `None` and the extracted pane was silently dropped.

- Resolve the destination by display position (`get_tab_by_position_mut`)
- `BreakPanesToTabWithId`: convert the tab id to a display position before calling the
  now position-based helper (also fixes `WithId` for position != id)
- Add regression test `break_pane_to_tab_after_closing_middle_tab`