### PR TITLE
fix(grid): scroll the region when a line wraps at its bottom margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+* fix(grid): scroll the region when a line wraps at its bottom margin (https://github.com/zellij-org/zellij/pull/5357)
 * feat: allow tabs to have different sizes if clients aren't focused on the same one (https://github.com/zellij-org/zellij/pull/5133)
 * feat: PWA support for the web client (manifest + icons + iOS meta tags) so the page can be installed as a standalone app (https://github.com/zellij-org/zellij/pull/5184)
 * feat: mobile UI (https://github.com/zellij-org/zellij/pull/5241)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
-* fix(grid): scroll the region when a line wraps at its bottom margin (https://github.com/zellij-org/zellij/pull/5357)
 * feat: allow tabs to have different sizes if clients aren't focused on the same one (https://github.com/zellij-org/zellij/pull/5133)
 * feat: PWA support for the web client (manifest + icons + iOS meta tags) so the page can be installed as a standalone app (https://github.com/zellij-org/zellij/pull/5184)
 * feat: mobile UI (https://github.com/zellij-org/zellij/pull/5241)
@@ -23,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * feat: allow opening panes/tabs from the CLI without changing focus (https://github.com/zellij-org/zellij/pull/5346)
 * feat: allow binding `SetDarkTheme`, `SetLightTheme` and `ToggleTheme` as direct keybinding actions (https://github.com/zellij-org/zellij/pull/5302)
 * feat: allow disabling ctrl-mouse-scroll to resize panes (https://github.com/zellij-org/zellij/pull/5283)
+* fix: scrolling region line wrap behavior at bottom edge (https://github.com/zellij-org/zellij/pull/5357)
 
 ## [0.44.3] - 2026-05-13
 * fix(windows): bump windows-sys to 0.59 to align manifest with code, fixing source builds via `cargo install`/`cargo binstall` (https://github.com/zellij-org/zellij/pull/5139)

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -2025,6 +2025,11 @@ impl Grid {
                     self.selection.move_up(1);
                 } else if scroll_region_top < self.viewport.len() {
                     self.viewport.remove(scroll_region_top);
+                    self.hyperlink_tracker.offset_cursor_lines_in_range(
+                        scroll_region_top as isize,
+                        scroll_region_bottom as isize,
+                        1,
+                    );
                 }
                 let wrapped_row = Row::new();
                 if self.viewport.len() >= scroll_region_bottom {

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1785,6 +1785,50 @@ impl Grid {
         }
         self.output_buffer.update_all_lines();
     }
+    fn scroll_region_up_at_bottom(&mut self, new_row: Row, offset_hyperlinks: bool) {
+        let (scroll_region_top, scroll_region_bottom) = self.scroll_region;
+        if scroll_region_top >= self.viewport.len() {
+            return;
+        }
+        if scroll_region_bottom == self.height.saturating_sub(1) && scroll_region_top == 0 {
+            if self.alternate_screen_state.is_none() {
+                self.transfer_rows_to_lines_above(1);
+                if offset_hyperlinks {
+                    self.hyperlink_tracker.offset_cursor_lines(1);
+                }
+            } else if !self.viewport.is_empty() {
+                self.viewport.pop_front();
+            }
+            self.viewport.push_back(new_row);
+            self.selection.move_up(1);
+        } else {
+            if scroll_region_top == 0
+                && self.alternate_screen_state.is_none()
+                && !self.viewport.is_empty()
+            {
+                self.transfer_rows_to_lines_above(1);
+                if offset_hyperlinks {
+                    self.hyperlink_tracker.offset_cursor_lines(1);
+                }
+                self.selection.move_up(1);
+            } else if scroll_region_top < self.viewport.len() {
+                self.viewport.remove(scroll_region_top);
+                if offset_hyperlinks {
+                    self.hyperlink_tracker.offset_cursor_lines_in_range(
+                        scroll_region_top as isize,
+                        scroll_region_bottom as isize,
+                        1,
+                    );
+                }
+            }
+            if self.viewport.len() >= scroll_region_bottom {
+                self.viewport.insert(scroll_region_bottom, new_row);
+            } else {
+                self.viewport.push_back(new_row);
+            }
+        }
+        self.output_buffer.update_all_lines();
+    }
     pub fn add_canonical_line(&mut self) {
         let (scroll_region_top, scroll_region_bottom) = self.scroll_region;
         self.hyperlink_tracker.update(
@@ -1795,47 +1839,12 @@ impl Grid {
             &mut self.link_handler.borrow_mut(),
         );
         if self.cursor.y == scroll_region_bottom {
-            // end of scroll region
-            // when we have a scroll region set and we're at its bottom
-            // we need to delete its first line, thus shifting all lines in it upwards
-            // then we add an empty line at its end which will be filled by the application
-            // controlling the scroll region (presumably filled by whatever comes next in the
-            // scroll buffer, but that's not something we control)
             if scroll_region_top >= self.viewport.len() {
-                // the state is corrupted
                 return;
             }
             let scroll_bg = self.cursor.pending_styles.background;
-            if scroll_region_bottom == self.height.saturating_sub(1) && scroll_region_top == 0 {
-                if self.alternate_screen_state.is_none() {
-                    self.transfer_rows_to_lines_above(1);
-                } else if !self.viewport.is_empty() {
-                    self.viewport.pop_front();
-                }
-
-                self.viewport
-                    .push_back(Row::new().canonical().with_bg_color(scroll_bg));
-                self.selection.move_up(1);
-            } else {
-                if scroll_region_top == 0
-                    && self.alternate_screen_state.is_none()
-                    && !self.viewport.is_empty()
-                {
-                    // Partial scroll region starting at top: preserve
-                    // scrolled-off lines in scrollback
-                    self.transfer_rows_to_lines_above(1);
-                    self.selection.move_up(1);
-                } else if scroll_region_top < self.viewport.len() {
-                    self.viewport.remove(scroll_region_top);
-                }
-                let new_row = Row::new().canonical().with_bg_color(scroll_bg);
-                if self.viewport.len() >= scroll_region_bottom {
-                    self.viewport.insert(scroll_region_bottom, new_row);
-                } else {
-                    self.viewport.push_back(new_row);
-                }
-            }
-            self.output_buffer.update_all_lines(); // TODO: only update scroll region lines
+            let new_row = Row::new().canonical().with_bg_color(scroll_bg);
+            self.scroll_region_up_at_bottom(new_row, false);
             return;
         }
         if self.viewport.len() <= self.cursor.y + 1 {
@@ -1995,50 +2004,10 @@ impl Grid {
         self.cursor.x = 0;
         let (scroll_region_top, scroll_region_bottom) = self.scroll_region;
         if self.cursor.y == scroll_region_bottom {
-            // wrapping at the bottom of the scroll region scrolls the region up by one line
-            // and keeps the cursor on its bottom row, same as a newline would
-            // (add_canonical_line above) - except that the new row is a wrapped row rather
-            // than a canonical one
             if scroll_region_top >= self.viewport.len() {
-                // the state is corrupted
                 return;
             }
-            if scroll_region_bottom == self.height.saturating_sub(1) && scroll_region_top == 0 {
-                if self.alternate_screen_state.is_none() {
-                    self.transfer_rows_to_lines_above(1);
-                    self.hyperlink_tracker.offset_cursor_lines(1);
-                } else if !self.viewport.is_empty() {
-                    self.viewport.pop_front();
-                }
-                let wrapped_row = Row::new();
-                self.viewport.push_back(wrapped_row);
-                self.selection.move_up(1);
-            } else {
-                if scroll_region_top == 0
-                    && self.alternate_screen_state.is_none()
-                    && !self.viewport.is_empty()
-                {
-                    // Partial scroll region starting at top: preserve
-                    // scrolled-off lines in scrollback
-                    self.transfer_rows_to_lines_above(1);
-                    self.hyperlink_tracker.offset_cursor_lines(1);
-                    self.selection.move_up(1);
-                } else if scroll_region_top < self.viewport.len() {
-                    self.viewport.remove(scroll_region_top);
-                    self.hyperlink_tracker.offset_cursor_lines_in_range(
-                        scroll_region_top as isize,
-                        scroll_region_bottom as isize,
-                        1,
-                    );
-                }
-                let wrapped_row = Row::new();
-                if self.viewport.len() >= scroll_region_bottom {
-                    self.viewport.insert(scroll_region_bottom, wrapped_row);
-                } else {
-                    self.viewport.push_back(wrapped_row);
-                }
-            }
-            self.output_buffer.update_all_lines();
+            self.scroll_region_up_at_bottom(Row::new(), true);
         } else if self.cursor.y == self.height.saturating_sub(1) {
             // the cursor is on the last line of the screen but below the scroll region's
             // bottom margin: there is nowhere to scroll to, so we wrap onto the same line

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1993,17 +1993,52 @@ impl Grid {
     }
     fn line_wrap(&mut self) {
         self.cursor.x = 0;
-        if self.cursor.y == self.height.saturating_sub(1) {
-            if self.alternate_screen_state.is_none() {
-                self.transfer_rows_to_lines_above(1);
-                self.hyperlink_tracker.offset_cursor_lines(1);
-            } else if !self.viewport.is_empty() {
-                self.viewport.pop_front();
+        let (scroll_region_top, scroll_region_bottom) = self.scroll_region;
+        if self.cursor.y == scroll_region_bottom {
+            // wrapping at the bottom of the scroll region scrolls the region up by one line
+            // and keeps the cursor on its bottom row, same as a newline would
+            // (add_canonical_line above) - except that the new row is a wrapped row rather
+            // than a canonical one
+            if scroll_region_top >= self.viewport.len() {
+                // the state is corrupted
+                return;
             }
-            let wrapped_row = Row::new();
-            self.viewport.push_back(wrapped_row);
-            self.selection.move_up(1);
+            if scroll_region_bottom == self.height.saturating_sub(1) && scroll_region_top == 0 {
+                if self.alternate_screen_state.is_none() {
+                    self.transfer_rows_to_lines_above(1);
+                    self.hyperlink_tracker.offset_cursor_lines(1);
+                } else if !self.viewport.is_empty() {
+                    self.viewport.pop_front();
+                }
+                let wrapped_row = Row::new();
+                self.viewport.push_back(wrapped_row);
+                self.selection.move_up(1);
+            } else {
+                if scroll_region_top == 0
+                    && self.alternate_screen_state.is_none()
+                    && !self.viewport.is_empty()
+                {
+                    // Partial scroll region starting at top: preserve
+                    // scrolled-off lines in scrollback
+                    self.transfer_rows_to_lines_above(1);
+                    self.hyperlink_tracker.offset_cursor_lines(1);
+                    self.selection.move_up(1);
+                } else if scroll_region_top < self.viewport.len() {
+                    self.viewport.remove(scroll_region_top);
+                }
+                let wrapped_row = Row::new();
+                if self.viewport.len() >= scroll_region_bottom {
+                    self.viewport.insert(scroll_region_bottom, wrapped_row);
+                } else {
+                    self.viewport.push_back(wrapped_row);
+                }
+            }
             self.output_buffer.update_all_lines();
+        } else if self.cursor.y == self.height.saturating_sub(1) {
+            // the cursor is on the last line of the screen but below the scroll region's
+            // bottom margin: there is nowhere to scroll to, so we wrap onto the same line
+            // (mirroring what add_canonical_line does in this situation)
+            self.output_buffer.update_line(self.cursor.y);
         } else {
             self.cursor.y += 1;
             if self.viewport.len() <= self.cursor.y {

--- a/zellij-server/src/panes/hyperlink_tracker.rs
+++ b/zellij-server/src/panes/hyperlink_tracker.rs
@@ -86,6 +86,27 @@ impl HyperlinkTracker {
         self.last_cursor = Some(current_pos);
     }
 
+    pub fn offset_cursor_lines_in_range(&mut self, top: isize, bottom: isize, offset: isize) {
+        // Offset only positions inside the given row range (a scroll region),
+        // used when a scroll region that does not start at the top of the
+        // screen scrolls: rows outside it do not move
+        for pos in &mut self.cursor_positions {
+            if pos.y >= top && pos.y <= bottom {
+                pos.y -= offset;
+            }
+        }
+        if let Some(start_pos) = &mut self.start_position {
+            if start_pos.y >= top && start_pos.y <= bottom {
+                start_pos.y -= offset;
+            }
+        }
+        if let Some(last_cursor) = &mut self.last_cursor {
+            if last_cursor.y >= top && last_cursor.y <= bottom {
+                last_cursor.y -= offset;
+            }
+        }
+    }
+
     pub fn offset_cursor_lines(&mut self, offset: isize) {
         // Offset all stored cursor positions
         for pos in &mut self.cursor_positions {

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -5737,6 +5737,41 @@ fn wrap_at_bottom_of_explicit_full_screen_scroll_region_keeps_wrap_flag() {
 }
 
 #[test]
+fn wrap_at_bottom_of_nonzero_top_scroll_region_keeps_hyperlink_tracking() {
+    // A plain-text URL that wraps at the bottom of a region not anchored at
+    // the top: the auto-linkifier's tracked positions must follow the rows
+    // as the region scrolls, or the URL loses its clickable anchors
+    let mut content: Vec<u8> = Vec::new();
+    content.extend_from_slice(b"AAA\r\nBBB\r\nCCC\r\nDDD\r\nEEE\r\nFFF");
+    content.extend_from_slice(b"\x1b[3;6r\x1b[6;1H");
+    content.extend_from_slice(b"https://example.com/");
+    content.extend_from_slice(&[b'a'; 30]); // 50 chars: wraps at the region bottom
+    content.extend_from_slice(b" ");
+
+    let grid = create_grid_with_size_and_raw(10, 40, &content);
+
+    let start_anchors_per_row: Vec<usize> = grid
+        .viewport
+        .iter()
+        .map(|row| {
+            row.columns
+                .iter()
+                .filter(|c| {
+                    matches!(
+                        c.styles.link_anchor,
+                        Some(crate::panes::terminal_character::LinkAnchor::Start(_))
+                    )
+                })
+                .count()
+        })
+        .collect();
+
+    // rows 0-3: AAA, BBB, DDD, EEE (CCC scrolled off and discarded) - no anchors;
+    // row 4 holds the URL's first 40 columns, row 5 the wrapped remainder
+    assert_eq!(start_anchors_per_row, vec![0, 0, 0, 0, 40, 10]);
+}
+
+#[test]
 fn scroll_region_newline_sets_bg_color_on_new_row() {
     // Set bg color, set scroll region 1-5, fill 5 lines, then newline to scroll
     let content = b"\x1b[48;2;26;26;26m\x1b[1;5r\

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -5612,6 +5612,131 @@ fn partial_scroll_region_all_three_mechanisms_transfer_in_order() {
 }
 
 #[test]
+fn wrap_at_bottom_of_partial_scroll_region_transfers_to_scrollback() {
+    // A long line that soft-wraps while the cursor is on the scroll region's
+    // bottom row must scroll the region, exactly like a newline there would
+    let mut content: Vec<u8> = Vec::new();
+    content.extend_from_slice(PARTIAL_SR);
+    content.extend_from_slice(FILL_8_LINES);
+    content.extend_from_slice(b"\r\n");
+    content.extend_from_slice(&[b'I'; 90]); // 90 cols on a 40-col grid: wraps twice
+
+    let grid = create_grid_with_size_and_raw(10, 40, &content);
+
+    // the newline scrolls AAA off, the two wraps scroll BBB and CCC off
+    assert_eq!(scrollback_texts(&grid), vec!["AAA", "BBB", "CCC"]);
+    let vp = viewport_texts(&grid);
+    assert_eq!(vp[0], "DDD");
+    assert_eq!(vp[4], "HHH");
+    assert_eq!(vp[5], "I".repeat(40));
+    assert_eq!(vp[6], "I".repeat(40));
+    assert_eq!(vp[7], "I".repeat(10));
+    assert_eq!(vp.len(), 8, "rows below the region must be untouched");
+    // the continuation rows are wrapped rows, so resize re-wraps them correctly
+    assert!(grid.viewport[5].is_canonical);
+    assert!(!grid.viewport[6].is_canonical);
+    assert!(!grid.viewport[7].is_canonical);
+}
+
+#[test]
+fn wrap_at_bottom_of_partial_scroll_region_keeps_cursor_inside_region() {
+    // Before the fix, the cursor would escape below the region's bottom margin
+    // on wrap, and no subsequent line could ever scroll into scrollback again
+    let mut content: Vec<u8> = Vec::new();
+    content.extend_from_slice(PARTIAL_SR);
+    content.extend_from_slice(FILL_8_LINES);
+    content.extend_from_slice(b"\r\n");
+    content.extend_from_slice(&[b'I'; 90]);
+
+    let grid = create_grid_with_size_and_raw(10, 40, &content);
+
+    // region is rows 0-7; after two wraps the cursor must still be on row 7
+    assert_eq!(
+        grid.cursor_coordinates().map(|(x, y, _)| (x, y)),
+        Some((10, 7))
+    );
+}
+
+#[test]
+fn wrap_at_bottom_of_nonzero_top_scroll_region_does_not_transfer() {
+    let mut content: Vec<u8> = Vec::new();
+    content.extend_from_slice(b"AAA\r\nBBB\r\nCCC\r\nDDD\r\nEEE\r\nFFF");
+    // Scroll region rows 3-6 (1-based), so top is row 2, not 0
+    content.extend_from_slice(b"\x1b[3;6r");
+    content.extend_from_slice(b"\x1b[6;1H");
+    content.extend_from_slice(&[b'X'; 50]); // wraps once at the region's bottom
+
+    let grid = create_grid_with_size_and_raw(10, 40, &content);
+
+    // regions not anchored at the top do not preserve scrolled-off lines
+    assert_eq!(grid.lines_above.len(), 0);
+    let vp = viewport_texts(&grid);
+    assert_eq!(vp[0], "AAA", "rows above the region must be untouched");
+    assert_eq!(vp[1], "BBB", "rows above the region must be untouched");
+    assert_eq!(vp[2], "DDD", "the region's top row (CCC) is discarded");
+    assert_eq!(vp[4], "X".repeat(40));
+    assert_eq!(vp[5], "X".repeat(10));
+}
+
+#[test]
+fn wrap_at_bottom_of_partial_scroll_region_does_not_transfer_on_alternate_screen() {
+    let mut content: Vec<u8> = Vec::new();
+    content.extend_from_slice(b"\x1b[?1049h");
+    content.extend_from_slice(PARTIAL_SR);
+    content.extend_from_slice(FILL_8_LINES);
+    content.extend_from_slice(b"\r\n");
+    content.extend_from_slice(&[b'I'; 90]);
+
+    let grid = create_grid_with_size_and_raw(10, 40, &content);
+
+    assert_eq!(grid.lines_above.len(), 0);
+    let vp = viewport_texts(&grid);
+    assert_eq!(vp[5], "I".repeat(40));
+    assert_eq!(vp[6], "I".repeat(40));
+    assert_eq!(vp[7], "I".repeat(10));
+}
+
+#[test]
+fn wrap_at_bottom_of_explicit_full_screen_scroll_region_keeps_wrap_flag() {
+    // CSI 1;10r on a 10-row grid covers the whole screen; wrap behavior must
+    // be identical to having no region set at all (scroll + wrapped row)
+    let mut content: Vec<u8> = Vec::new();
+    content.extend_from_slice(b"\x1b[1;10r");
+    for i in 1..=10u8 {
+        if i > 1 {
+            content.extend_from_slice(b"\r\n");
+        }
+        content.extend_from_slice(b"EARLY-");
+        content.push(b'0' + i / 10);
+        content.push(b'0' + i % 10);
+    }
+    content.extend_from_slice(b"\r\n");
+    content.extend_from_slice(&[b'I'; 90]); // wraps twice on a 40-col grid
+
+    let grid = create_grid_with_size_and_raw(10, 40, &content);
+
+    // the newline and the two wraps each scrolled one line into scrollback
+    assert_eq!(
+        scrollback_texts(&grid),
+        vec!["EARLY-01", "EARLY-02", "EARLY-03"]
+    );
+    let vp = viewport_texts(&grid);
+    assert_eq!(vp[6], "EARLY-10");
+    assert_eq!(vp[7], "I".repeat(40));
+    assert_eq!(vp[8], "I".repeat(40));
+    assert_eq!(vp[9], "I".repeat(10));
+    assert!(grid.viewport[7].is_canonical);
+    assert!(
+        !grid.viewport[8].is_canonical,
+        "continuation must stay a wrapped row"
+    );
+    assert!(
+        !grid.viewport[9].is_canonical,
+        "continuation must stay a wrapped row"
+    );
+}
+
+#[test]
 fn scroll_region_newline_sets_bg_color_on_new_row() {
     // Set bg color, set scroll region 1-5, fill 5 lines, then newline to scroll
     let content = b"\x1b[48;2;26;26;26m\x1b[1;5r\


### PR DESCRIPTION
When the cursor sits on the bottom row of a DECSTBM scroll region and a long line soft-wraps, `line_wrap()` moved the cursor to `region_bottom + 1` (outside the region) instead of scrolling the region, which is what xterm does here. From that point on, output that should have scrolled through the region (and, for top-anchored regions, into scrollback per #4941) never did: it walked down the rows below the region and then kept overwriting the last screen line, so nothing entered scrollback anymore.

This is how TUI apps that insert history through a top-anchored scroll region lose their transcript in zellij: the first over-wide line breaks the mechanism, and everything after it is lost. Codex leaves URL-only lines unwrapped so terminals can linkify them, which makes over-wide lines routine — and split panes are narrow, so the first one arrives almost immediately. That's the missing piece behind the "can't scroll up at all in a split pane" reports in #5267, and it's what openai/codex#30551 works around with a zellij-specific insertion path (their code comment: "Zellij does not constrain soft-wrapped continuation rows to Codex's scroll region").

### The fix

`line_wrap()` now mirrors `add_canonical_line()`: wrapping at the region's bottom margin scrolls the region up one line and keeps the cursor on the bottom row. The new row is a wrapped (non-canonical) row so resize re-wrapping stays correct. Top-anchored partial regions preserve the scrolled-off line in scrollback (same as #4941), regions not starting at the top discard it, and the alternate screen never transfers.

This also changes one edge case on purpose: with the cursor on the last screen line but the region's bottom margin somewhere else (a partial region above the cursor, or a bogus region whose bottom lies beyond the screen), a wrap previously scrolled the whole viewport; it now wraps in place, which is what `add_canonical_line` already does for a newline in that position.

### Repro

Pane at 20 rows x 78 cols (any width < 150 works), size unchanged throughout:

```python
# two files differing ONLY in the width of line 100
for name, wide in (("/tmp/wrap_control.bin", False), ("/tmp/wrap_bug.bin", True)):
    with open(name, "wb") as out:
        out.write(b'\x1b[1;13r\x1b[13;1H')  # DECSTBM 1..13, cursor at region bottom
        for i in range(1, 301):
            pad = b'W' * 141 if (wide and i == 100) else b'.' * 40
            out.write(b'\r\nLINE-%03d ' % i + pad)
        out.write(b'\x1b[r')
```

`cat` each file in a pane, then `zellij action dump-screen --full`:

|  | control | with one wide line |
|---|---|---|
| before | 300/300 lines | lines 1-87 in scrollback, 88-105 on screen, **106-300 lost** |
| after | 300/300 lines | 300/300 lines |

Also verified with a live codex session: on current main, splitting the pane leaves 23 lines of scrollback; with this fix the full transcript survives (456 lines, re-wrapped for the narrower pane).

### Tests

Five new unit tests next to the #4941 family (`wrap_at_bottom_of_*`): scrollback transfer + wrapped-row flags, cursor containment (the part that broke all subsequent scrolling), an explicitly-set full-screen region, non-top-anchored discard, and alternate-screen no-transfer. Full `cargo test -p zellij-server --lib`: 1180 passed, 0 failed.
