### PR TITLE
fix(layouts): reject negative swap pane constraints

### DIFF
--- a/zellij-utils/src/input/unit/layout_test.rs
+++ b/zellij-utils/src/input/unit/layout_test.rs
@@ -1952,6 +1952,26 @@ fn can_load_swap_layouts_from_a_different_file() {
 }
 
 #[test]
+fn negative_swap_layout_pane_constraints_are_rejected() {
+    for constraint in ["max_panes", "min_panes", "exact_panes"] {
+        let kdl_layout = format!(
+            r#"
+                layout {{
+                    swap_tiled_layout {{
+                        tab {constraint}=-1 {{
+                            pane
+                        }}
+                    }}
+                }}
+            "#
+        );
+        assert!(
+            Layout::from_kdl(&kdl_layout, Some("layout_file_name".into()), None, None).is_err()
+        );
+    }
+}
+
+#[test]
 fn can_define_stacked_children_for_pane_node() {
     let kdl_layout = r#"
         layout {

--- a/zellij-utils/src/kdl/kdl_layout_parser.rs
+++ b/zellij-utils/src/kdl/kdl_layout_parser.rs
@@ -2032,14 +2032,32 @@ impl<'a> KdlLayoutParser<'a> {
         let mut constraint_count = 0;
         let mut constraint = None;
         if let Some(max_panes) = max_panes {
+            if max_panes < 0 {
+                return Err(kdl_parsing_error!(
+                    "max_panes should be a non-negative number".to_owned(),
+                    layout_node
+                ));
+            }
             constraint_count += 1;
             constraint = Some(LayoutConstraint::MaxPanes(max_panes as usize));
         }
         if let Some(min_panes) = min_panes {
+            if min_panes < 0 {
+                return Err(kdl_parsing_error!(
+                    "min_panes should be a non-negative number".to_owned(),
+                    layout_node
+                ));
+            }
             constraint_count += 1;
             constraint = Some(LayoutConstraint::MinPanes(min_panes as usize));
         }
         if let Some(exact_panes) = exact_panes {
+            if exact_panes < 0 {
+                return Err(kdl_parsing_error!(
+                    "exact_panes should be a non-negative number".to_owned(),
+                    layout_node
+                ));
+            }
             constraint_count += 1;
             constraint = Some(LayoutConstraint::ExactPanes(exact_panes as usize));
         }


### PR DESCRIPTION
## Summary

- Reject negative `max_panes`, `min_panes`, and `exact_panes` values in swap-layout KDL.
- Add regression coverage for every affected constraint.

Negative values were parsed as signed integers and then cast to `usize`. For example, `max_panes=-1` became `usize::MAX`, allowing a layout to match every pane count.

## Testing

- `cargo test -p zellij-utils negative_swap_layout_pane_constraints_are_rejected`
- `cargo test -p zellij-utils can_load_swap_layouts_from_a_different_file`
