### PR TITLE
Typo fix in session nouns

### DIFF
--- a/zellij-utils/src/sessions.rs
+++ b/zellij-utils/src/sessions.rs
@@ -705,7 +705,7 @@ const NOUNS: &[&'static str] = &[
     "goose",
     "hill",
     "horse",
-    "iguanadon",
+    "iguanodon",
     "jellyfish",
     "kangaroo",
     "lake",


### PR DESCRIPTION
Changes "iguanadon" to "iguanodon"