### PR TITLE
fix: preserve background transparency upon receiving OSC 11 sequence

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -749,6 +749,8 @@ pub struct Grid {
     /// Pane-scoped override for the default background colour. Same
     /// invariant as `pane_default_fg`.
     pub pane_default_bg: Option<(u8, u8, u8)>,
+    pub osc_default_fg: Option<(u8, u8, u8)>,
+    pub osc_default_bg: Option<(u8, u8, u8)>,
     pub plugin_highlights: HashMap<u32, Vec<(String, CompiledHighlight)>>,
     // key: plugin_id (u32), inner vec: (pattern, compiled) pairs
     pub hover_position: Option<Position>, // pane-relative cursor cell; None when outside pane
@@ -772,8 +774,12 @@ impl Grid {
     }
     pub fn get_pane_default_color_strings(&self) -> (Option<String>, Option<String>) {
         (
-            self.pane_default_fg.map(rgb_to_hex_string),
-            self.pane_default_bg.map(rgb_to_hex_string),
+            self.pane_default_fg
+                .or(self.osc_default_fg)
+                .map(rgb_to_hex_string),
+            self.pane_default_bg
+                .or(self.osc_default_bg)
+                .map(rgb_to_hex_string),
         )
     }
 }
@@ -1093,6 +1099,8 @@ impl Grid {
             hyperlink_tracker: HyperlinkTracker::new(),
             pane_default_fg: None,
             pane_default_bg: None,
+            osc_default_fg: None,
+            osc_default_bg: None,
             plugin_highlights: HashMap::new(),
             hover_position: None,
             cached_hover_tooltip: None,
@@ -2612,6 +2620,8 @@ impl Grid {
         self.set_scroll_region_to_viewport_size();
         self.pane_default_fg = None;
         self.pane_default_bg = None;
+        self.osc_default_fg = None;
+        self.osc_default_bg = None;
         if let Some(images_to_reap) = self.sixel_grid.clear() {
             self.sixel_grid.reap_images(images_to_reap);
         }
@@ -4159,8 +4169,8 @@ impl Perform for Grid {
                                 // is actually rendering for them, not
                                 // the host terminal's background.
                                 let local_override = match dynamic_code {
-                                    10 => self.pane_default_fg,
-                                    11 => self.pane_default_bg,
+                                    10 => self.pane_default_fg.or(self.osc_default_fg),
+                                    11 => self.pane_default_bg.or(self.osc_default_bg),
                                     _ => None,
                                 };
                                 if let Some(rgb) = local_override {
@@ -4200,7 +4210,7 @@ impl Perform for Grid {
                                     self.pending_forwarded_queries.push(query);
                                 }
                             } else {
-                                // Set: parse color and store as pane
+                                // Set: parse color and store as OSC
                                 // default. Only literal RGB is stored;
                                 // palette-indexed / named variants (or
                                 // a parse failure) are silently dropped
@@ -4208,9 +4218,9 @@ impl Perform for Grid {
                                 // narrow.
                                 if let Some(rgb) = xparse_color(param).and_then(rgb_of_ansi_code) {
                                     if dynamic_code == 10 {
-                                        self.pane_default_fg = Some(rgb);
+                                        self.osc_default_fg = Some(rgb);
                                     } else if dynamic_code == 11 {
-                                        self.pane_default_bg = Some(rgb);
+                                        self.osc_default_bg = Some(rgb);
                                     }
                                     self.output_buffer.update_all_lines();
                                 }
@@ -4298,12 +4308,14 @@ impl Perform for Grid {
             // Reset foreground color.
             b"110" => {
                 self.pane_default_fg = None;
+                self.osc_default_fg = None;
                 self.output_buffer.update_all_lines();
             },
 
             // Reset background color.
             b"111" => {
                 self.pane_default_bg = None;
+                self.osc_default_bg = None;
                 self.output_buffer.update_all_lines();
             },
 

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -4295,7 +4295,7 @@ fn osc_11_set_and_query_pane_default_bg() {
     let set_bg = b"\x1b]11;#001a3a\x07";
     vte_parser.advance(&mut grid, set_bg);
 
-    assert_eq!(grid.pane_default_bg, Some((0, 26, 58)));
+    assert_eq!(grid.osc_default_bg, Some((0, 26, 58)));
 
     // Query background via OSC 11 — because a pane-scoped override is
     // in place, the query is short-circuited: apps inside the pane
@@ -4343,7 +4343,7 @@ fn osc_10_set_and_query_pane_default_fg() {
     let set_fg = b"\x1b]10;#00e000\x07";
     vte_parser.advance(&mut grid, set_fg);
 
-    assert_eq!(grid.pane_default_fg, Some((0, 224, 0)));
+    assert_eq!(grid.osc_default_fg, Some((0, 224, 0)));
 
     // Query foreground via OSC 10 — pane-scoped override is in place,
     // so the query is answered locally (see OSC 11 equivalent test for
@@ -4390,26 +4390,70 @@ fn osc_110_111_reset_pane_default_colors() {
     let set_bg = b"\x1b]11;#001a3a\x07";
     vte_parser.advance(&mut grid, set_bg);
 
-    assert_eq!(grid.pane_default_fg, Some((0, 224, 0)));
-    assert_eq!(grid.pane_default_bg, Some((0, 26, 58)));
+    assert_eq!(grid.osc_default_fg, Some((0, 224, 0)));
+    assert_eq!(grid.osc_default_bg, Some((0, 26, 58)));
 
     // Reset foreground via OSC 110
     let reset_fg = b"\x1b]110\x07";
     vte_parser.advance(&mut grid, reset_fg);
-    assert_eq!(grid.pane_default_fg, None);
-    assert_eq!(grid.pane_default_bg, Some((0, 26, 58)));
+    assert_eq!(grid.osc_default_fg, None);
+    assert_eq!(grid.osc_default_bg, Some((0, 26, 58)));
 
     // Reset background via OSC 111
     let reset_bg = b"\x1b]111\x07";
     vte_parser.advance(&mut grid, reset_bg);
-    assert_eq!(grid.pane_default_fg, None);
-    assert_eq!(grid.pane_default_bg, None);
+    assert_eq!(grid.osc_default_fg, None);
+    assert_eq!(grid.osc_default_bg, None);
 }
 
 #[test]
-fn osc_11_set_bg_produces_ansi_in_render_output() {
+fn set_pane_default_colors_produces_ansi_in_render_output() {
     use crate::panes::terminal_character::AnsiCode;
 
+    let sixel_image_store = Rc::new(RefCell::new(SixelImageStore::default()));
+    let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
+    let mut grid = Grid::new(
+        5,
+        10,
+        Rc::new(RefCell::new(Palette::default())),
+        terminal_emulator_color_codes,
+        Rc::new(RefCell::new(LinkHandler::new())),
+        Rc::new(RefCell::new(None)),
+        sixel_image_store,
+        Rc::new(RefCell::new(KittyImageStore::default())),
+        Style::default(),
+        false,
+        true,
+        true,
+        true,
+        false,
+    );
+
+    // Explicitly set background via set_pane_default_colors
+    grid.set_pane_default_colors(None, Some("#001a3a".to_string()));
+
+    assert_eq!(grid.pane_default_bg, Some((0, 26, 58)));
+
+    // Render the grid and check that the pane defaults are stamped on chunks
+    let style = Style::default();
+    let render_result = grid.render(0, 0, &style).unwrap();
+    assert!(render_result.is_some(), "Expected render output");
+
+    let (chunks, _, _, _) = render_result.unwrap();
+    assert!(!chunks.is_empty(), "Expected at least one character chunk");
+
+    // All chunks should carry the pane default bg
+    for chunk in &chunks {
+        assert_eq!(
+            chunk.pane_default_bg,
+            Some(AnsiCode::RgbCode((0, 26, 58))),
+            "Chunk should carry pane default background"
+        );
+    }
+}
+
+#[test]
+fn osc_11_does_not_force_opaque_background_rendering() {
     let mut vte_parser = vte::Parser::new();
     let sixel_image_store = Rc::new(RefCell::new(SixelImageStore::default()));
     let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
@@ -4430,27 +4474,23 @@ fn osc_11_set_bg_produces_ansi_in_render_output() {
         false,
     );
 
-    // Set background via OSC 11
+    // Set background via OSC 11 (e.g. from an app inside the pane)
     let set_bg = b"\x1b]11;#001a3a\x07";
     vte_parser.advance(&mut grid, set_bg);
 
-    assert_eq!(grid.pane_default_bg, Some((0, 26, 58)));
+    // OSC default bg is updated for queries, but cell rendering fallback stays None
+    assert_eq!(grid.osc_default_bg, Some((0, 26, 58)));
+    assert_eq!(grid.pane_default_bg, None);
 
-    // Render the grid and check that the pane defaults are stamped on chunks
     let style = Style::default();
     let render_result = grid.render(0, 0, &style).unwrap();
-    assert!(render_result.is_some(), "Expected render output");
-
-    let (chunks, _, _, _) = render_result.unwrap();
-    assert!(!chunks.is_empty(), "Expected at least one character chunk");
-
-    // All chunks should carry the pane default bg
-    for chunk in &chunks {
-        assert_eq!(
-            chunk.pane_default_bg,
-            Some(AnsiCode::RgbCode((0, 26, 58))),
-            "Chunk should carry pane default background"
-        );
+    if let Some((chunks, _, _, _)) = render_result {
+        for chunk in &chunks {
+            assert_eq!(
+                chunk.pane_default_bg, None,
+                "OSC 11 must not stamp pane_default_bg on chunks to preserve transparent background"
+            );
+        }
     }
 }
 
@@ -5815,7 +5855,7 @@ fn osc_11_set_stays_local() {
         grid.pending_forwarded_queries.is_empty(),
         "set (not query) must not forward"
     );
-    assert!(grid.pane_default_bg.is_some());
+    assert!(grid.osc_default_bg.is_some());
 }
 
 #[test]
@@ -5884,7 +5924,7 @@ fn osc_11_override_short_circuits_only_the_overridden_channel() {
     let mut parser = vte::Parser::new();
     let mut grid = new_grid_for_forwarding_test();
     parser.advance(&mut grid, b"\x1b]11;rgb:1010/2020/3030\x07");
-    assert!(grid.pane_default_bg.is_some());
+    assert!(grid.osc_default_bg.is_some());
     assert!(grid.pane_default_fg.is_none());
 
     parser.advance(&mut grid, b"\x1b]10;?\x07");


### PR DESCRIPTION
This solves for the `pane_default_bg/pane_default_fg` values being used for two distinct purposes, being both pane colors and capturing/storing OSC 10/11 sequences. To keep transparency intact we should catch OSC 10/11 in a separate variable.

This is an issue when running zellij in a transparent terminal emulator, with any program inside of it that sends an OSC 10/11 sequence (Starship prompt in my case).

main currently
<img width="2560" height="1440" alt="Screenshot From 2026-07-23 10-20-48" src="https://github.com/user-attachments/assets/efb02a41-0361-45cc-b313-d5275b7fe51e" />

main with patch
<img width="2560" height="1440" alt="Screenshot From 2026-07-23 10-17-33" src="https://github.com/user-attachments/assets/94dff1de-b34b-4b09-9976-760ceea06a02" />

Issue created here:
https://github.com/zellij-org/zellij/issues/5402

See also:
https://github.com/zellij-org/zellij/pull/4737
https://github.com/zellij-org/zellij/commit/f77cdec298576164f34baf0456e4b986bde269e6
