### PR TITLE
fix(tabs): avoid duplicate history entry when switching by ID

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -9164,13 +9164,6 @@ pub(crate) fn screen_thread_main(
                     if let Some(tab_position) = screen.get_tab_position_by_id(tab_id) {
                         // switch_active_tab expects 0-based position
                         screen.switch_active_tab(tab_position, None, true, client_id)?;
-                        screen.render(None)?;
-
-                        screen
-                            .tab_history
-                            .entry(client_id)
-                            .or_insert_with(Vec::new)
-                            .push(tab_id);
                     } else {
                         log::error!("Tab with ID {} not found", tab_id);
                     }


### PR DESCRIPTION
Closes #5384
## Summary
Fix `ToggleTab` requiring two invocations after switching tabs with
`go-to-tab-by-id`.
This also removes a redundant render from the same code path.
## Cause
The `ScreenInstruction::GoToTabWithId` handler calls:
```rust
screen.switch_active_tab(tab_position, None, true, client_id)?;
```
`switch_active_tab()` already updates the client's tab history through
`update_client_tab_focus()`, recording the previously active tab.
After switching, the `GoToTabWithId` handler additionally appended the
destination tab ID to the history:
```rust
screen
    .tab_history
    .entry(client_id)
    .or_insert_with(Vec::new)
    .push(tab_id);
```
This left the newly active tab as the most recent history entry.
As a result, the first `ToggleTab` invocation selected the already active
tab and appeared to do nothing. A second invocation was required to return
to the previously active tab.
The handler also called:
```rust
screen.render(None)?;
```
after `switch_active_tab()`. This was redundant because
`switch_active_tab()` already renders after switching tabs.
## Changes
- Remove the redundant destination tab ID insertion from the client's tab
  history
- Rely on the existing history management performed by
  `switch_active_tab()`
- Remove the redundant `screen.render(None)?` call because
  `switch_active_tab()` already performs the render
