### PR TITLE
fix(sixel): only advertise capability if host terminal supports it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * feat: handle nested Zellij sessions (https://github.com/zellij-org/zellij/pull/5417)
 * chore: remove outdated manpage and some build fixes (https://github.com/zellij-org/zellij/pull/5426)
 * feat: implement support for the kitty graphics protocol to display images in the terminal (https://github.com/zellij-org/zellij/pull/5428)
+* fix: only advertise Sixel support if the attached terminal also supports it (https://github.com/zellij-org/zellij/pull/5432)
 
 ## [0.44.3] - 2026-05-13
 * fix(windows): bump windows-sys to 0.59 to align manifest with code, fixing source builds via `cargo install`/`cargo binstall` (https://github.com/zellij-org/zellij/pull/5139)

--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -342,6 +342,10 @@ impl InputHandler {
                 self.os_input
                     .send_to_server(ClientToServerMsg::KittyGraphicsSupport { supported });
             },
+            AnsiStdinInstruction::SixelSupport(supported) => {
+                self.os_input
+                    .send_to_server(ClientToServerMsg::SixelSupport { supported });
+            },
         }
     }
     fn handle_nested_session_frame_from_host(&mut self, payload_bytes: Vec<u8>) {

--- a/zellij-client/src/stdin_ansi_parser.rs
+++ b/zellij-client/src/stdin_ansi_parser.rs
@@ -63,6 +63,7 @@ pub enum HostReply {
     /// terminal's color-palette theme mode (CSI 2031).
     HostTerminalThemeChanged(HostTerminalThemeMode),
     KittyGraphicsSupport(bool),
+    SixelSupport(bool),
 }
 
 /// Retained alias for the pre-refactor type name used by other modules in
@@ -155,6 +156,22 @@ impl HostReply {
             return Some(HostReply::HostTerminalThemeChanged(mode));
         }
         None
+    }
+
+    /// Classify a Primary Device Attributes reply (`CSI ? Ps ; Ps ... c`)
+    /// into a Sixel-capability advertisement. Attribute `4` in the reply
+    /// means the host terminal supports Sixel graphics.
+    ///
+    /// Replies that are not a primary-DA form (eg. secondary-DA `CSI > ... c`)
+    /// yield `None` so they do not clobber the host capability state.
+    pub fn sixel_support_from_primary_da(raw: &[u8]) -> Option<HostReply> {
+        lazy_static! {
+            static ref PRIMARY_DA_RE: Regex = Regex::new(r"^\u{1b}\[\?([0-9;]*)c$").unwrap();
+        }
+        let s = std::str::from_utf8(raw).ok()?;
+        let caps = PRIMARY_DA_RE.captures(s)?;
+        let supports_sixel = caps[1].split(';').any(|attribute| attribute == "4");
+        Some(HostReply::SixelSupport(supports_sixel))
     }
 }
 
@@ -418,6 +435,9 @@ impl StdinAnsiParser {
                             if self.startup_kitty_probe == StartupKittyProbe::AwaitingReply {
                                 self.startup_kitty_probe = StartupKittyProbe::Resolved;
                                 out.replies.push(HostReply::KittyGraphicsSupport(false));
+                            }
+                            if let Some(reply) = HostReply::sixel_support_from_primary_da(&raw) {
+                                out.replies.push(reply);
                             }
                             // Primary-DA — the barrier. Close the slot and
                             // emit the completed forwarded reply if active.

--- a/zellij-client/src/stdin_ansi_parser_tests.rs
+++ b/zellij-client/src/stdin_ansi_parser_tests.rs
@@ -146,9 +146,11 @@ fn forwarding_window_accumulates_and_barrier_closes() {
     chunk.extend_from_slice(b"\x1b]11;rgb:aaaa/bbbb/dddd\x1b\\");
     chunk.extend_from_slice(b"\x1b[?65;1c");
     let out = parser.feed(&chunk);
-    // OSC 11 was classified (double-dispatch).
-    assert_eq!(out.replies.len(), 1);
+    // OSC 11 was classified (double-dispatch), and the barrier itself
+    // advertises the host's sixel capability.
+    assert_eq!(out.replies.len(), 2);
     matches!(out.replies[0], HostReply::BackgroundColor(_));
+    matches!(out.replies[1], HostReply::SixelSupport(false));
     // Barrier closed the window, producing a completed forward.
     let (token, reply_bytes) = out
         .completed_forward
@@ -1241,11 +1243,59 @@ fn kitty_probe_absence_resolves_false_on_barrier() {
     parser.expect_kitty_probe_reply();
     let (replies, residue) = feed_once(&mut parser, b"\x1b[?62;4;52c");
     assert!(residue.is_empty());
-    assert_eq!(replies.len(), 1);
-    match &replies[0] {
-        HostReply::KittyGraphicsSupport(supported) => assert!(!*supported),
-        other => panic!("unexpected reply: {:?}", other),
-    }
+    let kitty_replies: Vec<bool> = replies
+        .iter()
+        .filter_map(|r| match r {
+            HostReply::KittyGraphicsSupport(supported) => Some(*supported),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(kitty_replies, vec![false]);
+}
+
+#[test]
+fn primary_da_with_sixel_attribute_classifies_sixel_support_true() {
+    let mut parser = StdinAnsiParser::new();
+    let (replies, residue) = feed_once(&mut parser, b"\x1b[?62;4;52c");
+    assert!(residue.is_empty());
+    let sixel_replies: Vec<bool> = replies
+        .iter()
+        .filter_map(|r| match r {
+            HostReply::SixelSupport(supported) => Some(*supported),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(sixel_replies, vec![true]);
+}
+
+#[test]
+fn primary_da_without_sixel_attribute_classifies_sixel_support_false() {
+    let mut parser = StdinAnsiParser::new();
+    let (replies, residue) = feed_once(&mut parser, b"\x1b[?62;22c");
+    assert!(residue.is_empty());
+    let sixel_replies: Vec<bool> = replies
+        .iter()
+        .filter_map(|r| match r {
+            HostReply::SixelSupport(supported) => Some(*supported),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(sixel_replies, vec![false]);
+}
+
+#[test]
+fn primary_da_sixel_attribute_is_not_matched_as_a_substring() {
+    let mut parser = StdinAnsiParser::new();
+    let (replies, residue) = feed_once(&mut parser, b"\x1b[?64;14;21;22c");
+    assert!(residue.is_empty());
+    let sixel_replies: Vec<bool> = replies
+        .iter()
+        .filter_map(|r| match r {
+            HostReply::SixelSupport(supported) => Some(*supported),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(sixel_replies, vec![false]);
 }
 
 #[test]

--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -61,6 +61,7 @@ pub(crate) fn stdin_loop(
         } else {
             let _ = send_input_instructions.send(InputInstruction::AnsiStdinInstructions(vec![
                 HostReply::KittyGraphicsSupport(false),
+                HostReply::SixelSupport(false),
             ]));
         }
     }

--- a/zellij-server/src/output/mod.rs
+++ b/zellij-server/src/output/mod.rs
@@ -641,6 +641,7 @@ pub struct Output {
     kitty_image_store: Rc<RefCell<KittyImageStore>>,
     kitty_host_capabilities: Rc<RefCell<HashMap<ClientId, bool>>>,
     kitty_host_state: Rc<RefCell<HashMap<ClientId, HostKittyState>>>,
+    sixel_host_capabilities: Rc<RefCell<HashMap<ClientId, bool>>>,
     character_cell_size: Rc<RefCell<Option<SizeInPixels>>>,
     floating_panes_stack: Option<FloatingPanesStack>,
     styled_underlines: bool,
@@ -659,6 +660,7 @@ impl Output {
         kitty_image_store: Rc<RefCell<KittyImageStore>>,
         kitty_host_capabilities: Rc<RefCell<HashMap<ClientId, bool>>>,
         kitty_host_state: Rc<RefCell<HashMap<ClientId, HostKittyState>>>,
+        sixel_host_capabilities: Rc<RefCell<HashMap<ClientId, bool>>>,
     ) -> Self {
         Output {
             sixel_image_store,
@@ -668,9 +670,11 @@ impl Output {
             kitty_image_store,
             kitty_host_capabilities,
             kitty_host_state,
+            sixel_host_capabilities,
             ..Default::default()
         }
     }
+
     pub fn add_clients(
         &mut self,
         client_ids: &HashSet<ClientId>,
@@ -901,6 +905,12 @@ impl Output {
                 .get(&client_id)
                 .copied()
                 .unwrap_or(false);
+            let client_host_is_sixel_capable = self
+                .sixel_host_capabilities
+                .borrow()
+                .get(&client_id)
+                .copied()
+                .unwrap_or(false);
             let mut kitty_image_store;
             let mut kitty_host_state_map;
             let kitty_input = if client_host_is_kitty_capable {
@@ -919,10 +929,15 @@ impl Output {
             };
 
             // append the actual vte
+            let sixel_chunks_for_client = if client_host_is_sixel_capable {
+                self.sixel_chunks.get(&client_id)
+            } else {
+                None
+            };
             client_serialized_render_instructions.push_str(
                 &serialize_chunks(
                     client_character_chunks,
-                    self.sixel_chunks.get(&client_id),
+                    sixel_chunks_for_client,
                     self.link_handler.as_mut(),
                     Some(&mut self.sixel_image_store.borrow_mut()),
                     self.styled_underlines,
@@ -988,10 +1003,21 @@ impl Output {
             }
 
             // append the actual vte with size constraints
+            let client_host_is_sixel_capable = self
+                .sixel_host_capabilities
+                .borrow()
+                .get(&client_id)
+                .copied()
+                .unwrap_or(false);
+            let sixel_chunks_for_client = if client_host_is_sixel_capable {
+                self.sixel_chunks.get(&client_id)
+            } else {
+                None
+            };
             client_serialized_render_instructions.push_str(
                 &serialize_chunks(
                     client_character_chunks,
-                    self.sixel_chunks.get(&client_id),
+                    sixel_chunks_for_client,
                     self.link_handler.as_mut(),
                     Some(&mut self.sixel_image_store.borrow_mut()),
                     self.styled_underlines,

--- a/zellij-server/src/output/unit/output_tests.rs
+++ b/zellij-server/src/output/unit/output_tests.rs
@@ -32,6 +32,7 @@ fn create_test_output() -> Output {
         Rc::new(RefCell::new(KittyImageStore::default())),
         Rc::new(RefCell::new(HashMap::new())),
         Rc::new(RefCell::new(HashMap::new())),
+        Rc::new(RefCell::new(HashMap::new())),
     )
 }
 
@@ -1150,6 +1151,7 @@ fn create_test_kitty_output(parts: &KittyTestParts) -> Output {
         parts.0.clone(),
         parts.1.clone(),
         parts.2.clone(),
+        Rc::new(RefCell::new(HashMap::new())),
     )
 }
 

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -1714,6 +1714,11 @@ impl FloatingPanes {
             pane.update_kitty_host_support(supported);
         }
     }
+    pub fn update_pane_sixel_host_support(&mut self, supported: bool) {
+        for pane in self.panes.values_mut() {
+            pane.update_sixel_host_support(supported);
+        }
+    }
     pub fn update_pane_rounded_corners(&mut self, rounded_corners: bool) {
         self.style.rounded_corners = rounded_corners;
         for pane in self.panes.values_mut() {

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -685,6 +685,7 @@ pub struct Grid {
     kitty_grid: KittyGrid,
     kitty_parser: KittyCommandParser,
     kitty_host_support: KittyHostSupport,
+    sixel_host_support: bool,
     pub changed_colors: Option<[Option<AnsiCode>; 256]>,
     pub should_render: bool,
     pub lock_renders: bool,
@@ -1072,6 +1073,7 @@ impl Grid {
             kitty_grid,
             kitty_parser: KittyCommandParser::new(),
             kitty_host_support: KittyHostSupport::Supported,
+            sixel_host_support: true,
             pending_clipboard_update: None,
             pending_osc7_cwd: None,
             pending_desktop_notifications: Vec::new(),
@@ -3828,6 +3830,9 @@ impl Grid {
     pub fn update_kitty_host_support(&mut self, supported: KittyHostSupport) {
         self.kitty_host_support = supported;
     }
+    pub fn update_sixel_host_support(&mut self, supported: bool) {
+        self.sixel_host_support = supported;
+    }
     pub fn has_selection(&self) -> bool {
         !self.selection.is_empty()
     }
@@ -4734,13 +4739,23 @@ impl Perform for Grid {
                     match query_type {
                         Some(&[1]) => {
                             // number of color registers
-                            let response = "\u{1b}[?1;0;65536S";
+                            let response = if self.sixel_host_support {
+                                "\u{1b}[?1;0;65536S"
+                            } else {
+                                "\u{1b}[?1;3;0S"
+                            };
                             self.pending_messages_to_pty
                                 .push(response.as_bytes().to_vec());
                         },
                         Some(&[2]) => {
                             // Sixel graphics geometry in pixels
-                            if let Some(character_cell_size) = *self.character_cell_size.borrow() {
+                            if !self.sixel_host_support {
+                                let response = "\u{1b}[?2;3;0S";
+                                self.pending_messages_to_pty
+                                    .push(response.as_bytes().to_vec());
+                            } else if let Some(character_cell_size) =
+                                *self.character_cell_size.borrow()
+                            {
                                 let sixel_area_geometry = format!(
                                     "\u{1b}[?2;0;{};{}S",
                                     character_cell_size.width * self.width,
@@ -4863,8 +4878,13 @@ impl Perform for Grid {
             // https://vt100.net/docs/vt510-rm/DA1.html
             match intermediates.get(0) {
                 None | Some(0) => {
-                    // primary device attributes - VT220 with sixel and OSC 52 clipboard
-                    let terminal_capabilities = "\u{1b}[?62;4;52c";
+                    // primary device attributes - VT220 with OSC 52 clipboard, advertising
+                    // sixel (attribute 4) only if the attached terminal supports it
+                    let terminal_capabilities = if self.sixel_host_support {
+                        "\u{1b}[?62;4;52c"
+                    } else {
+                        "\u{1b}[?62;52c"
+                    };
                     self.pending_messages_to_pty
                         .push(terminal_capabilities.as_bytes().to_vec());
                 },

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -1191,6 +1191,9 @@ impl Pane for TerminalPane {
     fn update_kitty_host_support(&mut self, supported: KittyHostSupport) {
         self.grid.update_kitty_host_support(supported);
     }
+    fn update_sixel_host_support(&mut self, supported: bool) {
+        self.grid.update_sixel_host_support(supported);
+    }
     fn update_rounded_corners(&mut self, rounded_corners: bool) {
         self.style.rounded_corners = rounded_corners;
         self.frame.clear();

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -3112,6 +3112,11 @@ impl TiledPanes {
             pane.update_kitty_host_support(supported);
         }
     }
+    pub fn update_pane_sixel_host_support(&mut self, supported: bool) {
+        for pane in self.panes.values_mut() {
+            pane.update_sixel_host_support(supported);
+        }
+    }
     pub fn update_pane_rounded_corners(&mut self, rounded_corners: bool) {
         self.style.rounded_corners = rounded_corners;
         for pane in self.panes.values_mut() {

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -8303,3 +8303,42 @@ fn kitty_placement_rejoins_its_text_after_editing_while_scrolled_back() {
         "the image must rejoin its marker line once the viewport is restored"
     );
 }
+
+#[test]
+fn primary_device_attributes_advertise_sixel_when_host_supports_it() {
+    let mut grid = create_grid_with_content("");
+    let mut vte_parser = vte::Parser::new();
+    grid.update_sixel_host_support(true);
+    vte_parser.advance(&mut grid, b"\x1b[c");
+    assert_eq!(
+        grid.pending_messages_to_pty,
+        vec![b"\x1b[?62;4;52c".to_vec()]
+    );
+}
+
+#[test]
+fn primary_device_attributes_omit_sixel_when_host_does_not_support_it() {
+    let mut grid = create_grid_with_content("");
+    let mut vte_parser = vte::Parser::new();
+    grid.update_sixel_host_support(false);
+    vte_parser.advance(&mut grid, b"\x1b[c");
+    assert_eq!(grid.pending_messages_to_pty, vec![b"\x1b[?62;52c".to_vec()]);
+}
+
+#[test]
+fn xtsmgraphics_color_registers_report_failure_when_host_does_not_support_sixel() {
+    let mut grid = create_grid_with_content("");
+    let mut vte_parser = vte::Parser::new();
+    grid.update_sixel_host_support(false);
+    vte_parser.advance(&mut grid, b"\x1b[?1;1S");
+    assert_eq!(grid.pending_messages_to_pty, vec![b"\x1b[?1;3;0S".to_vec()]);
+}
+
+#[test]
+fn xtsmgraphics_geometry_reports_failure_when_host_does_not_support_sixel() {
+    let mut grid = create_grid_with_content("");
+    let mut vte_parser = vte::Parser::new();
+    grid.update_sixel_host_support(false);
+    vte_parser.advance(&mut grid, b"\x1b[?2;1S");
+    assert_eq!(grid.pending_messages_to_pty, vec![b"\x1b[?2;3;0S".to_vec()]);
+}

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -2552,6 +2552,18 @@ pub(crate) fn route_thread_main(
                             )
                             .with_context(err_context)?;
                         },
+                        ClientToServerMsg::SixelSupport { supported } => {
+                            send_to_screen_or_retry_queue!(
+                                senders,
+                                ScreenInstruction::SetSixelSupport {
+                                    client_id,
+                                    supported
+                                },
+                                instruction,
+                                retry_queue
+                            )
+                            .with_context(err_context)?;
+                        },
                         ClientToServerMsg::BackgroundColor {
                             color: ref background_color_instruction,
                         } => {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -521,6 +521,10 @@ pub enum ScreenInstruction {
         client_id: ClientId,
         supported: bool,
     },
+    SetSixelSupport {
+        client_id: ClientId,
+        supported: bool,
+    },
     /// A pane's Grid intercepted an app-in-pane whitelisted query; Screen
     /// assigns a token, queues the forward, and dispatches to the client.
     /// `query` carries the classified form so Screen can match on it
@@ -1066,6 +1070,7 @@ impl From<&ScreenInstruction> for ScreenContext {
             ScreenInstruction::SetKittyGraphicsSupport { .. } => {
                 ScreenContext::SetKittyGraphicsSupport
             },
+            ScreenInstruction::SetSixelSupport { .. } => ScreenContext::SetSixelSupport,
             ScreenInstruction::ForwardHostQuery { .. } => ScreenContext::ForwardHostQuery,
             ScreenInstruction::NestedSessionMessageFromPane { .. } => {
                 ScreenContext::NestedSessionMessageFromPane
@@ -1497,6 +1502,7 @@ pub(crate) struct Screen {
     sixel_image_store: Rc<RefCell<SixelImageStore>>,
     kitty_image_store: Rc<RefCell<KittyImageStore>>,
     kitty_host_capabilities: Rc<RefCell<HashMap<ClientId, bool>>>,
+    sixel_host_capabilities: Rc<RefCell<HashMap<ClientId, bool>>>,
     client_kitty_host_state: Rc<RefCell<HashMap<ClientId, HostKittyState>>>,
     terminal_emulator_colors: Rc<RefCell<Palette>>,
     terminal_emulator_color_codes: Rc<RefCell<HashMap<usize, String>>>,
@@ -1682,6 +1688,7 @@ impl Screen {
             sixel_image_store: Rc::new(RefCell::new(SixelImageStore::default())),
             kitty_image_store: Rc::new(RefCell::new(KittyImageStore::default())),
             kitty_host_capabilities: Rc::new(RefCell::new(HashMap::new())),
+            sixel_host_capabilities: Rc::new(RefCell::new(HashMap::new())),
             client_kitty_host_state: Rc::new(RefCell::new(HashMap::new())),
             style: client_attributes.style,
             connected_clients: Rc::new(RefCell::new(HashMap::new())),
@@ -2644,6 +2651,30 @@ impl Screen {
         if let Some(aggregate) = self.kitty_host_support_aggregate() {
             for tab in self.tabs.values_mut() {
                 tab.update_kitty_host_support(aggregate);
+            }
+        }
+    }
+
+    pub fn update_sixel_support(&mut self, client_id: ClientId, supported: bool) {
+        self.sixel_host_capabilities
+            .borrow_mut()
+            .insert(client_id, supported);
+        self.push_sixel_host_support_to_tabs();
+    }
+
+    fn sixel_host_support_aggregate(&self) -> Option<bool> {
+        let capabilities = self.sixel_host_capabilities.borrow();
+        if capabilities.is_empty() {
+            None
+        } else {
+            Some(capabilities.values().any(|supported| *supported))
+        }
+    }
+
+    fn push_sixel_host_support_to_tabs(&mut self) {
+        if let Some(aggregate) = self.sixel_host_support_aggregate() {
+            for tab in self.tabs.values_mut() {
+                tab.update_sixel_host_support(aggregate);
             }
         }
     }
@@ -3966,6 +3997,7 @@ impl Screen {
                 self.kitty_image_store.clone(),
                 self.kitty_host_capabilities.clone(),
                 self.client_kitty_host_state.clone(),
+                self.sixel_host_capabilities.clone(),
             );
 
             let has_ansi_subscribers = self.pane_render_subscribers.values().any(|s| s.ansi);
@@ -4139,6 +4171,7 @@ impl Screen {
                     self.kitty_image_store.clone(),
                     self.kitty_host_capabilities.clone(),
                     self.client_kitty_host_state.clone(),
+                    self.sixel_host_capabilities.clone(),
                 );
 
                 let focused_tab_index_of_followed_client_id =
@@ -4494,6 +4527,9 @@ impl Screen {
         if let Some(aggregate) = self.kitty_host_support_aggregate() {
             tab.update_kitty_host_support(aggregate);
         }
+        if let Some(aggregate) = self.sixel_host_support_aggregate() {
+            tab.update_sixel_host_support(aggregate);
+        }
         self.tabs.insert(tab_id, tab);
         Ok(())
     }
@@ -4690,6 +4726,10 @@ impl Screen {
                 .borrow_mut()
                 .insert(client_id, false);
             self.push_kitty_host_support_to_tabs();
+            self.sixel_host_capabilities
+                .borrow_mut()
+                .insert(client_id, false);
+            self.push_sixel_host_support_to_tabs();
         }
         self.tab_history.insert(client_id, tab_history);
         self.tabs
@@ -4792,6 +4832,14 @@ impl Screen {
             .is_some();
         if removed_kitty_capability {
             self.push_kitty_host_support_to_tabs();
+        }
+        let removed_sixel_capability = self
+            .sixel_host_capabilities
+            .borrow_mut()
+            .remove(&client_id)
+            .is_some();
+        if removed_sixel_capability {
+            self.push_sixel_host_support_to_tabs();
         }
         self.client_sizes.remove(&client_id);
         self.pane_render_subscribers.remove(&client_id);
@@ -9313,6 +9361,12 @@ pub(crate) fn screen_thread_main(
                 supported,
             } => {
                 screen.update_kitty_graphics_support(client_id, supported);
+            },
+            ScreenInstruction::SetSixelSupport {
+                client_id,
+                supported,
+            } => {
+                screen.update_sixel_support(client_id, supported);
             },
             ScreenInstruction::ForwardHostQuery { pane_id, query } => {
                 screen.forward_host_query(pane_id, query);

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -242,6 +242,7 @@ pub(crate) struct Tab {
     debug: bool,
     arrow_fonts: bool,
     kitty_host_support: Option<KittyHostSupport>,
+    sixel_host_support: Option<bool>,
     styled_underlines: bool,
     osc8_hyperlinks: bool,
     explicitly_disable_kitty_keyboard_protocol: bool,
@@ -736,6 +737,7 @@ pub trait Pane {
     fn update_theme(&mut self, _theme: Styling) {}
     fn update_arrow_fonts(&mut self, _should_support_arrow_fonts: bool) {}
     fn update_kitty_host_support(&mut self, _supported: KittyHostSupport) {}
+    fn update_sixel_host_support(&mut self, _supported: bool) {}
     fn update_rounded_corners(&mut self, _rounded_corners: bool) {}
     fn set_should_be_suppressed(&mut self, _should_be_suppressed: bool) {}
     fn query_should_be_suppressed(&self) -> bool {
@@ -991,6 +993,7 @@ impl Tab {
             debug,
             arrow_fonts,
             kitty_host_support: None,
+            sixel_host_support: None,
             styled_underlines,
             osc8_hyperlinks,
             explicitly_disable_kitty_keyboard_protocol,
@@ -1766,6 +1769,11 @@ impl Tab {
             self.tiled_panes.update_pane_kitty_host_support(supported);
             self.floating_panes
                 .update_pane_kitty_host_support(supported);
+        }
+        if let Some(supported) = self.sixel_host_support {
+            self.tiled_panes.update_pane_sixel_host_support(supported);
+            self.floating_panes
+                .update_pane_sixel_host_support(supported);
         }
         Ok(())
     }
@@ -3211,6 +3219,9 @@ impl Tab {
                 if let Some(supported) = self.kitty_host_support {
                     new_pane.update_kitty_host_support(supported);
                 }
+                if let Some(supported) = self.sixel_host_support {
+                    new_pane.update_sixel_host_support(supported);
+                }
                 if let Some(borderless) = borderless {
                     new_pane.set_borderless(borderless);
                 }
@@ -3434,6 +3445,9 @@ impl Tab {
                 if let Some(supported) = self.kitty_host_support {
                     new_terminal.update_kitty_host_support(supported);
                 }
+                if let Some(supported) = self.sixel_host_support {
+                    new_terminal.update_sixel_host_support(supported);
+                }
                 if let Some(borderless) = borderless {
                     new_terminal.set_borderless(borderless);
                 }
@@ -3505,6 +3519,9 @@ impl Tab {
                 );
                 if let Some(supported) = self.kitty_host_support {
                     new_terminal.update_kitty_host_support(supported);
+                }
+                if let Some(supported) = self.sixel_host_support {
+                    new_terminal.update_sixel_host_support(supported);
                 }
                 if let Some(borderless) = borderless {
                     new_terminal.set_borderless(borderless);
@@ -3634,6 +3651,9 @@ impl Tab {
             );
             if let Some(supported) = self.kitty_host_support {
                 new_terminal.update_kitty_host_support(supported);
+            }
+            if let Some(supported) = self.sixel_host_support {
+                new_terminal.update_sixel_host_support(supported);
             }
             if let Some(borderless) = borderless {
                 new_terminal.set_borderless(borderless);
@@ -7416,6 +7436,15 @@ impl Tab {
             pane.update_kitty_host_support(supported);
         }
     }
+    pub fn update_sixel_host_support(&mut self, supported: bool) {
+        self.sixel_host_support = Some(supported);
+        self.floating_panes
+            .update_pane_sixel_host_support(supported);
+        self.tiled_panes.update_pane_sixel_host_support(supported);
+        for (_, pane) in self.suppressed_panes.values_mut() {
+            pane.update_sixel_host_support(supported);
+        }
+    }
     pub fn update_default_shell(&mut self, mut default_shell: Option<PathBuf>) {
         if let Some(default_shell) = default_shell.take() {
             self.default_shell = default_shell;
@@ -7690,6 +7719,9 @@ impl Tab {
         );
         if let Some(supported) = self.kitty_host_support {
             new_pane.update_kitty_host_support(supported);
+        }
+        if let Some(supported) = self.sixel_host_support {
+            new_pane.update_sixel_host_support(supported);
         }
         new_pane.update_name("EDITING SCROLLBACK"); // we do this here and not in the
                                                     // constructor so it won't be overrided

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -3861,6 +3861,8 @@ fn move_floating_pane_with_sixel_image() {
         width: 8,
         height: 21,
     })));
+    let sixel_host_capabilities = Rc::new(RefCell::new(HashMap::new()));
+    sixel_host_capabilities.borrow_mut().insert(client_id, true);
     let mut output = Output::new(
         sixel_image_store.clone(),
         character_cell_size,
@@ -3869,6 +3871,7 @@ fn move_floating_pane_with_sixel_image() {
         Rc::new(RefCell::new(KittyImageStore::default())),
         Rc::new(RefCell::new(HashMap::new())),
         Rc::new(RefCell::new(HashMap::new())),
+        sixel_host_capabilities,
     );
 
     tab.toggle_floating_panes(Some(client_id), None, None)
@@ -3928,6 +3931,8 @@ fn floating_pane_above_sixel_image() {
         width: 8,
         height: 21,
     })));
+    let sixel_host_capabilities = Rc::new(RefCell::new(HashMap::new()));
+    sixel_host_capabilities.borrow_mut().insert(client_id, true);
     let mut output = Output::new(
         sixel_image_store.clone(),
         character_cell_size,
@@ -3936,6 +3941,7 @@ fn floating_pane_above_sixel_image() {
         Rc::new(RefCell::new(KittyImageStore::default())),
         Rc::new(RefCell::new(HashMap::new())),
         Rc::new(RefCell::new(HashMap::new())),
+        sixel_host_capabilities,
     );
 
     tab.toggle_floating_panes(Some(client_id), None, None)

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -11669,3 +11669,65 @@ fn kitty_support_recomputed_on_client_detach() {
     assert!(reply.starts_with("\x1b_Gi=31;ENOTSUPPORTED"));
     assert!(reply.ends_with("\x1b\\"));
 }
+
+#[test]
+fn primary_da_advertises_sixel_when_capable_client_connected() {
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let mut screen = create_new_screen(size, true, true);
+    new_tab(&mut screen, 1, 0);
+    screen.update_sixel_support(1, true);
+    assert_eq!(screen.sixel_host_capabilities.borrow().get(&1), Some(&true));
+    let active_tab = screen.get_active_tab_mut(1).unwrap();
+    let active_pane = active_tab.get_active_pane_mut(1).unwrap();
+    active_pane.handle_pty_bytes(b"\x1b[c".to_vec());
+    assert_eq!(
+        active_pane.drain_messages_to_pty(),
+        vec![b"\x1b[?62;4;52c".to_vec()]
+    );
+}
+
+#[test]
+fn primary_da_omits_sixel_when_no_capable_client() {
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let mut screen = create_new_screen(size, true, true);
+    new_tab(&mut screen, 1, 0);
+    screen.update_sixel_support(1, false);
+    assert_eq!(
+        screen.sixel_host_capabilities.borrow().get(&1),
+        Some(&false)
+    );
+    let active_tab = screen.get_active_tab_mut(1).unwrap();
+    let active_pane = active_tab.get_active_pane_mut(1).unwrap();
+    active_pane.handle_pty_bytes(b"\x1b[c".to_vec());
+    assert_eq!(
+        active_pane.drain_messages_to_pty(),
+        vec![b"\x1b[?62;52c".to_vec()]
+    );
+}
+
+#[test]
+fn sixel_support_recomputed_on_client_detach() {
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let mut screen = create_new_screen(size, true, true);
+    new_tab(&mut screen, 1, 0);
+    screen.add_client(2, false).expect("TEST");
+    screen.update_sixel_support(1, false);
+    screen.update_sixel_support(2, true);
+    screen.remove_client(2).expect("TEST");
+    let active_tab = screen.get_active_tab_mut(1).unwrap();
+    let active_pane = active_tab.get_active_pane_mut(1).unwrap();
+    active_pane.handle_pty_bytes(b"\x1b[c".to_vec());
+    assert_eq!(
+        active_pane.drain_messages_to_pty(),
+        vec![b"\x1b[?62;52c".to_vec()]
+    );
+}

--- a/zellij-utils/assets/prost_ipc/client_server_contract.rs
+++ b/zellij-utils/assets/prost_ipc/client_server_contract.rs
@@ -3041,7 +3041,7 @@ impl NestedSessionHandling {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClientToServerMsg {
-    #[prost(oneof="client_to_server_msg::Message", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23")]
+    #[prost(oneof="client_to_server_msg::Message", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24")]
     pub message: ::core::option::Option<client_to_server_msg::Message>,
 }
 /// Nested message and enum types in `ClientToServerMsg`.
@@ -3095,6 +3095,8 @@ pub mod client_to_server_msg {
         NestedSessionFrameFromHost(super::NestedSessionFrameFromHostMsg),
         #[prost(message, tag="23")]
         KittyGraphicsSupport(super::KittyGraphicsSupportMsg),
+        #[prost(message, tag="24")]
+        SixelSupport(super::SixelSupportMsg),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3257,6 +3259,12 @@ pub struct NestedSessionFrameFromHostMsg {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct KittyGraphicsSupportMsg {
+    #[prost(bool, tag="1")]
+    pub supported: bool,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SixelSupportMsg {
     #[prost(bool, tag="1")]
     pub supported: bool,
 }

--- a/zellij-utils/src/client_server_contract/client_to_server.proto
+++ b/zellij-utils/src/client_server_contract/client_to_server.proto
@@ -28,6 +28,7 @@ message ClientToServerMsg {
     SoftKeyboardVisibilityChangedMsg soft_keyboard_visibility_changed = 21;
     NestedSessionFrameFromHostMsg nested_session_frame_from_host = 22;
     KittyGraphicsSupportMsg kitty_graphics_support = 23;
+    SixelSupportMsg sixel_support = 24;
   }
 }
 
@@ -145,5 +146,9 @@ message NestedSessionFrameFromHostMsg {
 }
 
 message KittyGraphicsSupportMsg {
+  bool supported = 1;
+}
+
+message SixelSupportMsg {
   bool supported = 1;
 }

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -315,6 +315,7 @@ pub enum ScreenContext {
     TerminalForegroundColor,
     TerminalColorRegisters,
     SetKittyGraphicsSupport,
+    SetSixelSupport,
     ForwardHostQuery,
     NestedSessionMessageFromPane,
     NestedGuestPingTick,

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -182,6 +182,9 @@ pub enum ClientToServerMsg {
     KittyGraphicsSupport {
         supported: bool,
     },
+    SixelSupport {
+        supported: bool,
+    },
 }
 
 // Types of messages sent from the server to the client

--- a/zellij-utils/src/ipc/protobuf_conversion.rs
+++ b/zellij-utils/src/ipc/protobuf_conversion.rs
@@ -14,7 +14,7 @@ use crate::{
         LayoutMetadata as ProtoLayoutMetadata, LogErrorMsg, LogMsg, NestedSessionFrameFromHostMsg,
         PaneMetadata as ProtoPaneMetadata, PaneRenderUpdateMsg, QueryTerminalSizeMsg,
         RenamedSessionMsg, RenderMsg, ResizeCause as ProtoResizeCause,
-        ServerToClientMsg as ProtoServerToClientMsg, SetSoftKeyboardMsg,
+        ServerToClientMsg as ProtoServerToClientMsg, SetSoftKeyboardMsg, SixelSupportMsg,
         SoftKeyboardVisibilityChangedMsg, StartWebServerMsg, SubscribeToPaneRendersMsg,
         SubscribedPaneClosedMsg, SwitchSessionMsg, TabMetadata as ProtoTabMetadata,
         TerminalPixelDimensionsMsg, TerminalResizeMsg, UnblockCliPipeInputMsg,
@@ -166,6 +166,9 @@ impl From<ClientToServerMsg> for ProtoClientToServerMsg {
                 client_to_server_msg::Message::KittyGraphicsSupport(KittyGraphicsSupportMsg {
                     supported,
                 })
+            },
+            ClientToServerMsg::SixelSupport { supported } => {
+                client_to_server_msg::Message::SixelSupport(SixelSupportMsg { supported })
             },
         };
 
@@ -324,6 +327,11 @@ impl TryFrom<ProtoClientToServerMsg> for ClientToServerMsg {
             },
             Some(client_to_server_msg::Message::KittyGraphicsSupport(msg)) => {
                 Ok(ClientToServerMsg::KittyGraphicsSupport {
+                    supported: msg.supported,
+                })
+            },
+            Some(client_to_server_msg::Message::SixelSupport(msg)) => {
+                Ok(ClientToServerMsg::SixelSupport {
                     supported: msg.supported,
                 })
             },

--- a/zellij-utils/src/ipc/tests/roundtrip_tests.rs
+++ b/zellij-utils/src/ipc/tests/roundtrip_tests.rs
@@ -354,6 +354,8 @@ fn test_client_messages() {
     });
     test_client_roundtrip!(ClientToServerMsg::KittyGraphicsSupport { supported: true });
     test_client_roundtrip!(ClientToServerMsg::KittyGraphicsSupport { supported: false });
+    test_client_roundtrip!(ClientToServerMsg::SixelSupport { supported: true });
+    test_client_roundtrip!(ClientToServerMsg::SixelSupport { supported: false });
     test_client_roundtrip!(ClientToServerMsg::BackgroundColor {
         color: "red".to_string(),
     });


### PR DESCRIPTION
Previously we unconditionally advertised Sixel image support when queried (I guess due to my unconscious reading of the concept 'capability'). Now we only advertise it if at least one of the connected clients supports it (queried on startup and attach).