### PR TITLE
fix(grid): properly pad rows in CUF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * feat: allow binding `SetDarkTheme`, `SetLightTheme` and `ToggleTheme` as direct keybinding actions (https://github.com/zellij-org/zellij/pull/5302)
 * feat: allow disabling ctrl-mouse-scroll to resize panes (https://github.com/zellij-org/zellij/pull/5283)
 * fix: scrolling region line wrap behavior at bottom edge (https://github.com/zellij-org/zellij/pull/5357)
+* fix: properly pad lines before CUF (https://github.com/zellij-org/zellij/pull/5377)
 
 ## [0.44.3] - 2026-05-13
 * fix(windows): bump windows-sys to 0.59 to align manifest with code, fixing source builds via `cargo install`/`cargo binstall` (https://github.com/zellij-org/zellij/pull/5139)

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1916,8 +1916,9 @@ impl Grid {
                 for _ in self.viewport.len()..self.cursor.y {
                     self.viewport.push_back(Row::new().canonical());
                 }
-                self.viewport
-                    .push_back(Row::new().with_character(terminal_character).canonical());
+                let mut new_row = Row::new().canonical();
+                new_row.add_character_at(terminal_character, self.cursor.x);
+                self.viewport.push_back(new_row);
                 self.output_buffer.update_line(self.cursor.y);
             },
         }

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -4257,6 +4257,33 @@ fn create_grid_with_content(content: &str) -> Grid {
 }
 
 #[test]
+fn cursor_forward_over_unwritten_line_positions_character() {
+    use crate::panes::terminal_character::AnsiCode;
+
+    let content = "\u{1b}[1BABC \u{1b}[1B\r\u{1b}[3C\u{1b}[42mDEF\u{1b}[0m";
+    let grid = create_grid_with_content(content);
+
+    let row = &grid.viewport[2];
+
+    assert_eq!(row.columns[0].character, ' ');
+    assert_eq!(row.columns[1].character, ' ');
+    assert_eq!(row.columns[2].character, ' ');
+    assert_eq!(row.columns[3].character, 'D');
+    assert_eq!(row.columns[4].character, 'E');
+    assert_eq!(row.columns[5].character, 'F');
+
+    let has_background = |c: &crate::panes::terminal_character::TerminalCharacter| {
+        !matches!(c.styles.background, Some(AnsiCode::Reset) | None)
+    };
+    assert!(!has_background(&row.columns[0]));
+    assert!(!has_background(&row.columns[1]));
+    assert!(!has_background(&row.columns[2]));
+    assert!(has_background(&row.columns[3]));
+    assert!(has_background(&row.columns[4]));
+    assert!(has_background(&row.columns[5]));
+}
+
+#[test]
 fn double_click_selection_preserved_after_scroll() {
     let content = "line 0\nline 1\nline 2\nline 3\nline 4\nthis is a word test\nline 6\nline 7\nline 8\nline 9\nline 10\nline 11\nline 12\nline 13\nline 14\nline 15\nline 16\nline 17\nline 18\nline 19\n";
     let mut grid = create_grid_with_content(content);


### PR DESCRIPTION
This is a fix for https://github.com/zellij-org/zellij/issues/5370
Specifically in CUF, when moving the cursor to a not-yet-existing line, we would not create it. Meaning it would be created by the next character inserted into that line. The latter logic assumes such a character is always at the beginning of the line, which was true except in this case.

Fixed by making sure to pad and insert a new character properly at cursor position in all cases.