### PR TITLE
fix(clipboard): answer OSC52 clipboard queries

### DIFF
--- a/zellij-integration-tests/tests/clipboard_query.rs
+++ b/zellij-integration-tests/tests/clipboard_query.rs
@@ -1,0 +1,46 @@
+#![cfg(unix)]
+
+use zellij_integration_tests::{claim_first_terminal_and_wait_for_prompt, start_zellij};
+
+#[test]
+fn clipboard_query_before_any_copy_gets_an_empty_reply() {
+    let mut zellij = start_zellij();
+    let terminal = claim_first_terminal_and_wait_for_prompt(&zellij);
+
+    terminal.output(b"\x1b]52;c;?\x07");
+
+    terminal.wait_for_stdin("empty clipboard reply reached the pane", |stdin_bytes| {
+        stdin_bytes
+            .windows(8)
+            .any(|window| window == b"\x1b]52;c;\x07")
+    });
+
+    zellij.quit();
+}
+
+#[test]
+fn clipboard_query_is_answered_from_the_last_copy() {
+    let mut zellij = start_zellij();
+    let terminal = claim_first_terminal_and_wait_for_prompt(&zellij);
+
+    // copy "hello" through zellij via an OSC 52 write, then query
+    terminal.output(b"\x1b]52;c;aGVsbG8=\x07");
+    terminal.output(b"\x1b]52;c;?\x07");
+
+    terminal.wait_for_stdin("bel-terminated reply carries the copy", |stdin_bytes| {
+        stdin_bytes
+            .windows(16)
+            .any(|window| window == b"\x1b]52;c;aGVsbG8=\x07")
+    });
+
+    // reply mirrors the query's destination and terminator
+    terminal.output(b"\x1b]52;p;?\x1b\\");
+
+    terminal.wait_for_stdin("st-terminated reply for primary", |stdin_bytes| {
+        stdin_bytes
+            .windows(17)
+            .any(|window| window == b"\x1b]52;p;aGVsbG8=\x1b\\")
+    });
+
+    zellij.quit();
+}

--- a/zellij-server/src/host_query.rs
+++ b/zellij-server/src/host_query.rs
@@ -11,6 +11,8 @@
 //! terminal), [`HostQuery::to_query_bytes`] re-derives them from the
 //! enum.
 
