### PR TITLE
feat(plugins): expose go_to_tab_with_id

### DIFF
--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -808,6 +808,14 @@ pub fn switch_tab_to(tab_idx: u32) {
     unsafe { host_run_plugin_command() };
 }
 
+/// Change the focused tab to the specified tab ID.
+pub fn go_to_tab_with_id(tab_id: u64) {
+    let plugin_command = PluginCommand::GoToTabWithId(tab_id);
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
 /// Set a timeout in seconds (or fractions thereof) after which the plugins [update](./plugin-api-events#update) method will be called with the [`Timer`](./plugin-api-events.md#timer) event.
 pub fn set_timeout(secs: f64) {
     let plugin_command = PluginCommand::SetTimeout(secs);


### PR DESCRIPTION
Closes #5389
## Summary
Expose the existing `GoToTabWithId` plugin command through
`zellij-tile`.
## Changes
Add the following public function to `zellij-tile`:
```rust
/// Change the focused tab to the specified tab ID.
pub fn go_to_tab_with_id(tab_id: u64) {
    let plugin_command = PluginCommand::GoToTabWithId(tab_id);
    let protobuf_plugin_command: ProtobufPluginCommand =
        plugin_command.try_into().unwrap();
    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
    unsafe { host_run_plugin_command() };
}
```
The command protocol, Protobuf conversion, and server-side handling
already exist. This change adds the missing public wrapper for plugin
authors.
## Motivation
Plugins can currently switch tabs with `switch_tab_to()`, which accepts a
tab position.
A plugin that stores the `tab_id` provided by `TabInfo` must therefore
find the tab's current position before switching. This also requires an
up-to-date `TabUpdate`.
With `go_to_tab_with_id()`, plugins can switch directly using the tab ID:
```rust
go_to_tab_with_id(tab_id as u64);
```