### PR TITLE
fix(panes): clear custom name when renaming

### DIFF
--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -6134,6 +6134,7 @@ impl Tab {
             .with_context(|| format!("no active pane found for client {client_id}"))
             .map(|active_pane| {
                 let to_update = match s {
+                    "\0" => s, // pane name terminator
                     "\u{007F}" | "\u{0008}" => {
                         // delete and backspace keys
                         s

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -16187,6 +16187,40 @@ pub fn interactive_rename_appends_to_existing_name() {
 }
 
 #[test]
+pub fn interactive_rename_nul_clears_existing_name() {
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let mut tab = create_new_tab(size, true);
+    let client_id = 1;
+    let pane_id = PaneId::Terminal(1);
+    let _ = tab.rename_pane_by_pane_id(pane_id, "flame".as_bytes().to_vec());
+    let _ = tab.update_active_pane_name(vec![0], client_id);
+    let pane = tab.get_pane_with_id(pane_id).unwrap();
+    assert_eq!(pane.custom_title(), None);
+
+    let _ = tab.update_active_pane_name(b"spark".to_vec(), client_id);
+    let pane = tab.get_pane_with_id(pane_id).unwrap();
+    assert_eq!(pane.custom_title(), Some("spark".to_owned()));
+}
+
+#[test]
+pub fn interactive_rename_sanitizes_other_control_characters() {
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let mut tab = create_new_tab(size, true);
+    let client_id = 1;
+    let pane_id = PaneId::Terminal(1);
+    let _ = tab.rename_pane_by_pane_id(pane_id, "flame".as_bytes().to_vec());
+    let _ = tab.update_active_pane_name(vec![0x01, 0x07, b'\n', b'\r', 0x1b], client_id);
+    let pane = tab.get_pane_with_id(pane_id).unwrap();
+    assert_eq!(pane.custom_title(), Some("flame".to_owned()));
+}
+
+#[test]
 pub fn interactive_rename_backspace_removes_chars() {
     let size = Size {
         cols: 121,


### PR DESCRIPTION
## Summary

- preserve the NUL pane-name terminator when entering rename mode
- add regression coverage for clearing and replacing an existing custom name
- verify other control characters remain sanitized

## Implementation

`Tab::update_active_pane_name` now forwards NUL alongside its existing backspace and delete exceptions instead of stripping it with `clean_string_from_control_and_linebreak`. This is the shared input path for terminal and plugin panes, whose `update_name` implementations already clear the custom pane name when they receive NUL.

## Test plan

- `cargo xtask format --check`
- `cargo test -p zellij-server interactive_rename_ -- --nocapture`
- `cargo test -p zellij-server --lib`

Fixes #4600.
Fixes #3309.