### PR TITLE
fix(plugins): deliver right-clicks to plugin panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+* fix: deliver right-clicks to plugin panes (https://github.com/zellij-org/zellij/issues/5350)
 * feat: allow tabs to have different sizes if clients aren't focused on the same one (https://github.com/zellij-org/zellij/pull/5133)
 * feat: PWA support for the web client (manifest + icons + iOS meta tags) so the page can be installed as a standalone app (https://github.com/zellij-org/zellij/pull/5184)
 * feat: mobile UI (https://github.com/zellij-org/zellij/pull/5241)

--- a/zellij-server/src/tab/mouse_handler.rs
+++ b/zellij-server/src/tab/mouse_handler.rs
@@ -176,6 +176,10 @@ enum MouseAction {
         pane_id: PaneId,
         position: Position,
     },
+    RightClick {
+        pane_id: PaneId,
+        position: Position,
+    },
     SendToTerminal {
         pane_id: PaneId,
         event: MouseEvent,
@@ -799,6 +803,14 @@ impl MouseHandler {
             MouseAction::FocusOnHover { pane_id, position } => {
                 Self::execute_focus_on_hover(tab, pane_id, position, client_id)
             },
+            MouseAction::RightClick { pane_id, position } => {
+                let pane = tab
+                    .get_pane_with_id_mut(pane_id)
+                    .ok_or_else(|| anyhow!("Failed to find pane {pane_id:?}"))?;
+                let relative_position = pane.relative_position(&position);
+                pane.handle_right_click(&relative_position, client_id);
+                Ok(MouseEffect::default())
+            },
             MouseAction::SendToTerminal { pane_id, event } => {
                 Self::execute_send_to_terminal(tab, pane_id, event, client_id)
             },
@@ -1405,6 +1417,36 @@ impl MouseHandler {
                 });
             } else {
                 return Ok(MouseAction::FocusPane {
+                    pane_id: details.pane_id,
+                    position: event.position,
+                });
+            }
+        }
+
+        let is_right_press = event.right && event.event_type == MouseEventType::Press;
+        if is_right_press {
+            let Some(details) = &ctx.clicked_pane else {
+                return Ok(MouseAction::NoAction);
+            };
+
+            let is_active_pane = Some(details.pane_id) == ctx.active_pane_id;
+
+            if details.on_frame {
+                if details.frame_intercepted {
+                    return Ok(MouseAction::FrameIntercepted {
+                        pane_id: details.pane_id,
+                    });
+                }
+
+                // A right press on a frame is deliberately inert: move and
+                // resize are left-button drag gestures, and their in-progress
+                // states only accept left-button motion/release — entering
+                // them from a right press would leave the pane stuck mid-drag.
+                return Ok(MouseAction::NoAction);
+            }
+
+            if is_active_pane && matches!(details.pane_id, PaneId::Plugin(_)) {
+                return Ok(MouseAction::RightClick {
                     pane_id: details.pane_id,
                     position: event.position,
                 });

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -13,10 +13,10 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 
 use zellij_utils::channels::Receiver;
-use zellij_utils::data::Direction;
 use zellij_utils::data::Resize;
 use zellij_utils::data::ResizeStrategy;
 use zellij_utils::data::WebSharing;
+use zellij_utils::data::{Direction, Event, Mouse};
 use zellij_utils::envs::set_session_name;
 use zellij_utils::errors::{prelude::*, ErrorContext};
 use zellij_utils::input::layout::{
@@ -12783,6 +12783,91 @@ fn create_new_tab_with_plugin_receiver(
 }
 
 #[test]
+fn right_click_on_plugin_pane_is_delivered_to_plugin() {
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let client_id = 1;
+    let (mut tab, mock_plugin_receiver) =
+        create_new_tab_with_plugin_receiver(size, ModeInfo::default());
+    let plugin_pane_id = PaneId::Plugin(2);
+
+    tab.new_pane(
+        plugin_pane_id,
+        None,
+        None,
+        false,
+        true,
+        NewPanePlacement::default(),
+        Some(client_id),
+        None,
+    )
+    .unwrap();
+
+    let click_position = {
+        let plugin_pane = tab.get_pane_with_id(plugin_pane_id).unwrap();
+        Position::new(
+            plugin_pane.get_content_y() as i32 + 2,
+            (plugin_pane.get_content_x() + 4) as u16,
+        )
+    };
+
+    tab.handle_mouse_event(
+        &MouseEvent::new_right_press_event(click_position),
+        client_id,
+    )
+    .unwrap();
+
+    let mut found_right_click = false;
+    while let Ok((instruction, _ctx)) = mock_plugin_receiver.try_recv() {
+        if let PluginInstruction::Update(updates) = instruction {
+            if updates
+                == vec![(
+                    Some(2),
+                    Some(client_id),
+                    Event::Mouse(Mouse::RightClick(2, 4)),
+                )]
+            {
+                found_right_click = true;
+                break;
+            }
+        }
+    }
+    assert!(
+        found_right_click,
+        "Expected right-click event to be sent to plugin pane"
+    );
+
+    let frame_click_position = {
+        let plugin_pane = tab.get_pane_with_id(plugin_pane_id).unwrap();
+        Position::new(
+            plugin_pane.get_content_y() as i32 - 1,
+            (plugin_pane.get_content_x() + 4) as u16,
+        )
+    };
+
+    tab.handle_mouse_event(
+        &MouseEvent::new_right_press_event(frame_click_position),
+        client_id,
+    )
+    .unwrap();
+
+    let mut found_frame_right_click = false;
+    while let Ok((instruction, _ctx)) = mock_plugin_receiver.try_recv() {
+        if let PluginInstruction::Update(updates) = instruction {
+            found_frame_right_click |= updates.iter().any(|(_, _, event)| {
+                matches!(event, Event::Mouse(Mouse::RightClick(line, _)) if *line < 0)
+            });
+        }
+    }
+    assert!(
+        !found_frame_right_click,
+        "Expected right-click on the pane frame not to be sent to the plugin"
+    );
+}
+
+#[test]
 fn click_on_plugin_highlight_sends_highlight_clicked() {
     let size = Size {
         cols: 121,
@@ -15038,5 +15123,55 @@ fn hidden_cursor_still_emits_cup_for_host_terminal_positioning() {
     assert!(
         !client_output.contains("\u{1b}[?25h"),
         "Show-cursor sequence must not be present when app has hidden the cursor"
+    );
+}
+
+#[test]
+fn right_click_on_floating_pane_frame_does_not_start_moving_it() {
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let client_id = 1;
+    let mut tab = create_new_tab(size, ModeInfo::default());
+    let floating_pane_id = PaneId::Terminal(2);
+    tab.toggle_floating_panes(Some(client_id), None, None)
+        .unwrap();
+    tab.new_pane(
+        floating_pane_id,
+        None,
+        None,
+        false,
+        true,
+        NewPanePlacement::default(),
+        Some(client_id),
+        None,
+    )
+    .unwrap();
+    let (x_before, y_before) = {
+        let pane = tab.get_pane_with_id(floating_pane_id).unwrap();
+        (pane.get_content_x(), pane.get_content_y())
+    };
+    let frame_position = Position::new(y_before as i32 - 1, (x_before + 4) as u16);
+    tab.handle_mouse_event(
+        &MouseEvent::new_right_press_event(frame_position),
+        client_id,
+    )
+    .unwrap();
+    // Had the right press wrongly entered the moving state, this left-button
+    // motion/release pair would drag the pane to a new position.
+    let drag_target = Position::new(y_before as i32 + 5, (x_before + 20) as u16);
+    tab.handle_mouse_event(&MouseEvent::new_left_motion_event(drag_target), client_id)
+        .unwrap();
+    tab.handle_mouse_event(&MouseEvent::new_left_release_event(drag_target), client_id)
+        .unwrap();
+    let (x_after, y_after) = {
+        let pane = tab.get_pane_with_id(floating_pane_id).unwrap();
+        (pane.get_content_x(), pane.get_content_y())
+    };
+    assert_eq!(
+        (x_before, y_before),
+        (x_after, y_after),
+        "a right press on a floating pane's frame must not start moving it"
     );
 }


### PR DESCRIPTION
Fixes #5350.

Plugins subscribe to EventType::Mouse and the API exposes Mouse::RightClick, but no right-click ever reached a plugin: PluginPane::handle_right_click existed with no callers, and the live mouse pipeline only routed right-clicks through the terminal-pane mouse-reporting passthrough. I shipped a right-click interaction in a plugin and found out in production that the event is unproducible.

This routes pane-targeted right-click presses through the same path and coordinate translation left-clicks get, into the existing forwarder. Terminal-pane right-click passthrough behavior is unchanged, with its focused test still passing. Middle-click is deliberately not included: it has no plugin-pane forwarder today, so wiring it is a bigger decision than this fix should carry.

The integration test mirrors the existing left-click delivery coverage for the right-click path.
