### PR TITLE
feat: configurable window size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * chore: switch cassowary deps to maintained fork kasuari (https://github.com/zellij-org/zellij/pull/5416)
 * chore: switch unmaintained daemonize with maintained fork daemonix (https://github.com/zellij-org/zellij/pull/4512)
 * feat: handle nested Zellij sessions (https://github.com/zellij-org/zellij/pull/5417)
+* feat: configurable `window_size` for multi-client sessions, mirroring tmux's `window-size` (https://github.com/zellij-org/zellij/pull/5425)
 
 ## [0.44.3] - 2026-05-13
 * fix(windows): bump windows-sys to 0.59 to align manifest with code, fixing source builds via `cargo install`/`cargo binstall` (https://github.com/zellij-org/zellij/pull/5139)

--- a/default-plugins/tab-bar/src/tab.rs
+++ b/default-plugins/tab-bar/src/tab.rs
@@ -52,6 +52,9 @@ pub fn render_tab(
         } else {
             palette.ribbon_unselected.emphasis_3
         }
+    } else if tab.active && tab.is_active_client {
+        // accent for the active client's tab (the one driving `window-size latest`)
+        palette.ribbon_selected.emphasis_1
     } else if tab.active {
         palette.ribbon_selected.base
     } else {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -664,6 +664,9 @@ pub(crate) fn start_client(opts: CliArgs) {
                     forget: false,
                     ca_cert: None,
                     insecure: false,
+                    // The server persists the window_size mode for the session, so a
+                    // reconnect need not re-assert it.
+                    window_size: None,
                 }));
             } else {
                 opts.command = None;
@@ -698,6 +701,7 @@ pub(crate) fn start_client(opts: CliArgs) {
             forget,
             ca_cert,
             insecure,
+            window_size,
         })) = opts.command.clone()
         {
             if let Some(remote_session_url) = session_name.as_ref().and_then(|s| {
@@ -815,6 +819,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                     client,
                     tab_position_to_focus,
                     pane_id_to_focus,
+                    window_size,
                     is_a_reconnect,
                     should_create_detached,
                 );
@@ -830,6 +835,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                     ClientInfo::New(session_name, layout_info, new_session_cwd),
                     None,
                     None,
+                    None, // window_size (new session takes the creating client's size anyway)
                     is_a_reconnect,
                     should_create_detached,
                 );
@@ -863,6 +869,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                                 client,
                                 None,
                                 None,
+                                None, // window_size (config-driven auto-attach uses the configured value)
                                 is_a_reconnect,
                                 should_create_detached,
                             );
@@ -877,6 +884,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                                 ClientInfo::New(session_name.clone(), layout_info, new_session_cwd),
                                 None,
                                 None,
+                                None, // window_size (new session takes the creating client's size anyway)
                                 is_a_reconnect,
                                 should_create_detached,
                             );
@@ -900,6 +908,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                     ClientInfo::New(session_name, layout_info, new_session_cwd),
                     None,
                     None,
+                    None, // window_size (new session takes the creating client's size anyway)
                     is_a_reconnect,
                     should_create_detached,
                 );
@@ -1007,6 +1016,7 @@ pub(crate) fn watch_session(session_name: Option<String>, opts: CliArgs) {
         client_info,
         None,  // tab_position_to_focus
         None,  // pane_id_to_focus
+        None,  // window_size
         false, // is_a_reconnect
         false, // should_create_detached
     );

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -155,7 +155,11 @@ use zellij_utils::{
     data::{ClientId, ConnectToSession, KeyWithModifier, LayoutInfo, LayoutMetadata},
     envs,
     errors::{ClientContext, ContextType, ErrorInstruction},
-    input::{cli_assets::CliAssets, config::Config, options::Options},
+    input::{
+        cli_assets::CliAssets,
+        config::Config,
+        options::{Options, WindowSize},
+    },
     ipc::{ClientToServerMsg, ExitReason, ResizeCause, ServerToClientMsg},
     nested_session,
     pane_size::Size,
@@ -912,6 +916,7 @@ pub fn start_client(
     info: ClientInfo,
     tab_position_to_focus: Option<usize>,
     pane_id_to_focus: Option<(u32, bool)>, // (pane_id, is_plugin)
+    window_size: Option<WindowSize>,       // per-attach window_size override (None => use config)
     is_a_reconnect: bool,
     start_detached_and_exit: bool,
 ) -> Option<ConnectToSession> {
@@ -1019,6 +1024,7 @@ pub fn start_client(
                         zellij_utils::ipc::PaneReference { pane_id, is_plugin }
                     }),
                     is_web_client,
+                    window_size,
                 },
                 ipc_pipe,
             )
@@ -1075,6 +1081,7 @@ pub fn start_client(
                 ClientToServerMsg::FirstClientConnected {
                     cli_assets,
                     is_web_client,
+                    window_size,
                 },
                 ipc_pipe,
             )
@@ -1131,6 +1138,7 @@ pub fn start_client(
                 ClientToServerMsg::FirstClientConnected {
                     cli_assets,
                     is_web_client,
+                    window_size,
                 },
                 ipc_pipe,
             )
