### PR TITLE
fix: deliver pane-title (OSC 0/2) changes to plugins

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -627,6 +627,10 @@ pub struct Grid {
     pub pending_messages_to_pty: Vec<Vec<u8>>,
     pub selection: Selection,
     pub title: Option<String>,
+    /// Set to `true` whenever `title` changes to a *different* value (via OSC 0/2 or a
+    /// title-stack pop). Consumed by the pane (see `Pane::take_title_changed`) so the screen
+    /// thread can push a fresh `SessionUpdate`/`PaneUpdate` to plugins on the next render tick.
+    pub title_changed: bool,
     pub is_scrolled: bool,
     pub link_handler: Rc<RefCell<LinkHandler>>,
     pub ring_bell: bool,
@@ -955,6 +959,7 @@ impl Grid {
             selection: Default::default(),
             title_stack: vec![],
             title: None,
+            title_changed: false,
             changed_colors: None,
             is_scrolled: false,
             link_handler,
@@ -2888,7 +2893,12 @@ impl Grid {
         }
     }
     fn set_title(&mut self, title: String) {
-        self.title = Some(title);
+        // Only flag a change when the value actually differs: apps commonly re-assert an
+        // identical title every frame, and we must not turn that into a plugin-update storm.
+        if self.title.as_deref() != Some(title.as_str()) {
+            self.title = Some(title);
+            self.title_changed = true;
+        }
     }
     fn push_current_title_to_stack(&mut self) {
         if self.title_stack.len() > MAX_TITLE_STACK_SIZE {
@@ -2900,6 +2910,9 @@ impl Grid {
     }
     fn pop_title_from_stack(&mut self) {
         if let Some(popped_title) = self.title_stack.pop() {
+            if self.title.as_deref() != Some(popped_title.as_str()) {
+                self.title_changed = true;
+            }
             self.title = Some(popped_title);
         }
     }

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -883,6 +883,13 @@ impl Pane for TerminalPane {
     fn set_title(&mut self, title: String) {
         self.pane_title = title;
     }
+    fn take_title_changed(&mut self) -> bool {
+        let changed = std::mem::replace(&mut self.grid.title_changed, false);
+        // A user-set pane name (via rename) overrides the OSC title in `current_title()`, so an
+        // OSC change under a custom name doesn't alter what plugins see — don't report it. The
+        // grid flag is still consumed above so it can't accumulate.
+        changed && self.pane_name.is_empty()
+    }
     fn current_title(&self) -> String {
         if self.pane_name.is_empty() {
             self.grid

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1469,6 +1469,10 @@ pub(crate) struct Screen {
     // is brought online
     web_server_ip: IpAddr,
     web_server_port: u16,
+    /// Set when a pane's OSC title changed; drained on the next (already-debounced) render tick to
+    /// push a fresh `SessionUpdate`/`PaneUpdate` to plugins. See `ScreenInstruction::PtyBytes` /
+    /// `RenderToClients`.
+    pending_session_state_report: bool,
     render_blocker: RenderBlocker,
     watcher_clients: HashMap<ClientId, WatcherState>,
     followed_client_id: Option<ClientId>,
@@ -1630,6 +1634,7 @@ impl Screen {
             mouse_click_through,
             web_server_ip,
             web_server_port,
+            pending_session_state_report: false,
             render_blocker: RenderBlocker::new(100),
             watcher_clients: HashMap::new(),
             followed_client_id: None,
@@ -6313,11 +6318,13 @@ pub(crate) fn screen_thread_main(
             ScreenInstruction::PtyBytes(pid, vte_bytes) => {
                 let all_tabs = screen.get_tabs_mut();
                 let mut vte_bytes = Some(vte_bytes);
+                let mut title_changed = false;
                 for tab in all_tabs.values_mut() {
                     if tab.has_terminal_pid(pid) {
                         if let Some(bytes) = vte_bytes.take() {
                             tab.handle_pty_bytes(pid, bytes)
                                 .context("failed to process pty bytes")?;
+                            title_changed = tab.take_pane_title_changed(pid);
                         }
                         break;
                     }
@@ -6327,6 +6334,12 @@ pub(crate) fn screen_thread_main(
                         .entry(PaneId::Terminal(pid))
                         .or_default()
                         .push(ScreenInstruction::PtyBytes(pid, vte_bytes));
+                }
+                // The OSC-title path only mutates in-memory grid state, so plugins would never
+                // otherwise learn of the change. Defer the (heavier) session-state report to the
+                // debounced render tick below, coalescing bursts into at most one update per tick.
+                if title_changed {
+                    screen.pending_session_state_report = true;
                 }
                 let _ = screen
                     .bus
@@ -6382,6 +6395,13 @@ pub(crate) fn screen_thread_main(
                     screen.render_to_clients()?;
                 } else {
                     screen.render(None)?;
+                }
+                // This tick is already debounced (see BackgroundJob::RenderToClients), so it's the
+                // natural place to flush a pending OSC-title change to plugins without adding a
+                // separate timer or emitting on every frame.
+                if screen.pending_session_state_report {
+                    screen.pending_session_state_report = false;
+                    screen.log_and_report_session_state()?;
                 }
             },
             ScreenInstruction::NewPane(

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -656,6 +656,12 @@ pub trait Pane {
     fn frame_color_override(&self) -> Option<PaletteColor>;
     fn invoked_with(&self) -> &Option<Run>;
     fn set_title(&mut self, title: String);
+    /// Returns whether this pane's plugin-visible title changed (via OSC 0/2) since the last
+    /// call, clearing the internal flag. Used to trigger a debounced `SessionUpdate`/`PaneUpdate`
+    /// to plugins on the render tick. Only terminal panes track this; defaults to `false`.
+    fn take_title_changed(&mut self) -> bool {
+        false
+    }
     fn update_loading_indication(&mut self, _loading_indication: LoadingIndication) {} // only relevant for plugins
     fn start_loading_indication(&mut self, _loading_indication: LoadingIndication) {} // only relevant for plugins
     fn progress_animation_offset(&mut self) {} // only relevant for plugins
@@ -3777,6 +3783,22 @@ impl Tab {
     pub fn has_shadow_focus_on(&self, client_id: ClientId, pane_id: PaneId) -> bool {
         self.tiled_panes.has_shadow_focus_on(client_id, pane_id)
             || self.floating_panes.has_shadow_focus_on(client_id, pane_id)
+    }
+    /// Consume (and clear) the "title changed" flag for the given terminal pane. Returns whether
+    /// its plugin-visible title changed since the last check. Looks the pane up across the same
+    /// collections as `handle_pty_bytes`.
+    pub fn take_pane_title_changed(&mut self, pid: u32) -> bool {
+        self.tiled_panes
+            .get_pane_mut(PaneId::Terminal(pid))
+            .or_else(|| self.floating_panes.get_pane_mut(PaneId::Terminal(pid)))
+            .or_else(|| {
+                self.suppressed_panes
+                    .values_mut()
+                    .find(|s_p| s_p.1.pid() == PaneId::Terminal(pid))
+                    .map(|s_p| &mut s_p.1)
+            })
+            .map(|pane| pane.take_title_changed())
+            .unwrap_or(false)
     }
     pub fn handle_pty_bytes(&mut self, pid: u32, bytes: VteBytes) -> Result<()> {
         if self.is_pending {


### PR DESCRIPTION
# fix: deliver pane-title (OSC 0/2) changes to plugins

## Summary

A pane title set by the running app via the standard **OSC 0/2** escape (`ESC ] 0 ; title BEL`) updates Zellij's UI instantly, but is **never delivered to plugins**. `Event::SessionUpdate` and `Event::PaneUpdate` only fire on *structural* session events (pane/tab open/close, focus, resize, layout, rename, attach/detach…), so a plugin's view of every pane title is frozen at the last such event — arbitrarily stale (minutes in practice; unbounded if the session is otherwise idle).

This PR makes an OSC title change flush a fresh `SessionUpdate`/`PaneUpdate` to plugins, **debounced onto the existing render tick** (no new timer, no per-frame event storm).

## Root cause

- OSC 0/2 → `Grid::osc_dispatch` → `Grid::set_title` (`zellij-server/src/panes/grid.rs`) just sets `self.title`. No notification.
- The `ScreenInstruction::PtyBytes` handler (`zellij-server/src/screen.rs`) processes the bytes and only triggers `BackgroundJob::RenderToClients` (a UI redraw). It never calls `Screen::log_and_report_session_state` — the **sole** function that pushes `SessionUpdate` / `PaneUpdate` / `TabUpdate` to plugins, and which is only invoked from ~90 *structural* `ScreenInstruction` handlers.
- `PaneInfo.title` is read live via `pane.current_title()`, so the data is *fresh at build time* — only the **push** was missing.
- No periodic tick compensates: the CWD ticker emits only `CwdChanged`/`CommandChanged`; the metadata-write ticker persists the *stale cached* `SessionInfo`.

(`PaneUpdate` shares the identical gate, so a plugin-side "subscribe `PaneUpdate` + merge" workaround does **not** solve own-session titles — both events needed fixing at the source.)

## The fix

Two small parts, reusing infrastructure that already exists:

**1. Detect the change (cheap, gated).**
- `Grid` gains a `title_changed: bool`, set **only when the title actually differs** from the current value — apps commonly re-assert an identical title every frame, and we must not turn that into an update storm. Handled in both `set_title` (OSC 0/2) and `pop_title_from_stack` (OSC title-stack restore) — the only two places `grid.title` is assigned.
- `TerminalPane::take_title_changed()` consumes the flag, returning `true` only when no user-set pane name is masking the OSC title (i.e. only when it would actually change what plugins see).
- `Pane::take_title_changed()` trait default is `false`; `Tab::take_pane_title_changed(pid)` looks the pane up across the same collections as `handle_pty_bytes`.

**2. Report at the already-coalesced tick (no new timer).**
- `Screen` gains a `pending_session_state_report` flag. The `PtyBytes` handler sets it when a title changed; the **already-debounced** `RenderToClients` tick (see `BackgroundJob::RenderToClients`, `REPAINT_DELAY_MS`) drains it with a single `log_and_report_session_state()` call — refreshing `SessionUpdate`, `PaneUpdate`, and the cross-session on-disk cache together.

### Why not a dedicated debounce timer?
The render path is already debounced and already runs on every PTY burst, so it's the natural place to piggyback. Gating on an *actual* title change (not mere re-assertion) is what really bounds the work — titles change when the app changes them (~1/s for a spinner), not per frame.

### Why not route OSC titles through the rename path?
Rename sets `pane_name` (a sticky *custom* title that overrides the OSC title in `current_title()`). Routing OSC titles through it would make a transient app title masquerade as a user-pinned name and suppress subsequent OSC titles. Wrong semantics.

## Files changed

| File | Change |
| - | - |
| `zellij-server/src/panes/grid.rs` | `title_changed` field + change-detection in `set_title` / `pop_title_from_stack` |
| `zellij-server/src/panes/terminal_pane.rs` | `take_title_changed()` impl (consumes grid flag, respects custom pane names) |
| `zellij-server/src/tab/mod.rs` | `Pane::take_title_changed()` default + `Tab::take_pane_title_changed(pid)` |
| `zellij-server/src/screen.rs` | `pending_session_state_report` flag; set in `PtyBytes`, drained in `RenderToClients` |

~63 insertions, 1 deletion. No public plugin-API change.

## Reproduction

The reproduction is **plugin-free**: the on-disk `session-metadata.kdl` is written from the *same* cached `SessionInfo` that plugins receive via `Event::SessionUpdate` (it is fed by `BackgroundJob::ReportSessionInfo`, sent only from `log_and_report_session_state`), and it serializes each pane's `title`. So its `title` node is an exact proxy for what a subscribed plugin would see. (Equivalently, load any `SessionUpdate`-subscribing plugin and watch the titles it logs.)

### Prerequisites

```bash
# a POSIX shell, python3, and a zellij binary. Build the patched one with:
cargo build --release            # or: cargo xtask build --release
# minimal single, nameless terminal pane (so current_title() reflects the OSC title directly):
printf 'layout {\n    pane\n}\n' > /tmp/zj-minimal-layout.kdl
```

### One-command before/after check

`verify_title_propagation.py` (below) runs an OSC-0 title loop and samples the plugin-facing title once/sec **with no structural event**. It prints `PASS` only if the title advances on its own.

```bash
# BEFORE (any released zellij, e.g. system 0.44.3):  ->  [FAIL] title frozen
ZELLIJ_BIN=zellij python3 verify_title_propagation.py

# AFTER (this branch):                               ->  [PASS] title advances
ZELLIJ_BIN=./target/release/zellij python3 verify_title_propagation.py
```

Observed (patched):

```
   t  UI title (LIVE)             plugin-facing disk title
----  --------------------------  ----------------------------------------
   1  … | PYTHON-TITLE-001        PYTHON-TITLE-001,(.) - zantiflow
   2  … | PYTHON-TITLE-002        PYTHON-TITLE-001,(.) - zantiflow
   3  … | PYTHON-TITLE-003        PYTHON-TITLE-002,(.) - zantiflow
   …                              (advances every second)
[PASS] plugin-facing title ADVANCED without any structural event
```

Before the fix the right-hand column stays frozen at the pane's initial title for the entire run, and only advances when an unrelated structural event is fired (see the "smoking-gun" script). The ~1-tick lag above is an artifact of the *observation channel* (the disk file is rewritten by a 1 s metadata ticker); the real `SessionUpdate` fires at the ~10 ms render tick.

<details>
<summary><code>verify_title_propagation.py</code> (primary reproduction — PASS/FAIL)</summary>

```python
#!/usr/bin/env python3
"""
Verify pane-title propagation to plugins. Observed plugin-free via the on-disk
session-metadata.kdl, which is written from the same cached SessionInfo that plugins receive via
Event::SessionUpdate. Runs an OSC-0 title loop and samples once/sec with NO structural event.

PASS = plugin-facing title advances on its own.   FAIL = title frozen (the bug).
Point at a binary with ZELLIJ_BIN=... (defaults to `zellij` on PATH).
"""
import os, pty, time, subprocess, glob, select, re

SESSION = "titlefix-verify"
SOCK = "/tmp/zellij-titlefix-sock"
ZBIN = os.environ.get("ZELLIJ_BIN", "zellij")
LAYOUT = "/tmp/zj-minimal-layout.kdl"

env = dict(os.environ)
env["ZELLIJ_SOCKET_DIR"] = SOCK
env["TERM"] = "xterm-256color"
env.pop("ZELLIJ", None); env.pop("ZELLIJ_SESSION_NAME", None)

def log(m): print(m, flush=True)
def kill():
    subprocess.run([ZBIN, "kill-session", SESSION], env=env,
                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
def meta_file():
    for base in filter(None, [env.get("XDG_CACHE_HOME"), os.path.expanduser("~/.cache")]):
        g = glob.glob(os.path.join(base, "zellij", "*", "session_info", SESSION, "session-metadata.kdl"))
        if g: return g[0]
    return None
def disk_titles(p):
    try:
        return re.findall(r'^\s*title\s+"((?:[^"\\]|\\.)*)"', open(p, errors="replace").read(), re.M)
    except OSError:
        return None
OSC = re.compile(rb'\x1b\][02];([^\x07\x1b]*)(?:\x07|\x1b\\)')

def main():
    kill(); time.sleep(1.0)
    pid, fd = pty.fork()
    if pid == 0:
        os.execvpe(ZBIN, [ZBIN, "-s", SESSION, "-n", LAYOUT], env); os._exit(127)

    buf = bytearray()
    def drain(dur):
        end = time.time() + dur
        while time.time() < end:
            r, _, _ = select.select([fd], [], [], max(0, end - time.time()))
            if fd in r:
                try:
                    d = os.read(fd, 65536)
                    if not d: break
                    buf.extend(d)
                except OSError: break
    def ui_title():
        m = OSC.findall(bytes(buf)); return m[-1].decode(errors="replace") if m else None

    seen = []
    try:
        log(f"[*] zellij binary: {ZBIN}")
        drain(5.0); os.write(fd, b"\x1b"); drain(1.0); os.write(fd, b"\r"); drain(2.0)
        m = meta_file()
        for _ in range(6):
            if m: break
            drain(1.0); m = meta_file()
        if not m:
            log("[!] session-metadata.kdl never appeared; tail:\n" + bytes(buf[-1200:]).decode(errors="replace"))
            return
        os.write(fd, (b"clear; for i in $(seq 1 120); do "
                      b"printf '\\033]0;PYTHON-TITLE-%03d\\007' $i; sleep 1; done\r"))
        log("[*] OSC-title loop started. Sampling 10s with NO structural event.\n")
        log(f"{'t':>4}  {'UI title (LIVE)':<26}  plugin-facing disk title")
        log(f"{'':->4}  {'':-<26}  {'':-<40}")
        for t in range(1, 11):
            drain(1.0)
            dt = disk_titles(meta_file() or m) or []
            seen.extend(x for x in dt if x.startswith("PYTHON-TITLE-"))
            log(f"{t:>4}  {str(ui_title()):<26}  {','.join(dt) if dt else '-'}")
    finally:
        try: os.write(fd, b"\x14q")
        except OSError: pass
        time.sleep(0.5); kill()
        try: os.close(fd)
        except OSError: pass

    uniq = sorted(set(seen))
    log("")
    if len(uniq) >= 2:
        log(f"[PASS] plugin-facing title ADVANCED without any structural event: {uniq[:6]}")
    elif len(uniq) == 1:
        log(f"[PARTIAL] updated once ({uniq}) but did not keep advancing — inspect.")
    else:
        log("[FAIL] plugin-facing title never showed PYTHON-TITLE-* — bug still present.")

if __name__ == "__main__":
    main()
```
</details>

<details>
<summary><code>smoking_gun.py</code> (demonstrates the pre-fix flush-on-structural-event, for context)</summary>

```python
#!/usr/bin/env python3
"""
Demonstrates the *bug* shape against an UNPATCHED zellij: the plugin-facing title stays frozen while
the OSC title loop advances, then flushes the instant an unrelated structural event (new tab) fires,
then re-freezes. Point at a binary with ZELLIJ_BIN=... (defaults to `zellij`).
"""
import os, pty, time, subprocess, glob, select, re

SESSION = "titlebug-repro"
SOCK = "/tmp/zellij-titlebug-sock"
ZBIN = os.environ.get("ZELLIJ_BIN", "zellij")
LAYOUT = "/tmp/zj-minimal-layout.kdl"

env = dict(os.environ)
env["ZELLIJ_SOCKET_DIR"] = SOCK
env["TERM"] = "xterm-256color"
env.pop("ZELLIJ", None); env.pop("ZELLIJ_SESSION_NAME", None)

def log(m): print(m, flush=True)
def kill():
    subprocess.run([ZBIN, "kill-session", SESSION], env=env,
                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
def meta_file():
    for base in filter(None, [env.get("XDG_CACHE_HOME"), os.path.expanduser("~/.cache")]):
        g = glob.glob(os.path.join(base, "zellij", "*", "session_info", SESSION, "session-metadata.kdl"))
        if g: return g[0]
    return None
def disk_titles(p):
    try:
        return re.findall(r'^\s*title\s+"((?:[^"\\]|\\.)*)"', open(p, errors="replace").read(), re.M)
    except OSError:
        return None
OSC = re.compile(rb'\x1b\][02];([^\x07\x1b]*)(?:\x07|\x1b\\)')

def main():
    kill(); time.sleep(1.0)
    pid, fd = pty.fork()
    if pid == 0:
        os.execvpe(ZBIN, [ZBIN, "-s", SESSION, "-n", LAYOUT], env); os._exit(127)

    buf = bytearray()
    def drain(dur):
        end = time.time() + dur
        while time.time() < end:
            r, _, _ = select.select([fd], [], [], max(0, end - time.time()))
            if fd in r:
                try:
                    d = os.read(fd, 65536)
                    if not d: break
                    buf.extend(d)
                except OSError: break
    def ui_title():
        m = OSC.findall(bytes(buf)); return m[-1].decode(errors="replace") if m else None

    try:
        drain(5.0); os.write(fd, b"\x1b"); drain(1.0); os.write(fd, b"\r"); drain(2.0)
        m = meta_file()
        for _ in range(6):
            if m: break
            drain(1.0); m = meta_file()
        if not m:
            log("[!] session did not start:\n" + bytes(buf[-1200:]).decode(errors="replace")); return
        os.write(fd, (b"clear; for i in $(seq 1 120); do "
                      b"printf '\\033]0;PYTHON-TITLE-%03d\\007' $i; sleep 1; done\r"))
        log(f"{'t':>4}  {'UI title (LIVE)':<26}  plugin-facing disk title")
        log(f"{'':->4}  {'':-<26}  {'':-<40}")
        def sample(t):
            drain(1.0)
            dt = disk_titles(meta_file() or m) or []
            log(f"{t:>4}  {str(ui_title()):<26}  {','.join(dt) if dt else '-'}")
        for t in range(1, 8): sample(t)
        log("--- firing a structural event: new tab (Ctrl-t, n) ---")
        os.write(fd, b"\x14"); drain(0.4); os.write(fd, b"n"); drain(0.4)
        for t in range(8, 12): sample(t)
    finally:
        try: os.write(fd, b"\x14q")
        except OSError: pass
        time.sleep(0.5); kill()
        try: os.close(fd)
        except OSError: pass

if __name__ == "__main__":
    main()
```
</details>

### Even more minimal (manual)

Per the issue's classic repro: run any title-changing process in a pane —

```bash
python3 - <<'EOF'
import sys, time
for i in range(300):
    sys.stdout.write(f"\033]0;PYTHON-TITLE-{i:03d}\007"); sys.stdout.flush(); time.sleep(1)
EOF
```

— load any `SessionUpdate`-subscribing plugin, and watch the titles it reports. Before: frozen until you switch tabs/open a pane. After: advances within ≤2 s on its own.

## Test plan

- `cargo test -p zellij-server --lib` → **1198 passed; 0 failed** (no regressions).
- `cargo fmt -- --check` → clean.
- Manual: `verify_title_propagation.py` → `FAIL` on 0.44.3 / unpatched `main`, `PASS` on this branch.
- Acceptance criteria met: with the repro running, the reported title advances within ≤2 s of each on-screen change with no other session activity, and there is no per-frame event storm (identical re-asserted titles are ignored; bursts coalesce onto one render-tick update).

## Notes / limitations

- **Scrolled pane:** if a title changes while its pane is scrolled back, the vte bytes are buffered and the flag is picked up when they later process; that single flush can lag until the user scrolls down or more output arrives. Rare and self-healing; deliberately not adding extra machinery for it.
- No plugin-facing API change; existing `SessionUpdate`/`PaneUpdate` consumers simply get fresher data.

## Before submitting (per CONTRIBUTING.md)

- [x] `cargo fmt`
- [x] `cargo test` (existing + covered by manual repro)
- [ ] File an issue describing the bug and link it here (`Fixes #XXXX`) — this is not a trivial fix.
- [ ] Add the CHANGELOG entry (see COMMIT.md).
- [ ] Consider a quick check-in with maintainers per their contribution policy.