### PR TITLE
fix(layouts): keep literal paths when shellexpand fails

### DIFF
--- a/zellij-utils/src/input/unit/layout_test.rs
+++ b/zellij-utils/src/input/unit/layout_test.rs
@@ -2246,6 +2246,10 @@ fn env_var_expansion() {
 
 #[test]
 fn env_var_missing() {
+    // A `$something` that doesn't resolve to a real environment variable is treated as a
+    // literal path component rather than a hard parse error - see the
+    // `literal_dollar_sign_in_cwd_is_not_a_parse_error` test below for the motivating case
+    // (zellij resurrection layouts can legitimately contain a `$` from a real directory name).
     std::env::remove_var("SOME_UNIQUE_VALUE");
     let kdl_layout = r#"
         layout {
@@ -2254,7 +2258,42 @@ fn env_var_missing() {
         }
     "#;
     let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None);
-    assert!(layout.is_err(), "invalid env var lookup should fail");
+    assert!(
+        layout.is_ok(),
+        "a missing env var lookup should fall back to the literal string rather than fail parsing"
+    );
+}
+
+#[test]
+fn literal_dollar_sign_in_cwd_is_not_a_parse_error() {
+    // Regression test for https://github.com/zellij-org/zellij/issues/5378
+    //
+    // Zellij writes resurrection layouts (session-layout.kdl) with the real, unescaped cwd
+    // of each pane. If that cwd contains a literal `$` that isn't a real environment
+    // variable (eg. a React Router / Remix route directory named `$programId+`),
+    // shellexpand::full used to return an Err which was propagated as a hard
+    // ConfigError, making the layout zellij itself wrote unparseable by zellij.
+    let kdl_layout = r#"
+        layout {
+            pane command="ls" cwd="/tmp/foo/$programId+" {
+                start_suspended true
+            }
+        }
+    "#;
+    let layout = Layout::from_kdl(kdl_layout, Some("layout_file_name".into()), None, None)
+        .expect("a literal, non-expandable $ in a cwd must not fail layout parsing");
+    let tab_layout = layout.template.expect("layout should have a template").0;
+    let pane = &tab_layout.children[0];
+    match pane.run.as_ref().expect("pane should have a run") {
+        Run::Command(run_command) => {
+            assert_eq!(
+                run_command.cwd,
+                Some(PathBuf::from("/tmp/foo/$programId+")),
+                "cwd with an unresolvable $ should be kept as-is"
+            );
+        },
+        other => panic!("expected a Run::Command, got {:?}", other),
+    }
 }
 
 #[test]

--- a/zellij-utils/src/kdl/kdl_layout_parser.rs
+++ b/zellij-utils/src/kdl/kdl_layout_parser.rs
@@ -421,11 +421,29 @@ impl<'a> KdlLayoutParser<'a> {
         name: &'static str,
     ) -> Result<Option<PathBuf>, ConfigError> {
         match kdl_get_string_property_or_child_value_with_error!(kdl_node, name) {
-            Some(s) => match shellexpand::full(s) {
-                Ok(s) => Ok(Some(PathBuf::from(s.as_ref()))),
-                Err(e) => Err(kdl_parsing_error!(e.to_string(), kdl_node)),
-            },
+            Some(s) => Ok(Some(Self::expand_path_or_fallback(s))),
             None => Ok(None),
+        }
+    }
+    /// Expand `~` and environment variables in a path-like string.
+    ///
+    /// A literal `$` that doesn't correspond to a real environment variable (eg. a
+    /// directory legitimately named `$foo`) is common in the wild, most notably in
+    /// resurrection layouts that zellij itself serializes verbatim from real cwds.
+    /// In that case we intentionally don't turn a shell-expansion failure into a hard
+    /// parsing error - we fall back to the original, unexpanded string so the layout
+    /// can still be loaded.
+    fn expand_path_or_fallback(s: &str) -> PathBuf {
+        match shellexpand::full(s) {
+            Ok(expanded) => PathBuf::from(expanded.as_ref()),
+            Err(e) => {
+                log::warn!(
+                    "Failed to shell-expand path \"{}\" ({}), using it as-is",
+                    s,
+                    e
+                );
+                PathBuf::from(s)
+            },
         }
     }
     fn parse_pane_command(


### PR DESCRIPTION
## Problem

Fixes #5378

Layout parsing runs `shellexpand::full()` on every `cwd`/`command`/`edit` path string (`KdlLayoutParser::parse_path` in `zellij-utils/src/kdl/kdl_layout_parser.rs`). If that string contains a literal `$` that doesn't happen to name a real environment variable (e.g. a directory called `$programId+`, as produced by React Router / Remix file-based routing), `shellexpand::full` returns an `Err`, which `parse_path` turns into a hard `ConfigError` - aborting the whole layout parse.

This is especially bad for **resurrection layouts**: zellij writes a pane's real, unescaped `cwd` verbatim into `session-layout.kdl`. If that cwd contains a literal `$`, the cache file zellij just wrote becomes unparseable by zellij itself, and `zellij attach` fails with only a generic error (`Failed to parse resurrection layout file ...: KdlDeserialization error: Failed to parse Zellij configuration.`), hiding the real cause.

Minimal repro (from the issue):
```kdl
layout {
    pane command="ls" cwd="/tmp/foo/$programId+" {
        start_suspended true
    }
}
```
```
zellij -n layout.kdl -s repro
```
fails with:
```
×  Failed to parse Zellij configuration
   pane command="ls" cwd="/tmp/foo/$programId+" {
   error looking key 'programId' up: environment variable not found
```

## Fix

`parse_path` now falls back to the original, unexpanded string when `shellexpand::full` errors, instead of propagating a `ConfigError`. A `log::warn!` is emitted so the fallback is still visible for debugging. Legitimate expansion (`~`, real `$VARS`) is unaffected - only the error case falls back to the raw string.

This mirrors the fallback pattern already used for plugin path expansion in `RunPluginLocation::parse` (`zellij-utils/src/input/layout.rs`), so it's consistent with existing conventions in this codebase.

## Testing

- Updated `env_var_missing` (`zellij-utils/src/input/unit/layout_test.rs`) to reflect the new behavior: a missing/unresolvable `$VAR` no longer hard-fails layout parsing, it falls back to the literal string.
- Added `literal_dollar_sign_in_cwd_is_not_a_parse_error`, a regression test using the exact repro from the issue (`pane command="ls" cwd="/tmp/foo/$programId+"`), asserting the layout parses and the pane's `cwd` is kept as the literal `/tmp/foo/$programId+`.
- Ran the full `zellij-utils` unit test suite:
  ```
  cargo test -p zellij-utils --lib -- --skip cli::tests
  ```
  `409 passed; 0 failed; 2 ignored` (the `cli::tests` module was skipped because several of its tests stack-overflow on this machine/toolchain independent of this change - reproduced identically on unmodified `main`).
- `cargo fmt -p zellij-utils -- --check` is clean.

## Note

I did not change how resurrection layouts are *serialized* (e.g. escaping `$` as `$$` when writing). The parser-side fallback fixes the actual symptom (an unparseable file zellij wrote itself) without needing to touch the writer, and keeps existing hand-written layouts with a genuinely-missing env var loading instead of hard-failing, which seems like the more robust behavior for a value that's just going to become a path string either way.
