### PR TITLE
docs: add Debian/Ubuntu install option via deb.griffo.io (unofficial apt repo)

### DIFF
--- a/docs/THIRD_PARTY_INSTALL.md
+++ b/docs/THIRD_PARTY_INSTALL.md
@@ -2,6 +2,7 @@
 
 * [Packages](#packages)
     * [Arch Linux](#arch-linux)
+    * [Debian/Ubuntu](#debianubuntu)
     * [MacOS](#macos)
     * [Fedora Linux](#fedora-linux)
     * [Void Linux](#void-linux)
@@ -23,6 +24,16 @@ Or install from AUR repository with [AUR Helper](https://wiki.archlinux.org/titl
 
 ```
 paru -S zellij-git
+```
+
+### Debian/Ubuntu
+You can install the `zellij` package from the unofficial [deb.griffo.io](https://deb.griffo.io/install-latest-zellij-in-debian.html) APT repository, maintained by [dariogriffo](https://github.com/dariogriffo). Packages are built automatically from the official releases:
+
+```
+sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://deb.griffo.io/EA0F721D231FDD3A0A17B9AC7808B4DD62C41256.asc | sudo gpg --dearmor --yes -o /etc/apt/keyrings/deb.griffo.io.gpg
+echo "deb [signed-by=/etc/apt/keyrings/deb.griffo.io.gpg] https://deb.griffo.io/apt $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/deb.griffo.io.list > /dev/null
+sudo apt update && sudo apt install zellij
 ```
 
 ### Fedora Linux


### PR DESCRIPTION
I maintain [deb.griffo.io](https://deb.griffo.io/install-latest-zellij-in-debian.html), an unofficial apt repository for Debian and Ubuntu whose packages are built automatically from the official Zellij releases within hours (packaging is open source at https://github.com/dariogriffo/zellij-debian). This adds a Debian/Ubuntu section to the third-party install page, which already carries the unaffiliated-packages disclaimer. 

The repo offers an annual subscription for the automatic updates, yet the packages can be freely downloaded from the GitHub repos where they are built