### PR TITLE
fix(action): normalize CRLF line endings for paste

### DIFF
--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -322,7 +322,7 @@ pub(crate) fn route_action(
             senders
                 .send_to_screen(ScreenInstruction::ClearScroll(client_id))
                 .with_context(err_context)?;
-            let bytes = chars.into_bytes();
+            let bytes = chars.replace("\r\n", "\n").into_bytes();
             senders
                 .send_to_screen(ScreenInstruction::Paste(
                     bytes,


### PR DESCRIPTION
Closes #5387
## Summary
Normalize CRLF line endings before sending text through the `Paste`
action.
Without normalization, applications that interpret both carriage return
and line feed as input line breaks receive two line breaks for each CRLF
sequence.
## Cause
The `Action::Paste` handler converted its input directly to bytes:
```rust
let bytes = chars.into_bytes();
```
This preserved Windows-style CRLF line endings as two separate control
characters.
The resulting bytes were then passed to `ScreenInstruction::Paste` and
wrapped in bracketed paste markers by `paste_to_pane_id()`.
When CRLF is sent as terminal input, CR and LF can each be processed as
a line break, resulting in an extra blank line for every CRLF sequence.
## Changes
Normalize CRLF to LF in the `Action::Paste` path before converting the
text to bytes:
```rust
let bytes = chars.replace("\r\n", "\n").into_bytes();
```
The normalization is intentionally limited to CRLF sequences:
```text
CRLF -> LF
LF   -> LF
CR   -> CR
```
Standalone carriage returns remain unchanged.
`WriteChars` and `WriteCharsToPaneId` are also left unchanged. These are
lower-level input actions and should preserve the exact characters
provided by the caller.