+use base64::engine::{general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
+
 /// The two OSC string terminators in common use. Apps that phrase
 /// their query with one expect the reply to mirror it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,6 +37,34 @@ impl OscTerminator {
             OscTerminator::St => b"\x1b\\",
             OscTerminator::Bel => b"\x07",
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClipboardQuery {
+    pub destination: char,
+    pub terminator: OscTerminator,
+}
+
+impl ClipboardQuery {
+    /// unknown destinations are ack'd as `c`.
+    pub fn new(destination: u8, bell_terminated: bool) -> Self {
+        ClipboardQuery {
+            destination: match destination {
+                b'c' | b'p' | b's' => destination as char,
+                _ => 'c',
+            },
+            terminator: OscTerminator::from_bell_terminated(bell_terminated),
+        }
+    }
+
+    pub fn reply_bytes(&self, content: Option<&str>) -> Vec<u8> {
+        let encoded = content
+            .map(|content| BASE64_STANDARD.encode(content))
+            .unwrap_or_default();
+        let mut v = format!("\x1b]52;{};{}", self.destination, encoded).into_bytes();
+        v.extend_from_slice(self.terminator.as_bytes());
+        v
     }
 }
 
@@ -164,6 +194,44 @@ mod tests {
             .to_query_bytes(),
             b"\x1b]4;255;?\x1b\\",
         );
+    }
+
+    #[test]
+    fn clipboard_query_reply_encodes_content_and_mirrors_terminator() {
+        let query = ClipboardQuery {
+            destination: 'c',
+            terminator: OscTerminator::St,
+        };
+        assert_eq!(
+            query.reply_bytes(Some("hello")),
+            b"\x1b]52;c;aGVsbG8=\x1b\\"
+        );
+
+        let query = ClipboardQuery {
+            destination: 'p',
+            terminator: OscTerminator::Bel,
+        };
+        assert_eq!(query.reply_bytes(Some("hello")), b"\x1b]52;p;aGVsbG8=\x07");
+    }
+
+    #[test]
+    fn clipboard_query_normalizes_unknown_destinations_to_c() {
+        assert_eq!(ClipboardQuery::new(b'p', false).destination, 'p');
+        assert_eq!(ClipboardQuery::new(b'q', false).destination, 'c');
+        assert_eq!(
+            ClipboardQuery::new(b'c', true).terminator,
+            OscTerminator::Bel
+        );
+    }
+
+    #[test]
+    fn clipboard_query_reply_is_empty_payload_when_nothing_was_copied() {
+        let query = ClipboardQuery {
+            destination: 'c',
+            terminator: OscTerminator::Bel,
+        };
+
+        assert_eq!(query.reply_bytes(None), b"\x1b]52;c;\x07");
     }
 
     #[test]

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -717,6 +717,7 @@ pub struct Grid {
     pub color_palette_notification_enabled: bool,
     pub search_results: SearchResult,
     pub pending_clipboard_update: Option<String>,
+    pub pending_clipboard_queries: Vec<crate::host_query::ClipboardQuery>,
     pub pending_osc7_cwd: Option<std::path::PathBuf>,
     /// Pending desktop notifications: (payload, terminator)
     /// Payload is the semicolon-joined params after "99", terminator is "\x07" or "\x1b\\"
@@ -1075,6 +1076,7 @@ impl Grid {
             kitty_host_support: KittyHostSupport::Supported,
             sixel_host_support: true,
             pending_clipboard_update: None,
+            pending_clipboard_queries: Vec::new(),
             pending_osc7_cwd: None,
             pending_desktop_notifications: Vec::new(),
             pending_forwarded_queries: Vec::new(),
@@ -4249,10 +4251,13 @@ impl Perform for Grid {
                     return;
                 }
 
-                let _clipboard = params[1].get(0).unwrap_or(&b'c');
+                let clipboard = params[1].get(0).copied().unwrap_or(b'c');
                 match params[2] {
                     b"?" => {
-                        // TBD: paste from own clipboard - currently unsupported
+                        // echo back the copy
+                        self.pending_clipboard_queries.push(
+                            crate::host_query::ClipboardQuery::new(clipboard, bell_terminated),
+                        );
                     },
                     base64 => {
                         if let Ok(bytes) = BASE64_DECODER.decode(base64) {

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -757,6 +757,10 @@ impl Pane for TerminalPane {
         self.grid.pending_forwarded_queries.drain(..).collect()
     }
 
+    fn drain_clipboard_queries(&mut self) -> Vec<crate::host_query::ClipboardQuery> {
+        self.grid.pending_clipboard_queries.drain(..).collect()
+    }
+
     fn drain_nested_session_messages(&mut self) -> Vec<NestedSessionMessage> {
         self.grid
             .pending_nested_session_messages

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -1,4 +1,5 @@
 use super::super::Grid;
+use crate::host_query::{ClipboardQuery, OscTerminator};
 use crate::panes::grid::SixelImageStore;
 use crate::panes::kitty_graphics::KittyImageStore;
 use crate::panes::link_handler::LinkHandler;
@@ -3492,6 +3493,103 @@ pub fn osc_4_background_query() {
         .map(|q| String::from_utf8(q.to_query_bytes()).unwrap())
         .collect();
     assert_eq!(forwarded_string, "\u{1b}]10;?\u{1b}\\");
+}
+
+#[test]
+pub fn osc_52_clipboard_query_is_queued_for_local_reply() {
+    let mut vte_parser = vte::Parser::new();
+    let sixel_image_store = Rc::new(RefCell::new(SixelImageStore::default()));
+    let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
+    let debug = false;
+    let arrow_fonts = true;
+    let styled_underlines = true;
+    let osc8_hyperlinks = true;
+    let explicitly_disable_kitty_keyboard_protocol = false;
+
+    let mut grid = Grid::new(
+        51,
+        97,
+        Rc::new(RefCell::new(Palette::default())),
+        terminal_emulator_color_codes,
+        Rc::new(RefCell::new(LinkHandler::new())),
+        Rc::new(RefCell::new(None)),
+        sixel_image_store,
+        Rc::new(RefCell::new(KittyImageStore::default())),
+        Style::default(),
+        debug,
+        arrow_fonts,
+        styled_underlines,
+        osc8_hyperlinks,
+        explicitly_disable_kitty_keyboard_protocol,
+    );
+
+    // st-terminated query for the system clipboard
+    let content = "\u{1b}]52;c;?\u{1b}\\";
+    vte_parser.advance(&mut grid, content.as_bytes());
+
+    // bel-terminated query for selection
+    let content = "\u{1b}]52;p;?\u{07}";
+    vte_parser.advance(&mut grid, content.as_bytes());
+
+    // unknown responder
+    let content = "\u{1b}]52;q;?\u{07}";
+    vte_parser.advance(&mut grid, content.as_bytes());
+
+    assert!(grid.pending_forwarded_queries.is_empty());
+    assert!(grid.pending_messages_to_pty.is_empty());
+    assert!(grid.pending_clipboard_update.is_none());
+    assert_eq!(
+        grid.pending_clipboard_queries,
+        vec![
+            ClipboardQuery {
+                destination: 'c',
+                terminator: OscTerminator::St,
+            },
+            ClipboardQuery {
+                destination: 'p',
+                terminator: OscTerminator::Bel,
+            },
+            ClipboardQuery {
+                destination: 'c',
+                terminator: OscTerminator::Bel,
+            },
+        ],
+    );
+}
+
+#[test]
+pub fn osc_52_clipboard_write_is_not_treated_as_a_query() {
+    let mut vte_parser = vte::Parser::new();
+    let sixel_image_store = Rc::new(RefCell::new(SixelImageStore::default()));
+    let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
+    let debug = false;
+    let arrow_fonts = true;
+    let styled_underlines = true;
+    let osc8_hyperlinks = true;
+    let explicitly_disable_kitty_keyboard_protocol = false;
+
+    let mut grid = Grid::new(
+        51,
+        97,
+        Rc::new(RefCell::new(Palette::default())),
+        terminal_emulator_color_codes,
+        Rc::new(RefCell::new(LinkHandler::new())),
+        Rc::new(RefCell::new(None)),
+        sixel_image_store,
+        Rc::new(RefCell::new(KittyImageStore::default())),
+        Style::default(),
+        debug,
+        arrow_fonts,
+        styled_underlines,
+        osc8_hyperlinks,
+        explicitly_disable_kitty_keyboard_protocol,
+    );
+
+    let content = "\u{1b}]52;c;aGVsbG8=\u{07}"; // "hello"
+    vte_parser.advance(&mut grid, content.as_bytes());
+
+    assert!(grid.pending_clipboard_queries.is_empty());
+    assert_eq!(grid.pending_clipboard_update, Some("hello".to_owned()));
 }
 
 #[test]

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1506,6 +1506,8 @@ pub(crate) struct Screen {
     client_kitty_host_state: Rc<RefCell<HashMap<ClientId, HostKittyState>>>,
     terminal_emulator_colors: Rc<RefCell<Palette>>,
     terminal_emulator_color_codes: Rc<RefCell<HashMap<usize, String>>>,
+    /// for osc52 clipboard queries
+    last_copied_text: Rc<RefCell<Option<String>>>,
     connected_clients: Rc<RefCell<HashMap<ClientId, bool>>>, // bool -> is_web_client
     /// The indices of this [`Screen`]'s active [`Tab`]s.
     active_tab_ids: BTreeMap<ClientId, usize>,
@@ -1699,6 +1701,7 @@ impl Screen {
             last_single_pane_tab_names: HashMap::new(),
             terminal_emulator_colors: Rc::new(RefCell::new(Palette::default())),
             terminal_emulator_color_codes: Rc::new(RefCell::new(HashMap::new())),
+            last_copied_text: Rc::new(RefCell::new(None)),
             tab_history: BTreeMap::new(),
             pane_history: BTreeMap::new(),
             mode_info: BTreeMap::new(),
@@ -4497,6 +4500,7 @@ impl Screen {
             self.copy_options.clone(),
             self.terminal_emulator_colors.clone(),
             self.terminal_emulator_color_codes.clone(),
+            self.last_copied_text.clone(),
             swap_layouts,
             self.default_shell.clone(),
             self.debug,

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -229,6 +229,7 @@ pub(crate) struct Tab {
     copy_on_select: bool,
     terminal_emulator_colors: Rc<RefCell<Palette>>,
     terminal_emulator_color_codes: Rc<RefCell<HashMap<usize, String>>>,
+    last_copied_text: Rc<RefCell<Option<String>>>,
     pids_waiting_resize: HashSet<u32>, // u32 is the terminal_id
     cursor_positions_and_shape: HashMap<ClientId, (usize, usize, String)>, // (x_position,
     // y_position,
@@ -471,6 +472,10 @@ pub trait Pane {
     fn drain_forwarded_queries(&mut self) -> Vec<crate::host_query::HostQuery> {
         // Only terminal panes forward whitelisted queries to the host;
         // plugin panes have no such concept.
+        vec![]
+    }
+    fn drain_clipboard_queries(&mut self) -> Vec<crate::host_query::ClipboardQuery> {
+        // Only terminal panes can ask for the clipboard via OSC 52.
         vec![]
     }
     fn drain_nested_session_messages(&mut self) -> Vec<NestedSessionMessage> {
@@ -855,6 +860,7 @@ impl Tab {
         copy_options: CopyOptions,
         terminal_emulator_colors: Rc<RefCell<Palette>>,
         terminal_emulator_color_codes: Rc<RefCell<HashMap<usize, String>>>,
+        last_copied_text: Rc<RefCell<Option<String>>>,
         swap_layouts: (Vec<SwapTiledLayout>, Vec<SwapFloatingLayout>),
         default_shell: PathBuf,
         debug: bool,
@@ -984,6 +990,7 @@ impl Tab {
             copy_on_select: copy_options.copy_on_select,
             terminal_emulator_colors,
             terminal_emulator_color_codes,
+            last_copied_text,
             pids_waiting_resize: HashSet::new(),
             cursor_positions_and_shape: HashMap::new(),
             is_pending: true, // will be switched to false once the layout is applied
@@ -4222,6 +4229,7 @@ impl Tab {
             }
             let nested_session_messages = terminal_output.drain_nested_session_messages();
             let clipboard_update = terminal_output.drain_clipboard_update();
+            let clipboard_queries = terminal_output.drain_clipboard_queries();
             let desktop_notifications = terminal_output.drain_desktop_notifications();
             let osc7_cwd = terminal_output.drain_osc7_cwd();
             for message in messages_to_pty {
@@ -4248,10 +4256,19 @@ impl Tab {
                 self.write_selection_to_clipboard(&string)
                     .with_context(err_context)?;
             }
+
+            // allow for an immediate yank and paste
+            for query in clipboard_queries {
+                let reply = query.reply_bytes(self.last_copied_text.borrow().as_deref());
+                self.write_to_pane_id_without_preprocessing(reply, PaneId::Terminal(pid))
+                    .with_context(err_context)?;
+            }
+
             if !desktop_notifications.is_empty() {
                 self.forward_desktop_notifications(desktop_notifications, pid)
                     .with_context(err_context)?;
             }
+
             if let Some(path) = osc7_cwd {
                 let _ = self
                     .senders
@@ -6456,6 +6473,8 @@ impl Tab {
 
     fn write_selection_to_clipboard(&self, selection: &str) -> Result<()> {
         let err_context = || format!("failed to write selection to clipboard: '{}'", selection);
+
+        self.last_copied_text.replace(Some(selection.to_owned()));
 
         let mut output = Output::default();
         let connected_clients: HashSet<ClientId> =

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -264,6 +264,7 @@ fn create_new_tab(size: Size, default_mode: ModeInfo) -> Tab {
         copy_options,
         terminal_emulator_colors,
         terminal_emulator_color_codes,
+        Rc::new(RefCell::new(None)),
         (vec![], vec![]),
         PathBuf::from("my_default_shell"),
         debug,
@@ -362,6 +363,7 @@ fn create_new_tab_with_stacked_pane_list(
         copy_options,
         terminal_emulator_colors,
         terminal_emulator_color_codes,
+        Rc::new(RefCell::new(None)),
         (vec![], vec![]),
         PathBuf::from("my_default_shell"),
         debug,
@@ -456,6 +458,7 @@ fn create_new_tab_without_pane_frames(size: Size, default_mode: ModeInfo) -> Tab
         copy_options,
         terminal_emulator_colors,
         terminal_emulator_color_codes,
+        Rc::new(RefCell::new(None)),
         (vec![], vec![]),
         PathBuf::from("my_default_shell"),
         debug,
@@ -567,6 +570,7 @@ fn create_new_tab_with_swap_layouts(
         copy_options,
         terminal_emulator_colors,
         terminal_emulator_color_codes,
+        Rc::new(RefCell::new(None)),
         swap_layouts,
         PathBuf::from("my_default_shell"),
         debug,
@@ -675,6 +679,7 @@ fn create_new_tab_with_os_api(
         copy_options,
         terminal_emulator_colors,
         terminal_emulator_color_codes,
+        Rc::new(RefCell::new(None)),
         (vec![], vec![]), // swap layouts
         PathBuf::from("my_default_shell"),
         debug,
@@ -769,6 +774,7 @@ fn create_new_tab_with_layout(size: Size, default_mode: ModeInfo, layout: &str) 
         copy_options,
         terminal_emulator_colors,
         terminal_emulator_color_codes,
+        Rc::new(RefCell::new(None)),
         (vec![], vec![]), // swap layouts
         PathBuf::from("my_default_shell"),
         debug,
@@ -877,6 +883,7 @@ fn create_new_tab_with_mock_pty_writer(
         copy_options,
         terminal_emulator_colors,
         terminal_emulator_color_codes,
+        Rc::new(RefCell::new(None)),
         (vec![], vec![]), // swap layouts
         PathBuf::from("my_default_shell"),
         debug,
@@ -976,6 +983,7 @@ fn create_new_tab_with_sixel_support(
         copy_options,
         terminal_emulator_colors,
         terminal_emulator_color_codes,
+        Rc::new(RefCell::new(None)),
         (vec![], vec![]), // swap layouts
         PathBuf::from("my_default_shell"),
         debug,
@@ -4379,6 +4387,41 @@ fn enter_search_floating_pane() {
         Palette::default(),
     );
     assert_snapshot!("search_floating_tab_highlight_fring", snapshot);
+}
+
+#[test]
+fn osc_52_clipboard_query_is_answered_from_the_last_copy() {
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+
+    let mut pty_instruction_bus = MockPtyInstructionBus::new();
+    let mut tab = create_new_tab_with_mock_pty_writer(
+        size,
+        ModeInfo::default(),
+        pty_instruction_bus.pty_write_sender(),
+    );
+    pty_instruction_bus.start();
+
+    // Nothing copied yet: the conventional empty-clipboard reply
+    tab.handle_pty_bytes(1, "\u{1b}]52;c;?\u{07}".as_bytes().to_vec())
+        .unwrap();
+    // An app copies via OSC 52, then queries: it reads its own copy back,
+    // with the reply mirroring the query's terminator
+    tab.handle_pty_bytes(1, "\u{1b}]52;c;aGVsbG8=\u{07}".as_bytes().to_vec())
+        .unwrap();
+    tab.handle_pty_bytes(1, "\u{1b}]52;c;?\u{1b}\\".as_bytes().to_vec())
+        .unwrap();
+
+    pty_instruction_bus.exit();
+    assert_eq!(
+        pty_instruction_bus.clone_output(),
+        vec![
+            "\u{1b}]52;c;\u{07}".to_string(),
+            "\u{1b}]52;c;aGVsbG8=\u{1b}\\".to_string(),
+        ],
+    );
 }
 
 #[test]
@@ -13354,6 +13397,7 @@ fn create_new_tab_with_plugin_receiver(
         copy_options,
         terminal_emulator_colors,
         terminal_emulator_color_codes,
+        Rc::new(RefCell::new(None)),
         (vec![], vec![]),
         PathBuf::from("my_default_shell"),
         debug,
@@ -15142,6 +15186,7 @@ fn create_new_tab_with_server_receiver(
         copy_options,
         terminal_emulator_colors,
         terminal_emulator_color_codes,
+        Rc::new(RefCell::new(None)),
         (vec![], vec![]),
         PathBuf::from("my_default_shell"),
         false, // debug

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -206,6 +206,7 @@ fn create_new_tab(size: Size, stacked_resize: bool) -> Tab {
         copy_options,
         terminal_emulator_colors,
         terminal_emulator_color_codes,
+        Rc::new(RefCell::new(None)),
         (vec![], vec![]), // swap layouts
         PathBuf::from("my_default_shell"),
         debug,
@@ -297,6 +298,7 @@ fn create_new_tab_with_layout(size: Size, layout: TiledPaneLayout) -> Tab {
         copy_options,
         terminal_emulator_colors,
         terminal_emulator_color_codes,
+        Rc::new(RefCell::new(None)),
         (vec![], vec![]), // swap layouts
         PathBuf::from("my_default_shell"),
         debug,
@@ -394,6 +396,7 @@ fn create_new_tab_with_cell_size(
         copy_options,
         terminal_emulator_colors,
         terminal_emulator_color_codes,
+        Rc::new(RefCell::new(None)),
         (vec![], vec![]), // swap layouts
         PathBuf::from("my_default_shell"),
         debug,


### PR DESCRIPTION
- closes out a TODO for OSC52 clipboard queries
- **important**: this does not touch the host clipboard, but does conform to how tmux does this (query the multiplexer, not the host)
- previous attempts at making this system integrated #2647 would _also_ be an improvement, but opens up a lot more questions about security and ownership which can be skirted until someone much more knowledgeable than i can own that e2e

related:
- #3133
- #3135
-  #1288
- #3951 