### PR TITLE
fix(windows): route Windows Terminal through the VT input path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix: fragmented STDIN causing "garbage" input on slow SSH connections (https://github.com/zellij-org/zellij/pull/5320)
 * feat: stacked lists - new stack UI (https://github.com/zellij-org/zellij/pull/5331)
 * fix: more verbose startup errors (https://github.com/zellij-org/zellij/pull/5334)
+* fix(windows): route Windows Terminal through the VT input path (https://github.com/zellij-org/zellij/pull/5335)
 
 ## [0.44.3] - 2026-05-13
 * fix(windows): bump windows-sys to 0.59 to align manifest with code, fixing source builds via `cargo install`/`cargo binstall` (https://github.com/zellij-org/zellij/pull/5139)

--- a/zellij-client/src/os_input_output_windows.rs
+++ b/zellij-client/src/os_input_output_windows.rs
@@ -9,6 +9,30 @@ use std::io::Write;
 use std::path::Path;
 use zellij_utils::ipc::{IpcReceiverWithContext, IpcSenderWithContext};
 
+/// Whether zellij should use the VT byte path on Windows (raw stdin via
+/// `ReadFile` + termwiz/kitty parsing) instead of the native-console path
+/// (crossterm `INPUT_RECORD`s).
+///
+/// True when either of these environment variables is set:
+///
+/// * `TERM` — set automatically by terminal emulators that expose a Unix-style
+///   environment (Alacritty, WezTerm, WSL sessions inheriting bash's env), or
+///   set manually by users who want zellij on the VT path (e.g. adding
+///   `TERM=xterm-256color` to a Windows Terminal / PowerShell profile).
+/// * `WT_SESSION` — set per-session by Windows Terminal itself. Detecting it
+///   means default WT installs land on the VT path without the user having to
+///   set `TERM`, so they get bracketed paste, kitty keyboard, SGR mouse, and
+///   the other features that depend on raw VT input.
+///
+/// Every VT-path-conditional code site (stdin handler, mouse mode setup,
+/// future input-related code) should call this so the gates can't drift —
+/// when they did drift, mouse setup using `crossterm::EnableMouseCapture`
+/// clobbered the `ENABLE_VIRTUAL_TERMINAL_INPUT` flag the stdin path had
+/// just set and broke all input from WT.
+pub(crate) fn use_vt_path() -> bool {
+    std::env::var("TERM").is_ok() || std::env::var("WT_SESSION").is_ok()
+}
+
 /// Windows async signal listener.
 ///
 /// Polls `crossterm::terminal::size()` at 100ms intervals for resize events,
@@ -206,7 +230,7 @@ fn enable_vt_processing_on_stdout() {
 /// Windows Terminal) and use crossterm's Console API approach.
 pub(crate) fn enable_mouse_support(stdout: &mut dyn Write) -> Result<()> {
     let err_context = "failed to enable mouse mode";
-    if std::env::var("TERM").is_ok() {
+    if use_vt_path() {
         enable_vt_processing_on_stdout();
         stdout
             .write_all(super::os_input_output::ENABLE_MOUSE_SUPPORT.as_bytes())
@@ -236,7 +260,7 @@ pub(crate) fn restore_console_mode() {
 /// See `enable_mouse_support()` for rationale on VT vs Console API paths.
 pub(crate) fn disable_mouse_support(stdout: &mut dyn Write) -> Result<()> {
     let err_context = "failed to disable mouse mode";
-    if std::env::var("TERM").is_ok() {
+    if use_vt_path() {
         stdout
             .write_all(super::os_input_output::DISABLE_MOUSE_SUPPORT.as_bytes())
             .context(err_context)?;

--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -1,5 +1,7 @@
 use crate::keyboard_parser::{KittyKeyboardParser, KittyParseOutcome};
 use crate::os_input_output::ClientOsApi;
+#[cfg(windows)]
+use crate::os_input_output_windows::use_vt_path;
 use crate::stdin_ansi_parser::{PendingPartial, StdinAnsiParser};
 #[cfg(windows)]
 use crate::stdin_handler_windows::enable_vt_input;
@@ -21,19 +23,11 @@ pub(crate) fn stdin_loop(
     explicitly_disable_kitty_keyboard_protocol: bool,
     resize_sender: Option<std::sync::mpsc::Sender<()>>,
 ) {
-    // On Windows, choose between two input strategies early — we need this
-    // decision before the startup ANSI query below.
-    //
-    // 1. Native console (no TERM env var): Use crossterm's event::read() which
-    //    reads INPUT_RECORDs via ReadConsoleInput. Works in cmd.exe, PowerShell,
-    //    and Windows Terminal where ALT is reported as a modifier flag.
-    //
-    // 2. Terminal emulator (TERM is set, e.g. Alacritty): Enable
-    //    ENABLE_VIRTUAL_TERMINAL_INPUT so ReadFile on stdin returns raw VT bytes,
-    //    bypassing conpty's lossy VT→INPUT_RECORD translation. Then use the
-    //    termwiz byte parser (same as Unix) which understands ESC-prefixed ALT.
+    // On Windows we choose between the VT byte path (termwiz/kitty parsing)
+    // and the native-console path (crossterm INPUT_RECORDs) early, before the
+    // startup ANSI query below. See `use_vt_path()` for the trigger conditions.
     #[cfg(windows)]
-    let use_vt_reader = std::env::var("TERM").is_ok() && enable_vt_input();
+    let use_vt_reader = use_vt_path() && enable_vt_input();
 
     // Send the startup host query string so the host terminal replies
     // with its live pixel dimensions, fg/bg, sync-output support, and


### PR DESCRIPTION
Fixes #4885 and, more broadly, moves Windows Terminal onto the VT byte input path.

### The multi-line paste issue

The native-console input path (crossterm `INPUT_RECORD`s via `ReadConsoleInput`) can't observe bracketed-paste sequences (`\e[200~ ... \e[201~`). They're filtered before the app ever sees them. Multi-line paste therefore ran each line as a separate command because every `\r\n` inside the paste hit the shell as a real Enter.

An alternative fix would be to synthesize paste events on the native path (watching for input surges, sampling the clipboard, emitting a synthetic paste event). That approach is fragile and, more importantly, doesn't address the other limitations of the native path (KKP, emoji, richer mouse).

### Moving WT to the VT path

WT sets `WT_SESSION` per-process. Adding it as a second trigger for the VT reader path (`use_vt_path()` helper) means default WT installs get raw VT bytes without users having to add `TERM=xterm-256color` to their profile.

The stdin handler and the mouse setup each had their own `TERM`-only check. Bumping just the stdin gate made mouse setup fall through to `crossterm::EnableMouseCapture`, which calls `SetConsoleMode` and clobbered the `ENABLE_VIRTUAL_TERMINAL_INPUT` flag the VT reader had just set, breaking all WT input.

To make that class of drift impossible, this PR introduces `use_vt_path()` in `os_input_output_windows.rs` as the single source of truth. All VT-path-conditional code (stdin handler + mouse setup) calls it, so future additions can't misalign.

### What was tested

- **Standard WT usage (`WT → pwsh → zellij`), `TERM` unset, `WT_SESSION` set** → the common scenario: a default WT profile spawns pwsh, from which the user launches zellij. Confirmed the fix is what unlocks the new behavior (`main` is broken, this branch works).
- **WT profile launching zellij directly (`WT → zellij`, no pwsh in the chain), `TERM` unset** → a custom WT profile whose commandline is `zellij.exe`, no parent shell process. Same working outcome; confirms the fix doesn't depend on a wrapper shell.
- **Alacritty / WezTerm on Windows** → already worked, verified no regression.

Applications verified to receive multi-line paste correctly under the fix:

- WSL bash (readline)
- vim
- Claude CLI (Ink-based TUI)

**Note**: PowerShell, cmd, and Nushell still don't handle multi-line paste, even without zellij in the chain. All three are upstream bracketed-paste-support gaps (see [PSReadLine#1471](https://github.com/PowerShell/PSReadLine/issues/1471), blocked on [dotnet/runtime#60107](https://github.com/dotnet/runtime/issues/60107)). Nothing zellij can do about those from this side.

### Why this is the right long-term direction

The native-console input path on Windows exists as a bridge for the legacy console host. Everything zellij cares about is either already better on the VT path or is arriving there:

- **Bracketed paste** : only visible on the VT byte stream (fixed here).
- **Kitty keyboard protocol** : WT 1.25+ ships full KKP support. Zellij's kitty parser expects raw VT bytes; the native path can't feed it.
- **Emoji / supplementary-plane input** : the native path suffers from the crossterm surrogate-pair bug (key-up events corrupting the pair buffer). The VT path delivers UTF-8 bytes directly and sidesteps it entirely.
- **SGR mouse encoding** : richer than the legacy console mouse events.
- **Path parity with Unix** : same parser, same code paths, fewer platform-specific quirks.

Native console will still be selected when neither `TERM` nor `WT_SESSION` is set (legacy conhost or any environment where `cmd`/`pwsh` are spawned without WT wrapping)