### PR TITLE
fix(grid): keep spaces before a wrapped line continuation when dumping

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -392,15 +392,23 @@ macro_rules! dump_screen {
     ($lines:expr) => {{
         let mut is_first = true;
         let mut buf = String::with_capacity($lines.iter().map(|l| l.len()).sum());
+        let mut lines = $lines.iter().peekable();
 
-        for line in &$lines {
+        while let Some(line) = lines.next() {
             if line.is_canonical && !is_first {
                 buf.push_str("\n");
             }
             let s: String = (&line.columns).into_iter().map(|x| x.character).collect();
-            // Replace the spaces at the end of the line. Sometimes, the lines are
-            // collected with spaces until the end of the panel.
-            buf.push_str(&s.trim_end_matches(' '));
+            // A row followed by a wrapped continuation row ends mid-logical-line, so its
+            // trailing spaces are content rather than padding and must be kept. Only the
+            // last row of a logical line gets the padding trimmed. Sometimes, the lines
+            // are collected with spaces until the end of the panel.
+            let wraps_onto_next_row = lines.peek().map_or(false, |next| !next.is_canonical);
+            if wraps_onto_next_row {
+                buf.push_str(&s);
+            } else {
+                buf.push_str(&s.trim_end_matches(' '));
+            }
             is_first = false;
         }
         buf
@@ -413,23 +421,30 @@ macro_rules! dump_screen_with_ansi {
         let mut is_first = true;
         let mut buf = String::new();
         let mut last_styles: Option<RcCharacterStyles> = None;
+        let mut lines = $lines.iter().peekable();
 
-        for line in &$lines {
+        while let Some(line) = lines.next() {
             if line.is_canonical && !is_first {
                 buf.push_str("\n");
                 last_styles = None;
             }
 
-            let last_non_space = line
-                .columns
-                .iter()
-                .rposition(|tc| {
-                    let space = tc.character == ' ';
-                    let styled = !matches!(tc.styles.background, Some(AnsiCode::Reset) | None);
-                    !space || styled // it's, something drawable
-                })
-                .map(|i| i + 1)
-                .unwrap_or(0);
+            // A row followed by a wrapped continuation row ends mid-logical-line, so its
+            // trailing spaces are content rather than padding and must be kept.
+            let wraps_onto_next_row = lines.peek().map_or(false, |next| !next.is_canonical);
+            let last_non_space = if wraps_onto_next_row {
+                line.columns.len()
+            } else {
+                line.columns
+                    .iter()
+                    .rposition(|tc| {
+                        let space = tc.character == ' ';
+                        let styled = !matches!(tc.styles.background, Some(AnsiCode::Reset) | None);
+                        !space || styled // it's, something drawable
+                    })
+                    .map(|i| i + 1)
+                    .unwrap_or(0)
+            };
 
             for tc in line.columns.iter().take(last_non_space) {
                 // Only output style codes if style changed

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -6138,3 +6138,52 @@ fn ui_component_flag_prefixes_parse_order_independently() {
         );
     }
 }
+
+#[test]
+fn dump_screen_keeps_spaces_before_a_wrapped_continuation() {
+    // A logical line that wraps mid-line keeps its trailing spaces as content: they sit
+    // before the continuation on the next row, not at the end of the logical line. Trimming
+    // them per-physical-row used to turn "a   b     c" into "a   bc" when dumped.
+    let mut parser = vte::Parser::new();
+    let mut grid = Grid::new(
+        5,
+        10,
+        Rc::new(RefCell::new(Palette::default())),
+        Rc::new(RefCell::new(HashMap::new())),
+        Rc::new(RefCell::new(LinkHandler::new())),
+        Rc::new(RefCell::new(None)),
+        Rc::new(RefCell::new(SixelImageStore::default())),
+        Style::default(),
+        false,
+        true,
+        true,
+        true,
+        false,
+    );
+    parser.advance(&mut grid, b"a   b     c");
+    assert_eq!(grid.dump_screen(false), "a   b     c");
+}
+
+#[test]
+fn dump_screen_still_trims_padding_at_end_of_a_logical_line() {
+    // The padding trim must stay in place for rows that actually end a logical line,
+    // otherwise every dumped line gets padded out to the pane width.
+    let mut parser = vte::Parser::new();
+    let mut grid = Grid::new(
+        5,
+        10,
+        Rc::new(RefCell::new(Palette::default())),
+        Rc::new(RefCell::new(HashMap::new())),
+        Rc::new(RefCell::new(LinkHandler::new())),
+        Rc::new(RefCell::new(None)),
+        Rc::new(RefCell::new(SixelImageStore::default())),
+        Style::default(),
+        false,
+        true,
+        true,
+        true,
+        false,
+    );
+    parser.advance(&mut grid, b"hi\r\nthere");
+    assert_eq!(grid.dump_screen(false), "hi\nthere");
+}


### PR DESCRIPTION
Fixes #5259

## Problem

`dump_screen` and `dump_screen_with_ansi` trim trailing spaces from **every physical
row**. That is right for a row that ends a logical line (the row is padded out to the
pane width), but wrong for a row that wraps: the continuation row is appended with no
newline, so those trailing spaces sit *between* content and are part of the logical
line.

With a 10 column pane, the logical line `a   b     c` wraps as:

```text
a   b␣␣␣␣␣
c
```

and dumps as `a   bc` instead of `a   b     c`. This affects `zellij action dump-screen`
and `zellij action edit-scrollback`, both with and without `--ansi` (the ANSI path has
the same per-row truncation via `last_non_space`).

## Changes

Both macros now look ahead one row and only trim the padding when the current row
actually ends a logical line — i.e. when the next row is canonical, or there is no next
row. A row followed by a non-canonical (continuation) row is emitted in full.

The fix is applied to both `dump_screen!` and `dump_screen_with_ansi!` so the `--ansi`
variants behave the same.

## Tests

Added two tests in `grid_tests.rs`:

- `dump_screen_keeps_spaces_before_a_wrapped_continuation` — the reproduction from the
  issue. **Fails without the change** with exactly the reported output:
  ```
  assertion `left == right` failed
    left: "a   bc"
   right: "a   b     c"
  ```
- `dump_screen_still_trims_padding_at_end_of_a_logical_line` — guards the existing
  behaviour, so the padding trim isn't simply removed and every dumped line padded out
  to the pane width.

## Verification

- `cargo test -p zellij-server --lib` — 1200 passed, 0 failed (run twice, deterministic)
- baseline on `main` for comparison — 1198 passed, 0 failed
- `cargo fmt --check -p zellij-server` — clean
- `cargo clippy -p zellij-server --lib` — no new warnings in the changed macros (the
  remaining warnings are pre-existing elsewhere in the file)

## Note

I deliberately kept this scoped to the per-row trimming. `dump_screen` joins
`lines_above` and the viewport with an unconditional `\n`, so a logical line spanning
that boundary is still split — that looked like separate behaviour (closer to #5256), so
I left it alone rather than widening the change.
