### PR TITLE
fix(mouse): forward scroll modifier state to applications

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -3732,11 +3732,27 @@ impl Grid {
             },
         }
     }
-    pub fn mouse_scroll_up_signal(&self, position: &Position) -> Option<String> {
+    /// The modifier bits shared by the x10/utf8 and SGR mouse encodings.
+    fn mouse_modifiers_value(event: &MouseEvent) -> u8 {
+        let mut value = 0;
+        if event.shift {
+            value |= 0x04;
+        }
+        if event.alt {
+            value |= 0x08;
+        }
+        if event.ctrl {
+            value |= 0x10;
+        }
+        value
+    }
+    pub fn mouse_scroll_up_signal(&self, event: &MouseEvent) -> Option<String> {
+        let position = &event.position;
+        let modifiers = Self::mouse_modifiers_value(event);
         match (&self.mouse_mode, &self.mouse_tracking) {
             (_, MouseTracking::Off) => None,
             (MouseMode::NoEncoding | MouseMode::Utf8, _) => {
-                let mut msg: Vec<u8> = vec![27, b'[', b'M', b'`'];
+                let mut msg: Vec<u8> = vec![27, b'[', b'M', b'`' | modifiers];
                 msg.append(&mut utf8_mouse_coordinates(
                     position.column() + 1,
                     position.line() + 1,
@@ -3745,7 +3761,8 @@ impl Grid {
             },
             (MouseMode::Sgr, _) => {
                 let mouse_event = format!(
-                    "\u{1b}[<64;{:?};{:?}M",
+                    "\u{1b}[<{:?};{:?};{:?}M",
+                    64 | modifiers,
                     position.column.0 + 1,
                     position.line.0 + 1
                 );
@@ -3753,11 +3770,13 @@ impl Grid {
             },
         }
     }
-    pub fn mouse_scroll_down_signal(&self, position: &Position) -> Option<String> {
+    pub fn mouse_scroll_down_signal(&self, event: &MouseEvent) -> Option<String> {
+        let position = &event.position;
+        let modifiers = Self::mouse_modifiers_value(event);
         match (&self.mouse_mode, &self.mouse_tracking) {
             (_, MouseTracking::Off) => None,
             (MouseMode::NoEncoding | MouseMode::Utf8, _) => {
-                let mut msg: Vec<u8> = vec![27, b'[', b'M', b'a'];
+                let mut msg: Vec<u8> = vec![27, b'[', b'M', b'a' | modifiers];
                 msg.append(&mut utf8_mouse_coordinates(
                     position.column() + 1,
                     position.line() + 1,
@@ -3766,7 +3785,8 @@ impl Grid {
             },
             (MouseMode::Sgr, _) => {
                 let mouse_event = format!(
-                    "\u{1b}[<65;{:?};{:?}M",
+                    "\u{1b}[<{:?};{:?};{:?}M",
+                    65 | modifiers,
                     position.column.0 + 1,
                     position.line.0 + 1
                 );

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -990,11 +990,11 @@ impl Pane for TerminalPane {
     fn mouse_middle_click_release(&self, position: &Position) -> Option<String> {
         self.grid.mouse_middle_click_release_signal(position)
     }
-    fn mouse_scroll_up(&self, position: &Position) -> Option<String> {
-        self.grid.mouse_scroll_up_signal(position)
+    fn mouse_scroll_up(&self, event: &MouseEvent) -> Option<String> {
+        self.grid.mouse_scroll_up_signal(event)
     }
-    fn mouse_scroll_down(&self, position: &Position) -> Option<String> {
-        self.grid.mouse_scroll_down_signal(position)
+    fn mouse_scroll_down(&self, event: &MouseEvent) -> Option<String> {
+        self.grid.mouse_scroll_down_signal(event)
     }
     fn focus_event(&self) -> Option<String> {
         self.grid.focus_event()

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -10,6 +10,7 @@ use vte;
 use zellij_utils::consts::SCROLL_BUFFER_SIZE;
 use zellij_utils::{
     data::{Palette, Style},
+    input::mouse::MouseEvent,
     pane_size::SizeInPixels,
     position::Position,
 };
@@ -8301,5 +8302,69 @@ fn kitty_placement_rejoins_its_text_after_editing_while_scrolled_back() {
         kitty_image_absolute_cell_row(&grid),
         marker_row,
         "the image must rejoin its marker line once the viewport is restored"
+    );
+}
+
+fn grid_with_sgr_mouse_tracking() -> Grid {
+    let mut parser = vte::Parser::new();
+    let mut grid = Grid::new(
+        10,
+        20,
+        Rc::new(RefCell::new(Palette::default())),
+        Rc::new(RefCell::new(HashMap::new())),
+        Rc::new(RefCell::new(LinkHandler::new())),
+        Rc::new(RefCell::new(None)),
+        Rc::new(RefCell::new(SixelImageStore::default())),
+        Rc::new(RefCell::new(KittyImageStore::default())),
+        Style::default(),
+        false,
+        true,
+        true,
+        true,
+        false,
+    );
+    // button event tracking (1002) with SGR encoding (1006)
+    parser.advance(&mut grid, b"\x1b[?1002;1006h");
+    grid
+}
+
+#[test]
+fn scroll_signals_forward_modifier_state_to_the_application() {
+    // The modifier bits an application expects on a wheel event, per the SGR mouse
+    // encoding: shift 0x04, alt 0x08, ctrl 0x10, OR-ed onto the wheel button value
+    // (64 for wheel up, 65 for wheel down). These used to be dropped entirely, so an
+    // app running in a pane saw a bare scroll with no modifiers.
+    let grid = grid_with_sgr_mouse_tracking();
+    let position = Position::new(0, 0);
+
+    let mut shift_scroll_up = MouseEvent::new_scroll_up_event(position);
+    shift_scroll_up.shift = true;
+    assert_eq!(
+        grid.mouse_scroll_up_signal(&shift_scroll_up),
+        Some(String::from("\u{1b}[<68;1;1M"))
+    );
+
+    let mut alt_scroll_down = MouseEvent::new_scroll_down_event(position);
+    alt_scroll_down.alt = true;
+    assert_eq!(
+        grid.mouse_scroll_down_signal(&alt_scroll_down),
+        Some(String::from("\u{1b}[<73;1;1M"))
+    );
+}
+
+#[test]
+fn scroll_signals_are_unchanged_without_modifiers() {
+    // Guards the existing encoding: a plain wheel event must still report the bare
+    // button value, so adding the modifier bits doesn't shift every scroll sequence.
+    let grid = grid_with_sgr_mouse_tracking();
+    let position = Position::new(0, 0);
+
+    assert_eq!(
+        grid.mouse_scroll_up_signal(&MouseEvent::new_scroll_up_event(position)),
+        Some(String::from("\u{1b}[<64;1;1M"))
+    );
+    assert_eq!(
+        grid.mouse_scroll_down_signal(&MouseEvent::new_scroll_down_event(position)),
+        Some(String::from("\u{1b}[<65;1;1M"))
     );
 }

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -641,10 +641,10 @@ pub trait Pane {
     fn mouse_middle_click_release(&self, _position: &Position) -> Option<String> {
         None
     }
-    fn mouse_scroll_up(&self, _position: &Position) -> Option<String> {
+    fn mouse_scroll_up(&self, _event: &MouseEvent) -> Option<String> {
         None
     }
-    fn mouse_scroll_down(&self, _position: &Position) -> Option<String> {
+    fn mouse_scroll_down(&self, _event: &MouseEvent) -> Option<String> {
         None
     }
     fn focus_event(&self) -> Option<String> {
@@ -6093,7 +6093,7 @@ impl Tab {
         let synthetic_position = Position::new(0, 0);
         let (mouse_sgr, is_alt) = match self.get_pane_with_id(pane_id) {
             Some(pane) => (
-                pane.mouse_scroll_up(&synthetic_position),
+                pane.mouse_scroll_up(&MouseEvent::new_scroll_up_event(synthetic_position)),
                 pane.is_alternate_mode_active(),
             ),
             None => return Ok(()),
@@ -6132,7 +6132,7 @@ impl Tab {
         let synthetic_position = Position::new(0, 0);
         let (mouse_sgr, is_alt) = match self.get_pane_with_id(pane_id) {
             Some(pane) => (
-                pane.mouse_scroll_down(&synthetic_position),
+                pane.mouse_scroll_down(&MouseEvent::new_scroll_down_event(synthetic_position)),
                 pane.is_alternate_mode_active(),
             ),
             None => return Ok(()),
@@ -6306,7 +6306,12 @@ impl Tab {
         lines: usize,
         client_id: ClientId,
     ) -> Result<MouseEffect> {
-        MouseHandler::handle_scrollwheel_up(self, point, lines, client_id)
+        MouseHandler::handle_scrollwheel_up(
+            self,
+            &MouseEvent::new_scroll_up_event(*point),
+            lines,
+            client_id,
+        )
     }
 
     pub fn handle_scrollwheel_down(
@@ -6315,7 +6320,12 @@ impl Tab {
         lines: usize,
         client_id: ClientId,
     ) -> Result<MouseEffect> {
-        MouseHandler::handle_scrollwheel_down(self, point, lines, client_id)
+        MouseHandler::handle_scrollwheel_down(
+            self,
+            &MouseEvent::new_scroll_down_event(*point),
+            lines,
+            client_id,
+        )
     }
 
     fn get_pane_id_at(

--- a/zellij-server/src/tab/mouse_handler.rs
+++ b/zellij-server/src/tab/mouse_handler.rs
@@ -820,11 +820,10 @@ impl MouseHandler {
                 Self::execute_stop_moving_floating_pane(tab, position, client_id)
             },
             MouseAction::ScrollUp { pane_id: _, lines } => {
-                Self::handle_scrollwheel_up(tab, &event.position, lines, client_id)
-                    .with_context(err_context)
+                Self::handle_scrollwheel_up(tab, event, lines, client_id).with_context(err_context)
             },
             MouseAction::ScrollDown { pane_id: _, lines } => {
-                Self::handle_scrollwheel_down(tab, &event.position, lines, client_id)
+                Self::handle_scrollwheel_down(tab, event, lines, client_id)
                     .with_context(err_context)
             },
             MouseAction::ScrollLeft { pane_id, cols } => {
@@ -1629,17 +1628,20 @@ impl MouseHandler {
 
     pub(crate) fn handle_scrollwheel_up(
         tab: &mut Tab,
-        point: &Position,
+        event: &MouseEvent,
         lines: usize,
         client_id: ClientId,
     ) -> Result<MouseEffect> {
+        let point = &event.position;
         let err_context = || {
             format!("failed to handle scrollwheel up at position {point:?} for client {client_id}")
         };
 
         if let Some(pane) = Self::get_pane_at(tab, point, false).with_context(err_context)? {
-            let relative_position = pane.relative_position(point);
-            if let Some(mouse_event) = pane.mouse_scroll_up(&relative_position) {
+            // keep the modifier state, but report the position relative to the pane
+            let mut event_for_pane = *event;
+            event_for_pane.position = pane.relative_position(point);
+            if let Some(mouse_event) = pane.mouse_scroll_up(&event_for_pane) {
                 tab.write_to_terminal_at(mouse_event.into_bytes(), point, client_id)
                     .with_context(err_context)?;
             } else if pane.is_alternate_mode_active() {
@@ -1657,10 +1659,11 @@ impl MouseHandler {
 
     pub(crate) fn handle_scrollwheel_down(
         tab: &mut Tab,
-        point: &Position,
+        event: &MouseEvent,
         lines: usize,
         client_id: ClientId,
     ) -> Result<MouseEffect> {
+        let point = &event.position;
         let err_context = || {
             format!(
                 "failed to handle scrollwheel down at position {point:?} for client {client_id}"
@@ -1668,8 +1671,10 @@ impl MouseHandler {
         };
 
         if let Some(pane) = Self::get_pane_at(tab, point, false).with_context(err_context)? {
-            let relative_position = pane.relative_position(point);
-            if let Some(mouse_event) = pane.mouse_scroll_down(&relative_position) {
+            // keep the modifier state, but report the position relative to the pane
+            let mut event_for_pane = *event;
+            event_for_pane.position = pane.relative_position(point);
+            if let Some(mouse_event) = pane.mouse_scroll_down(&event_for_pane) {
                 tab.write_to_terminal_at(mouse_event.into_bytes(), point, client_id)
                     .with_context(err_context)?;
             } else if pane.is_alternate_mode_active() {


### PR DESCRIPTION
Fixes #5306

## Problem

Wheel events lose their modifier state on the way to the application running in a
pane. `mouse_scroll_up_signal` / `mouse_scroll_down_signal` took only a `Position`,
so they emitted a bare wheel button value — `64`/`65` for SGR, `` ` ``/`a` for
x10/utf8 — with no modifier bits. Every other mouse signal encodes them through
`mouse_buttons_value_sgr` / `mouse_buttons_value_x10` (shift `0x04`, alt `0x08`,
ctrl `0x10`).

The result is what the issue reports: a crossterm/ratatui app asking for
shift+scroll sees a plain scroll with no modifier.

## Changes

- `mouse_scroll_up_signal` / `mouse_scroll_down_signal` now take the `&MouseEvent`
  and OR the modifier bits onto the wheel value. The bare values are unchanged when
  no modifier is held, and the x10 byte and SGR button number are otherwise
  untouched.
- The event is threaded through `handle_scrollwheel_up` / `_down`, which already had
  it in scope at the dispatch site. Position is still reported relative to the pane,
  mirroring the existing `event_for_pane` pattern used for clicks.
- The public `Tab::handle_scrollwheel_up` / `_down` keep their `&Position` signature
  and synthesize a modifier-free event, so `screen.rs` and existing tests are
  unaffected.

## Scope

Ctrl+scroll is deliberately left alone. It is claimed by zellij for pane resizing,
and dropped entirely when `mouse_scroll_resize` is off, so it never reaches this
code — that part of the issue ("no events when holding ctrl") is a separate
behaviour decision I did not want to make unilaterally. This PR fixes the shift/alt
case the reporter demonstrated.

I also noticed while here that `mouse_buttons_value_x10` returns `68`/`69` for
wheel up/down, while the scroll path uses `` ` ``/`a` (96/97, i.e. `32 + 64`). Those
disagree, so I deliberately did **not** route scroll through the shared helper —
that would have silently changed the emitted bytes. Flagging it as possibly worth a
separate look.

## Tests

Two tests in `grid_tests.rs`:

- `scroll_signals_forward_modifier_state_to_the_application` — shift+wheel-up must
  encode `68`, alt+wheel-down must encode `73`. **Fails without the change:**
  ```
  left: Some("\u{1b}[<64;1;1M")
  right: Some("\u{1b}[<68;1;1M")
  ```
- `scroll_signals_are_unchanged_without_modifiers` — guards the existing encoding so
  a plain scroll still reports the bare `64`/`65`.

## Verification

- `cargo test -p zellij-server --lib` — 1445 passed, 0 failed
- `cargo fmt --check -p zellij-server` — clean
- `cargo clippy -p zellij-server --lib` — no new warnings from these changes
