### PR TITLE
fix(xtask): skip copying unchanged plugin assets

### DIFF
--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -329,8 +329,27 @@ fn move_plugin_to_assets(sh: &Shell, plugin_name: &str) -> anyhow::Result<()> {
             .with_context(err_context);
     }
 
-    // This is a plugin we want to move
+    // Only copy the plugin when its contents changed. Unconditionally copying it updates the
+    // asset's modification time, causing Cargo to rebuild zellij-utils and its dependent crates.
     let from = plugin.as_path();
     let to = asset_name.as_path();
+    if files_are_equal(from, to).with_context(err_context)? {
+        return Ok(());
+    }
     sh.copy_file(from, to).with_context(err_context)
+}
+
+fn files_are_equal(first: &Path, second: &Path) -> std::io::Result<bool> {
+    let first_metadata = std::fs::metadata(first)?;
+    let second_metadata = match std::fs::metadata(second) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error),
+    };
+
+    if first_metadata.len() != second_metadata.len() {
+        return Ok(false);
+    }
+
+    Ok(std::fs::read(first)? == std::fs::read(second)?)
 }


### PR DESCRIPTION
Fixes #5355.

## Summary
Avoid copying plugin WASM assets when the destination already contains
identical contents.
Previously, `move_plugin_to_assets()` always copied release plugin
artifacts into `zellij-utils/assets/plugins`, even when the generated
WASM file had not changed.
This updated the destination file's modification time, causing Cargo to
consider `zellij-utils` stale and triggering rebuilds of dependent
native crates (`zellij-utils`, `zellij-server`, `zellij-client`, and
the main `zellij` binary).
## Changes
- Compare source and destination plugin assets before copying
- Skip the copy when the files are identical
- Continue copying when:
  - the destination file does not exist
  - file sizes differ
  - file contents differ
## Result
The following workflow now reuses existing native build artifacts:
```sh
cargo xtask build --release
cargo xtask build --release
```
Likewise:
```sh
cargo xtask build --release
cargo xtask install ~/.cargo/bin
```
no longer rebuilds native crates when plugin assets are unchanged.
## Notes
This change only affects release builds, where
`move_plugin_to_assets()` is used.
Debug builds continue to use the existing plugin stamp mechanism.