### PR TITLE
feat: expose per-pane bell state and add list-panes --bell filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+* feat: expose per-pane bell notification state in `PaneInfo` and add a `--bell` filter to `zellij action list-panes`
 * feat: allow tabs to have different sizes if clients aren't focused on the same one (https://github.com/zellij-org/zellij/pull/5133)
 * feat: PWA support for the web client (manifest + icons + iOS meta tags) so the page can be installed as a standalone app (https://github.com/zellij-org/zellij/pull/5184)
 * feat: mobile UI (https://github.com/zellij-org/zellij/pull/5241)

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -1708,11 +1708,16 @@ pub(crate) fn route_action(
             show_geometry,
             show_all,
             output_json,
+            filter_bell,
         } => {
             let maybe_panes =
                 request_panes_from_screen(&senders, show_all).with_context(err_context)?;
 
             if let Some(mut pane_entries) = maybe_panes {
+                if filter_bell {
+                    pane_entries.retain(|entry| entry.pane_info.has_bell_notification);
+                }
+
                 if show_command || show_all || output_json {
                     enrich_panes_with_pty_data(&mut pane_entries, &senders)
                         .with_context(err_context)?;
@@ -2949,6 +2954,7 @@ fn build_table_header(
         header.push("FOCUSED");
         header.push("FLOATING");
         header.push("EXITED");
+        header.push("BELL");
     }
 
     if show_geometry {
@@ -2989,6 +2995,7 @@ fn build_table_row(
         row.push(entry.pane_info.is_focused.to_string());
         row.push(entry.pane_info.is_floating.to_string());
         row.push(entry.pane_info.exited.to_string());
+        row.push(entry.pane_info.has_bell_notification.to_string());
     }
 
     if show_geometry {

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -7497,6 +7497,7 @@ pub fn pane_info_for_pane(
     pane_info.exited = pane.exited();
     pane_info.exit_status = pane.exit_status();
     pane_info.is_held = pane.is_held();
+    pane_info.has_bell_notification = pane.get_bell_notification();
     let index_in_pane_group: BTreeMap<ClientId, usize> = current_pane_group
         .iter()
         .filter_map(|(client_id, pane_ids)| {

--- a/zellij-utils/assets/prost/api.event.rs
+++ b/zellij-utils/assets/prost/api.event.rs
@@ -617,6 +617,8 @@ pub struct PaneInfo {
     pub default_fg: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(string, optional, tag="25")]
     pub default_bg: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(bool, tag="26")]
+    pub has_bell_notification: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/zellij-utils/assets/prost_ipc/client_server_contract.rs
+++ b/zellij-utils/assets/prost_ipc/client_server_contract.rs
@@ -675,6 +675,8 @@ pub struct ListPanesAction {
     pub show_all: bool,
     #[prost(bool, tag="6")]
     pub output_json: bool,
+    #[prost(bool, tag="7")]
+    pub filter_bell: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -1583,6 +1583,10 @@ tail -f /tmp/my-live-logfile | zellij action pipe --name logs --plugin https://e
         /// Output as JSON
         #[clap(short, long, value_parser)]
         json: bool,
+
+        /// Only show panes that currently have a pending bell notification
+        #[clap(short, long, value_parser)]
+        bell: bool,
     },
     /// List all tabs with their information
     ///

--- a/zellij-utils/src/client_server_contract/common_types.proto
+++ b/zellij-utils/src/client_server_contract/common_types.proto
@@ -369,6 +369,7 @@ message ListPanesAction {
   bool show_geometry = 4;
   bool show_all = 5;
   bool output_json = 6;
+  bool filter_bell = 7;
 }
 message ListTabsAction {
   bool show_state = 1;

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -2330,6 +2330,9 @@ pub struct PaneInfo {
     /// A "held" pane is a paused pane that is waiting for user input (eg. a command pane that
     /// exited and is waiting to be re-run or closed)
     pub is_held: bool,
+    /// Whether this pane has an active (pending) bell notification - set when the pane receives a
+    /// terminal bell while not focused, and cleared when the pane is focused
+    pub has_bell_notification: bool,
     pub pane_x: usize,
     pub pane_content_x: usize,
     pub pane_y: usize,

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -547,6 +547,8 @@ pub enum Action {
         show_geometry: bool,
         show_all: bool,
         output_json: bool,
+        /// Only include panes that currently have a pending bell notification
+        filter_bell: bool,
     },
     ListTabs {
         show_state: bool,
@@ -1946,6 +1948,7 @@ impl Action {
                 geometry,
                 all,
                 json,
+                bell,
             } => Ok(vec![Action::ListPanes {
                 show_tab: tab,
                 show_command: command,
@@ -1953,6 +1956,7 @@ impl Action {
                 show_geometry: geometry,
                 show_all: all,
                 output_json: json,
+                filter_bell: bell,
             }]),
             CliAction::ListTabs {
                 state,

--- a/zellij-utils/src/ipc/protobuf_conversion.rs
+++ b/zellij-utils/src/ipc/protobuf_conversion.rs
@@ -1729,6 +1729,7 @@ impl From<crate::input::actions::Action>
                 show_geometry,
                 show_all,
                 output_json,
+                filter_bell,
             } => ActionType::ListPanes(ListPanesAction {
                 show_tab,
                 show_command,
@@ -1736,6 +1737,7 @@ impl From<crate::input::actions::Action>
                 show_geometry,
                 show_all,
                 output_json,
+                filter_bell,
             }),
             crate::input::actions::Action::TogglePanePinned => {
                 ActionType::TogglePanePinned(TogglePanePinnedAction {})
@@ -2612,6 +2614,7 @@ impl TryFrom<crate::client_server_contract::client_server_contract::Action>
                     show_geometry: list_panes_action.show_geometry,
                     show_all: list_panes_action.show_all,
                     output_json: list_panes_action.output_json,
+                    filter_bell: list_panes_action.filter_bell,
                 })
             },
             ActionType::ListTabs(list_tabs_action) => Ok(crate::input::actions::Action::ListTabs {

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -6384,6 +6384,12 @@ impl PaneInfo {
         let terminal_command = optional_string_node!("terminal_command");
         let plugin_url = optional_string_node!("plugin_url");
         let is_selectable = bool_node!("is_selectable");
+        // tolerate absence for backwards compatibility with older session dumps
+        let has_bell_notification = kdl_document
+            .get("has_bell_notification")
+            .and_then(|n| n.entries().iter().next())
+            .and_then(|e| e.value().as_bool())
+            .unwrap_or(false);
 
         let pane_info = PaneInfo {
             id,
@@ -6411,6 +6417,7 @@ impl PaneInfo {
             index_in_pane_group: Default::default(), // we don't serialize this
             default_fg: None,
             default_bg: None,
+            has_bell_notification,
         };
         Ok((tab_position, pane_info))
     }
@@ -6471,6 +6478,7 @@ impl PaneInfo {
             string_node!("plugin_url", plugin_url.to_string());
         }
         bool_node!("is_selectable", self.is_selectable);
+        bool_node!("has_bell_notification", self.has_bell_notification);
         kdl_doucment
     }
 }
@@ -6561,6 +6569,7 @@ fn serialize_and_deserialize_session_info_with_data() {
             index_in_pane_group: Default::default(), // we don't serialize this
             default_fg: None,
             default_bg: None,
+            has_bell_notification: true,
         },
         PaneInfo {
             id: 1,
@@ -6588,6 +6597,7 @@ fn serialize_and_deserialize_session_info_with_data() {
             index_in_pane_group: Default::default(), // we don't serialize this
             default_fg: None,
             default_bg: None,
+            has_bell_notification: false,
         },
     ];
     let mut panes = HashMap::new();

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__serialize_and_deserialize_session_info_with_data.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__serialize_and_deserialize_session_info_with_data.snap
@@ -64,6 +64,7 @@ panes {
         cursor_coordinates_in_pane 0 0
         terminal_command "foo"
         is_selectable true
+        has_bell_notification true
         tab_position 0
     }
     pane {
@@ -87,6 +88,7 @@ panes {
         cursor_coordinates_in_pane 0 0
         plugin_url "i_am_a_fake_plugin"
         is_selectable true
+        has_bell_notification false
         tab_position 0
     }
 }

--- a/zellij-utils/src/plugin_api/event.proto
+++ b/zellij-utils/src/plugin_api/event.proto
@@ -465,6 +465,7 @@ message PaneInfo {
     repeated IndexInPaneGroup index_in_pane_group = 23;
     optional string default_fg = 24;
     optional string default_bg = 25;
+    bool has_bell_notification = 26;
 }
 
 message IndexInPaneGroup {

--- a/zellij-utils/src/plugin_api/event.rs
+++ b/zellij-utils/src/plugin_api/event.rs
@@ -1835,6 +1835,7 @@ impl TryFrom<ProtobufPaneInfo> for PaneInfo {
                 .collect(),
             default_fg: protobuf_pane_info.default_fg,
             default_bg: protobuf_pane_info.default_bg,
+            has_bell_notification: protobuf_pane_info.has_bell_notification,
         })
     }
 }
@@ -1880,6 +1881,7 @@ impl TryFrom<PaneInfo> for ProtobufPaneInfo {
                 .collect(),
             default_fg: pane_info.default_fg,
             default_bg: pane_info.default_bg,
+            has_bell_notification: pane_info.has_bell_notification,
         })
     }
 }
@@ -2917,6 +2919,7 @@ fn serialize_session_update_event_with_non_default_values() {
             index_in_pane_group: index_in_pane_group_1,
             default_fg: None,
             default_bg: None,
+            has_bell_notification: true,
         },
         PaneInfo {
             id: 1,
@@ -2944,6 +2947,7 @@ fn serialize_session_update_event_with_non_default_values() {
             index_in_pane_group: index_in_pane_group_2,
             default_fg: None,
             default_bg: None,
+            has_bell_notification: false,
         },
     ];
     panes.insert(0, panes_list);


### PR DESCRIPTION
Add a `has_bell_notification` field to `PaneInfo` so the pending-bell state of each pane is visible through the plugin API (GetPaneInfo, PaneUpdate/PaneManifest), the `list-panes` JSON/table output, and persisted session info.

Also add a `-b/--bell` flag to `zellij action list-panes` to filter to only panes with a pending bell, and a `BELL` column to the `--state` table. KDL session decoding tolerates the field's absence for backwards compatibility with older dumps.