@@ -1527,6 +1535,8 @@ pub fn start_server_detached(
     config.env.set_vars();
 
     let should_start_web_server = config_options.web_server.map(|w| w).unwrap_or(false);
+    // detached server start: no attaching client, so use the configured window_size
+    let window_size: Option<WindowSize> = None;
 
     let (first_msg, ipc_pipe) = match info {
         ClientInfo::Resurrect(name, path_to_layout, force_run_commands, cwd) => {
@@ -1568,6 +1578,7 @@ pub fn start_server_detached(
                 ClientToServerMsg::FirstClientConnected {
                     cli_assets,
                     is_web_client,
+                    window_size,
                 },
                 ipc_pipe,
             )
@@ -1624,6 +1635,7 @@ pub fn start_server_detached(
                 ClientToServerMsg::FirstClientConnected {
                     cli_assets,
                     is_web_client,
+                    window_size,
                 },
                 ipc_pipe,
             )

--- a/zellij-client/src/web_client/session_management.rs
+++ b/zellij-client/src/web_client/session_management.rs
@@ -107,6 +107,7 @@ pub fn create_first_message(
         ClientToServerMsg::FirstClientConnected {
             cli_assets,
             is_web_client,
+            window_size: None,
         }
     } else {
         let cli_assets = CliAssets {
@@ -129,6 +130,8 @@ pub fn create_first_message(
             tab_position_to_focus: None,
             pane_to_focus: None,
             is_web_client,
+            // mobile/web clients drive sizing through mobile mode; no per-attach override
+            window_size: None,
         }
     }
 }

--- a/zellij-integration-tests/src/runner.rs
+++ b/zellij-integration-tests/src/runner.rs
@@ -213,6 +213,7 @@ fn spawn_client_thread(
                 client_info,
                 tab_position_to_focus,
                 pane_id_to_focus,
+                None, // window_size
                 is_a_reconnect,
                 start_detached_and_exit,
             )

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -71,7 +71,7 @@ use zellij_utils::{
         config::{watch_config_file_changes, watch_layout_dir_changes, Config},
         keybinds::Keybinds,
         layout::{FloatingPaneLayout, Layout, PluginAlias, Run, RunPluginOrAlias},
-        options::Options,
+        options::{Options, WindowSize},
         plugins::PluginAliases,
     },
     ipc::{ClientAttributes, ExitReason, ServerToClientMsg},
@@ -85,7 +85,8 @@ pub type ClientId = u16;
 pub enum ServerInstruction {
     FirstClientConnected(
         CliAssets,
-        bool, // is_web_client
+        bool,               // is_web_client
+        Option<WindowSize>, // per-attach window_size override (None => use config)
         ClientId,
     ),
     Render(Option<HashMap<ClientId, String>>),
@@ -100,6 +101,7 @@ pub enum ServerInstruction {
         Option<usize>,       // tab position to focus
         Option<(u32, bool)>, // (pane_id, is_plugin) => pane_id to focus
         bool,                // is_web_client
+        Option<WindowSize>,  // per-attach window_size override (None => use config)
         ClientId,
     ),
     AttachWatcherClient(ClientId, Size, bool), // bool -> is_web_client
@@ -967,7 +969,12 @@ pub fn start_server_impl(
         let (instruction, mut err_ctx) = server_receiver.recv().unwrap();
         err_ctx.add_call(ContextType::IPCServer((&instruction).into()));
         match instruction {
-            ServerInstruction::FirstClientConnected(cli_assets, is_web_client, client_id) => {
+            ServerInstruction::FirstClientConnected(
+                cli_assets,
+                is_web_client,
+                window_size,
+                client_id,
+            ) => {
                 let (config, layout) = cli_assets.load_config_and_layout();
                 let layout_is_welcome_screen = cli_assets.layout
                     == Some(LayoutInfo::BuiltIn("welcome".to_owned()))
@@ -985,12 +992,16 @@ pub fn start_server_impl(
                 // false, we should never launch it.
                 let should_launch_setup_wizard = successfully_written_config;
 
-                let runtime_config_options = match &cli_assets.configuration_options {
+                let mut runtime_config_options = match &cli_assets.configuration_options {
                     Some(configuration_options) => {
                         config.options.merge(configuration_options.clone())
                     },
                     None => config.options.clone(),
                 };
+                // apply the creating client's `--window-size` (no AddClient carries it here)
+                if let Some(window_size) = window_size {
+                    runtime_config_options.window_size = Some(window_size);
+                }
 
                 let client_attributes = ClientAttributes {
                     size: cli_assets.terminal_window_size,
@@ -1165,6 +1176,7 @@ pub fn start_server_impl(
                 tab_position_to_focus,
                 pane_id_to_focus,
                 is_web_client,
+                window_size,
                 client_id,
             ) => {
                 let mut rlock = session_data.write().unwrap();
@@ -1223,6 +1235,7 @@ pub fn start_server_impl(
                         client_attributes.size,
                         tab_position_to_focus,
                         pane_id_to_focus,
+                        window_size,
                     ))
                     .unwrap();
                 session_data

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -2585,10 +2585,12 @@ pub(crate) fn route_thread_main(
                         ClientToServerMsg::FirstClientConnected {
                             cli_assets,
                             is_web_client,
+                            window_size,
                         } => {
                             let new_client_instruction = ServerInstruction::FirstClientConnected(
                                 cli_assets,
                                 is_web_client,
+                                window_size,
                                 client_id,
                             );
                             to_server
@@ -2600,6 +2602,7 @@ pub(crate) fn route_thread_main(
                             tab_position_to_focus,
                             pane_to_focus: pane_id_to_focus,
                             is_web_client,
+                            window_size,
                         } => {
                             let allow_web_connections = session_data
                                 .read()
@@ -2615,6 +2618,7 @@ pub(crate) fn route_thread_main(
                                     tab_position_to_focus,
                                     pane_id_to_focus.map(|p| (p.pane_id, p.is_plugin)),
                                     is_web_client,
+                                    window_size,
                                     client_id,
                                 );
                                 to_server

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -53,7 +53,7 @@ use zellij_utils::input::config::Config;
 use zellij_utils::input::keybinds::{shortcut_for_action, Keybinds};
 use zellij_utils::input::mouse::{MouseEvent, MouseEventType};
 use zellij_utils::input::options::{
-    Clipboard, MobileLayoutConfiguration, NestedSessionHandling, PaneFrameStyle,
+    Clipboard, MobileLayoutConfiguration, NestedSessionHandling, PaneFrameStyle, WindowSize,
 };
 use zellij_utils::ipc::{ExitReason, ServerToClientMsg};
 use zellij_utils::pane_size::{PaneGeom, Size, SizeInPixels};
@@ -590,6 +590,7 @@ pub enum ScreenInstruction {
         Size,                // client viewport size
         Option<usize>,       // tab position to focus
         Option<(u32, bool)>, // (pane_id, is_plugin) => pane_id to focus
+        Option<WindowSize>,  // per-attach window_size override (None => keep session's)
     ),
     RemoveClient(ClientId),
     SuppressRenderUntilMobile(ClientId),
@@ -1493,6 +1494,11 @@ pub(crate) struct Screen {
     /// The indices of this [`Screen`]'s active [`Tab`]s.
     active_tab_ids: BTreeMap<ClientId, usize>,
     client_sizes: HashMap<ClientId, Size>,
+    // tmux `window-size` parity; sticky for the session
+    window_size: WindowSize,
+    // drives tab sizing under `window_size` latest. Distinct from lib.rs's Key-only
+    // `last_active_client`: this tracks broader activity (attach/resize/mouse, not hover).
+    last_interacting_client: Option<ClientId>,
     global_last_active_tab_id: usize,
     tab_history: BTreeMap<ClientId, Vec<usize>>,
     pane_history: BTreeMap<ClientId, Vec<PaneId>>,
@@ -1671,6 +1677,8 @@ impl Screen {
             connected_clients: Rc::new(RefCell::new(HashMap::new())),
             active_tab_ids: BTreeMap::new(),
             client_sizes: HashMap::new(),
+            window_size: WindowSize::default(),
+            last_interacting_client: None,
             global_last_active_tab_id: 0,
             tabs: BTreeMap::new(),
             last_single_pane_tab_names: HashMap::new(),
@@ -2496,6 +2504,22 @@ impl Screen {
         self.client_sizes.insert(client_id, size);
     }
 
+    // Mark a client active; under `window_size` latest, refit its tab to its viewport.
+    // Cheap to call on every input event (no-op if already active).
+    pub fn mark_client_active(&mut self, client_id: ClientId) -> Result<()> {
+        if self.last_interacting_client == Some(client_id) {
+            return Ok(());
+        }
+        self.last_interacting_client = Some(client_id);
+        if self.window_size == WindowSize::Latest {
+            if let Some(tab_id) = self.active_tab_ids.get(&client_id).copied() {
+                self.recompute_tab_size(tab_id)?;
+            }
+        }
+        self.generate_and_report_tab_state()?; // refresh the active-client indicator
+        Ok(())
+    }
+
     pub fn recompute_tab_size(&mut self, tab_id: usize) -> Result<()> {
         let err_context = || format!("failed to recompute size for tab {tab_id}");
 
@@ -2519,6 +2543,27 @@ impl Screen {
             return Ok(());
         }
 
+        // Latest: size to the most-recently-active client viewing this tab; falls
+        // through to smallest/largest below if that client is gone.
+        if self.window_size == WindowSize::Latest {
+            if let Some(active) = self.last_interacting_client {
+                if self.active_tab_ids.get(&active) == Some(&tab_id) {
+                    if let Some(&new_size) = self.client_sizes.get(&active) {
+                        if let Some(tab) = self.tabs.get_mut(&tab_id) {
+                            if tab.size != new_size {
+                                tab.resize_whole_tab(new_size).with_context(err_context)?;
+                                // clear so a smaller client doesn't keep stale rows
+                                tab.set_should_clear_display_before_rendering();
+                                tab.set_force_render();
+                            }
+                        }
+                        return Ok(());
+                    }
+                }
+            }
+        }
+
+        // Smallest / Largest: min/max viewport per axis across clients on this tab.
         let mut rows: Vec<usize> = Vec::new();
         let mut cols: Vec<usize> = Vec::new();
         for (client_id, active_tab) in self.active_tab_ids.iter() {
@@ -2534,13 +2579,20 @@ impl Screen {
         }
         rows.sort_unstable();
         cols.sort_unstable();
+        let idx = if self.window_size == WindowSize::Largest {
+            rows.len() - 1
+        } else {
+            0
+        };
         let new_size = Size {
-            rows: rows[0],
-            cols: cols[0],
+            rows: rows[idx],
+            cols: cols[idx],
         };
         if let Some(tab) = self.tabs.get_mut(&tab_id) {
             if tab.size != new_size {
                 tab.resize_whole_tab(new_size).with_context(err_context)?;
+                // clear so a smaller client (under `largest`) doesn't keep stale rows
+                tab.set_should_clear_display_before_rendering();
                 tab.set_force_render();
             }
         }
@@ -4042,7 +4094,42 @@ impl Screen {
             }
 
             if non_watcher_output_was_dirty || has_bell {
-                let mut serialized_output = output.serialize().context(err_context)?;
+                // A client smaller than the grid garbles the shared render, so crop it
+                // through the watcher path; larger/equal clients keep the plain path.
+                let undersized: Vec<(ClientId, Size)> = {
+                    let connected = self.connected_clients.borrow();
+                    connected
+                        .keys()
+                        .filter(|id| !self.watcher_clients.contains_key(id))
+                        .filter_map(|id| {
+                            let client_size = *self.client_sizes.get(id)?;
+                            let tab_id = *self.active_tab_ids.get(id)?;
+                            let grid_size = self.tabs.get(&tab_id)?.size;
+                            let needs_crop = client_size.cols < grid_size.cols
+                                || client_size.rows < grid_size.rows;
+                            needs_crop.then_some((*id, grid_size))
+                        })
+                        .collect()
+                };
+                let mut serialized_output = if undersized.is_empty() {
+                    output.serialize().context(err_context)?
+                } else {
+                    // crop each undersized client from a clone, override the base render
+                    let mut overrides: HashMap<ClientId, String> = HashMap::new();
+                    for (client_id, grid_size) in &undersized {
+                        let client_size = self.client_sizes.get(client_id).copied();
+                        let mut per_client = output.clone();
+                        let mut sized = per_client
+                            .serialize_with_size(client_size, Some(*grid_size))
+                            .context(err_context)?;
+                        if let Some(rendered) = sized.remove(client_id) {
+                            overrides.insert(*client_id, rendered);
+                        }
+                    }
+                    let mut base = output.serialize().context(err_context)?;
+                    base.extend(overrides);
+                    base
+                };
                 self.mobile_render_gate
                     .blank_gated_clients(&mut serialized_output);
                 if !serialized_output.is_empty() {
@@ -4713,6 +4800,10 @@ impl Screen {
         self.connected_clients.borrow_mut().remove(&client_id);
         self.client_sizes.remove(&client_id);
         self.pane_render_subscribers.remove(&client_id);
+        // if the `latest` driver left, drop the stale pointer so recompute falls back
+        if self.last_interacting_client == Some(client_id) {
+            self.last_interacting_client = None;
+        }
         if let Some(prev_tab_id) = previously_active_tab_id {
             self.recompute_tab_size(prev_tab_id)
                 .with_context(err_context)?;
@@ -4809,6 +4900,7 @@ impl Screen {
                     && !self.active_tab_ids.values().any(|i| i == &tab.id),
                 is_flashing_bell: tab.tab_bell_flash
                     && !self.active_tab_ids.values().any(|i| i == &tab.id),
+                is_active_client: false,
             };
             tab_infos_for_screen_state.insert(tab.position, tab_info_for_screen);
         }
@@ -4866,6 +4958,8 @@ impl Screen {
                     tab_id: tab.id,
                     has_bell_notification: tab.tab_has_pending_bell && *active_tab_index != tab.id,
                     is_flashing_bell: tab.tab_bell_flash && *active_tab_index != tab.id,
+                    is_active_client: self.window_size == WindowSize::Latest
+                        && self.last_interacting_client == Some(*client_id),
                 };
                 plugin_tab_updates.push(tab_info_for_plugins);
             }
@@ -6917,6 +7011,7 @@ impl Screen {
                     && !self.active_tab_ids.values().any(|i| i == &tab.id),
                 is_flashing_bell: tab.tab_bell_flash
                     && !self.active_tab_ids.values().any(|i| i == &tab.id),
+                is_active_client: false,
             }
         })
     }
@@ -7435,6 +7530,7 @@ pub(crate) fn screen_thread_main(
     );
     screen.host_theme_dark_styling = host_theme_dark_styling;
     screen.host_theme_light_styling = host_theme_light_styling;
+    screen.window_size = config_options.window_size.unwrap_or_default();
 
     let mut pending_tab_ids: HashSet<usize> = HashSet::new();
     let mut pending_tab_switches: HashSet<(usize, ClientId)> = HashSet::new(); // usize is the
@@ -7796,6 +7892,8 @@ pub(crate) fn screen_thread_main(
                         continue;
                     }
                 }
+                // Typing makes this device the active one (for `window_size latest`).
+                screen.mark_client_active(client_id)?;
                 let mut state_changed = false;
                 let client_input_mode = screen.get_client_input_mode(client_id);
                 match client_input_mode {
@@ -9203,6 +9301,8 @@ pub(crate) fn screen_thread_main(
             },
             ScreenInstruction::RecomputeTabSize(client_id, new_size) => {
                 screen.set_client_size(client_id, new_size);
+                // A resizing client becomes the active one for `window_size latest`.
+                screen.last_interacting_client = Some(client_id);
                 let active_tab_id = screen.active_tab_ids.get(&client_id).copied();
                 if let Some(tab_id) = active_tab_id {
                     screen.recompute_tab_size(tab_id)?;
@@ -9320,6 +9420,19 @@ pub(crate) fn screen_thread_main(
                 _completion_tx, // the action ends here, dropping this will release anything
                                 // waiting for it
             ) => {
+                // Interaction marks the client active (`window_size` latest), but bare
+                // hover motion doesn't count -- otherwise sweeping the mouse across two
+                // differently-sized clients would refit on every motion event and tear.
+                // Click/drag/scroll begin with a Press, which still marks it active.
+                let is_bare_motion = event.event_type == MouseEventType::Motion
+                    && !event.left
+                    && !event.right
+                    && !event.middle
+                    && !event.wheel_up
+                    && !event.wheel_down;
+                if !is_bare_motion {
+                    screen.mark_client_active(client_id)?;
+                }
                 screen.handle_mouse_event(event, client_id);
             },
             ScreenInstruction::Copy(
@@ -9348,8 +9461,14 @@ pub(crate) fn screen_thread_main(
                 client_size,
                 tab_position_to_focus,
                 pane_id_to_focus,
+                window_size,
             ) => {
                 screen.set_client_size(client_id, client_size);
+                // set both before `add_client` (which recomputes tab sizes)
+                if let Some(window_size) = window_size {
+                    screen.window_size = window_size;
+                }
+                screen.last_interacting_client = Some(client_id);
                 screen.add_client(client_id, is_web_client)?;
                 let pane_id = pane_id_to_focus.map(|(pane_id, is_plugin)| {
                     if is_plugin {

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -18,7 +18,7 @@ use zellij_utils::input::layout::{
     RunPlugin, RunPluginLocation, RunPluginOrAlias, SplitDirection, TiledPaneLayout,
 };
 use zellij_utils::input::mouse::MouseEvent;
-use zellij_utils::input::options::{NestedSessionHandling, Options, PaneFrameStyle};
+use zellij_utils::input::options::{NestedSessionHandling, Options, PaneFrameStyle, WindowSize};
 use zellij_utils::ipc::IpcReceiverWithContext;
 use zellij_utils::pane_size::{Size, SizeInPixels};
 use zellij_utils::position::Position;
@@ -9874,6 +9874,201 @@ fn recompute_tab_size_takes_independent_min_across_axes() {
 }
 
 #[test]
+fn window_size_latest_sizes_to_active_client_not_min() {
+    let initial_size = Size {
+        cols: 200,
+        rows: 60,
+    };
+    let mut screen = create_new_screen(initial_size, true, true);
+    new_tab(&mut screen, 1, 0);
+    screen.add_client(2, false).expect("TEST");
+
+    // A large active client (1) and a small co-attached client (2), both on tab 0.
+    screen.set_client_size(
+        1,
+        Size {
+            cols: 200,
+            rows: 60,
+        },
+    );
+    screen.set_client_size(2, Size { cols: 80, rows: 24 });
+
+    screen.window_size = WindowSize::Latest;
+    screen.last_interacting_client = Some(1);
+    screen.recompute_tab_size(0).expect("TEST");
+
+    assert_eq!(
+        screen.tabs.get(&0).unwrap().size,
+        Size {
+            cols: 200,
+            rows: 60,
+        },
+        "window_size latest sizes the tab to the active client, not the smaller co-attached one"
+    );
+}
+
+#[test]
+fn window_size_latest_follows_active_client_on_switch() {
+    let initial_size = Size {
+        cols: 200,
+        rows: 60,
+    };
+    let mut screen = create_new_screen(initial_size, true, true);
+    new_tab(&mut screen, 1, 0);
+    screen.add_client(2, false).expect("TEST");
+    screen.set_client_size(
+        1,
+        Size {
+            cols: 200,
+            rows: 60,
+        },
+    );
+    screen.set_client_size(
+        2,
+        Size {
+            cols: 100,
+            rows: 30,
+        },
+    );
+    screen.window_size = WindowSize::Latest;
+
+    screen.last_interacting_client = Some(1);
+    screen.recompute_tab_size(0).expect("TEST");
+    assert_eq!(
+        screen.tabs.get(&0).unwrap().size,
+        Size {
+            cols: 200,
+            rows: 60,
+        },
+        "tab fits client 1 while it is the active client"
+    );
+
+    screen.last_interacting_client = Some(2);
+    screen.recompute_tab_size(0).expect("TEST");
+    assert_eq!(
+        screen.tabs.get(&0).unwrap().size,
+        Size {
+            cols: 100,
+            rows: 30,
+        },
+        "tab refits to client 2 once it becomes the active client (the switch case)"
+    );
+}
+
+#[test]
+fn window_size_latest_falls_back_to_min_without_active_client() {
+    let initial_size = Size {
+        cols: 200,
+        rows: 60,
+    };
+    let mut screen = create_new_screen(initial_size, true, true);
+    new_tab(&mut screen, 1, 0);
+    screen.add_client(2, false).expect("TEST");
+    screen.set_client_size(
+        1,
+        Size {
+            cols: 200,
+            rows: 24,
+        },
+    );
+    screen.set_client_size(2, Size { cols: 80, rows: 60 });
+
+    // `latest` set, but no active client (e.g. the active client just detached):
+    // sizing must fall back to the default smallest-client clamp.
+    screen.window_size = WindowSize::Latest;
+    screen.last_interacting_client = None;
+    screen.recompute_tab_size(0).expect("TEST");
+
+    assert_eq!(
+        screen.tabs.get(&0).unwrap().size,
+        Size { cols: 80, rows: 24 },
+        "with no active client, `latest` falls back to the per-axis min clamp"
+    );
+}
+
+#[test]
+fn window_size_latest_switches_to_client_that_interacts() {
+    let initial_size = Size {
+        cols: 200,
+        rows: 60,
+    };
+    let mut screen = create_new_screen(initial_size, true, true);
+    new_tab(&mut screen, 1, 0);
+    screen.add_client(2, false).expect("TEST");
+    screen.set_client_size(
+        1,
+        Size {
+            cols: 200,
+            rows: 60,
+        },
+    );
+    screen.set_client_size(
+        2,
+        Size {
+            cols: 100,
+            rows: 30,
+        },
+    );
+    screen.window_size = WindowSize::Latest;
+
+    screen.last_interacting_client = Some(1);
+    screen.recompute_tab_size(0).expect("TEST");
+    assert_eq!(
+        screen.tabs.get(&0).unwrap().size,
+        Size {
+            cols: 200,
+            rows: 60,
+        },
+        "tab fits client 1 while it is active"
+    );
+
+    // client 2 interacts (e.g. types) without resizing or re-attaching:
+    // it should become active and the tab should refit to it immediately.
+    screen.mark_client_active(2).expect("TEST");
+    assert_eq!(
+        screen.tabs.get(&0).unwrap().size,
+        Size {
+            cols: 100,
+            rows: 30,
+        },
+        "interacting with client 2 refits the tab to its viewport"
+    );
+}
+
+#[test]
+fn window_size_largest_sizes_to_per_axis_max() {
+    let initial_size = Size {
+        cols: 200,
+        rows: 60,
+    };
+    let mut screen = create_new_screen(initial_size, true, true);
+    new_tab(&mut screen, 1, 0);
+    screen.add_client(2, false).expect("TEST");
+    // Max cols and max rows come from different clients, so the result must be
+    // the per-axis maximum rather than any single client's viewport.
+    screen.set_client_size(
+        1,
+        Size {
+            cols: 200,
+            rows: 24,
+        },
+    );
+    screen.set_client_size(2, Size { cols: 80, rows: 60 });
+
+    screen.window_size = WindowSize::Largest;
+    screen.recompute_tab_size(0).expect("TEST");
+
+    assert_eq!(
+        screen.tabs.get(&0).unwrap().size,
+        Size {
+            cols: 200,
+            rows: 60,
+        },
+        "largest sizes the tab to the per-axis max across all viewers"
+    );
+}
+
+#[test]
 fn recompute_tab_size_isolates_tabs_with_different_viewers() {
     let initial_size = Size {
         cols: 200,
@@ -10809,6 +11004,7 @@ pub fn render_report_writes_per_client_plugin_pane_contents_in_fallback() {
         size,
         None,
         None,
+        None, // window_size
     ));
     std::thread::sleep(std::time::Duration::from_millis(50));
 

--- a/zellij-utils/assets/prost/api.event.rs
+++ b/zellij-utils/assets/prost/api.event.rs
@@ -668,6 +668,8 @@ pub struct TabInfo {
     pub has_bell_notification: bool,
     #[prost(bool, tag="19")]
     pub is_flashing_bell: bool,
+    #[prost(bool, tag="20")]
+    pub is_active_client: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/zellij-utils/assets/prost_ipc/client_server_contract.rs
+++ b/zellij-utils/assets/prost_ipc/client_server_contract.rs
@@ -2036,6 +2036,8 @@ pub struct Options {
     pub nested_session_handling: ::core::option::Option<i32>,
     #[prost(bool, optional, tag="54")]
     pub mouse_scroll_resize: ::core::option::Option<bool>,
+    #[prost(string, optional, tag="55")]
+    pub window_size: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// Pane-targeting action messages
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3138,6 +3140,8 @@ pub struct FirstClientConnectedMsg {
     pub cli_assets: ::core::option::Option<CliAssets>,
     #[prost(bool, tag="2")]
     pub is_web_client: bool,
+    #[prost(string, optional, tag="3")]
+    pub window_size: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -3150,6 +3154,8 @@ pub struct AttachClientMsg {
     pub pane_to_focus: ::core::option::Option<PaneReference>,
     #[prost(bool, tag="4")]
     pub is_web_client: bool,
+    #[prost(string, optional, tag="5")]
+    pub window_size: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -4,7 +4,7 @@ use crate::{
     consts::{ZELLIJ_CONFIG_DIR_ENV, ZELLIJ_CONFIG_FILE_ENV},
     input::{
         layout::PluginUserConfiguration,
-        options::{Options, PaneFrameStyle},
+        options::{Options, PaneFrameStyle, WindowSize},
     },
 };
 use clap::builder::styling::{AnsiColor, Color, Style, Styles};
@@ -363,6 +363,10 @@ pub enum Sessions {
         /// Skip TLS certificate validation (DANGEROUS — development only)
         #[clap(long, value_parser)]
         insecure: bool,
+
+        /// Override the configured window_size for this attach (smallest/largest/latest)
+        #[clap(long, value_enum, value_parser)]
+        window_size: Option<WindowSize>,
     },
 
     /// Watch a session (read-only)

--- a/zellij-utils/src/client_server_contract/client_to_server.proto
+++ b/zellij-utils/src/client_server_contract/client_to_server.proto
@@ -64,6 +64,7 @@ enum ResizeCause {
 message FirstClientConnectedMsg {
   CliAssets cli_assets = 1;
   bool is_web_client = 2;
+  optional string window_size = 3;
 }
 
 message AttachClientMsg {
@@ -71,6 +72,7 @@ message AttachClientMsg {
   optional uint32 tab_position_to_focus = 2;
   optional PaneReference pane_to_focus = 3;
   bool is_web_client = 4;
+  optional string window_size = 5;
 }
 
 message AttachWatcherClientMsg {

--- a/zellij-utils/src/client_server_contract/common_types.proto
+++ b/zellij-utils/src/client_server_contract/common_types.proto
@@ -1211,6 +1211,7 @@ message Options {
   optional bool stacked_pane_list = 52;
   optional NestedSessionHandling nested_session_handling = 53;
   optional bool mouse_scroll_resize = 54;
+  optional string window_size = 55;
 }
 
 enum OnForceClose {

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -2269,6 +2269,9 @@ pub struct TabInfo {
     pub is_sync_panes_active: bool,
     pub are_floating_panes_visible: bool,
     pub other_focused_clients: Vec<ClientId>,
+    /// Whether this client is the session's active (most-recently-interacted) one,
+    /// i.e. the one driving `window-size latest`. Used for the tab-bar indicator.
+    pub is_active_client: bool,
     pub active_swap_layout_name: Option<String>,
     /// Whether the user manually changed the layout, moving out of the swap layout scheme
     pub is_swap_layout_dirty: bool,

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -106,6 +106,50 @@ impl FromStr for NestedSessionHandling {
     }
 }
 
+/// How the session is sized when multiple clients are attached. Mirrors tmux's
+/// `window-size` option.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize, Serialize, ValueEnum)]
+pub enum WindowSize {
+    /// Clamp to the smallest attached client (the default).
+    #[serde(alias = "smallest")]
+    Smallest,
+    /// Size to the largest attached client; smaller clients see only part of it.
+    #[serde(alias = "largest")]
+    Largest,
+    /// Size to the most-recently-active client (tmux `latest`).
+    #[serde(alias = "latest")]
+    Latest,
+}
+
+impl Default for WindowSize {
+    fn default() -> Self {
+        Self::Smallest
+    }
+}
+
+impl std::fmt::Display for WindowSize {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            WindowSize::Smallest => "smallest",
+            WindowSize::Largest => "largest",
+            WindowSize::Latest => "latest",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+impl FromStr for WindowSize {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Smallest" | "smallest" => Ok(Self::Smallest),
+            "Largest" | "largest" => Ok(Self::Largest),
+            "Latest" | "latest" => Ok(Self::Latest),
+            _ => Err(format!("No such window_size: {}", s)),
+        }
+    }
+}
+
 impl Default for OnForceClose {
     fn default() -> Self {
         Self::Detach
@@ -376,6 +420,12 @@ pub struct Options {
     #[serde(default)]
     pub show_release_notes: Option<bool>,
 
+    /// How to size the session with multiple clients (tmux `window-size`). Also
+    /// settable per-attach with `--window-size`.
+    #[clap(long, value_enum, value_parser)]
+    #[serde(default)]
+    pub window_size: Option<WindowSize>,
+
     /// Whether to enable mouse hover effects and pane grouping functionality
     /// default is true
     #[clap(long, value_parser)]
@@ -540,6 +590,7 @@ impl Options {
         let stacked_pane_list = other.stacked_pane_list.or(self.stacked_pane_list);
         let show_startup_tips = other.show_startup_tips.or(self.show_startup_tips);
         let show_release_notes = other.show_release_notes.or(self.show_release_notes);
+        let window_size = other.window_size.or(self.window_size);
         let advanced_mouse_actions = other.advanced_mouse_actions.or(self.advanced_mouse_actions);
         let mouse_scroll_resize = other.mouse_scroll_resize.or(self.mouse_scroll_resize);
         let mouse_hover_effects = other.mouse_hover_effects.or(self.mouse_hover_effects);
@@ -606,6 +657,7 @@ impl Options {
             stacked_pane_list,
             show_startup_tips,
             show_release_notes,
+            window_size,
             advanced_mouse_actions,
             mouse_scroll_resize,
             mouse_hover_effects,
@@ -691,6 +743,7 @@ impl Options {
         let stacked_pane_list = other.stacked_pane_list.or(self.stacked_pane_list);
         let show_startup_tips = other.show_startup_tips.or(self.show_startup_tips);
         let show_release_notes = other.show_release_notes.or(self.show_release_notes);
+        let window_size = other.window_size.or(self.window_size);
         let advanced_mouse_actions = other.advanced_mouse_actions.or(self.advanced_mouse_actions);
         let mouse_scroll_resize = other.mouse_scroll_resize.or(self.mouse_scroll_resize);
         let mouse_hover_effects = other.mouse_hover_effects.or(self.mouse_hover_effects);
@@ -757,6 +810,7 @@ impl Options {
             stacked_pane_list,
             show_startup_tips,
             show_release_notes,
+            window_size,
             advanced_mouse_actions,
             mouse_scroll_resize,
             mouse_hover_effects,

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -2,7 +2,7 @@
 use crate::{
     data::{ClientId, ConnectToSession, HostTerminalThemeMode, KeyWithModifier, PaneId, Style},
     errors::{prelude::*, ErrorContext},
-    input::{actions::Action, cli_assets::CliAssets},
+    input::{actions::Action, cli_assets::CliAssets, options::WindowSize},
     pane_size::{Size, SizeInPixels},
 };
 use interprocess::local_socket::Stream as LocalSocketStream;
@@ -127,12 +127,18 @@ pub enum ClientToServerMsg {
     FirstClientConnected {
         cli_assets: CliAssets,
         is_web_client: bool,
+        // per-attach window_size override for the session-creating client
+        // (None => use the configured window_size)
+        window_size: Option<WindowSize>,
     },
     AttachClient {
         cli_assets: CliAssets,
         tab_position_to_focus: Option<usize>,
         pane_to_focus: Option<PaneReference>,
         is_web_client: bool,
+        // per-attach override for how the session is sized (smallest/largest/latest);
+        // None falls back to the configured window_size
+        window_size: Option<WindowSize>,
     },
     AttachWatcherClient {
         terminal_size: Size,

--- a/zellij-utils/src/ipc/protobuf_conversion.rs
+++ b/zellij-utils/src/ipc/protobuf_conversion.rs
@@ -64,20 +64,24 @@ impl From<ClientToServerMsg> for ProtoClientToServerMsg {
             ClientToServerMsg::FirstClientConnected {
                 cli_assets,
                 is_web_client,
+                window_size,
             } => client_to_server_msg::Message::FirstClientConnected(FirstClientConnectedMsg {
                 cli_assets: Some(cli_assets.into()),
                 is_web_client,
+                window_size: window_size.map(|w| w.to_string()),
             }),
             ClientToServerMsg::AttachClient {
                 cli_assets,
                 tab_position_to_focus,
                 pane_to_focus,
                 is_web_client,
+                window_size,
             } => client_to_server_msg::Message::AttachClient(AttachClientMsg {
                 cli_assets: Some(cli_assets.into()),
                 tab_position_to_focus: tab_position_to_focus.map(|pos| pos as u32),
                 pane_to_focus: pane_to_focus.map(|p| p.into()),
                 is_web_client,
+                window_size: window_size.map(|w| w.to_string()),
             }),
             ClientToServerMsg::AttachWatcherClient {
                 terminal_size,
@@ -226,6 +230,9 @@ impl TryFrom<ProtoClientToServerMsg> for ClientToServerMsg {
                         .ok_or_else(|| anyhow!("Missing cli_assets"))?
                         .try_into()?,
                     is_web_client: first_client.is_web_client,
+                    window_size: first_client
+                        .window_size
+                        .and_then(|s| s.parse::<crate::input::options::WindowSize>().ok()),
                 })
             },
             Some(client_to_server_msg::Message::AttachClient(attach)) => {
@@ -237,6 +244,9 @@ impl TryFrom<ProtoClientToServerMsg> for ClientToServerMsg {
                     tab_position_to_focus: attach.tab_position_to_focus.map(|pos| pos as usize),
                     pane_to_focus: attach.pane_to_focus.map(|p| p.try_into()).transpose()?,
                     is_web_client: attach.is_web_client,
+                    window_size: attach
+                        .window_size
+                        .and_then(|s| s.parse::<crate::input::options::WindowSize>().ok()),
                 })
             },
             Some(client_to_server_msg::Message::AttachWatcherClient(attach_watcher)) => {
@@ -762,6 +772,7 @@ impl From<crate::input::options::Options>
             stacked_pane_list: options.stacked_pane_list,
             show_startup_tips: options.show_startup_tips,
             show_release_notes: options.show_release_notes,
+            window_size: options.window_size.map(|w| w.to_string()),
             advanced_mouse_actions: options.advanced_mouse_actions,
             mouse_scroll_resize: options.mouse_scroll_resize,
             mouse_hover_effects: options.mouse_hover_effects,
@@ -896,6 +907,9 @@ impl TryFrom<crate::client_server_contract::client_server_contract::Options>
             stacked_pane_list: options.stacked_pane_list,
             show_startup_tips: options.show_startup_tips,
             show_release_notes: options.show_release_notes,
+            window_size: options
+                .window_size
+                .and_then(|s| s.parse::<crate::input::options::WindowSize>().ok()),
             advanced_mouse_actions: options.advanced_mouse_actions,
             mouse_scroll_resize: options.mouse_scroll_resize,
             mouse_hover_effects: options.mouse_hover_effects,

--- a/zellij-utils/src/ipc/tests/roundtrip_tests.rs
+++ b/zellij-utils/src/ipc/tests/roundtrip_tests.rs
@@ -15,7 +15,7 @@ use crate::input::layout::{
 use crate::input::mouse::{MouseEvent, MouseEventType};
 use crate::input::options::{
     Clipboard, MobileLayoutConfiguration, NestedSessionHandling, OnForceClose, Options,
-    PaneFrameStyle,
+    PaneFrameStyle, WindowSize,
 };
 use crate::ipc::{
     ClientToServerMsg, ColorRegister, ExitReason, PaneReference, PixelDimensions, ResizeCause,
@@ -401,10 +401,17 @@ fn test_client_messages() {
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets::default(),
         is_web_client: false,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets::default(),
         is_web_client: true,
+        window_size: None,
+    });
+    test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
+        cli_assets: CliAssets::default(),
+        is_web_client: false,
+        window_size: Some(WindowSize::Smallest),
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -421,6 +428,7 @@ fn test_client_messages() {
             cwd: Some(PathBuf::from("/path/to/cwd")),
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -437,6 +445,7 @@ fn test_client_messages() {
             cwd: Some(PathBuf::from("/path/to/cwd")),
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -481,6 +490,7 @@ fn test_client_messages() {
                 stacked_pane_list: Some(true),
                 show_startup_tips: Some(true),
                 show_release_notes: Some(true),
+                window_size: Some(WindowSize::Latest),
                 advanced_mouse_actions: Some(true),
                 mouse_scroll_resize: Some(true),
                 web_server_ip: Some("1.1.1.1".parse().unwrap()),
@@ -508,6 +518,7 @@ fn test_client_messages() {
             cwd: Some(PathBuf::from("/path/to/cwd")),
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -518,6 +529,7 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -528,6 +540,7 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -538,6 +551,7 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -548,6 +562,7 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -558,6 +573,7 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -568,6 +584,7 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -578,6 +595,7 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -588,6 +606,7 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -598,6 +617,7 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -608,6 +628,7 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -618,6 +639,7 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -628,6 +650,7 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -638,6 +661,7 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -648,6 +672,7 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -658,6 +683,7 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -668,6 +694,7 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -678,6 +705,7 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -688,6 +716,7 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -698,6 +727,7 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -708,6 +738,7 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -718,6 +749,7 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::FirstClientConnected {
         cli_assets: CliAssets {
@@ -728,18 +760,21 @@ fn test_client_messages() {
             ..Default::default()
         },
         is_web_client: true,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::AttachClient {
         cli_assets: CliAssets::default(),
         tab_position_to_focus: None,
         pane_to_focus: None,
         is_web_client: false,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::AttachClient {
         cli_assets: CliAssets::default(),
         tab_position_to_focus: Some(0),
         pane_to_focus: None,
         is_web_client: false,
+        window_size: Some(WindowSize::Latest),
     });
     test_client_roundtrip!(ClientToServerMsg::AttachClient {
         cli_assets: CliAssets::default(),
@@ -749,6 +784,7 @@ fn test_client_messages() {
             is_plugin: false,
         }),
         is_web_client: false,
+        window_size: None,
     });
     test_client_roundtrip!(ClientToServerMsg::AttachClient {
         cli_assets: CliAssets::default(),
@@ -758,6 +794,7 @@ fn test_client_messages() {
             is_plugin: true,
         }),
         is_web_client: true,
+        window_size: Some(WindowSize::Latest),
     });
     test_client_roundtrip!(ClientToServerMsg::AttachClient {
         cli_assets: CliAssets {
@@ -770,6 +807,7 @@ fn test_client_messages() {
         tab_position_to_focus: None,
         pane_to_focus: None,
         is_web_client: false,
+        window_size: None,
     });
     // TODO: Action
     test_client_roundtrip!(ClientToServerMsg::Action {

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -2856,6 +2856,17 @@ impl Options {
         let show_release_notes =
             kdl_property_first_arg_as_bool_or_error!(kdl_options, "show_release_notes")
                 .map(|(v, _)| v);
+        let window_size =
+            match kdl_property_first_arg_as_string_or_error!(kdl_options, "window_size") {
+                Some((value, entry)) => {
+                    use crate::input::options::WindowSize;
+                    match value.parse::<WindowSize>() {
+                        Ok(v) => Some(v),
+                        Err(e) => return Err(kdl_parsing_error!(e, entry)),
+                    }
+                },
+                None => None,
+            };
         let advanced_mouse_actions =
             kdl_property_first_arg_as_bool_or_error!(kdl_options, "advanced_mouse_actions")
                 .map(|(v, _)| v);
@@ -2998,6 +3009,7 @@ impl Options {
             stacked_pane_list,
             show_startup_tips,
             show_release_notes,
+            window_size,
             advanced_mouse_actions,
             mouse_scroll_resize,
             mouse_hover_effects,
@@ -3494,6 +3506,20 @@ impl Options {
         } else {
             None
         }
+    }
+    fn window_size_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
+        // Only serialize an explicitly-set value, so it survives a config rewrite;
+        // leave the default (None) implicit to keep the generated config minimal.
+        let window_size = self.window_size.as_ref()?;
+        let mut node = KdlNode::new("window_size");
+        node.push(window_size.to_string());
+        if add_comments {
+            node.set_leading(
+                "\n// How the session is sized with multiple clients\n// (smallest, largest, latest)\n"
+                    .to_string(),
+            );
+        }
+        Some(node)
     }
     fn scroll_buffer_size_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
         let comment_text = format!(
@@ -4652,6 +4678,9 @@ impl Options {
         }
         if let Some(on_force_close) = self.on_force_close_to_kdl(add_comments) {
             nodes.push(on_force_close);
+        }
+        if let Some(window_size) = self.window_size_to_kdl(add_comments) {
+            nodes.push(window_size);
         }
         if let Some(scroll_buffer_size) = self.scroll_buffer_size_to_kdl(add_comments) {
             nodes.push(scroll_buffer_size);
@@ -6251,6 +6280,7 @@ impl TabInfo {
             tab_id,
             has_bell_notification: false,
             is_flashing_bell: false,
+            is_active_client: false,
         })
     }
     pub fn encode_to_kdl(&self) -> KdlDocument {
@@ -6690,6 +6720,7 @@ fn serialize_and_deserialize_session_info_with_data() {
                 tab_id: 0,
                 is_flashing_bell: false,
                 has_bell_notification: false,
+                is_active_client: false,
             },
             TabInfo {
                 position: 1,
@@ -6711,6 +6742,7 @@ fn serialize_and_deserialize_session_info_with_data() {
                 tab_id: 1,
                 is_flashing_bell: false,
                 has_bell_notification: false,
+                is_active_client: false,
             },
         ],
         panes: PaneManifest { panes },

--- a/zellij-utils/src/plugin_api/event.proto
+++ b/zellij-utils/src/plugin_api/event.proto
@@ -492,6 +492,7 @@ message TabInfo {
     uint32 tab_id = 17;
     bool has_bell_notification = 18;
     bool is_flashing_bell = 19;
+    bool is_active_client = 20;
 }
 
 message ModeUpdatePayload {

--- a/zellij-utils/src/plugin_api/event.rs
+++ b/zellij-utils/src/plugin_api/event.rs
@@ -1912,6 +1912,7 @@ impl TryFrom<ProtobufTabInfo> for TabInfo {
             tab_id: protobuf_tab_info.tab_id as usize,
             has_bell_notification: protobuf_tab_info.has_bell_notification,
             is_flashing_bell: protobuf_tab_info.is_flashing_bell,
+            is_active_client: protobuf_tab_info.is_active_client,
         })
     }
 }
@@ -1943,6 +1944,7 @@ impl TryFrom<TabInfo> for ProtobufTabInfo {
             tab_id: tab_info.tab_id as u32,
             has_bell_notification: tab_info.has_bell_notification,
             is_flashing_bell: tab_info.is_flashing_bell,
+            is_active_client: tab_info.is_active_client,
         })
     }
 }
@@ -2569,6 +2571,7 @@ fn serialize_tab_update_event_with_non_default_values() {
             tab_id: 0,
             has_bell_notification: false,
             is_flashing_bell: false,
+            is_active_client: false,
         },
         TabInfo {
             position: 1,
@@ -2590,6 +2593,7 @@ fn serialize_tab_update_event_with_non_default_values() {
             tab_id: 1,
             has_bell_notification: false,
             is_flashing_bell: false,
+            is_active_client: false,
         },
         TabInfo::default(),
     ]);
@@ -2915,6 +2919,7 @@ fn serialize_session_update_event_with_non_default_values() {
             tab_id: 0,
             has_bell_notification: false,
             is_flashing_bell: false,
+            is_active_client: false,
         },
         TabInfo {
             position: 1,
@@ -2936,6 +2941,7 @@ fn serialize_session_update_event_with_non_default_values() {
             tab_id: 1,
             has_bell_notification: false,
             is_flashing_bell: false,
+            is_active_client: false,
         },
         TabInfo::default(),
     ];

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
@@ -42,6 +42,7 @@ Options {
     stacked_pane_list: None,
     show_startup_tips: None,
     show_release_notes: None,
+    window_size: None,
     advanced_mouse_actions: None,
     mouse_scroll_resize: None,
     mouse_hover_effects: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
@@ -42,6 +42,7 @@ Options {
     stacked_pane_list: None,
     show_startup_tips: None,
     show_release_notes: None,
+    window_size: None,
     advanced_mouse_actions: None,
     mouse_scroll_resize: None,
     mouse_hover_effects: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
@@ -40,6 +40,7 @@ Options {
     stacked_pane_list: None,
     show_startup_tips: None,
     show_release_notes: None,
+    window_size: None,
     advanced_mouse_actions: None,
     mouse_scroll_resize: None,
     mouse_hover_effects: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
@@ -6065,6 +6065,7 @@ Config {
         stacked_pane_list: None,
         show_startup_tips: None,
         show_release_notes: None,
+        window_size: None,
         advanced_mouse_actions: None,
         mouse_scroll_resize: None,
         mouse_hover_effects: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
@@ -6065,6 +6065,7 @@ Config {
         stacked_pane_list: None,
         show_startup_tips: None,
         show_release_notes: None,
+        window_size: None,
         advanced_mouse_actions: None,
         mouse_scroll_resize: None,
         mouse_hover_effects: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
@@ -127,6 +127,7 @@ Config {
         stacked_pane_list: None,
         show_startup_tips: None,
         show_release_notes: None,
+        window_size: None,
         advanced_mouse_actions: None,
         mouse_scroll_resize: None,
         mouse_hover_effects: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
@@ -42,6 +42,7 @@ Options {
     stacked_pane_list: None,
     show_startup_tips: None,
     show_release_notes: None,
+    window_size: None,
     advanced_mouse_actions: None,
     mouse_scroll_resize: None,
     mouse_hover_effects: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
@@ -6065,6 +6065,7 @@ Config {
         stacked_pane_list: None,
         show_startup_tips: None,
         show_release_notes: None,
+        window_size: None,
         advanced_mouse_actions: None,
         mouse_scroll_resize: None,
         mouse_hover_effects: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
@@ -6065,6 +6065,7 @@ Config {
         stacked_pane_list: None,
         show_startup_tips: None,
         show_release_notes: None,
+        window_size: None,
         advanced_mouse_actions: None,
         mouse_scroll_resize: None,
         mouse_hover_effects: None,


### PR DESCRIPTION
This adds a `window_size` option that controls how a session is sized when more than one client is attached, mirroring tmux's `window-size`. Right now Zellij always clamps the session to the smallest attached client so everyone can see the whole grid — this makes that configurable. Tracks #3816, and covers the request in #4253 for the session to follow the last-connected client the way tmux does.

I wanted this so I can drive a session from whichever device I'm on: with `latest`, interacting with a client resizes the session to it on the fly. In practice that lets me scale a full-screen TUI (Claude Code, in my case) down to fit a smaller window, or widen the session so long lines aren't wrapped and I can copy them in one piece.

<img width="900" height="975" alt="Before, on stock Zellij: the session is clamped to the smaller client at 48 columns, so a long command wraps and copying it picks up newlines that break the paste. After, with window_size latest: interacting with the wide client grows the session to 95 columns, the command sits on one line, and it copy-pastes whole." src="https://github.com/user-attachments/assets/bf625704-fe81-4942-a553-7d79898eaac6" />

There are three modes, mirroring tmux's `window-size`:

- `smallest` (the default) — clamp to the smallest client, i.e. the current behaviour.
- `largest` — size to the largest attached client.
- `latest` — size to whichever client interacted last (tmux's `latest`), so the session follows the device you're actively using.

You can set it in the config (`window_size "latest"`) or per-attach, which overrides the config (`zellij attach --window-size latest <session>`). It defaults to `smallest`, so nothing changes unless you opt in.

For `latest`, a client is marked active on real interaction (keypress, mouse click/drag) rather than on bare hover — refitting on hover was causing repaint flicker with two clients attached — and the session then refits to that client. The override is also honoured on the session-creating client, not just on later attaches.

To go with this, the active client's focused tab name is tinted with the theme accent, so on a shared or mirrored session you can see at a glance which device is currently driving the size. It's surfaced to the tab-bar plugin through a new `TabInfo.is_active_client` field, refreshes on takeover, and works with pane frames off.

Rendering when clients differ in size: since the grid is one size, a client smaller than the grid (under `largest`, or `latest` when a larger client is active) can't show the whole thing. Rather than broadcast the raw grid to it, size-mismatched clients go through the existing `serialize_with_size` crop/pad path — the same one watcher clients use — so an undersized client gets a clean top-left crop and an oversized one gets clean padding; clients that match the grid keep the fast `serialize()` path. The one caveat is that the crop is top-left only: there's no viewport pan today, so an undersized non-active client can't scroll to the rest of the grid. `smallest` and `latest` don't hit this in practice, since the active client always matches the grid.

Discussed on Discord before opening (I'm `dgigz` there) — this is the follow-up to that thread.

