### PR TITLE
feat: WebSocket remote-control API and MCP server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,21 +27,21 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy 0.7.34",
+ "zerocopy",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -59,16 +59,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -134,24 +128,24 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
-dependencies = [
- "backtrace",
-]
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
-version = "1.5.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "asn1-rs"
@@ -177,7 +171,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -189,29 +183,30 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "async-channel"
-version = "1.8.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
- "event-listener",
+ "event-listener-strategy",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -233,15 +228,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -249,28 +244,29 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.3.1",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -288,7 +284,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -303,7 +299,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "mime",
@@ -316,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef252edff26ddba56bbcdf2ee3307b8129acb86f5749b68990c168a6fcc9c76"
+checksum = "be44683b41ccb9ab2d23a5230015c9c3c55be97a25e4428366de8873103f7970"
 dependencies = [
  "axum",
  "axum-core",
@@ -326,7 +322,7 @@ dependencies = [
  "cookie",
  "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "mime",
@@ -346,7 +342,7 @@ dependencies = [
  "bytes",
  "either",
  "fs-err",
- "http 1.3.1",
+ "http 1.5.0",
  "http-body",
  "hyper",
  "hyper-util",
@@ -389,6 +385,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,9 +407,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -429,27 +431,27 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cap-fs-ext"
-version = "3.4.4"
+version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e41cc18551193fe8fa6f15c1e3c799bc5ec9e2cfbfaa8ed46f37013e3e6c173c"
+checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -459,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "3.4.4"
+version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1e394ed14f39f8bc26f59d4c0c010dbe7f0a1b9bafff451b1f98b67c8af62a"
+checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
@@ -469,7 +471,7 @@ dependencies = [
  "io-lifetimes",
  "ipnet",
  "maybe-owned",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "rustix-linux-procfs",
  "windows-sys 0.59.0",
  "winx",
@@ -477,51 +479,54 @@ dependencies = [
 
 [[package]]
 name = "cap-rand"
-version = "3.4.4"
+version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0acb89ccf798a28683f00089d0630dfaceec087234eae0d308c05ddeaa941b40"
+checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
 dependencies = [
  "ambient-authority",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
 name = "cap-std"
-version = "3.4.4"
+version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c0355ca583dd58f176c3c12489d684163861ede3c9efa6fd8bba314c984189"
+checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
 dependencies = [
  "cap-primitives",
  "io-extras",
  "io-lifetimes",
- "rustix 1.1.2",
+ "rustix 1.1.4",
 ]
 
 [[package]]
 name = "cap-time-ext"
-version = "3.4.4"
+version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491af520b8770085daa0466978c75db90368c71896523f2464214e38359b1a5b"
+checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
 dependencies = [
  "ambient-authority",
  "cap-primitives",
  "iana-time-zone",
  "once_cell",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "winx",
 ]
 
 [[package]]
 name = "castaway"
-version = "0.1.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -531,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -554,23 +559,21 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
- "wasm-bindgen",
- "windows-targets 0.52.6",
+ "serde",
+ "windows-link",
 ]
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -578,15 +581,15 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
- "terminal_size 0.4.4",
+ "terminal_size",
 ]
 
 [[package]]
@@ -628,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.54"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -652,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "colorsys"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dfdf9179d546b55ff3f88c9d93ecfaa3e9760163da5a1080af5243230dbbb70"
+checksum = "54261aba646433cb567ec89844be4c4825ca92a4f8afba52fc4dd88436e31bbd"
 
 [[package]]
 name = "compact-bar"
@@ -668,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.2.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -684,17 +687,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.0"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
- "encode_unicode 0.3.6",
+ "encode_unicode",
  "libc",
  "once_cell",
- "regex",
- "terminal_size 0.1.17",
- "unicode-width 0.1.14",
- "winapi",
+ "unicode-width 0.2.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -703,7 +704,7 @@ version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
- "encode_unicode 1.0.0",
+ "encode_unicode",
  "libc",
  "windows-sys 0.61.2",
 ]
@@ -737,9 +738,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -764,11 +765,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam"
-version = "0.8.1"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
 dependencies = [
- "cfg-if",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -778,57 +778,46 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.8"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "lazy_static",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.5"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
-dependencies = [
- "cfg-if",
-]
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -836,12 +825,12 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "document-features",
  "mio",
- "parking_lot 0.12.1",
- "rustix 1.1.2",
+ "parking_lot",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -858,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -877,24 +866,24 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.44"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
+checksum = "3a45ee8994e5307cb4c60cfc1c20bf7263ffb771ddc135c9f768a14bcbc15b09"
 dependencies = [
  "curl-sys",
  "libc",
- "openssl-probe 0.1.5",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
- "socket2 0.4.9",
- "winapi",
+ "socket2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "curl-sys"
-version = "0.4.68+curl-8.4.0"
+version = "0.4.90+curl-8.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a0d18d88360e374b16b2273c832b5e57258ffc1d4aa4f96b108e0738d5752f"
+checksum = "97799a0d220bfb3361e0fe4936966ff8c4b24d65c3f06dfc70d7b680b44e7897"
 dependencies = [
  "cc",
  "libc",
@@ -903,7 +892,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -916,10 +905,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.9.0"
+name = "darling"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "der-parser"
@@ -940,19 +963,27 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "powerfmt",
+ "derive_more-impl",
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
+name = "derive_more-impl"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.96",
+ "rustc_version",
+ "syn 2.0.119",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -961,9 +992,9 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
- "console 0.15.0",
+ "console 0.15.11",
  "shell-words",
- "thiserror 1.0.61",
+ "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -974,7 +1005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
 ]
 
 [[package]]
@@ -993,27 +1024,16 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
 dependencies = [
- "dirs-sys 0.5.0",
+ "dirs-sys",
 ]
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys 0.3.7",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users 0.4.3",
- "winapi",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -1024,32 +1044,32 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.5.2",
+ "redox_users",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "dissimilar"
-version = "1.0.6"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "210ec60ae7d710bed8683e333e9d2855a8a56a3e9892b38bad3bb0d4d29b0d5e"
+checksum = "aeda16ab4059c5fd2a83f2b9c9e9c981327b18aa8e3b313f7e6563799d4f093e"
 
 [[package]]
 name = "doctest-file"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
 
 [[package]]
 name = "document-features"
@@ -1067,6 +1087,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,23 +1100,17 @@ checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "embed-resource"
-version = "3.0.6"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a075fc573c64510038d7ee9abc7990635863992f83ebc52c8b433b8411a02e"
+checksum = "fbfdaacccebec3b28e4866b8973543c7647797db5ada1bdab552e48fe665fbbd"
 dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 0.9.6",
+ "toml",
  "vswhom",
  "winreg",
 ]
-
-[[package]]
-name = "encode_unicode"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encode_unicode"
@@ -1100,40 +1120,54 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "event-listener"
-version = "2.5.2"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "expect-test"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d9eafeadd538e68fb28016364c9732d78e420b9ff8853fa5e4058861e9f8d3"
+checksum = "63af43ff4431e848fb47472a920f14fa71c24de13255a5692e93d4e90302acb0"
 dependencies = [
  "dissimilar",
  "once_cell",
@@ -1153,28 +1187,19 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fd-lock"
-version = "4.0.2"
+version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
- "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1188,11 +1213,11 @@ dependencies = [
 
 [[package]]
 name = "file-id"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bc904b9bbefcadbd8e3a9fb0d464a9b979de6324c03b3c663e8994f46a5be36"
+checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1233,9 +1258,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1245,18 +1270,18 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
 name = "fs-err"
-version = "3.1.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f89bda4c2a21204059a977ed3bfe746677dfd137b83c339e702b0ac91d482aa"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
 dependencies = [
  "autocfg",
  "tokio",
@@ -1264,13 +1289,13 @@ dependencies = [
 
 [[package]]
 name = "fs-set-times"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033b337d725b97690d86893f9de22b67b80dcc4e9ad815f348254c38119db8fb"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
- "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1290,9 +1315,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1305,9 +1330,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1315,15 +1340,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1332,53 +1357,51 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-lite"
-version = "1.13.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
- "fastrand 1.7.0",
+ "fastrand",
  "futures-core",
  "futures-io",
- "memchr",
  "parking",
  "pin-project-lite",
- "waker-fn",
 ]
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1388,7 +1411,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1403,9 +1425,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -1413,34 +1435,34 @@ dependencies = [
 
 [[package]]
 name = "getopts"
-version = "0.2.21"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width 0.1.14",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.6",
+ "r-efi 5.3.0",
+ "wasip2",
 ]
 
 [[package]]
@@ -1451,7 +1473,7 @@ checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.1",
 ]
 
@@ -1472,19 +1494,13 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
- "indexmap 2.14.0",
+ "http 1.5.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hashbrown"
@@ -1498,11 +1514,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash 0.1.4",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1560,9 +1576,9 @@ checksum = "c706f1711006204c2ba8fb1a7bd55f689bbf7feca9ff40325206b5e140cff6df"
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -1571,34 +1587,33 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http 1.5.0",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.5.0",
  "http-body",
  "pin-project-lite",
 ]
@@ -1617,15 +1632,15 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -1641,7 +1656,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.3.1",
+ "http 1.5.0",
  "http-body",
  "httparse",
  "httpdate",
@@ -1649,6 +1664,7 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -1657,27 +1673,36 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
- "http 1.3.1",
+ "futures-channel",
+ "futures-util",
+ "http 1.5.0",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core",
 ]
 
 [[package]]
@@ -1691,12 +1716,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1704,9 +1730,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1717,9 +1743,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1731,15 +1757,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1751,15 +1777,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1769,6 +1795,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1783,9 +1815,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1793,31 +1825,21 @@ dependencies = [
 
 [[package]]
 name = "include_dir"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18762faeff7122e89e0857b02f7ce6fcc0d101d5e9ad2ad7846cc01d61b7f19e"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
 dependencies = [
  "include_dir_macros",
 ]
 
 [[package]]
 name = "include_dir_macros"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
 dependencies = [
  "proc-macro2",
  "quote",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
-dependencies = [
- "autocfg",
- "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -1836,7 +1858,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "inotify-sys",
  "libc",
 ]
@@ -1863,19 +1885,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "interprocess"
-version = "2.3.1"
+version = "2.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bf2b0e0785c5394a7392f66d7c4fb9c653633c29b27a932280da3cb344c66a"
+checksum = "798de1433ba514cc6c04c4144c2469af81396e4906195218737c776d47769572"
 dependencies = [
  "doctest-file",
  "futures-core",
@@ -1883,7 +1896,7 @@ dependencies = [
  "recvmsg",
  "tokio",
  "widestring",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1898,15 +1911,15 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a611371471e98973dbcab4e0ec66c31a10bc356eeb4d54a0e05eac8158fe38c"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "ipnet"
-version = "2.9.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_ci"
@@ -1922,9 +1935,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "isahc"
-version = "1.7.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "334e04b4d781f436dc315cb1e7515bd96826426345d498149e4bde36b67f8ee9"
+checksum = "fbce0b6b4f5c50b8e014e227d51ddf721558308566b4f6ba608abcea4d272cce"
 dependencies = [
  "async-channel",
  "castaway",
@@ -1934,10 +1947,9 @@ dependencies = [
  "encoding_rs",
  "event-listener",
  "futures-lite",
- "http 0.2.9",
+ "http 0.2.12",
  "log",
  "mime",
- "once_cell",
  "polling",
  "slab",
  "sluice",
@@ -1949,34 +1961,37 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
-version = "0.1.31"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -1992,20 +2007,20 @@ dependencies = [
 
 [[package]]
 name = "kdl"
-version = "4.5.0"
+version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8388a371e0e2ede18bbd94e476fcd45b4ac65cefcedf0c06fd13bd8389574a6"
+checksum = "e03e2e96c5926fe761088d66c8c2aee3a4352a2573f4eaca50043ad130af9117"
 dependencies = [
- "miette 5.8.0",
+ "miette 5.10.0",
  "nom",
- "thiserror 1.0.61",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "kqueue"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -2017,7 +2032,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "libc",
 ]
 
@@ -2034,15 +2049,15 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
 name = "leb128fmt"
@@ -2058,21 +2073,21 @@ checksum = "72d9d1bd215936bc8647ad92986bb56f3f216550b53c44ab785e3217ae33625e"
 
 [[package]]
 name = "libc"
-version = "0.2.176"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libnghttp2-sys"
-version = "0.1.8+1.55.1"
+version = "0.1.13+1.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fae956c192dadcdb5dace96db71fa0b827333cce7c7b38dc71446f024d8a340"
+checksum = "492e00167f1418c15648144f42bbfc63099806ecee9bf8d09a6353d6b4856b3c"
 dependencies = [
  "cc",
  "libc",
@@ -2080,11 +2095,10 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
- "bitflags 2.11.0",
  "libc",
 ]
 
@@ -2101,9 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.2.23"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+checksum = "c04141a07bb0c0bc461cb657808764de571702a59bc5c726c400ac9a7625e3ab"
 dependencies = [
  "cc",
  "libc",
@@ -2115,9 +2129,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.8"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "libc",
@@ -2140,15 +2154,15 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -2158,11 +2172,10 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -2180,20 +2193,22 @@ checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
 
 [[package]]
 name = "log4rs"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36ca1786d9e79b8193a68d480a0907b612f109537115c6ff655a3a1967533fd"
+checksum = "3e947bb896e702c711fccc2bf02ab2abb6072910693818d1d6b07ee2b9dfd86c"
 dependencies = [
  "anyhow",
  "arc-swap",
  "chrono",
- "derivative",
+ "derive_more",
  "fnv",
  "log",
  "log-mdc",
- "parking_lot 0.12.1",
- "thiserror 1.0.61",
+ "mock_instant",
+ "parking_lot",
+ "thiserror 2.0.19",
  "thread-id",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -2210,28 +2225,19 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
-
-[[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miette"
-version = "5.8.0"
+version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a992891d5579caa9efd8e601f82e30a1caa79a27a5db075dde30ecb9eab357"
+checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
 dependencies = [
- "miette-derive 5.8.0",
+ "miette-derive 5.10.0",
  "once_cell",
- "thiserror 1.0.61",
+ "thiserror 1.0.69",
  "unicode-width 0.1.14",
 ]
 
@@ -2249,20 +2255,20 @@ dependencies = [
  "supports-color",
  "supports-hyperlinks",
  "supports-unicode",
- "terminal_size 0.4.4",
+ "terminal_size",
  "textwrap",
  "unicode-width 0.1.14",
 ]
 
 [[package]]
 name = "miette-derive"
-version = "5.8.0"
+version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c65c625186a9bcce6699394bee511e1b1aec689aa7e3be1bf4e996e75834153"
+checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2273,7 +2279,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2300,21 +2306,27 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "multimap"
-version = "0.8.3"
+name = "mock_instant"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+checksum = "9bb517913cfcfb9eeda59f36020269075a152701a01606c612f547e4890be399"
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "multiple-select"
@@ -2329,7 +2341,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -2338,7 +2350,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2346,9 +2358,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -2360,7 +2372,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -2391,34 +2403,33 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "ntapi"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70f219e21142367c70c0b30c6a9e3a14d55b4d12a204d897fbec83a0363f081"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
 ]
 
 [[package]]
 name = "num-bigint"
-version = "0.4.3"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2431,9 +2442,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -2454,7 +2465,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2487,9 +2498,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2499,9 +2510,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -2511,18 +2522,18 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.4+3.5.4"
+version = "300.6.1+3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -2545,57 +2556,38 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking"
-version = "2.0.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.9",
+ "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
- "instant",
  "libc",
- "redox_syscall 0.2.13",
+ "redox_syscall",
  "smallvec",
- "winapi",
+ "windows-link",
 ]
 
 [[package]]
-name = "parking_lot_core"
-version = "0.9.9"
+name = "pastey"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall 0.4.1",
- "smallvec",
- "windows-targets 0.48.0",
-]
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pem"
@@ -2603,63 +2595,57 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 1.8.2",
+ "indexmap",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.3"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.3"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.25"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plugin-manager"
@@ -2685,22 +2671,23 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "2.2.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
- "libc",
- "log",
- "wepoll-ffi",
- "winapi",
+ "concurrent-queue",
+ "hermit-abi 0.5.2",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2713,9 +2700,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.16"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "pretty-bytes"
@@ -2775,7 +2765,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2798,30 +2788,35 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.0",
- "zerocopy 0.8.17",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2842,7 +2837,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2852,26 +2847,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.0"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.3.1",
- "zerocopy 0.8.17",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2902,31 +2896,11 @@ checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom 0.2.10",
- "redox_syscall 0.2.13",
- "thiserror 1.0.61",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2935,16 +2909,48 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.19",
 ]
 
 [[package]]
-name = "regex"
-version = "1.8.1"
+name = "ref-cast"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2953,9 +2959,43 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.5.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
 
 [[package]]
 name = "ring"
@@ -2965,10 +3005,55 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.10",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "094c075f6698deef5a657cf4df6b684dff65157d255978b92b552ec22503f17a"
+dependencies = [
+ "async-trait",
+ "base64 0.23.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "http 1.5.0",
+ "http-body",
+ "http-body-util",
+ "pastey",
+ "pin-project-lite",
+ "rand 0.10.2",
+ "reqwest",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "737d947bcfd946fae6a179a4ef6487be6dcf25c930c2393856b820f1386e52a6"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2977,7 +3062,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78046161564f5e7cd9008aff3b2990b3850dc8e0349119b98e8f251e099f24d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3015,7 +3100,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3024,14 +3109,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3042,14 +3127,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
 dependencies = [
  "once_cell",
- "rustix 1.1.2",
+ "rustix 1.1.4",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3062,9 +3147,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe 0.2.1",
  "rustls-pki-types",
@@ -3083,9 +3168,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
@@ -3103,10 +3188,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.10"
+name = "rustversion"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3118,34 +3209,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.3.4"
+name = "schannel"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b2d775fb28f245817589471dd49c5edf64237f4a19d10ce9a92ff4651a27f4"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "sdd",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.22"
+name = "schemars"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
- "windows-sys 0.48.0",
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "sdd"
-version = "3.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -3153,7 +3255,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3172,15 +3274,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3188,44 +3290,57 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
 dependencies = [
  "itoa",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3251,27 +3366,27 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
- "futures",
+ "futures-executor",
+ "futures-util",
  "log",
  "once_cell",
- "parking_lot 0.12.1",
- "scc",
+ "parking_lot",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3287,12 +3402,12 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.2",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -3317,24 +3432,24 @@ dependencies = [
 
 [[package]]
 name = "shell-words"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shellexpand"
-version = "3.0.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd1c7ddea665294d484c39fd0c0d2b7e35bbfe10035c5fe1854741a57f6880e1"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
  "dirs",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -3359,10 +3474,11 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -3374,9 +3490,9 @@ checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "similar"
-version = "2.1.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "sixel-image"
@@ -3394,20 +3510,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71b7f6629ac964d60179c1fb00dfb80da265fc3465a17245e26c1eaf678d476"
 dependencies = [
  "arrayvec",
- "thiserror 1.0.61",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "sluice"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7400c0eff44aa2fcb5e31a5f24ba9716ed90138769e4977a2ba6014ae63eb5"
+checksum = "160b744a45e8261307bcfe03c98e2f8274502207d534c9a64b675c4db1b6bd58"
 dependencies = [
  "async-channel",
  "futures-core",
@@ -3416,46 +3532,49 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+
+[[package]]
+name = "sse-stream"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "ssh2"
-version = "0.9.3"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "269343e64430067a14937ae0e3c4ec604c178fb896dde0964b1acd22b3e2eeb1"
+checksum = "c95eb3c09e378543395a3fa9796f897861862466ee331d59140ade4ea0dcfdfc"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.1",
  "libc",
  "libssh2-sys",
- "parking_lot 0.11.2",
+ "parking_lot",
 ]
 
 [[package]]
@@ -3496,7 +3615,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23de088478b31c349c9ba67816fa55d9355232d63c3afea8bf513e31f0f1d2c0"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.5",
  "serde",
 ]
 
@@ -3530,7 +3649,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3571,20 +3690,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.96"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3607,6 +3715,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -3616,7 +3727,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3635,17 +3746,17 @@ dependencies = [
 
 [[package]]
 name = "system-interface"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b858526d22750088a9b3cf2e3c2aacebd5377f13adeec02860c30d09113010a6"
+checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "cap-fs-ext",
  "cap-std",
  "fd-lock",
  "io-lifetimes",
  "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -3661,24 +3772,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "cfg-if",
- "fastrand 2.1.0",
- "rustix 0.38.44",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3687,7 +3789,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3703,11 +3805,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.61",
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -3721,13 +3823,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3743,33 +3845,30 @@ dependencies = [
 
 [[package]]
 name = "thread-id"
-version = "4.0.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fdfe0627923f7411a43ec9ec9c39c3a9b4151be313e0922042581fb6c9b717f"
+checksum = "2010d27add3f3240c1fef7959f46c814487b216baee662af53be645ba7831c07"
 dependencies = [
  "libc",
- "redox_syscall 0.2.13",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -3779,15 +3878,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3795,9 +3894,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3805,37 +3904,36 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.7",
+ "socket2",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -3843,9 +3941,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3861,36 +3959,34 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.28.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2a4cf385da23d1d53bc15cdfa5c2109e93d8d362393c801e87da2f72f0e201"
-dependencies = [
- "indexmap 2.14.0",
- "serde_core",
- "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
 ]
 
 [[package]]
@@ -3899,22 +3995,13 @@ version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.4",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
+ "winnow",
 ]
 
 [[package]]
@@ -3932,7 +4019,7 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.4",
+ "winnow",
 ]
 
 [[package]]
@@ -3943,9 +4030,9 @@ checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -3959,16 +4046,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.4"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "bytes",
- "http 1.3.1",
+ "futures-util",
+ "http 1.5.0",
+ "http-body",
  "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -3985,9 +4076,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -3997,20 +4088,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
@@ -4026,6 +4117,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4033,13 +4130,29 @@ checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.3.1",
+ "http 1.5.0",
  "httparse",
  "log",
- "rand 0.9.0",
+ "rand 0.9.5",
  "sha1",
  "thiserror 2.0.19",
  "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.5.0",
+ "httparse",
+ "log",
+ "rand 0.9.5",
+ "sha1",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4050,15 +4163,21 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -4073,6 +4192,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4080,14 +4205,15 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4116,12 +4242,14 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom 0.3.1",
- "serde",
+ "getrandom 0.4.3",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4132,9 +4260,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vswhom"
@@ -4177,9 +4305,9 @@ dependencies = [
 
 [[package]]
 name = "waker-fn"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walkdir"
@@ -4192,28 +4320,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+name = "want"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasi"
-version = "0.13.3+wasi-0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "wit-bindgen-rt",
+ "try-lock",
 ]
 
 [[package]]
-name = "wasi-common"
-version = "36.0.12"
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5eb67546a23b30761dc1e30325984e166e8f6961ae97e3e82d5a7570255838"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi-common"
+version = "36.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "337c0c9192c21e139d7fe4cf8bf900a5e95c5f384e3a08b11531b802c2f19478"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "cap-fs-ext",
  "cap-rand",
  "cap-std",
@@ -4222,7 +4350,7 @@ dependencies = [
  "io-extras",
  "io-lifetimes",
  "log",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "system-interface",
  "thiserror 2.0.19",
  "tracing",
@@ -4231,35 +4359,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.87"
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
+ "wit-bindgen",
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.87"
+name = "wasm-bindgen"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
- "bumpalo",
- "log",
+ "cfg-if",
  "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.96",
+ "rustversion",
+ "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.87"
+name = "wasm-bindgen-futures"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4267,31 +4402,47 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
- "wasm-bindgen-backend",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-encoder"
-version = "0.239.0"
+version = "0.255.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be00faa2b4950c76fe618c409d2c3ea5a3c9422013e079482d78544bb2d184c"
+checksum = "9b524283fb5df62eec102ed0574838961bdd7ba5ac9c50d38e2756c51c971a42"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.255.0",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -4304,7 +4455,7 @@ dependencies = [
  "wasmi_collections",
  "wasmi_core",
  "wasmi_ir",
- "wasmparser",
+ "wasmparser 0.239.0",
  "wat",
 ]
 
@@ -4352,8 +4503,18 @@ version = "0.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
 dependencies = [
- "bitflags 2.11.0",
- "indexmap 2.14.0",
+ "bitflags 2.13.1",
+ "indexmap",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.255.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e329ef4b5d46e73b91d3ac6924417cad55a8cbbf869c199283383427c3320b"
+dependencies = [
+ "bitflags 2.13.1",
+ "indexmap",
 ]
 
 [[package]]
@@ -4367,9 +4528,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "239.0.0"
+version = "255.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9139176fe8a2590e0fb174cdcaf373b224cb93c3dde08e4297c1361d2ba1ea5d"
+checksum = "55ffec530f199bd3d553ac442c13dd108353cad533cad8514bc41e1f1f0fe686"
 dependencies = [
  "bumpalo",
  "leb128fmt",
@@ -4380,20 +4541,21 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.239.0"
+version = "1.255.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1c941927d34709f255558166f8901a2005f8ab4a9650432e9281b7cc6f3b75"
+checksum = "dda82c82e1486c7eed42a0465e544d80fff37abc3b39482e0d34dbaabe2fe5b1"
 dependencies = [
- "wast 239.0.0",
+ "wast 255.0.0",
 ]
 
 [[package]]
-name = "wepoll-ffi"
-version = "0.1.2"
+name = "web-sys"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
- "cc",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4413,13 +4575,13 @@ checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "wiggle"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a0751406b641ff50ef42d4a1ca843a03040c488c0c27f92093633447464013"
+checksum = "3185c97adf4d5f4c0d2abfea7f0bdeb21b486970acd2cf19c7a7fd95308f1764"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags 2.11.0",
+ "bitflags 2.13.1",
  "thiserror 2.0.19",
  "tracing",
  "wiggle-macro",
@@ -4427,27 +4589,27 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab62083fdcecdd0cac61b8c46e7de4f2629ebe8699fd9ce790d922cc89d50f5f"
+checksum = "13a019367ecff91d714d8f6cba589c36d7b16195eff0598236f9ce5aaf8b811d"
 dependencies = [
  "anyhow",
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.119",
  "witx",
 ]
 
 [[package]]
 name = "wiggle-macro"
-version = "36.0.12"
+version = "36.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756b7a4a7f57ee2f53e9ef3501ed0faacda4b8dcb169a921cddc8bc09ebd199e"
+checksum = "5e2f5a33059321aee91888c331b45de1d6e9f9d0f89ab88398ef1fda2d3ee1fb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.119",
  "wiggle-generate",
 ]
 
@@ -4469,11 +4631,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4489,7 +4651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.2",
+ "windows-core",
  "windows-future",
  "windows-numerics",
 ]
@@ -4500,16 +4662,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -4531,7 +4684,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
  "windows-threading",
 ]
@@ -4544,7 +4697,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4555,7 +4708,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4570,7 +4723,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
 ]
 
@@ -4590,15 +4743,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -4635,21 +4779,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -4696,12 +4825,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4714,12 +4837,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4729,12 +4846,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4762,12 +4873,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4777,12 +4882,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4798,12 +4897,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4816,12 +4909,6 @@ checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
@@ -4831,12 +4918,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
@@ -4856,22 +4937,19 @@ dependencies = [
 
 [[package]]
 name = "winx"
-version = "0.36.3"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9643b83820c0cd246ecabe5fa454dd04ba4fa67996369466d0747472d337346"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
- "bitflags 2.11.0",
- "windows-sys 0.52.0",
+ "bitflags 2.13.1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.33.0"
+name = "wit-bindgen"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
-dependencies = [
- "bitflags 2.11.0",
-]
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "witx"
@@ -4881,15 +4959,15 @@ checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
 dependencies = [
  "anyhow",
  "log",
- "thiserror 1.0.61",
+ "thiserror 1.0.69",
  "wast 35.0.2",
 ]
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x509-parser"
@@ -4947,7 +5025,7 @@ dependencies = [
  "prost-build",
  "serde_json",
  "sha2",
- "toml 1.1.4+spec-1.1.0",
+ "toml",
  "which",
  "xflags",
  "xshell",
@@ -4965,9 +5043,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4976,13 +5054,13 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -5006,9 +5084,31 @@ dependencies = [
  "ssh2",
  "suggest",
  "thiserror 2.0.19",
+ "tokio",
  "vte 0.15.0",
+ "zellij-api",
  "zellij-client",
  "zellij-server",
+ "zellij-utils",
+]
+
+[[package]]
+name = "zellij-api"
+version = "0.45.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "futures",
+ "futures-util",
+ "log",
+ "serde",
+ "serde_json",
+ "similar",
+ "tempfile",
+ "tokio",
+ "tokio-tungstenite 0.28.0",
+ "uuid",
+ "zellij-client",
  "zellij-utils",
 ]
 
@@ -5048,7 +5148,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-rustls",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tokio-util",
  "tower-http",
  "url",
@@ -5078,6 +5178,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "zellij-mcp"
+version = "0.45.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "futures-util",
+ "log",
+ "rmcp",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tokio-tungstenite 0.28.0",
+ "uuid",
+]
+
+[[package]]
 name = "zellij-server"
 version = "0.45.0"
 dependencies = [
@@ -5085,7 +5204,7 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -5152,8 +5271,8 @@ version = "0.45.0"
 dependencies = [
  "anyhow",
  "backtrace",
- "base64",
- "bitflags 2.11.0",
+ "base64 0.22.1",
+ "bitflags 2.13.1",
  "clap",
  "clap_complete",
  "colored",
@@ -5204,76 +5323,56 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
- "zerocopy-derive 0.7.34",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
-dependencies = [
- "zerocopy-derive 0.8.17",
+ "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5282,9 +5381,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5293,11 +5392,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.119",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+zellij-api = { path = "zellij-api/", version = "0.45.0" }
 zellij-client = { path = "zellij-client/", version = "0.45.0" }
 zellij-server = { path = "zellij-server/", version = "0.45.0" }
 zellij-utils = { workspace = true }
@@ -28,6 +29,7 @@ miette = { workspace = true }
 names = { workspace = true }
 suggest = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 isahc = { workspace = true }
 
 [target.'cfg(windows)'.build-dependencies]
@@ -55,7 +57,9 @@ members = [
     "default-plugins/multiple-select",
     "default-plugins/layout-manager",
     "default-plugins/link",
+    "zellij-api",
     "zellij-client",
+    "zellij-mcp",
     "zellij-integration-tests",
     "zellij-server",
     "zellij-utils",

--- a/MCP.md
+++ b/MCP.md
@@ -1,0 +1,240 @@
+# Zellij Remote Control — MCP Server
+
+`zellij-mcp` exposes the [WebSocket remote-control API](./REMOTE_API.md) as MCP
+tools, so an LLM agent (Claude, or anything else that speaks
+[MCP](https://modelcontextprotocol.io)) can list, create, and drive Zellij
+sessions directly.
+
+It is a **thin client** of the WebSocket API, not a reimplementation of it —
+every tool call becomes one JSON command sent to an already-running
+`zellij api-server`, the same protocol `zellij-api/examples/drive.rs` speaks.
+All session/tab/pane/input logic lives in `zellij-api` and is tested there;
+this crate's own job is the MCP wiring, and that is what its own tests focus
+on.
+
+```
+  MCP client (an LLM agent)
+        │ Streamable HTTP, JSON-RPC, Authorization: Bearer <mcp token>
+        ▼
+┌──────────────────┐
+│    zellij-mcp     │   rmcp server, 21 tools, stateless
+└─────────┬─────────┘
+          │ WebSocket, ?token=<api token>          (one connection per call)
+          ▼
+┌──────────────────┐
+│  zellij api-server │  ← unchanged; see REMOTE_API.md
+└──────────────────┘
+```
+
+## Why "attach" needs its own tool
+
+A human running `zellij attach` gets oriented by *looking at the screen*. An
+MCP agent has no screen to look at — so `attach_session` is the composite tool
+that gives it the same orientation in one call: every tab, every pane, and the
+current on-screen content of each terminal pane, in one JSON response. Call it
+first when picking up a session. `read_screen` is the single-pane version, for
+checking on one pane after driving it.
+
+## Tools
+
+| Tool | Wraps |
+| --- | --- |
+| `list_sessions` | `session.list` |
+| `create_session` | `session.create` |
+| `kill_session` | `session.kill` |
+| `rename_session` | `session.rename` |
+| `attach_session` | `tab.list` + `pane.list` + `screen.subscribe` + `screen.snapshot` per pane |
+| `list_tabs` / `create_tab` / `focus_tab` / `close_tab` / `rename_tab` | `tab.*` |
+| `list_panes` / `create_pane` / `focus_pane` / `close_pane` / `rename_pane` / `resize_pane` | `pane.*` |
+| `send_text` / `send_keys` / `send_mouse` | `input.*` |
+| `read_screen` | `screen.snapshot` (auto-subscribes if not already followed) |
+| `screen_history` | `screen.history` |
+
+Every tool's parameters and behavior match the underlying command exactly —
+see [REMOTE_API.md](./REMOTE_API.md#protocol) for the full semantics (what
+`pane_id` omitted means, why a directional split needs focus, and so on).
+Nothing here changes any of that; it only translates.
+
+**Writing and focusing are separate, deliberately.** `send_text`/
+`send_keys`/`send_mouse` only write bytes — they never move focus, even
+when addressed to a `pane_id` in a different tab than the one currently
+focused. Only `focus_pane`/`focus_tab` actually change what's focused. This
+matters in practice when a person is also attached to the same session
+live: writing to an explicit pane never yanks their view somewhere else,
+only an explicit focus call does. Each tool's own description repeats this
+so it's visible without cross-referencing this doc.
+
+## Running it
+
+```sh
+zellij-mcp --port 8788 --token <mcp-secret> \
+  --api-url ws://127.0.0.1:8787/api --api-token <api-secret>
+```
+
+Two separate tokens, two separate trust boundaries: `--token` is what an MCP
+client must present to *this* server; `--api-token` is what this server
+presents to the WebSocket API it drives. Reusing one token for both would
+conflate "who can ask an agent to drive Zellij" with "what the WS API itself
+accepts" — keeping them apart means either can be rotated independently.
+
+Like the WS API, this refuses to start quietly unauthenticated — without
+`--token` it prints a warning naming exactly what that means.
+
+### As a service
+
+Deployed the same way as the WS API — a systemd **user** service, alongside
+it:
+
+```ini
+# ~/.config/systemd/user/zellij-mcp.service
+[Unit]
+After=zellij-api-server.service
+Wants=zellij-api-server.service
+
+[Service]
+ExecStart=%h/.local/bin/zellij-mcp --bind 127.0.0.1 --port 8788
+EnvironmentFile=%h/.config/zellij-api/env   # ZELLIJ_MCP_TOKEN, ZELLIJ_API_TOKEN
+Restart=always
+RestartSec=2
+NoNewPrivileges=true
+
+[Install]
+WantedBy=default.target
+```
+
+**No `KillMode=process` here, unlike the WS API's own unit.** That setting
+exists because the WS API daemonizes session servers that must outlive it —
+this process spawns nothing; it is only a WebSocket client. A cgroup-wide kill
+on restart takes down nothing that needs to survive it.
+
+```sh
+systemctl --user daemon-reload
+systemctl --user enable --now zellij-mcp
+```
+
+## Auth
+
+Bearer token via the `Authorization: Bearer <token>` header, checked with a
+constant-time comparison (see `zellij-api`'s own `tokens_match` for why a
+plain `==` would leak timing information). `GET /health` is deliberately
+unauthenticated, for liveness checks.
+
+## Testing
+
+```sh
+cargo xtask build                      # target/dev-opt/zellij
+cargo build -p zellij-mcp              # target/debug/zellij-mcp
+ZELLIJ_API_E2E=target/dev-opt/zellij ZELLIJ_MCP_E2E=target/debug/zellij-mcp \
+  cargo test -p zellij-mcp --test e2e -- --nocapture
+```
+
+The e2e suite drives a real MCP client (`rmcp`'s own) against a real
+`zellij-mcp` server against a real `zellij api-server` against a real Zellij
+session: `create_session` → `attach_session` → `send_text` → `read_screen` →
+`kill_session`, plus a check that every tool is discoverable and that the
+wrong bearer token is refused. It does not re-test the underlying command
+semantics — `zellij-api`'s own suite already does that exhaustively; this
+suite exists to catch protocol-wiring and schema mistakes specific to the MCP
+layer.
+
+## Defects found by testing
+
+Five, so far — each reproduced against a live deployment, not reasoned about
+in the abstract, and each guarded by a regression test proven to actually
+catch the bug (run against the pre-fix binary first, confirmed it failed
+the same way). The most severe — `send_text`/`send_keys` writing every
+character twice — turned out to be caused by `TERM` being unset when this
+service runs as a systemd daemon (no controlling terminal to inherit it
+from), breaking the spawned shell's own redraw logic. See
+[REMOTE_API.md](./REMOTE_API.md#defects-found-by-adversarial-testing) for
+the full write-up and fix (`start_api_server` now defaults `TERM` if empty,
+the way tmux/screen do for their own panes).
+
+### `attach_session`/`read_screen` came back empty on a race
+
+`attach_session`'s snapshot loop first came back with `"screens": []` — every
+pane correctly listed, none snapshotted. Root cause: `screen.subscribe`
+returns as soon as the *subscription request* is acknowledged, not once the
+canvas actually has content — the first render event that populates it arrives
+asynchronously afterward. Calling `screen.snapshot` immediately after
+subscribing can race that and fail with "subscribe first," and the original
+code was silently swallowing that failure (`if let Ok(snapshot) = ...`) rather
+than surfacing or retrying it. Fixed with a short bounded retry (up to 8
+attempts, 100ms apart) in both `attach_session` and `read_screen`'s
+auto-subscribe path. Caught by the e2e test, not by inspection — the JSON
+Value the test asserted on made the empty array impossible to miss.
+
+### Business failures were protocol-level errors, not tool-level ones
+
+Every tool used to report failures — "session not running," "unknown key
+name," "give `command` or `plugin`, not both" — by returning
+`Err(McpError::internal_error(...))`. In MCP terms that's a JSON-RPC
+`error` object: it says "I couldn't even attempt this," the same category as
+a malformed request or an unknown tool name. An agent calling `list_tabs` on
+a typo'd session name doesn't get a `CallToolResult` back to reason about —
+it gets a client-side call failure, indistinguishable from the tool not
+existing at all.
+
+Per rmcp's own documented convention: a protocol-level error means the
+server couldn't run anything; a tool-level error (`Ok(CallToolResult::error(
+vec![ContentBlock::text(msg)]))`, `isError: true` in the result) means the
+tool ran, produced no useful result, and the *caller* should see why and
+react. All 21 tools' business-logic failures now go through a shared
+`err_result()` helper that does the latter. Two composite tools needed
+restructuring beyond a search-and-replace: `attach_session`'s per-pane
+snapshot loop used to drop a failed pane silently (only a `log::warn!`) —
+it now reports `{"pane_id": ..., "error": ...}` inline instead of a gap
+in the array; `read_screen`'s `screen.subscribe` failure is now surfaced
+directly rather than falling through to a less specific error from the
+snapshot call that follows it.
+
+Verified live (curl against the deployed service) and with a regression
+test, `business_failures_are_tool_errors_not_protocol_errors` in
+`zellij-mcp/tests/e2e.rs`: a nonexistent session returns `isError: true`
+with `"...not running"` in the content, while a genuinely nonexistent tool
+name still comes back as a real `Err` from `call_tool` — the protocol-level
+case is still a protocol-level error, only the business-logic case moved.
+
+### Inconsistent parameter naming (`kill_session` / `rename_session`)
+
+19 of the 21 tools name their "which session" parameter `session`.
+`kill_session` and `rename_session` were the odd ones out — they took
+`name` instead, a leftover from mirroring the underlying wire command's
+own field name too literally. In practice this meant an agent that had
+correctly learned the convention from any of the other 19 tools got a
+confusing `"missing field \`session\`"` on exactly these two, with no way
+to guess the right name short of reading that tool's schema individually.
+Fixed by renaming the parameter (the underlying `zellij-api` wire call
+still sends `name`, unaffected — this was purely the MCP-facing schema).
+`create_session` is the one deliberate exception: its `name` names the
+session being *created*, not one being looked up, so it stays as-is.
+
+Caught by re-reading the tool schemas end to end, not by inspection of any
+one tool in isolation — the inconsistency was only visible across all 21 at
+once. Guarded going forward by
+`every_tool_names_its_session_parameter_consistently` in
+`zellij-mcp/tests/e2e.rs`, which asserts every tool but `create_session`/
+`list_sessions` declares a `session` property in its schema. Proved the
+test actually catches the bug via the same revert-then-retest the rest of
+this PR's fixes went through.
+
+### `read_screen`/`screen_history` couldn't default to the focused pane
+
+`send_text` and `send_keys` both make `pane_id` optional and default to
+whatever pane the session currently has focused — the same thing a human
+typing at a terminal would mean by "wherever I am." `read_screen` and
+`screen_history` required `pane_id` outright, so an agent could blindly
+type into "the pane, whichever it is" but couldn't read the result back
+without already knowing that pane's exact id — found via a holistic smoke
+test (create a session, split panes, switch tabs, drive it without ever
+naming a pane), not isolated per-tool fuzzing.
+
+Fixed symmetrically with the input tools: `pane_id` is optional on both,
+defaulting to the focused pane via `zellij-api`'s existing `resolve_pane`
+helper. `read_screen` got its own dedicated params type rather than reusing
+the `pane_id`-required one shared by `close_pane`/`focus_pane`/
+`rename_pane` — those three stay required on purpose, since defaulting a
+*mutation* to "whichever pane happens to be focused" is a meaningfully
+riskier default than defaulting a *read*. Guarded by
+`read_screen_and_screen_history_default_to_the_focused_pane` in
+`zellij-mcp/tests/e2e.rs`.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,50 @@
     </a>
 </p>
 
+# Remote control over WebSocket
+
+Zellij sessions can optionally be driven over a **WebSocket control plane**,
+so that a remote program — rather than a person at a keyboard — creates,
+inspects and drives them.
+
+```sh
+zellij api-server --port 8787 --token <secret>
+```
+
+- **Sessions and tabs through the API** — create, list, rename, focus and close.
+- **Focus is controllable** — the API attaches a real client to each session, so
+  focusing a tab or pane actually moves focus (and is confirmed before the
+  command returns). Splits, "current tab" behaviour and unaddressed input all
+  follow it, exactly as they would for a person at a terminal.
+- **Input through the API** — type text, send named keys (`ctrl-c`, `enter`,
+  `f5`), and click with the mouse, addressed to a specific pane in a specific
+  tab in a specific session.
+- **Screen history as diffs** — each pane's canvas is treated as a file, and
+  every change to it is reported as a unified, git-style diff:
+
+  ```
+  @@ -3,1 +3,1 @@
+  -sudr
+  +sudo
+  ```
+
+  Diffs stream live as `screen.diff` events and are kept in a per-pane history
+  you can replay from any version.
+
+Sessions started this way are ordinary Zellij sessions — `zellij attach`,
+`zellij list-sessions` and friends all see and can interact with them exactly
+as they would a session started interactively. The API is an additional way
+in, not a separate namespace.
+
+The protocol, the design, and how to run and test it are documented in
+**[REMOTE_API.md](./REMOTE_API.md)**. All the new code lives in the
+`zellij-api/` crate.
+
+**An MCP server** (`zellij-mcp/`) exposes the same API as MCP tools — list
+sessions, attach to one, drive it, read its screen — for any MCP-speaking agent
+(Claude included). It's a thin client of the WebSocket API above, not a second
+implementation of session control. See **[MCP.md](./MCP.md)**.
+
 # What is this?
 
 [Zellij](#origin-of-the-name) is a workspace aimed at developers, ops-oriented people and anyone who loves the terminal. Similar programs are sometimes called "Terminal Multiplexers".

--- a/REMOTE_API.md
+++ b/REMOTE_API.md
@@ -1,0 +1,611 @@
+# Zellij Remote Control API
+
+Adds a **WebSocket control plane** on top of the existing multiplexer.
+Instead of a human driving the terminal, a remote program drives it: it manages
+sessions and tabs, injects keyboard/mouse input, and receives a **git-diff-style
+history of every change that appears on screen**.
+
+Want an LLM agent driving it instead of writing WebSocket JSON by hand? See
+**[MCP.md](./MCP.md)** — an MCP server that exposes this same API as tools.
+
+## Design goals
+
+1. **Keep the multiplexer.** No changes to how Zellij multiplexes. The API is an
+   additional front-end, not a replacement. A session driven over the API is an
+   ordinary Zellij session under the hood — discovered by `zellij list-sessions`
+   and attachable with `zellij attach` exactly like one started interactively.
+2. **Remote control instead of direct user control.** One WebSocket endpoint
+   speaks a JSON command/event protocol.
+3. **Session and tab management through the API.**
+4. **Input through the API** — type text, send named keys, click with the mouse,
+   addressed to a specific pane in a specific tab in a specific session.
+5. **Screen history as diffs.** A pane's canvas is treated as a text file. Every
+   change to that file produces a unified diff (`+sudo` / `-sudr`), stored in a
+   per-pane history and streamed live.
+
+## Why this shape
+
+Zellij is already a client/server system: `zellij-server` owns a session and
+speaks a protobuf IPC protocol over a unix socket per session
+(`ClientToServerMsg` / `ServerToClientMsg`). Three existing primitives make a
+control plane possible without forking the core:
+
+| Need | Existing primitive |
+| --- | --- |
+| Drive the session | `ClientToServerMsg::Action { action, is_cli_client: true }` — the `Action` enum already covers tabs, panes, focus, resize, writes and mouse events |
+| Query state | `Action::ListTabs/ListPanes/ListClients { output_json: true }` → replies as `ServerToClientMsg::Log { lines }` |
+| Observe the screen | `ClientToServerMsg::SubscribeToPaneRenders { pane_ids, scrollback, ansi }` → `ServerToClientMsg::PaneRenderUpdate { pane_id, viewport: Vec<String>, .. }` pushed on every change |
+| Create a session headlessly | `spawn_server(socket_path)` + `ClientToServerMsg::FirstClientConnected` (the same path the bundled web client uses — no TTY required) |
+
+So the API server is a **process that acts as a headless multi-session client**.
+It is not a patch to the render loop, so it composes with any future change to
+that loop rather than fighting it.
+
+```
+   remote program
+        │  JSON over WebSocket
+        ▼
+┌──────────────────────┐
+│  zellij api-server   │   axum WS + session registry + canvas/diff engine
+└─────────┬────────────┘
+          │ protobuf IPC (one control conn + one observer conn per session)
+   ┌──────┴───────┬──────────────┐
+   ▼              ▼              ▼
+zellij-server  zellij-server  zellij-server      (unchanged multiplexer)
+ session A      session B      session C
+```
+
+### Three IPC connections per session
+
+- **Control connection** — a CLI-style client used for queries and commands
+  that need a reply. Serialized request/reply: one `Action` at a time.
+- **Observer connection** — dedicated to `SubscribeToPaneRenders`, so the
+  unsolicited render stream never interleaves with command replies.
+- **Focus connection** — a *real attached client*, so the session has somewhere
+  to hold focus (see below). Focus-dependent actions are sent here with
+  `is_cli_client: false`, which makes the server attribute them to that client.
+  A thread drains this socket: an attached client that stops reading its render
+  stream would eventually block the server and stall the session.
+
+The set of live panes is refreshed from `ListPanes` and the subscription is
+renewed when panes appear or disappear, so newly created panes are tracked
+automatically.
+
+#### Matching replies to requests
+
+The IPC protocol carries no request ids, so a reply can only be matched to its
+request by position — and two server behaviours make naive position-matching
+wrong:
+
+- `UnblockInputThread` is **not** one-per-action. The server emits extra ones
+  (a broadcast unblock reaches every connected client, ours included), so
+  treating it as a terminator shifts every later reply by one.
+- Some actions log more than once. `NewTab` reports both the new tab's id and
+  the new pane's id, leaving a spare `Log` in the stream.
+
+So each action declares the *shape* of its answer (`session_link::ReplyShape`)
+and the reader skips anything that cannot be it. Queries ask for a JSON array or
+object, which no stray line from another action parses as — which makes them
+self-resynchronising rather than merely lucky.
+
+## Protocol
+
+Transport: WebSocket, text frames, one JSON object per frame.
+Endpoint: `ws://<bind>:<port>/api?token=<token>`.
+
+**Command** — `{"id": "<caller id>", "cmd": "<name>", ...params}`
+**Reply** — `{"id": "<caller id>", "ok": true, "result": {...}}` or
+`{"id": "<caller id>", "ok": false, "error": "..."}`
+**Event** — `{"event": "<name>", ...}` (unsolicited, no `id`)
+
+### Commands
+
+| Command | Params | Result |
+| --- | --- | --- |
+| `session.list` | — | sessions: name, age_secs, resurrectable |
+| `session.create` | `name?`, `layout?`, `cwd?`, `rows?`, `cols?` | created session name |
+| `session.kill` | `name` | — |
+| `session.rename` | `name`, `new_name` | — |
+| `tab.list` | `session` | tabs: id, name, active, panes |
+| `tab.create` | `session`, `name?`, `cwd?`, `layout?` | — |
+| `tab.close` | `session`, `tab_id` | — |
+| `tab.focus` | `session`, `tab_id` | focused tab id (once the session confirms it) |
+| `tab.rename` | `session`, `tab_id`, `name` | — |
+| `pane.list` | `session` | panes: id, title, tab, focused, geometry, command |
+| `pane.create` | `session`, `command?`, `plugin?`, `plugin_config?`, `args?`, `cwd?`, `floating?`, `direction?`, `name?`, `tab_id?` | created pane id |
+| `pane.close` | `session`, `pane_id` | — |
+| `pane.focus` | `session`, `pane_id` | — (focuses the pane and its tab) |
+| `pane.rename` | `session`, `pane_id`, `name` | — |
+| `pane.resize` | `session`, `pane_id`, `resize`, `direction?` | — |
+| `input.text` | `session`, `pane_id?`, `text` | bytes written |
+| `input.keys` | `session`, `pane_id?`, `keys: ["ctrl-c", "enter", ...]` | bytes written |
+| `input.mouse` | `session`, `kind`, `x`, `y`, `button?` | — |
+| `screen.snapshot` | `session`, `pane_id`, `scrollback?` | viewport lines + version |
+| `screen.history` | `session`, `pane_id`, `since?`, `limit?` | list of diffs |
+| `screen.subscribe` | `session`, `pane_ids?` (omit = all) | — |
+| `screen.unsubscribe` | `session` | — |
+
+### Events
+
+- `screen.diff` — a pane's canvas changed:
+
+```json
+{
+  "event": "screen.diff",
+  "session": "main",
+  "pane_id": "terminal:1",
+  "seq": 42,
+  "ts": 1754342400123,
+  "added": 1,
+  "removed": 1,
+  "unified": "--- pane/terminal:1@41\n+++ pane/terminal:1@42\n@@ -3,1 +3,1 @@\n-sudr\n+sudo\n"
+}
+```
+
+- `screen.reset` — a canvas baseline, sent when a pane is first followed (and
+  after a resubscribe). Carries `lines` instead of a diff; the version it
+  establishes is `seq`.
+- `pane.opened`, `pane.closed` — the session's pane set changed.
+- `session.ended` — the session's server went away.
+- `stream.lagged` — this connection could not keep up and `dropped` events were
+  discarded. Resync with `screen.snapshot`, then continue from its `version`.
+
+## Running it
+
+```sh
+zellij api-server --port 8787 --token <secret>     # --token may also come from ZELLIJ_API_TOKEN
+```
+
+Without `--token` the API accepts any connection that can reach the port, and
+says so on startup. There is a `GET /health` endpoint for liveness checks.
+
+### Running it as a service
+
+To keep the API up across reboots, install the binary somewhere stable and run
+it as a **systemd user service** (no root involved — sessions belong to your
+user, and its sockets live under `/run/user/$UID`):
+
+```ini
+# ~/.config/systemd/user/zellij-api-server.service
+[Unit]
+Description=Zellij remote-control API (WebSocket)
+
+[Service]
+Type=simple
+ExecStart=%h/.local/bin/zellij api-server --bind 127.0.0.1 --port 8787
+EnvironmentFile=%h/.config/zellij-api/env   # holds ZELLIJ_API_TOKEN=...
+Restart=always
+RestartSec=2
+KillMode=process   # see below — without this, restarting the service kills every session it created
+NoNewPrivileges=true
+
+[Install]
+WantedBy=default.target
+```
+
+```sh
+systemctl --user daemon-reload
+systemctl --user enable --now zellij-api-server
+loginctl enable-linger "$USER"   # only if not already on: start at boot without logging in
+```
+
+**`KillMode=process` is required, not optional.** Zellij daemonizes a session's
+server process (double-fork + setsid) precisely so it survives whatever spawned
+it — that is the entire basis for "a session driven over the API is an
+ordinary Zellij session". systemd's default, `KillMode=control-group`, does not
+honor that: it tracks descendants by cgroup membership, which daemonizing does
+not escape (unlike a traditional process group). Left at the default, every
+service restart — including a routine redeploy — silently kills every session
+the API created. Reproduced directly: create a session, kill the service's
+tracked PID, and watch the session's own process die at the same moment,
+despite having correctly detached from it.
+
+Three things worth being deliberate about:
+
+- **Install a release binary to a stable path.** The API server spawns session
+  servers by re-executing itself, so it must point at a binary that a later
+  `cargo build` (or `cargo clean`) will not replace or delete.
+- **Keep it on loopback, with a token.** Anything that can reach this port can
+  run commands in your terminal sessions. `--bind 127.0.0.1` plus a token in a
+  `0600` environment file is the sane default; exposing it to a network means
+  putting real authentication and TLS in front of it.
+- **`TERM` doesn't need to be set — the server defaults it if it's missing.**
+  A daemon has no controlling terminal to inherit `TERM` from, and every
+  session this server creates is a fork of itself, so an empty `TERM` here
+  becomes an empty `TERM` in every pane's shell — which breaks
+  terminal-aware shell behavior (redraws that assume terminfo capabilities
+  they never actually confirmed). `start_api_server` defaults it to
+  `xterm-256color` at startup if empty, the way tmux/screen default it for
+  their own panes. Found and fixed after a genuinely confusing bug: see
+  "Defects found by adversarial testing" below.
+
+A worked example client lives in `zellij-api/examples/drive.rs`:
+
+```sh
+cargo run -p zellij-api --example drive -- --token <secret> --session demo
+```
+
+It creates a session, subscribes, types a command, and prints the diffs as they
+arrive:
+
+```
+[screen.diff] pane="terminal_0" seq=3 +2 -0
+  @@ -1,2 +1,4 @@
+   echo hello_from_the_api
+   ~/dev/zellij ❯ echo hello_from_the_api
+  +hello_from_the_api
+  +
+```
+
+### Knowing when a pane is ready
+
+A remote driver cannot ask a shell whether it has finished starting, and a shell
+discards anything typed before it is ready. The diff stream is the signal:
+after creating a tab or pane, wait until no `screen.diff` has arrived for that
+pane for a beat, then send input. `zellij-api/tests/e2e.rs` does exactly this.
+
+### Plugin panes
+
+Plugin panes are driven exactly like terminal panes — open one, address it by
+id, and its UI reacts:
+
+```json
+{"cmd": "pane.create", "session": "main", "plugin": "session-manager", "floating": true}
+→ {"pane_id": "plugin_3"}
+
+{"cmd": "input.text", "session": "main", "pane_id": "plugin_3", "text": "abc"}
+{"cmd": "input.keys", "session": "main", "pane_id": "plugin_3", "keys": ["backspace"]}
+```
+
+and the change comes back on the same diff stream as any other pane:
+
+```
++Session: abc_ <ENTER> - Create new
++Session: ab_ <ENTER> - Create new
+```
+
+`plugin` takes a URL (`file:/path/to.wasm`, `https://…`) or a built-in alias
+(`session-manager`, `about`, `strider`, …), with optional `plugin_config`.
+
+What differs is only underneath: Zellij hands the bytes to a plugin as **key
+events** rather than writing them to a pty, so `input.text` on a plugin is a
+sequence of keypresses, not a paste. `input.keys` is usually what you want, and
+named keys (`down`, `esc`, `enter`) are how a plugin UI is actually driven.
+
+Two things to keep in mind:
+
+- **A plugin pane can close itself.** `esc` dismisses the session manager, and
+  its pane goes with it. Writing to a pane the session no longer has used to
+  succeed silently — every `input.*` now checks the pane exists first and fails
+  with `session 'main' has no pane plugin_3`.
+- **Tiled plugin panes take no `direction`.** The pane is placed only once the
+  plugin has loaded, by which time the reference pane may have moved, so
+  upstream refuses it and so do we. Use `floating`, or omit `direction`.
+
+### Focus is owned by the API
+
+Much of Zellij is defined relative to *the requesting client*: which tab is
+active, which pane a split happens next to, where unaddressed input goes. That
+reference only exists if a client is attached — and a CLI message does not
+count, because the server attributes it to the *last active client*, which is
+only ever set by a keystroke.
+
+So the API **attaches a real client to each session it drives**, and sends
+focus-dependent actions as that client. Focus then behaves exactly as it does
+for a person at a terminal, and it is fully controllable:
+
+- `tab.focus` makes that tab active — `tab.list` reports `active: true` for it,
+  and everything tab-relative follows.
+- `pane.focus` focuses the pane *and* its tab, so input and splits land there.
+- `pane.create` focuses the target first, then creates — which is what makes a
+  directional split land where the caller asked. With a `direction` it also
+  moves focus onto a terminal pane, since a floating pane cannot be split.
+
+Focus commands are **verified, not assumed**: they reply only once the session
+reports the new focus, and return an error if it never takes. `pane.create`
+likewise identifies the new pane by watching it appear, because the server
+reports a pane id before placing it and drops an unresolvable placement without
+an error.
+
+### Choosing the target pane
+
+`input.*` without a `pane_id` goes to **the pane the attached client is sitting
+on** — no cleverness, no preference for one kind of pane over another. So
+`pane.focus` then `input.text` does what you would expect, and the reply always
+reports which pane was written to. Pass `pane_id` explicitly to address any pane
+regardless of focus, including a plugin pane (see above); a pane the session
+does not have is rejected rather than silently written to.
+
+`screen.snapshot` and `screen.history` follow the same rule when `pane_id` is
+left out — read back whatever is focused, symmetric with writing to it. This
+was not always true: they used to require `pane_id` explicitly, so a caller
+could type blind into "the pane, whichever it is" but not read the result
+back without already knowing its exact id.
+
+For that to be useful, focus has to start somewhere sensible. Zellij greets a
+new session with release notes and a startup tip, both floating plugin panes —
+and a floating pane takes focus, so a freshly created session would sit with a
+welcome screen focused and swallow the first thing you typed. Sessions the API
+creates therefore set `show_release_notes = false` and `show_startup_tips =
+false`, so the greeting is never created and focus starts on the shell.
+
+**A human and the API can end up typing into the same pane at once.** Nothing
+stops it — `input.*` writes to a pane's pty exactly like a keystroke does, and
+a pty has no concept of "whose" byte arrived. If you are interacting with a
+pane by hand at the same moment the API sends it text, the two interleave at
+the byte level, arbitrarily. Confirmed directly: a stray character a person
+typed landed *inside* a string the API sent to the same pane a moment later,
+read back as if it had come from nowhere until the person who typed it said
+so. Not a bug to fix — the same thing happens if two people type into a shared
+tmux pane — but worth knowing before assuming a character you didn't expect
+means something is wrong with the pipe.
+
+> **Do not read focus off `pane.list`.** Its `is_focused` flag means "focused
+> within its layer", so several panes carry it at once — a tiled pane and a
+> floating pane, in *every* tab. After focusing a second pane in a tab, both
+> still report `is_focused: true`. The single pane a client is actually on comes
+> from `ListClients`, which is what this API uses internally and what
+> `input.*` follows. `pane.list`'s flag is still useful for layout, just not for
+> answering "where does typing go".
+
+## Canvas-as-a-file model
+
+Each pane maps to a virtual path `session/<name>/pane/<pane_id>.screen`.
+
+- The first `PaneRenderUpdate` (`is_initial`) establishes **version 0**; it is
+  recorded as a snapshot, not a diff.
+- Every later update is diffed line-by-line against the previous version with a
+  Myers diff, emitted as a unified diff with 3 lines of context, and appended to
+  a bounded per-pane history (default 1000 entries, oldest dropped).
+- `screen.snapshot` returns the current materialised lines plus the version, so
+  a client that dropped events can resync and then continue from `seq`.
+
+Trailing whitespace is trimmed per line before diffing, so cursor movement that
+does not change visible text produces no diff entry.
+
+## Testing
+
+```sh
+cargo test -p zellij-api                       # protocol, key encoding, diff and history units
+
+cargo xtask build                              # the API server re-executes this binary
+ZELLIJ_API_E2E=target/dev-opt/zellij \
+  cargo test -p zellij-api --test e2e          # drives a real session end to end
+```
+
+The end-to-end test creates a session, adds a tab, subscribes to every pane,
+types into the focused one, asserts the resulting diff and history, and kills
+the session again. It skips itself unless `ZELLIJ_API_E2E` points at a built
+binary, so a plain `cargo test` never spawns sessions.
+
+## Known limitations
+
+Deliberate trade-offs rather than oversights — worth knowing before building on
+this.
+
+- **Commands on one connection run one at a time.** The read loop awaits each
+  command before taking the next, so a slow one (creating a session, or an
+  action that hits the 10s timeout) holds up everything else on that socket,
+  including commands for other sessions. This is on purpose: input must not be
+  reordered, and running commands concurrently would make the order in which
+  keystrokes arrive depend on task scheduling. Use a second WebSocket
+  connection for work that must not queue behind another.
+- **Every `input.*` costs one query.** Naming a pane checks it exists; omitting
+  one asks which pane the client is on. Both are a round trip to the session, so
+  input is a few milliseconds rather than microseconds. Sending a whole line as
+  one `input.text` is much cheaper than one call per keystroke.
+- **A wedged session retires its link.** If the server never answers, the
+  command times out and the link is marked dead; the next command opens a fresh
+  one. That recovers service, but the in-flight command is lost rather than
+  retried — commands are not idempotent, so retrying them automatically would be
+  worse.
+- **`screen.snapshot` and `screen.history` only know about panes you have
+  subscribed to.** The canvas is built from the render stream, so a pane that
+  was never followed has no state to report.
+- **`screen.unsubscribe` stops delivery, not production.** Zellij has no
+  unsubscribe message; the session keeps sending updates and we stop forwarding
+  them.
+- **One token, all-or-nothing.** Presenting it grants every command on every
+  session the API server can see. There are no per-session or read-only scopes.
+- **`pane.create`'s `plugin` hangs for anything not built in.** Zellij
+  auto-grants permissions to bundled plugins (`plugin_env.plugin.is_builtin()`
+  in `zellij_exports.rs`) — that's every alias in the tools table below
+  (`about`, `session-manager`, `strider`, ...), confirmed working end to end
+  through the API. A plugin loaded from an external URL or `file://` path is
+  *not* auto-trusted: it shows an interactive permission prompt and waits for
+  a keypress, same as it would for a person at a terminal — and there is no
+  person, so it waits forever. Not something the API should paper over by
+  auto-granting (that would quietly weaken a deliberate security gate); if
+  you need a non-built-in plugin driven over the API, its permissions need
+  to be pre-approved some other way before `pane.create` requests it.
+
+## Validation
+
+Every command that names a session, tab, or pane checks it exists before
+acting, and fails with a message that says exactly what was not found —
+`session 'main' has no pane terminal_9`, `session 'main' has no tab 3 (known
+tab ids: 0)`. This is not the server's default behavior: Zellij typically
+drops an action aimed at something that is not there and reports nothing,
+which reads as success from the caller's side. Affects `input.*`,
+`pane.close`, `pane.focus`, `pane.rename`, `pane.resize`, `tab.close`,
+`tab.rename`, `screen.subscribe`, and `screen.history`.
+
+A parameter the command does not recognise is rejected —
+`{"error": "unknown parameter: paneids"}` — rather than silently ignored. A
+misspelled `pane_ids` on `screen.subscribe` would otherwise fall back to its
+default and follow every pane in the session instead of the one named.
+
+`session.create`'s `layout` is checked to exist on disk (when it looks like a
+path) before the session is created, and `session.rename`'s `new_name` is
+validated the same way `session.create`'s name is — see "Two defects found by
+adversarial testing" below for why that one matters more than it sounds.
+
+`pane.create`'s `args` is rejected if `command` isn't also given — it has no
+meaning attached to a bare terminal pane or to `plugin`, and used to be
+silently accepted and silently ignored in that case.
+
+## Defects found by adversarial testing
+
+Worth recording because none of these were hypothetical — each was reproduced
+against a live session, not reasoned about in the abstract.
+
+**Blocking work running directly on the async runtime, three places.** The
+overlong-session-name bug below is one instance of a class: `SessionCreate`,
+`SessionKill`, and — found while looking for siblings of the first two —
+`link_for` (used by nearly every other command) each called synchronous,
+blocking code straight from an `async fn`. For `SessionCreate`/
+`SessionKill` that meant no bound on how long the *caller* could be left
+waiting (see below). For `link_for`, calling `SessionManager::link`
+directly meant the first time any session gets linked — three socket
+connects with handshakes, plus a poll loop that can take up to a second —
+ran on a Tokio worker thread and blocked *every other task scheduled on
+that same thread*, not just the one request. All three now go through
+`spawn_blocking`, moving the work off the runtime's worker pool; the first
+two also get an outer `CALL_TIMEOUT` (15s) as a backstop in case their own
+inner deadlines ever fail to fire again for a reason not yet found.
+
+**An overlong session name hung `session.create` indefinitely.** A
+300-character session name caused the call to hang — not slowly respond,
+*hang*: the code's own internal 10-second startup deadline
+(`SESSION_START_TIMEOUT`) is only checked after receiving some message
+from the session server, and a session server that fails at `bind()`
+before sending anything at all never gives that check a chance to run.
+Root cause: a session name's socket path can exceed the OS's Unix-domain-
+socket path limit (`sockaddr_un.sun_path`, ~104-108 bytes depending on
+platform), and the daemonized session server fails silently when it does —
+no error, no reply. The interactive CLI already guards against this
+(`zellij_client::check_ipc_pipe_length`), but that check lives on a code
+path this API never calls, since it spawns the session server directly
+rather than going through `start_client`. Fixed by teaching
+`validate_session_name` (`zellij-utils/src/sessions.rs` — already called
+from both `session.create` and `session.rename`) to compute the real
+socket path and reject it upfront, mirroring the CLI's own check but
+returning a `Result` instead of exiting the process. Verified live: a
+15-second-plus hang before the fix, a 0.007-second response with a clear
+error after it.
+
+**RESOLVED — every character written via `input.text`/`input.keys` appeared
+twice on screen when this service ran as a systemd unit.** A brand-new
+session, a clean baseline (`~ ❯` with nothing typed), one `input.text` call
+with `text: "A"` — the screen read `~ ❯ AA`. Reliably reproduced when
+deployed as a systemd unit; never reproduced from an ad-hoc
+foreground process launched from an interactive shell — which is exactly
+what made this hard to find, since every natural way to test it by hand
+avoided the real failure condition.
+
+**Root cause: `TERM` was empty.** A systemd service is a daemon with no
+controlling terminal, so it has no `TERM` to inherit — unlike a process
+launched interactively, which always has one. Every session this server
+creates is a fork of this process itself (`zellij_server::spawn_server`),
+so whatever `TERM` the server had at startup is what every pane's shell
+inherits. With `TERM` empty, the pane's shell has no terminfo entry to
+consult, and its syntax-highlighting redraw (re-coloring what it just
+echoed) came back malformed: `"Z"` (plain echo), immediately followed by
+`"\x1b[31mZ\x1b[39m"` (red, no leading backspace) instead of the correct
+`"\x08\x1b[31mZ\x1b[39m"` (backspace, *then* red) — missing the
+cursor-repositioning byte that would have made it an in-place overwrite.
+Applied literally, that lands two visible characters from one keystroke.
+Confirmed with `log::error!` instrumentation directly in `screen.rs`'s
+`ScreenInstruction::PtyBytes` handler (not `eprintln!`, which never reaches
+a daemonized process — its stdout/stderr go to `/dev/null`), and with two
+independent, statistically overwhelming batches against the live deployed
+service: 30/30 reproductions with `TERM` empty, 0/70 across three
+rebuild-and-redeploy cycles once fixed.
+
+**Fixed** in `src/commands.rs`'s `start_api_server`: default `TERM` to
+`xterm-256color` at startup if empty or unset, the same way tmux/screen
+default it for their own panes. Regression test
+`typing_without_a_term_environment_variable_does_not_duplicate_characters`
+in `zellij-api/tests/e2e.rs` reproduces the exact condition deterministically
+with `Command::env_remove("TERM")` (proved it catches the bug: failed on the
+first try against the pre-fix binary, passed consistently once fixed). A
+second test from earlier in the investigation,
+`typing_with_no_other_client_attached_does_not_duplicate_characters`,
+exercises a real but independent correctness bug found along the way —
+`ClearScroll(client_id)` resolving a client-relative "active pane" instead
+of the pane a pane-id-addressed write already names explicitly, fixed by
+adding `ClearScrollForPaneId` — which turned out not to be the cause of
+this particular symptom, but was still worth fixing on its own merits.
+
+**`session.rename` allowed a path-traversal socket rename.** Upstream's
+`RenameSession` handler builds `ZELLIJ_SOCK_DIR.join(&new_name)` and
+`std::fs::rename`s the socket to it, with no validation of `new_name` at all.
+Renaming a session to `../evil` moved its socket *out of* the directory session
+discovery scans:
+
+```
+$ session.rename "audit7" -> "../evil"
+$ ls /run/user/1000/zellij/
+contract_version_1/  evil          ← orphaned, outside the scanned dir
+```
+
+The session was still running, just no longer reachable by name through either
+`zellij` or the API — an orphaned process. A longer `../../..` reaches further.
+This is reachable through a wire protocol in a way it is not through the
+interactive rename UI (a person types a plain name), so `session.rename` now
+runs `new_name` through `validate_session_name` — the same gate
+`session.create` already used — before the action is ever sent.
+
+**Renaming, then acting on the new name immediately, was flaky.** The socket
+file rename is synchronous by the time the rename command replies, but a
+probe connecting to the just-renamed path failed roughly one time in three in
+practice — reproduced by chaining `session.create` → `session.rename` →
+`session.kill` on the new name in one connection. The session was verifiably
+running throughout (`list-sessions` moments later always showed it); the
+existence check just lost a narrow race. `session_exists_settled` in
+`zellij-api/src/session_link.rs` retries the check briefly (five attempts,
+150ms apart) before concluding a session is not there, which stopped the
+failure from reproducing across repeated runs.
+
+**Two callers touching an unlinked session at once could attach two clients.**
+`SessionManager::link()` used to check the link map, then — outside the lock —
+open a new link if none existed. Two commands arriving together for the same
+not-yet-linked session each saw "none exists" and each opened one. Since a link
+attaches a real client (see "Focus is owned by the API" above), the session
+ended up with two attached, which does not fail loudly — it quietly breaks
+focus resolution, which identifies "our" client by it being the only one
+attached. Fixed by holding the map lock across the whole get-or-open. Confirmed
+by temporarily reverting the fix and re-running the regression test: five
+callers produced five attached clients instead of one.
+
+**`pane.focus` was the one mutation that skipped the existence check.**
+Every other pane/tab mutation validates its target first and fails at once
+with a specific message; `pane.focus` instead ran the full ~1.2s
+focus-confirmation retry loop (waiting for a focus change that was never
+going to happen) before failing with the vaguer "the session did not focus
+pane X (no attached client moved to it)". Fixed by adding the same
+`pane_exists` check the other handlers already use. Regression test
+`focusing_a_missing_pane_fails_fast_with_a_specific_message` in
+`zellij-api/tests/e2e.rs` asserts both the message and a sub-500ms latency
+bound; proved it catches the regression by running it against the binary
+built before this fix and watching it fail with the old vague message.
+
+**`screen.history` had no existence check at all, unlike every other
+pane-targeting command.** It's a read against the canvas store, keyed
+purely by pane id string — "never subscribed" and "no such pane" are the
+same absent-key case to that lookup, and only the former should report an
+empty history rather than an error. Found by fuzzing a made-up pane id
+against a live session: it came back `{"diffs": [], "ok": true}` instead of
+failing. Fixed by adding the same `pane_exists` check every other
+pane-targeting handler already has. Regression test
+`screen_history_rejects_a_pane_that_does_not_exist` covers both directions
+so the fix can't regress the legitimate empty-history case.
+
+## Footprint
+
+Most of the new code lives in a new workspace crate, `zellij-api/`, plus the
+MCP server on top of it in `zellij-mcp/`. Existing crates gained:
+
+- `Cargo.toml` — add the two crates to the workspace and `zellij-api` to the
+  binary's deps.
+- `zellij-utils/src/cli.rs` — one new `ApiServer` subcommand.
+- `src/commands.rs` / `src/main.rs` — dispatch that subcommand.
+- `zellij-utils/src/sessions.rs` — `validate_session_name` also rejects
+  overlong socket paths and is now applied to `session.rename`, not just
+  `session.create` (see "Defects found by adversarial testing" below).
+- `zellij-utils/src/errors.rs`, `zellij-server/src/route.rs`,
+  `zellij-server/src/screen.rs`, `zellij-server/src/tab/mod.rs` — the
+  pane-id-scoped `ClearScrollForPaneId` fix, also described below.
+
+The multiplexer, renderer, plugin system and IPC contract are otherwise
+untouched.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -46,6 +46,54 @@ use zellij_utils::{
 
 pub(crate) use zellij_utils::sessions::list_sessions;
 
+/// Run the WebSocket remote-control API server in the foreground.
+pub(crate) fn start_api_server(opts: zellij_utils::cli::ApiServerCli) {
+    // Every session this server creates is a fork of this process (see
+    // `zellij_server::spawn_server`), so whatever environment this process
+    // has at startup is what every pane's shell inherits. Launched
+    // interactively, `TERM` comes along for free; launched as a daemon
+    // (systemd, cron, ssh without a tty) there is no controlling terminal
+    // to inherit it from, and it ends up completely unset. That is not
+    // cosmetic: with `TERM` empty, the shell has no terminfo entry to
+    // consult, and terminal-aware line editors (zsh's ZLE, syntax
+    // highlighting redraws, etc.) can emit output that assumes capabilities
+    // or cursor state it never actually confirmed. Default it the way
+    // tmux/screen do for their own panes, so a session started this way
+    // behaves the same as one started from an interactive shell.
+    if std::env::var("TERM").map(|t| t.is_empty()).unwrap_or(true) {
+        std::env::set_var("TERM", "xterm-256color");
+    }
+
+    let ip: IpAddr = match opts.bind.parse() {
+        Ok(ip) => ip,
+        Err(e) => {
+            eprintln!("Invalid --bind address '{}': {}", opts.bind, e);
+            process::exit(1);
+        },
+    };
+    let addr = std::net::SocketAddr::new(ip, opts.port);
+
+    if opts.token.is_none() {
+        eprintln!(
+            "WARNING: starting without a token. Anyone who can reach {} can drive your sessions.",
+            addr
+        );
+        eprintln!("         Pass --token <secret> (or set ZELLIJ_API_TOKEN) to require one.");
+    }
+
+    let runtime = match tokio::runtime::Runtime::new() {
+        Ok(runtime) => runtime,
+        Err(e) => {
+            eprintln!("Could not start the async runtime: {}", e);
+            process::exit(1);
+        },
+    };
+    if let Err(e) = runtime.block_on(zellij_api::server::serve(addr, opts.token)) {
+        eprintln!("API server stopped: {}", e);
+        process::exit(1);
+    }
+}
+
 pub(crate) fn kill_all_sessions(yes: bool) {
     match get_sessions() {
         Ok(sessions) if sessions.is_empty() => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,10 @@ fn main() {
             commands::subscribe_to_session(subscribe_cli, opts.session, config);
             std::process::exit(0);
         }
+        if let Some(Command::ApiServer(api_opts)) = opts.command {
+            commands::start_api_server(api_opts);
+            std::process::exit(0);
+        }
         if let Some(Command::Sessions(Sessions::Run {
             command,
             direction,

--- a/zellij-api/Cargo.toml
+++ b/zellij-api/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "zellij-api"
+version.workspace = true
+edition.workspace = true
+description = "WebSocket remote-control API for Zellij sessions"
+license.workspace = true
+
+[dependencies]
+zellij-utils = { workspace = true }
+zellij-client = { path = "../zellij-client/", version = "0.45.0" }
+
+anyhow = { workspace = true }
+axum = { version = "0.8.4", features = ["ws"] }
+futures = "0.3.30"
+log = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+similar = { version = "2", default-features = false, features = ["text"] }
+tokio = { workspace = true }
+uuid = { workspace = true }
+
+[features]
+# Mirrors the root package: isahc pulls in curl -> openssl-sys, and without
+# this the build needs a system libssl. See zellij-utils/Cargo.toml.
+default = ["vendored_curl"]
+vendored_curl = ["zellij-utils/vendored_curl"]
+
+[dev-dependencies]
+tempfile = "3"
+tokio-tungstenite = "0.28"
+futures-util = "0.3"

--- a/zellij-api/examples/drive.rs
+++ b/zellij-api/examples/drive.rs
@@ -1,0 +1,187 @@
+//! A small client for the Zellij remote-control API — useful both as a live
+//! demo and for debugging the event stream.
+//!
+//! ```sh
+//! target/dev-opt/zellij api-server --token secret &
+//! cargo run -p zellij-api --example drive -- --token secret --session demo
+//! ```
+//!
+//! It creates (or reuses) a session, subscribes to every pane, types a command
+//! and prints every frame the server sends, so you can watch the screen diffs
+//! arrive.
+
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use tokio_tungstenite::tungstenite::Message;
+
+#[tokio::main]
+async fn main() {
+    let mut port = 8787u16;
+    let mut token: Option<String> = None;
+    let mut session = "demo".to_string();
+    let mut text = "echo hello_from_the_api\n".to_string();
+    let mut watch_secs = 8u64;
+    let mut exec: Vec<Value> = Vec::new();
+
+    let args: Vec<String> = std::env::args().collect();
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--port" => {
+                port = args[i + 1].parse().expect("bad --port");
+                i += 2;
+            },
+            "--token" => {
+                token = Some(args[i + 1].clone());
+                i += 2;
+            },
+            "--session" => {
+                session = args[i + 1].clone();
+                i += 2;
+            },
+            "--text" => {
+                text = args[i + 1].clone();
+                i += 2;
+            },
+            "--watch" => {
+                watch_secs = args[i + 1].parse().expect("bad --watch");
+                i += 2;
+            },
+            // Send a raw JSON command instead of the scripted scenario. May be
+            // repeated; commands run in order.
+            "--exec" => {
+                exec.push(
+                    serde_json::from_str::<Value>(&args[i + 1]).expect("--exec must be JSON"),
+                );
+                i += 2;
+            },
+            other => {
+                eprintln!("unknown argument: {}", other);
+                std::process::exit(2);
+            },
+        }
+    }
+
+    let url = match &token {
+        Some(token) => format!("ws://127.0.0.1:{}/api?token={}", port, token),
+        None => format!("ws://127.0.0.1:{}/api", port),
+    };
+    let (mut socket, _) = tokio_tungstenite::connect_async(&url)
+        .await
+        .expect("could not connect — is `zellij api-server` running?");
+
+    let mut next_id = 1u64;
+    let mut call = |command: Value| {
+        let id = next_id.to_string();
+        next_id += 1;
+        let mut command = command;
+        command["id"] = json!(id);
+        (id, command)
+    };
+
+    // Helper that sends a command and prints frames until its reply arrives.
+    macro_rules! run {
+        ($cmd:expr) => {{
+            let (id, command) = call($cmd);
+            println!("\x1b[36m-> {}\x1b[0m", command);
+            socket
+                .send(Message::Text(command.to_string().into()))
+                .await
+                .expect("send failed");
+            loop {
+                let Some(Ok(Message::Text(raw))) = socket.next().await else {
+                    panic!("socket closed");
+                };
+                let value: Value = serde_json::from_str(&raw).expect("not JSON");
+                if value["id"] == json!(id) {
+                    println!("\x1b[32m<- {}\x1b[0m", value);
+                    break value;
+                }
+                print_event(&value);
+            }
+        }};
+    }
+
+    if !exec.is_empty() {
+        for command in exec.clone() {
+            run!(command);
+        }
+        println!("\n--- watching events for {}s ---\n", watch_secs);
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(watch_secs);
+        while let Ok(Some(Ok(Message::Text(raw)))) =
+            tokio::time::timeout_at(deadline, socket.next()).await
+        {
+            if let Ok(value) = serde_json::from_str::<Value>(&raw) {
+                print_event(&value);
+            }
+        }
+        return;
+    }
+
+    let sessions = run!(json!({"cmd": "session.list"}));
+    let existing: Vec<&str> = sessions["result"]["sessions"]
+        .as_array()
+        .map(|s| {
+            s.iter()
+                .filter(|s| s["resurrectable"] == json!(false))
+                .filter_map(|s| s["name"].as_str())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if !existing.contains(&session.as_str()) {
+        run!(json!({"cmd": "session.create", "name": session, "rows": 24, "cols": 80}));
+    }
+
+    run!(json!({"cmd": "tab.list", "session": session}));
+    run!(json!({"cmd": "pane.list", "session": session}));
+    run!(json!({"cmd": "screen.subscribe", "session": session}));
+    run!(json!({"cmd": "input.text", "session": session, "text": text}));
+
+    println!("\n--- watching events for {}s ---\n", watch_secs);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(watch_secs);
+    loop {
+        match tokio::time::timeout_at(deadline, socket.next()).await {
+            Ok(Some(Ok(Message::Text(raw)))) => {
+                let value: Value = serde_json::from_str(&raw).expect("not JSON");
+                print_event(&value);
+            },
+            Ok(Some(Ok(_))) => continue,
+            Ok(Some(Err(e))) => {
+                eprintln!("websocket error: {}", e);
+                break;
+            },
+            Ok(None) | Err(_) => break,
+        }
+    }
+}
+
+fn print_event(value: &Value) {
+    match value["event"].as_str() {
+        Some("screen.diff") => {
+            println!(
+                "\x1b[33m[screen.diff] pane={} seq={} +{} -{}\x1b[0m",
+                value["pane_id"], value["seq"], value["added"], value["removed"]
+            );
+            for line in value["unified"].as_str().unwrap_or("").lines() {
+                let colour = match line.chars().next() {
+                    Some('+') => "\x1b[32m",
+                    Some('-') => "\x1b[31m",
+                    Some('@') => "\x1b[36m",
+                    _ => "\x1b[90m",
+                };
+                println!("  {}{}\x1b[0m", colour, line);
+            }
+        },
+        Some("screen.reset") => println!(
+            "\x1b[35m[screen.reset] pane={} seq={} ({} lines)\x1b[0m",
+            value["pane_id"],
+            value["seq"],
+            value["lines"].as_array().map(|l| l.len()).unwrap_or(0)
+        ),
+        Some(other) => println!("\x1b[90m[{}] {}\x1b[0m", other, value),
+        None => println!("\x1b[90m{}\x1b[0m", value),
+    }
+}

--- a/zellij-api/src/canvas.rs
+++ b/zellij-api/src/canvas.rs
@@ -1,0 +1,365 @@
+//! Per-pane canvas state and its change history.
+//!
+//! Each pane is treated as a file whose contents are the visible screen rows.
+//! Every update the server pushes becomes a new *version* of that file, and the
+//! change between consecutive versions is stored as a unified diff. A caller
+//! can therefore ask "what happened on this pane since version N?" and get back
+//! a list of diffs, exactly like walking a file's git history.
+
+use std::collections::{HashMap, VecDeque};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+
+use crate::diff::{diff_canvas, normalize_canvas, CanvasDiff};
+
+/// How many diffs we keep per pane before dropping the oldest.
+pub const DEFAULT_HISTORY_CAPACITY: usize = 1000;
+
+pub fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// One recorded change to a pane's canvas.
+#[derive(Debug, Clone, Serialize)]
+pub struct HistoryEntry {
+    pub seq: u64,
+    pub ts: u64,
+    pub added: usize,
+    pub removed: usize,
+    pub unified: String,
+    pub hunks: Vec<crate::diff::DiffHunk>,
+}
+
+/// What applying an update produced.
+#[derive(Debug, Clone)]
+pub enum CanvasUpdate {
+    /// A new baseline was established; there is no diff to report.
+    Reset { seq: u64, ts: u64, lines: Vec<String> },
+    /// The canvas changed.
+    Changed { ts: u64, diff: CanvasDiff },
+    /// Nothing visible changed.
+    Unchanged,
+}
+
+#[derive(Debug)]
+pub struct PaneCanvas {
+    /// Current materialised contents.
+    pub lines: Vec<String>,
+    /// Version of `lines`. Starts at 0 for the first snapshot and increments
+    /// once per recorded change.
+    pub version: u64,
+    history: VecDeque<HistoryEntry>,
+    capacity: usize,
+}
+
+impl PaneCanvas {
+    fn new(lines: Vec<String>, capacity: usize) -> Self {
+        PaneCanvas {
+            lines,
+            version: 0,
+            history: VecDeque::new(),
+            capacity,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CanvasStore {
+    panes: HashMap<String, PaneCanvas>,
+    capacity: usize,
+}
+
+impl Default for CanvasStore {
+    fn default() -> Self {
+        Self::new(DEFAULT_HISTORY_CAPACITY)
+    }
+}
+
+impl CanvasStore {
+    pub fn new(capacity: usize) -> Self {
+        CanvasStore {
+            panes: HashMap::new(),
+            capacity: capacity.max(1),
+        }
+    }
+
+    /// Feed an update from the server.
+    ///
+    /// `is_initial` is set by the server on the snapshot it sends when a
+    /// subscription is (re)established. We treat it as a baseline rather than a
+    /// diff, because diffing against a stale canvas from before a resubscribe
+    /// would manufacture a change that never happened on screen.
+    pub fn apply(
+        &mut self,
+        pane_id: &str,
+        raw_lines: Vec<String>,
+        is_initial: bool,
+    ) -> CanvasUpdate {
+        let lines = normalize_canvas(&raw_lines);
+        let ts = now_ms();
+
+        let Some(canvas) = self.panes.get_mut(pane_id) else {
+            let canvas = PaneCanvas::new(lines.clone(), self.capacity);
+            let seq = canvas.version;
+            self.panes.insert(pane_id.to_string(), canvas);
+            return CanvasUpdate::Reset { seq, ts, lines };
+        };
+
+        if is_initial {
+            // Re-baseline without inventing history, but keep what we already
+            // recorded so earlier diffs remain queryable.
+            if canvas.lines == lines {
+                return CanvasUpdate::Unchanged;
+            }
+            canvas.lines = lines.clone();
+            return CanvasUpdate::Reset {
+                seq: canvas.version,
+                ts,
+                lines,
+            };
+        }
+
+        let label = format!("pane/{}", pane_id);
+        let next_version = canvas.version + 1;
+        let Some(diff) = diff_canvas(&canvas.lines, &lines, canvas.version, next_version, &label)
+        else {
+            return CanvasUpdate::Unchanged;
+        };
+
+        canvas.lines = lines;
+        canvas.version = next_version;
+        canvas.history.push_back(HistoryEntry {
+            seq: next_version,
+            ts,
+            added: diff.added,
+            removed: diff.removed,
+            unified: diff.unified.clone(),
+            hunks: diff.hunks.clone(),
+        });
+        while canvas.history.len() > canvas.capacity {
+            canvas.history.pop_front();
+        }
+
+        CanvasUpdate::Changed { ts, diff }
+    }
+
+    /// Current contents and version of a pane's canvas.
+    pub fn snapshot(&self, pane_id: &str) -> Option<(u64, Vec<String>)> {
+        self.panes
+            .get(pane_id)
+            .map(|c| (c.version, c.lines.clone()))
+    }
+
+    /// Recorded changes for a pane, oldest first.
+    ///
+    /// `since` returns only entries newer than that version; `limit` keeps the
+    /// most recent N of whatever remains.
+    pub fn history(&self, pane_id: &str, since: Option<u64>, limit: Option<usize>) -> Vec<HistoryEntry> {
+        let Some(canvas) = self.panes.get(pane_id) else {
+            return Vec::new();
+        };
+        let mut entries: Vec<HistoryEntry> = canvas
+            .history
+            .iter()
+            .filter(|e| since.map(|s| e.seq > s).unwrap_or(true))
+            .cloned()
+            .collect();
+        if let Some(limit) = limit {
+            if entries.len() > limit {
+                entries.drain(..entries.len() - limit);
+            }
+        }
+        entries
+    }
+
+    /// Whether we have ever seen this pane.
+    pub fn knows(&self, pane_id: &str) -> bool {
+        self.panes.contains_key(pane_id)
+    }
+
+    pub fn forget(&mut self, pane_id: &str) {
+        self.panes.remove(pane_id);
+    }
+
+    pub fn pane_ids(&self) -> Vec<String> {
+        self.panes.keys().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lines(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn first_update_is_a_baseline_not_a_diff() {
+        let mut store = CanvasStore::default();
+        let update = store.apply("terminal_1", lines(&["$ "]), true);
+        match update {
+            CanvasUpdate::Reset { seq, lines: l, .. } => {
+                assert_eq!(seq, 0);
+                // Stored normalised: trailing padding is stripped so that
+                // later cursor movement does not read as a change.
+                assert_eq!(l, lines(&["$"]));
+            },
+            other => panic!("expected a baseline, got {:?}", other),
+        }
+        assert!(store.history("terminal_1", None, None).is_empty());
+    }
+
+    #[test]
+    fn subsequent_updates_are_recorded_as_diffs() {
+        let mut store = CanvasStore::default();
+        store.apply("terminal_1", lines(&["$ sudr"]), true);
+        let update = store.apply("terminal_1", lines(&["$ sudo"]), false);
+
+        match update {
+            CanvasUpdate::Changed { diff, .. } => {
+                assert_eq!(diff.from_version, 0);
+                assert_eq!(diff.to_version, 1);
+                assert!(diff.unified.contains("-$ sudr"));
+                assert!(diff.unified.contains("+$ sudo"));
+            },
+            other => panic!("expected a change, got {:?}", other),
+        }
+
+        let history = store.history("terminal_1", None, None);
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].seq, 1);
+        assert_eq!(history[0].added, 1);
+        assert_eq!(history[0].removed, 1);
+    }
+
+    #[test]
+    fn version_advances_only_on_real_change() {
+        let mut store = CanvasStore::default();
+        store.apply("p", lines(&["a"]), true);
+        store.apply("p", lines(&["a"]), false);
+        store.apply("p", lines(&["a   "]), false); // padding only
+        assert_eq!(store.snapshot("p").unwrap().0, 0);
+        assert!(store.history("p", None, None).is_empty());
+
+        store.apply("p", lines(&["b"]), false);
+        assert_eq!(store.snapshot("p").unwrap().0, 1);
+    }
+
+    #[test]
+    fn snapshot_tracks_the_latest_contents() {
+        let mut store = CanvasStore::default();
+        store.apply("p", lines(&["one"]), true);
+        store.apply("p", lines(&["one", "two"]), false);
+        let (version, contents) = store.snapshot("p").unwrap();
+        assert_eq!(version, 1);
+        assert_eq!(contents, lines(&["one", "two"]));
+    }
+
+    #[test]
+    fn history_can_be_replayed_from_a_known_version() {
+        let mut store = CanvasStore::default();
+        store.apply("p", lines(&["v0"]), true);
+        for i in 1..=5 {
+            store.apply("p", lines(&[&format!("v{}", i)]), false);
+        }
+        let all = store.history("p", None, None);
+        assert_eq!(all.len(), 5);
+        assert_eq!(all.first().unwrap().seq, 1);
+        assert_eq!(all.last().unwrap().seq, 5);
+
+        let since_3 = store.history("p", Some(3), None);
+        assert_eq!(
+            since_3.iter().map(|e| e.seq).collect::<Vec<_>>(),
+            vec![4, 5],
+            "a caller resuming at v3 gets only what it missed"
+        );
+    }
+
+    #[test]
+    fn limit_keeps_the_most_recent_entries() {
+        let mut store = CanvasStore::default();
+        store.apply("p", lines(&["v0"]), true);
+        for i in 1..=5 {
+            store.apply("p", lines(&[&format!("v{}", i)]), false);
+        }
+        let last_two = store.history("p", None, Some(2));
+        assert_eq!(last_two.iter().map(|e| e.seq).collect::<Vec<_>>(), vec![4, 5]);
+    }
+
+    #[test]
+    fn history_is_bounded() {
+        let mut store = CanvasStore::new(3);
+        store.apply("p", lines(&["v0"]), true);
+        for i in 1..=10 {
+            store.apply("p", lines(&[&format!("v{}", i)]), false);
+        }
+        let history = store.history("p", None, None);
+        assert_eq!(history.len(), 3, "oldest entries are dropped");
+        assert_eq!(
+            history.iter().map(|e| e.seq).collect::<Vec<_>>(),
+            vec![8, 9, 10]
+        );
+        // The live canvas is still correct despite the trimmed history.
+        assert_eq!(store.snapshot("p").unwrap().1, lines(&["v10"]));
+    }
+
+    #[test]
+    fn resubscribing_rebaselines_without_a_phantom_diff() {
+        let mut store = CanvasStore::default();
+        store.apply("p", lines(&["a"]), true);
+        store.apply("p", lines(&["b"]), false);
+        let before = store.history("p", None, None).len();
+
+        // The server re-sends a snapshot after a resubscribe.
+        let update = store.apply("p", lines(&["totally different"]), true);
+        assert!(matches!(update, CanvasUpdate::Reset { .. }));
+        assert_eq!(
+            store.history("p", None, None).len(),
+            before,
+            "a re-baseline must not fabricate a history entry"
+        );
+        assert_eq!(store.snapshot("p").unwrap().1, lines(&["totally different"]));
+    }
+
+    #[test]
+    fn identical_rebaseline_is_a_no_op() {
+        let mut store = CanvasStore::default();
+        store.apply("p", lines(&["a"]), true);
+        assert!(matches!(
+            store.apply("p", lines(&["a"]), true),
+            CanvasUpdate::Unchanged
+        ));
+    }
+
+    #[test]
+    fn forgetting_a_pane_drops_its_state() {
+        let mut store = CanvasStore::default();
+        store.apply("p", lines(&["a"]), true);
+        assert!(store.knows("p"));
+        store.forget("p");
+        assert!(!store.knows("p"));
+        assert!(store.snapshot("p").is_none());
+        assert!(store.history("p", None, None).is_empty());
+    }
+
+    #[test]
+    fn panes_are_tracked_independently() {
+        let mut store = CanvasStore::default();
+        store.apply("terminal_1", lines(&["one"]), true);
+        store.apply("terminal_2", lines(&["two"]), true);
+        store.apply("terminal_1", lines(&["one!"]), false);
+
+        assert_eq!(store.snapshot("terminal_1").unwrap().0, 1);
+        assert_eq!(store.snapshot("terminal_2").unwrap().0, 0);
+        assert_eq!(store.history("terminal_2", None, None).len(), 0);
+
+        let mut ids = store.pane_ids();
+        ids.sort();
+        assert_eq!(ids, vec!["terminal_1", "terminal_2"]);
+    }
+}

--- a/zellij-api/src/canvas.rs
+++ b/zellij-api/src/canvas.rs
@@ -38,7 +38,11 @@ pub struct HistoryEntry {
 #[derive(Debug, Clone)]
 pub enum CanvasUpdate {
     /// A new baseline was established; there is no diff to report.
-    Reset { seq: u64, ts: u64, lines: Vec<String> },
+    Reset {
+        seq: u64,
+        ts: u64,
+        lines: Vec<String>,
+    },
     /// The canvas changed.
     Changed { ts: u64, diff: CanvasDiff },
     /// Nothing visible changed.
@@ -158,7 +162,12 @@ impl CanvasStore {
     ///
     /// `since` returns only entries newer than that version; `limit` keeps the
     /// most recent N of whatever remains.
-    pub fn history(&self, pane_id: &str, since: Option<u64>, limit: Option<usize>) -> Vec<HistoryEntry> {
+    pub fn history(
+        &self,
+        pane_id: &str,
+        since: Option<u64>,
+        limit: Option<usize>,
+    ) -> Vec<HistoryEntry> {
         let Some(canvas) = self.panes.get(pane_id) else {
             return Vec::new();
         };
@@ -288,7 +297,10 @@ mod tests {
             store.apply("p", lines(&[&format!("v{}", i)]), false);
         }
         let last_two = store.history("p", None, Some(2));
-        assert_eq!(last_two.iter().map(|e| e.seq).collect::<Vec<_>>(), vec![4, 5]);
+        assert_eq!(
+            last_two.iter().map(|e| e.seq).collect::<Vec<_>>(),
+            vec![4, 5]
+        );
     }
 
     #[test]
@@ -323,7 +335,10 @@ mod tests {
             before,
             "a re-baseline must not fabricate a history entry"
         );
-        assert_eq!(store.snapshot("p").unwrap().1, lines(&["totally different"]));
+        assert_eq!(
+            store.snapshot("p").unwrap().1,
+            lines(&["totally different"])
+        );
     }
 
     #[test]

--- a/zellij-api/src/diff.rs
+++ b/zellij-api/src/diff.rs
@@ -1,0 +1,288 @@
+//! Treats a pane's canvas as a text file and describes each change to it as a
+//! unified (git-style) diff.
+//!
+//! A pane viewport arrives from the server as `Vec<String>` — one entry per
+//! screen row. We keep the previous version of that "file" per pane and, on
+//! every update, emit the diff between the two versions:
+//!
+//! ```text
+//! @@ -3,1 +3,1 @@
+//! -sudr
+//! +sudo
+//! ```
+
+use serde::{Deserialize, Serialize};
+use similar::{ChangeTag, TextDiff};
+
+/// Number of unchanged context lines kept around each hunk, matching git's default.
+pub const CONTEXT_RADIUS: usize = 3;
+
+/// A single hunk of a canvas diff, in the shape a git user expects.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DiffHunk {
+    /// 1-based first line of the hunk in the old version.
+    pub old_start: usize,
+    pub old_lines: usize,
+    /// 1-based first line of the hunk in the new version.
+    pub new_start: usize,
+    pub new_lines: usize,
+    /// The hunk body: each entry prefixed with ' ', '-' or '+'.
+    pub lines: Vec<String>,
+}
+
+/// The change between two consecutive versions of one pane's canvas.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CanvasDiff {
+    /// Version this diff moves the canvas *from*.
+    pub from_version: u64,
+    /// Version this diff moves the canvas *to*.
+    pub to_version: u64,
+    pub added: usize,
+    pub removed: usize,
+    pub hunks: Vec<DiffHunk>,
+    /// The whole diff rendered as unified-diff text, ready to print.
+    pub unified: String,
+}
+
+impl CanvasDiff {
+    pub fn is_empty(&self) -> bool {
+        self.hunks.is_empty()
+    }
+}
+
+/// Normalise a screen row before diffing.
+///
+/// The terminal pads rows out to the pane width, and the cursor moving around
+/// rewrites rows without changing anything visible. Trimming the trailing
+/// padding keeps those non-events out of the history.
+fn normalize(line: &str) -> String {
+    line.trim_end().to_string()
+}
+
+pub fn normalize_canvas(lines: &[String]) -> Vec<String> {
+    lines.iter().map(|l| normalize(l)).collect()
+}
+
+/// Diff two canvas versions. Returns `None` when nothing visible changed.
+pub fn diff_canvas(
+    old: &[String],
+    new: &[String],
+    from_version: u64,
+    to_version: u64,
+    label: &str,
+) -> Option<CanvasDiff> {
+    if old == new {
+        return None;
+    }
+
+    // `TextDiff::from_slices` compares the rows as opaque units, which is what
+    // we want: a screen row is the unit of change, like a line in a file.
+    let old_rows: Vec<&str> = old.iter().map(|s| s.as_str()).collect();
+    let new_rows: Vec<&str> = new.iter().map(|s| s.as_str()).collect();
+    let diff = TextDiff::from_slices(&old_rows, &new_rows);
+
+    let mut hunks: Vec<DiffHunk> = Vec::new();
+    let mut added = 0usize;
+    let mut removed = 0usize;
+
+    for group in diff.grouped_ops(CONTEXT_RADIUS).iter() {
+        let mut lines: Vec<String> = Vec::new();
+        let mut old_start = usize::MAX;
+        let mut new_start = usize::MAX;
+        let mut old_lines = 0usize;
+        let mut new_lines = 0usize;
+
+        for op in group {
+            for change in diff.iter_changes(op) {
+                let idx_old = change.old_index();
+                let idx_new = change.new_index();
+                if let Some(i) = idx_old {
+                    old_start = old_start.min(i);
+                }
+                if let Some(i) = idx_new {
+                    new_start = new_start.min(i);
+                }
+                let value = change.value();
+                match change.tag() {
+                    ChangeTag::Equal => {
+                        old_lines += 1;
+                        new_lines += 1;
+                        lines.push(format!(" {}", value));
+                    },
+                    ChangeTag::Delete => {
+                        old_lines += 1;
+                        removed += 1;
+                        lines.push(format!("-{}", value));
+                    },
+                    ChangeTag::Insert => {
+                        new_lines += 1;
+                        added += 1;
+                        lines.push(format!("+{}", value));
+                    },
+                }
+            }
+        }
+
+        if lines.is_empty() {
+            continue;
+        }
+
+        hunks.push(DiffHunk {
+            // Unified diff line numbers are 1-based. An empty side is
+            // conventionally reported as starting at 0.
+            old_start: if old_lines == 0 {
+                0
+            } else {
+                old_start.saturating_add(1)
+            },
+            old_lines,
+            new_start: if new_lines == 0 {
+                0
+            } else {
+                new_start.saturating_add(1)
+            },
+            new_lines,
+            lines,
+        });
+    }
+
+    if hunks.is_empty() {
+        return None;
+    }
+
+    let unified = render_unified(&hunks, label, from_version, to_version);
+
+    Some(CanvasDiff {
+        from_version,
+        to_version,
+        added,
+        removed,
+        hunks,
+        unified,
+    })
+}
+
+fn render_unified(hunks: &[DiffHunk], label: &str, from_version: u64, to_version: u64) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("--- {}@{}\n", label, from_version));
+    out.push_str(&format!("+++ {}@{}\n", label, to_version));
+    for hunk in hunks {
+        out.push_str(&format!(
+            "@@ -{},{} +{},{} @@\n",
+            hunk.old_start, hunk.old_lines, hunk.new_start, hunk.new_lines
+        ));
+        for line in &hunk.lines {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn canvas(lines: &[&str]) -> Vec<String> {
+        lines.iter().map(|l| l.to_string()).collect()
+    }
+
+    #[test]
+    fn identical_canvases_produce_no_diff() {
+        let a = canvas(&["$ ls", "foo bar", ""]);
+        assert!(diff_canvas(&a, &a, 0, 1, "pane/terminal_1").is_none());
+    }
+
+    #[test]
+    fn single_line_edit_reads_like_git() {
+        // The motivating example from the goal: a typo corrected in place.
+        let old = canvas(&["$ ", "line two", "sudr", "line four"]);
+        let new = canvas(&["$ ", "line two", "sudo", "line four"]);
+        let diff = diff_canvas(&old, &new, 4, 5, "pane/terminal_1").expect("expected a diff");
+
+        assert_eq!(diff.added, 1);
+        assert_eq!(diff.removed, 1);
+        assert!(
+            diff.unified.contains("-sudr\n+sudo\n"),
+            "unified diff should show the replacement, got:\n{}",
+            diff.unified
+        );
+        assert!(diff.unified.contains("--- pane/terminal_1@4"));
+        assert!(diff.unified.contains("+++ pane/terminal_1@5"));
+    }
+
+    #[test]
+    fn hunk_line_numbers_are_one_based() {
+        let old = canvas(&["a", "b", "c"]);
+        let new = canvas(&["a", "B", "c"]);
+        let diff = diff_canvas(&old, &new, 0, 1, "p").unwrap();
+        assert_eq!(diff.hunks.len(), 1);
+        let hunk = &diff.hunks[0];
+        // The hunk starts at line 1 because of the context line above it.
+        assert_eq!(hunk.old_start, 1);
+        assert_eq!(hunk.new_start, 1);
+        assert_eq!(hunk.old_lines, 3);
+        assert_eq!(hunk.new_lines, 3);
+        assert!(diff.unified.contains("@@ -1,3 +1,3 @@"));
+    }
+
+    #[test]
+    fn appended_output_is_an_addition_only_hunk() {
+        let old = canvas(&["$ ls"]);
+        let new = canvas(&["$ ls", "Cargo.toml", "src"]);
+        let diff = diff_canvas(&old, &new, 0, 1, "p").unwrap();
+        assert_eq!(diff.added, 2);
+        assert_eq!(diff.removed, 0);
+        assert!(diff.unified.contains("+Cargo.toml"));
+        assert!(diff.unified.contains("+src"));
+    }
+
+    #[test]
+    fn scrolling_shows_as_removal_at_top_and_addition_at_bottom() {
+        let old = canvas(&["one", "two", "three"]);
+        let new = canvas(&["two", "three", "four"]);
+        let diff = diff_canvas(&old, &new, 1, 2, "p").unwrap();
+        assert_eq!(diff.removed, 1);
+        assert_eq!(diff.added, 1);
+        assert!(diff.unified.contains("-one"));
+        assert!(diff.unified.contains("+four"));
+    }
+
+    #[test]
+    fn trailing_padding_is_not_a_change() {
+        // The renderer pads rows to the pane width; that must not register.
+        let old = normalize_canvas(&canvas(&["$ echo hi", "hi"]));
+        let new = normalize_canvas(&canvas(&["$ echo hi    ", "hi        "]));
+        assert_eq!(old, new);
+        assert!(diff_canvas(&old, &new, 0, 1, "p").is_none());
+    }
+
+    #[test]
+    fn distant_changes_produce_separate_hunks() {
+        let mut old_lines: Vec<String> = (0..40).map(|i| format!("line {}", i)).collect();
+        let mut new_lines = old_lines.clone();
+        new_lines[2] = "changed near top".to_string();
+        new_lines[35] = "changed near bottom".to_string();
+        old_lines.truncate(40);
+        new_lines.truncate(40);
+
+        let diff = diff_canvas(&old_lines, &new_lines, 7, 8, "p").unwrap();
+        assert_eq!(
+            diff.hunks.len(),
+            2,
+            "changes 30 lines apart should not be merged into one hunk"
+        );
+        assert_eq!(diff.added, 2);
+        assert_eq!(diff.removed, 2);
+    }
+
+    #[test]
+    fn clearing_the_screen_removes_every_line() {
+        let old = canvas(&["a", "b", "c"]);
+        let new: Vec<String> = vec![];
+        let diff = diff_canvas(&old, &new, 3, 4, "p").unwrap();
+        assert_eq!(diff.removed, 3);
+        assert_eq!(diff.added, 0);
+        assert_eq!(diff.hunks[0].new_start, 0, "empty side starts at 0");
+    }
+}

--- a/zellij-api/src/keys.rs
+++ b/zellij-api/src/keys.rs
@@ -1,0 +1,266 @@
+//! Turns human-readable key names from the API (`"ctrl-c"`, `"enter"`, `"f5"`)
+//! into the bytes a terminal application expects on its stdin.
+//!
+//! We deliberately emit raw bytes rather than `KeyWithModifier`, because the
+//! bytes are what a pane's PTY consumes and they survive being addressed at a
+//! specific pane via `Action::WriteToPaneId`.
+
+/// Parse one key name into the byte sequence to write to a pane.
+///
+/// Accepted forms:
+/// - named keys: `enter`, `tab`, `esc`, `space`, `backspace`, `delete`,
+///   `insert`, `home`, `end`, `pageup`, `pagedown`, `up`/`down`/`left`/`right`
+/// - function keys: `f1` .. `f12`
+/// - a single character: `a`, `Z`, `/`
+/// - modifiers, combinable and separated by `-` or `+`:
+///   `ctrl-c`, `alt-f`, `shift-tab`, `ctrl-alt-delete`
+pub fn key_to_bytes(name: &str) -> Result<Vec<u8>, String> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err("empty key name".to_string());
+    }
+
+    let mut ctrl = false;
+    let mut alt = false;
+    let mut shift = false;
+
+    // Split modifiers off the front, walking the original string. The final
+    // segment is the key itself, so a literal "-" or "+" as the key still
+    // works.
+    //
+    // This deliberately does not walk a lowercased copy in parallel: case
+    // conversion can change a string's byte length (`İ` lowercases to two
+    // chars), and offsets taken from one string then applied to the other
+    // would slice through a character. `-` and `+` are ASCII, so splitting the
+    // original is always on a character boundary.
+    let mut rest = trimmed;
+    loop {
+        let split = rest
+            .find('-')
+            .or_else(|| rest.find('+'))
+            .filter(|idx| *idx > 0 && *idx + 1 < rest.len());
+        let Some(idx) = split else { break };
+        let (prefix, remainder) = rest.split_at(idx);
+        let remainder = &remainder[1..];
+        match prefix.to_lowercase().as_str() {
+            "ctrl" | "control" | "c" => ctrl = true,
+            "alt" | "meta" | "opt" | "option" | "m" => alt = true,
+            "shift" | "s" => shift = true,
+            _ => break,
+        }
+        rest = remainder;
+    }
+
+    let base_original = rest;
+    let base_lowered = rest.to_lowercase();
+    let base = base_lowered.as_str();
+    let mut bytes = match base {
+        "enter" | "return" | "cr" => vec![b'\r'],
+        "newline" | "lf" => vec![b'\n'],
+        "tab" if !shift => vec![b'\t'],
+        "tab" => b"\x1b[Z".to_vec(), // shift-tab is back-tab
+        "esc" | "escape" => vec![0x1b],
+        "space" => vec![b' '],
+        "backspace" | "bs" => vec![0x7f],
+        "delete" | "del" => b"\x1b[3~".to_vec(),
+        "insert" | "ins" => b"\x1b[2~".to_vec(),
+        "home" => b"\x1b[H".to_vec(),
+        "end" => b"\x1b[F".to_vec(),
+        "pageup" | "pgup" => b"\x1b[5~".to_vec(),
+        "pagedown" | "pgdn" | "pgdown" => b"\x1b[6~".to_vec(),
+        "up" => b"\x1b[A".to_vec(),
+        "down" => b"\x1b[B".to_vec(),
+        "right" => b"\x1b[C".to_vec(),
+        "left" => b"\x1b[D".to_vec(),
+        "f1" => b"\x1bOP".to_vec(),
+        "f2" => b"\x1bOQ".to_vec(),
+        "f3" => b"\x1bOR".to_vec(),
+        "f4" => b"\x1bOS".to_vec(),
+        "f5" => b"\x1b[15~".to_vec(),
+        "f6" => b"\x1b[17~".to_vec(),
+        "f7" => b"\x1b[18~".to_vec(),
+        "f8" => b"\x1b[19~".to_vec(),
+        "f9" => b"\x1b[20~".to_vec(),
+        "f10" => b"\x1b[21~".to_vec(),
+        "f11" => b"\x1b[23~".to_vec(),
+        "f12" => b"\x1b[24~".to_vec(),
+        other => {
+            let mut chars = other.chars();
+            let (Some(ch), None) = (chars.next(), chars.next()) else {
+                return Err(format!("unknown key name: '{}'", name));
+            };
+            // Use the caller's original casing for plain characters, so "A"
+            // stays uppercase even though we lowercased for lookup.
+            let ch = base_original.chars().next().unwrap_or(ch);
+            let ch = if shift {
+                ch.to_uppercase().next().unwrap_or(ch)
+            } else {
+                ch
+            };
+            if ctrl {
+                // Control codes: ctrl-a == 0x01 ... ctrl-z == 0x1a, plus the
+                // handful of punctuation control codes.
+                let upper = ch.to_ascii_uppercase();
+                let code = match upper {
+                    'A'..='Z' => (upper as u8) - b'A' + 1,
+                    '@' => 0,
+                    '[' => 0x1b,
+                    '\\' => 0x1c,
+                    ']' => 0x1d,
+                    '^' => 0x1e,
+                    '_' => 0x1f,
+                    ' ' => 0,
+                    _ => return Err(format!("no control code for key '{}'", name)),
+                };
+                ctrl = false; // consumed
+                vec![code]
+            } else {
+                let mut buf = [0u8; 4];
+                ch.encode_utf8(&mut buf).as_bytes().to_vec()
+            }
+        },
+    };
+
+    if ctrl {
+        // ctrl applied to a named key (e.g. ctrl-left) — emit the xterm
+        // modified-key form where we know it, otherwise report it rather than
+        // silently dropping the modifier.
+        bytes = match base {
+            "up" => b"\x1b[1;5A".to_vec(),
+            "down" => b"\x1b[1;5B".to_vec(),
+            "right" => b"\x1b[1;5C".to_vec(),
+            "left" => b"\x1b[1;5D".to_vec(),
+            "home" => b"\x1b[1;5H".to_vec(),
+            "end" => b"\x1b[1;5F".to_vec(),
+            "delete" | "del" => b"\x1b[3;5~".to_vec(),
+            _ => return Err(format!("ctrl modifier not supported for key '{}'", name)),
+        };
+    }
+
+    if alt {
+        // Alt is transmitted as ESC followed by the key.
+        let mut prefixed = vec![0x1b];
+        prefixed.extend(bytes);
+        bytes = prefixed;
+    }
+
+    Ok(bytes)
+}
+
+/// Encode a whole sequence of key names into one byte stream.
+pub fn keys_to_bytes(keys: &[String]) -> Result<Vec<u8>, String> {
+    let mut out = Vec::new();
+    for key in keys {
+        out.extend(key_to_bytes(key)?);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_characters_pass_through() {
+        assert_eq!(key_to_bytes("a").unwrap(), b"a");
+        assert_eq!(key_to_bytes("Z").unwrap(), b"Z");
+        assert_eq!(key_to_bytes("/").unwrap(), b"/");
+    }
+
+    #[test]
+    fn named_keys_use_their_terminal_sequences() {
+        assert_eq!(key_to_bytes("enter").unwrap(), b"\r");
+        assert_eq!(key_to_bytes("tab").unwrap(), b"\t");
+        assert_eq!(key_to_bytes("esc").unwrap(), vec![0x1b]);
+        assert_eq!(key_to_bytes("backspace").unwrap(), vec![0x7f]);
+        assert_eq!(key_to_bytes("up").unwrap(), b"\x1b[A");
+        assert_eq!(key_to_bytes("f5").unwrap(), b"\x1b[15~");
+    }
+
+    #[test]
+    fn ctrl_maps_to_control_codes() {
+        assert_eq!(key_to_bytes("ctrl-c").unwrap(), vec![0x03]);
+        assert_eq!(key_to_bytes("ctrl-a").unwrap(), vec![0x01]);
+        assert_eq!(key_to_bytes("ctrl-z").unwrap(), vec![0x1a]);
+        // Capitalised and alternate spellings agree.
+        assert_eq!(key_to_bytes("CTRL-C").unwrap(), vec![0x03]);
+        assert_eq!(key_to_bytes("control+c").unwrap(), vec![0x03]);
+    }
+
+    #[test]
+    fn alt_prefixes_with_escape() {
+        assert_eq!(key_to_bytes("alt-f").unwrap(), vec![0x1b, b'f']);
+        assert_eq!(key_to_bytes("alt-enter").unwrap(), vec![0x1b, b'\r']);
+    }
+
+    #[test]
+    fn shift_tab_is_back_tab() {
+        assert_eq!(key_to_bytes("shift-tab").unwrap(), b"\x1b[Z");
+    }
+
+    #[test]
+    fn shift_uppercases_characters() {
+        assert_eq!(key_to_bytes("shift-a").unwrap(), b"A");
+    }
+
+    #[test]
+    fn combined_modifiers_stack() {
+        // ESC prefix, then the control code.
+        assert_eq!(key_to_bytes("ctrl-alt-c").unwrap(), vec![0x1b, 0x03]);
+        assert_eq!(key_to_bytes("ctrl-left").unwrap(), b"\x1b[1;5D");
+    }
+
+    #[test]
+    fn unknown_keys_are_reported_rather_than_dropped() {
+        assert!(key_to_bytes("nonsense").is_err());
+        assert!(key_to_bytes("").is_err());
+        // A modifier we cannot faithfully encode must fail loudly.
+        assert!(key_to_bytes("ctrl-f5").is_err());
+    }
+
+    #[test]
+    fn hostile_key_names_are_rejected_not_fatal() {
+        // Key names arrive from the network, and the parser splits modifiers by
+        // byte offset across a lowercase conversion — which can change a
+        // string's length (`İ` lowercases to two chars). Anything unparseable
+        // must come back as an error, never a panic.
+        let nasty = [
+            "İ",
+            "ctrl-İ",
+            "c-İ",
+            "ctrl-alt-İ",
+            "ß",
+            "ctrl-ß",
+            "-",
+            "+",
+            "--",
+            "ctrl-",
+            "-a",
+            "ctrl+",
+            "ctrl-alt-",
+            "🎉",
+            "ctrl-🎉",
+            "shift-🎉",
+            "\u{0130}\u{0131}",
+            "ctrl-\u{0130}\u{0131}",
+            " ",
+            "\t",
+            "\u{feff}",
+            "a\u{0300}",
+            "ctrl-a\u{0300}",
+        ];
+        for name in nasty {
+            // The assertion is simply that this returns rather than unwinds.
+            let _ = key_to_bytes(name);
+        }
+    }
+
+    #[test]
+    fn sequences_concatenate() {
+        let keys: Vec<String> = ["s", "u", "d", "o", "enter"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(keys_to_bytes(&keys).unwrap(), b"sudo\r");
+    }
+}

--- a/zellij-api/src/lib.rs
+++ b/zellij-api/src/lib.rs
@@ -1,0 +1,14 @@
+//! WebSocket remote-control API for Zellij.
+//!
+//! See `REMOTE_API.md` at the repository root for the protocol and the design
+//! rationale. In short: this crate is a headless multi-session Zellij client
+//! that exposes session/tab/pane management, input injection and a git-style
+//! diff history of everything that appears on screen over a WebSocket.
+
+pub mod canvas;
+pub mod diff;
+pub mod keys;
+pub mod protocol;
+pub mod server;
+pub mod session_link;
+pub mod sessions;

--- a/zellij-api/src/protocol.rs
+++ b/zellij-api/src/protocol.rs
@@ -1,0 +1,461 @@
+//! The JSON protocol spoken over the control WebSocket.
+//!
+//! Three message shapes travel over the socket:
+//!
+//! - a **request** from the caller: `{"id": "1", "cmd": "tab.create", "session": "main"}`
+//! - a **reply** from us:          `{"id": "1", "ok": true, "result": {...}}`
+//! - an **event** from us:         `{"event": "screen.diff", ...}` (unsolicited)
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::diff::{CanvasDiff, DiffHunk};
+
+/// One inbound frame.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Request {
+    /// Echoed back on the reply so callers can correlate. Optional, but
+    /// without it a caller cannot tell replies apart.
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(flatten)]
+    pub command: Command,
+}
+
+impl Request {
+    /// Parameters in `raw` that this command does not understand.
+    ///
+    /// Serde ignores unknown fields by default, and `deny_unknown_fields` does
+    /// not work through `flatten` (nor does a catch-all map — with two
+    /// flattened targets the map swallows every field). So the known names are
+    /// taken from the command itself, by serialising it back: that cannot drift
+    /// out of step with the variants the way a hand-written list would.
+    ///
+    /// It matters because a misspelt parameter would otherwise be dropped in
+    /// silence and the command would run with a default — writing `paneids`
+    /// instead of `pane_ids` would quietly subscribe to *every* pane in the
+    /// session rather than the one asked for.
+    pub fn unknown_fields(&self, raw: &Value) -> Vec<String> {
+        let Some(sent) = raw.as_object() else {
+            return Vec::new();
+        };
+        let mut known: Vec<String> = vec!["cmd".to_string(), "id".to_string()];
+        if let Ok(Value::Object(fields)) = serde_json::to_value(&self.command) {
+            known.extend(fields.keys().cloned());
+        }
+        sent.keys()
+            .filter(|name| !known.contains(name))
+            .cloned()
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "cmd")]
+pub enum Command {
+    // ---- sessions -------------------------------------------------------
+    #[serde(rename = "session.list")]
+    SessionList,
+    #[serde(rename = "session.create")]
+    SessionCreate {
+        #[serde(default)]
+        name: Option<String>,
+        #[serde(default)]
+        layout: Option<String>,
+        #[serde(default)]
+        cwd: Option<String>,
+        /// Geometry of the virtual terminal the session is laid out in. This
+        /// is the size the canvas diffs are computed against.
+        #[serde(default)]
+        rows: Option<usize>,
+        #[serde(default)]
+        cols: Option<usize>,
+    },
+    #[serde(rename = "session.kill")]
+    SessionKill { name: String },
+    #[serde(rename = "session.rename")]
+    SessionRename { name: String, new_name: String },
+
+    // ---- tabs -----------------------------------------------------------
+    #[serde(rename = "tab.list")]
+    TabList { session: String },
+    #[serde(rename = "tab.create")]
+    TabCreate {
+        session: String,
+        #[serde(default)]
+        name: Option<String>,
+        #[serde(default)]
+        cwd: Option<String>,
+    },
+    #[serde(rename = "tab.close")]
+    TabClose { session: String, tab_id: u64 },
+    #[serde(rename = "tab.focus")]
+    TabFocus { session: String, tab_id: u64 },
+    #[serde(rename = "tab.rename")]
+    TabRename {
+        session: String,
+        tab_id: u64,
+        name: String,
+    },
+
+    // ---- panes ----------------------------------------------------------
+    #[serde(rename = "pane.list")]
+    PaneList { session: String },
+    #[serde(rename = "pane.create")]
+    PaneCreate {
+        session: String,
+        #[serde(default)]
+        command: Option<String>,
+        /// A plugin to run in the pane instead of a command: a URL
+        /// (`file:/path/to.wasm`, `https://...`) or an alias (`session-manager`).
+        #[serde(default)]
+        plugin: Option<String>,
+        /// Configuration passed to the plugin on startup.
+        #[serde(default)]
+        plugin_config: Option<std::collections::BTreeMap<String, String>>,
+        #[serde(default)]
+        args: Vec<String>,
+        #[serde(default)]
+        cwd: Option<String>,
+        #[serde(default)]
+        floating: bool,
+        /// One of `right`, `left`, `up`, `down`.
+        #[serde(default)]
+        direction: Option<String>,
+        #[serde(default)]
+        name: Option<String>,
+        /// Which tab to open the pane in. Defaults to the session's active tab
+        /// (or its first tab, when nothing is attached to focus one).
+        #[serde(default)]
+        tab_id: Option<u64>,
+    },
+    #[serde(rename = "pane.close")]
+    PaneClose { session: String, pane_id: String },
+    #[serde(rename = "pane.focus")]
+    PaneFocus { session: String, pane_id: String },
+    #[serde(rename = "pane.rename")]
+    PaneRename {
+        session: String,
+        pane_id: String,
+        name: String,
+    },
+    #[serde(rename = "pane.resize")]
+    PaneResize {
+        session: String,
+        pane_id: String,
+        /// `increase` or `decrease`.
+        resize: String,
+        #[serde(default)]
+        direction: Option<String>,
+    },
+
+    // ---- input ----------------------------------------------------------
+    #[serde(rename = "input.text")]
+    InputText {
+        session: String,
+        /// Omit to target the session's focused pane.
+        #[serde(default)]
+        pane_id: Option<String>,
+        text: String,
+    },
+    #[serde(rename = "input.keys")]
+    InputKeys {
+        session: String,
+        #[serde(default)]
+        pane_id: Option<String>,
+        /// Key names such as `enter`, `ctrl-c`, `alt-f`, `up`, `f5`, `a`.
+        keys: Vec<String>,
+    },
+    #[serde(rename = "input.mouse")]
+    InputMouse {
+        session: String,
+        /// `press`, `release` or `motion`.
+        kind: String,
+        /// Column, 0-based, in the session's coordinate space.
+        x: u16,
+        /// Row, 0-based, in the session's coordinate space.
+        y: u16,
+        /// `left`, `right`, `middle`, `wheel_up`, `wheel_down`.
+        #[serde(default)]
+        button: Option<String>,
+        #[serde(default)]
+        alt: bool,
+        #[serde(default)]
+        ctrl: bool,
+        #[serde(default)]
+        shift: bool,
+    },
+
+    // ---- screen ---------------------------------------------------------
+    #[serde(rename = "screen.snapshot")]
+    ScreenSnapshot {
+        session: String,
+        /// Omit to target the session's currently focused pane, the same
+        /// way `input.*` does.
+        #[serde(default)]
+        pane_id: Option<String>,
+    },
+    #[serde(rename = "screen.history")]
+    ScreenHistory {
+        session: String,
+        /// Omit to target the session's currently focused pane, the same
+        /// way `input.*` does.
+        #[serde(default)]
+        pane_id: Option<String>,
+        /// Return only entries with `seq` greater than this.
+        #[serde(default)]
+        since: Option<u64>,
+        #[serde(default)]
+        limit: Option<usize>,
+    },
+    #[serde(rename = "screen.subscribe")]
+    ScreenSubscribe {
+        session: String,
+        /// Omit to follow every pane in the session, including ones opened later.
+        #[serde(default)]
+        pane_ids: Option<Vec<String>>,
+    },
+    #[serde(rename = "screen.unsubscribe")]
+    ScreenUnsubscribe { session: String },
+}
+
+/// One outbound reply frame.
+#[derive(Debug, Clone, Serialize)]
+pub struct Reply {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl Reply {
+    pub fn ok(id: Option<String>, result: Value) -> Self {
+        Reply {
+            id,
+            ok: true,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub fn err(id: Option<String>, error: impl std::fmt::Display) -> Self {
+        Reply {
+            id,
+            ok: false,
+            result: None,
+            error: Some(error.to_string()),
+        }
+    }
+}
+
+/// One outbound event frame.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "event")]
+pub enum Event {
+    /// A pane's canvas changed. This is the git-diff of the screen.
+    #[serde(rename = "screen.diff")]
+    ScreenDiff {
+        session: String,
+        pane_id: String,
+        /// Monotonic per-pane sequence number; equals the new canvas version.
+        seq: u64,
+        /// Unix milliseconds.
+        ts: u64,
+        added: usize,
+        removed: usize,
+        unified: String,
+        hunks: Vec<DiffHunk>,
+    },
+    /// The canvas baseline was (re)established — on first subscribe, or after
+    /// a resync. Carries the full contents rather than a diff.
+    #[serde(rename = "screen.reset")]
+    ScreenReset {
+        session: String,
+        pane_id: String,
+        seq: u64,
+        ts: u64,
+        lines: Vec<String>,
+    },
+    #[serde(rename = "pane.opened")]
+    PaneOpened { session: String, pane_id: String },
+    #[serde(rename = "pane.closed")]
+    PaneClosed { session: String, pane_id: String },
+    #[serde(rename = "session.ended")]
+    SessionEnded { session: String },
+}
+
+impl Event {
+    pub fn from_diff(session: &str, pane_id: &str, ts: u64, diff: &CanvasDiff) -> Self {
+        Event::ScreenDiff {
+            session: session.to_string(),
+            pane_id: pane_id.to_string(),
+            seq: diff.to_version,
+            ts,
+            added: diff.added,
+            removed: diff.removed,
+            unified: diff.unified.clone(),
+            hunks: diff.hunks.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(raw: serde_json::Value) -> Request {
+        serde_json::from_value(raw).expect("request should parse")
+    }
+
+    #[test]
+    fn parses_a_command_with_no_params() {
+        let req = parse(serde_json::json!({"id": "7", "cmd": "session.list"}));
+        assert_eq!(req.id.as_deref(), Some("7"));
+        assert!(matches!(req.command, Command::SessionList));
+    }
+
+    #[test]
+    fn parses_dotted_command_names_with_params() {
+        let req = parse(serde_json::json!({
+            "id": "1", "cmd": "input.text", "session": "main", "pane_id": "terminal_3",
+            "text": "sudo\n"
+        }));
+        match req.command {
+            Command::InputText {
+                session,
+                pane_id,
+                text,
+            } => {
+                assert_eq!(session, "main");
+                assert_eq!(pane_id.as_deref(), Some("terminal_3"));
+                assert_eq!(text, "sudo\n");
+            },
+            other => panic!("wrong command: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn optional_params_may_be_omitted() {
+        let req = parse(serde_json::json!({"cmd": "session.create"}));
+        match req.command {
+            Command::SessionCreate {
+                name,
+                layout,
+                cwd,
+                rows,
+                cols,
+            } => {
+                assert!(name.is_none() && layout.is_none() && cwd.is_none());
+                assert!(rows.is_none() && cols.is_none());
+            },
+            other => panic!("wrong command: {:?}", other),
+        }
+        assert!(req.id.is_none(), "id is optional");
+    }
+
+    #[test]
+    fn omitting_pane_ids_means_follow_every_pane() {
+        let req = parse(serde_json::json!({"cmd": "screen.subscribe", "session": "main"}));
+        match req.command {
+            Command::ScreenSubscribe { pane_ids, .. } => assert!(pane_ids.is_none()),
+            other => panic!("wrong command: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn unknown_command_is_rejected_not_silently_ignored() {
+        let raw = serde_json::json!({"cmd": "nope.nope"});
+        assert!(serde_json::from_value::<Request>(raw).is_err());
+    }
+
+    #[test]
+    fn a_misspelt_parameter_is_reported_rather_than_dropped() {
+        // `paneids` is not `pane_ids`; taken silently this would follow every
+        // pane in the session instead of the one the caller named.
+        let raw = serde_json::json!({
+            "cmd": "screen.subscribe", "session": "main", "paneids": ["terminal_0"],
+        });
+        let req = parse(raw.clone());
+        assert_eq!(req.unknown_fields(&raw), vec!["paneids".to_string()]);
+    }
+
+    #[test]
+    fn a_well_formed_command_has_nothing_left_over() {
+        let raw = serde_json::json!({
+            "id": "1", "cmd": "screen.subscribe", "session": "main",
+            "pane_ids": ["terminal_0"],
+        });
+        let req = parse(raw.clone());
+        assert!(
+            req.unknown_fields(&raw).is_empty(),
+            "recognised fields must not be reported as unknown: {:?}",
+            req.unknown_fields(&raw)
+        );
+    }
+
+    #[test]
+    fn optional_fields_left_out_are_not_unknown() {
+        let raw = serde_json::json!({"cmd": "session.create"});
+        let req = parse(raw.clone());
+        assert!(req.unknown_fields(&raw).is_empty());
+    }
+
+    #[test]
+    fn every_documented_parameter_is_accepted() {
+        // Guards the check itself: if serialising a command ever stopped
+        // naming its fields, every parameter would look unknown.
+        let raw = serde_json::json!({
+            "id": "7", "cmd": "pane.create", "session": "main",
+            "command": "htop", "args": ["-d", "5"], "cwd": "/tmp",
+            "floating": true, "direction": "right", "name": "top",
+            "tab_id": 2, "plugin": null, "plugin_config": null,
+        });
+        let req = parse(raw.clone());
+        assert!(
+            req.unknown_fields(&raw).is_empty(),
+            "documented parameters rejected: {:?}",
+            req.unknown_fields(&raw)
+        );
+    }
+
+    #[test]
+    fn replies_omit_the_unused_half() {
+        let ok = serde_json::to_value(Reply::ok(Some("1".into()), serde_json::json!({"a": 1})))
+            .unwrap();
+        assert_eq!(ok["ok"], true);
+        assert!(ok.get("error").is_none(), "successful reply carries no error");
+
+        let err = serde_json::to_value(Reply::err(Some("1".into()), "boom")).unwrap();
+        assert_eq!(err["ok"], false);
+        assert_eq!(err["error"], "boom");
+        assert!(err.get("result").is_none(), "failed reply carries no result");
+    }
+
+    #[test]
+    fn diff_events_serialize_in_the_documented_shape() {
+        let diff = crate::diff::diff_canvas(
+            &["sudr".to_string()],
+            &["sudo".to_string()],
+            41,
+            42,
+            "pane/terminal_1",
+        )
+        .unwrap();
+        let event = Event::from_diff("main", "terminal_1", 1754342400123, &diff);
+        let json = serde_json::to_value(&event).unwrap();
+
+        assert_eq!(json["event"], "screen.diff");
+        assert_eq!(json["session"], "main");
+        assert_eq!(json["pane_id"], "terminal_1");
+        assert_eq!(json["seq"], 42);
+        assert_eq!(json["ts"], 1754342400123u64);
+        assert_eq!(json["added"], 1);
+        assert_eq!(json["removed"], 1);
+        assert!(json["unified"].as_str().unwrap().contains("-sudr"));
+        assert!(json["unified"].as_str().unwrap().contains("+sudo"));
+        assert!(json["hunks"].is_array());
+    }
+}

--- a/zellij-api/src/protocol.rs
+++ b/zellij-api/src/protocol.rs
@@ -423,15 +423,21 @@ mod tests {
 
     #[test]
     fn replies_omit_the_unused_half() {
-        let ok = serde_json::to_value(Reply::ok(Some("1".into()), serde_json::json!({"a": 1})))
-            .unwrap();
+        let ok =
+            serde_json::to_value(Reply::ok(Some("1".into()), serde_json::json!({"a": 1}))).unwrap();
         assert_eq!(ok["ok"], true);
-        assert!(ok.get("error").is_none(), "successful reply carries no error");
+        assert!(
+            ok.get("error").is_none(),
+            "successful reply carries no error"
+        );
 
         let err = serde_json::to_value(Reply::err(Some("1".into()), "boom")).unwrap();
         assert_eq!(err["ok"], false);
         assert_eq!(err["error"], "boom");
-        assert!(err.get("result").is_none(), "failed reply carries no result");
+        assert!(
+            err.get("result").is_none(),
+            "failed reply carries no result"
+        );
     }
 
     #[test]

--- a/zellij-api/src/server.rs
+++ b/zellij-api/src/server.rs
@@ -1,0 +1,859 @@
+//! The WebSocket control plane.
+//!
+//! One endpoint, `GET /api`, upgrades to a WebSocket that speaks the JSON
+//! protocol in [`crate::protocol`]. Each connection may drive any number of
+//! sessions and may subscribe to their screen-diff streams.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use axum::{
+    extract::{
+        ws::{Message, WebSocket, WebSocketUpgrade},
+        Query, State,
+    },
+    http::StatusCode,
+    response::IntoResponse,
+    routing::get,
+    Router,
+};
+use futures::{SinkExt, StreamExt};
+use serde::Deserialize;
+use serde_json::json;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+use zellij_utils::data::{Direction, PaneId, Resize};
+use zellij_utils::input::actions::Action;
+use zellij_utils::input::command::RunCommandAction;
+use zellij_utils::input::layout::RunPluginOrAlias;
+use zellij_utils::input::mouse::{MouseEvent, MouseEventType};
+use zellij_utils::position::Position;
+
+use crate::keys::keys_to_bytes;
+use crate::protocol::{Command, Reply, Request};
+use crate::session_link::{SessionLink, PANE_POLL_INTERVAL};
+use crate::sessions::SessionManager;
+
+/// Backstop for the blocking session-create/kill calls below. Both have
+/// their own internal logic that's supposed to bound how long they take,
+/// but that logic depends on the session server sending *something* back —
+/// if it never does (found live: a silent `bind()` failure), the blocking
+/// call can outlive its own intended deadline. This is longer than either
+/// inner deadline so it only fires when that inner logic has already
+/// failed to, not as a matter of course.
+const CALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
+#[derive(Clone)]
+pub struct ApiState {
+    pub sessions: Arc<SessionManager>,
+    /// When set, callers must present `?token=...` to connect.
+    pub token: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ConnectParams {
+    #[serde(default)]
+    pub token: Option<String>,
+}
+
+pub fn router(state: ApiState) -> Router {
+    Router::new()
+        .route("/api", get(ws_handler))
+        .route("/health", get(|| async { "ok" }))
+        .with_state(state)
+}
+
+/// Run the API server until the process is stopped.
+pub async fn serve(addr: SocketAddr, token: Option<String>) -> anyhow::Result<()> {
+    let state = ApiState {
+        sessions: Arc::new(SessionManager::new()),
+        token,
+    };
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    log::info!("zellij api server listening on ws://{}/api", addr);
+    axum::serve(listener, router(state)).await?;
+    Ok(())
+}
+
+async fn ws_handler(
+    ws: WebSocketUpgrade,
+    Query(params): Query<ConnectParams>,
+    State(state): State<ApiState>,
+) -> impl IntoResponse {
+    if let Some(expected) = &state.token {
+        let presented = params.token.as_deref().unwrap_or_default();
+        if !tokens_match(expected, presented) {
+            return (StatusCode::UNAUTHORIZED, "invalid or missing token").into_response();
+        }
+    }
+    ws.on_upgrade(move |socket| handle_connection(socket, state))
+        .into_response()
+}
+
+/// Compare tokens without giving away how much of one was right.
+///
+/// A `==` on strings stops at the first differing byte, so how long the check
+/// takes leaks the length of the correct prefix. This reads both to the end
+/// regardless. The length is compared separately — it is not a secret.
+fn tokens_match(expected: &str, presented: &str) -> bool {
+    let (expected, presented) = (expected.as_bytes(), presented.as_bytes());
+    if expected.len() != presented.len() {
+        return false;
+    }
+    expected
+        .iter()
+        .zip(presented)
+        .fold(0u8, |differences, (a, b)| differences | (a ^ b))
+        == 0
+}
+
+/// Per-connection state: the sessions this caller is streaming, and the tasks
+/// doing the streaming.
+#[derive(Default)]
+struct Streams {
+    tasks: HashMap<String, Vec<JoinHandle<()>>>,
+}
+
+impl Streams {
+    fn stop(&mut self, session: &str) {
+        if let Some(handles) = self.tasks.remove(session) {
+            for handle in handles {
+                handle.abort();
+            }
+        }
+    }
+
+    fn stop_all(&mut self) {
+        for (_, handles) in self.tasks.drain() {
+            for handle in handles {
+                handle.abort();
+            }
+        }
+    }
+}
+
+async fn handle_connection(socket: WebSocket, state: ApiState) {
+    let (mut sink, mut stream) = socket.split();
+    let (out_tx, mut out_rx) = mpsc::unbounded_channel::<String>();
+
+    // A single writer task owns the sink, so replies and events never interleave
+    // mid-frame.
+    let writer = tokio::spawn(async move {
+        while let Some(text) = out_rx.recv().await {
+            if sink.send(Message::Text(text.into())).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    let mut streams = Streams::default();
+
+    while let Some(Ok(message)) = stream.next().await {
+        let text = match message {
+            Message::Text(text) => text.to_string(),
+            Message::Binary(bytes) => match String::from_utf8(bytes.to_vec()) {
+                Ok(text) => text,
+                Err(_) => {
+                    send_json(&out_tx, &Reply::err(None, "binary frames must be UTF-8 JSON"));
+                    continue;
+                },
+            },
+            Message::Close(_) => break,
+            _ => continue,
+        };
+
+        let raw: serde_json::Value = match serde_json::from_str(&text) {
+            Ok(raw) => raw,
+            Err(e) => {
+                send_json(&out_tx, &Reply::err(None, format!("bad request: {}", e)));
+                continue;
+            },
+        };
+        let request: Request = match serde_json::from_value(raw.clone()) {
+            Ok(request) => request,
+            Err(e) => {
+                send_json(&out_tx, &Reply::err(None, format!("bad request: {}", e)));
+                continue;
+            },
+        };
+
+        let id = request.id.clone();
+        // Reject what we do not understand rather than acting on a command the
+        // caller did not quite write.
+        let unknown = request.unknown_fields(&raw);
+        if !unknown.is_empty() {
+            send_json(
+                &out_tx,
+                &Reply::err(id, format!("unknown parameter: {}", unknown.join(", "))),
+            );
+            continue;
+        }
+        let reply = match dispatch(request.command, &state, &out_tx, &mut streams).await {
+            Ok(result) => Reply::ok(id, result),
+            Err(e) => Reply::err(id, e),
+        };
+        send_json(&out_tx, &reply);
+    }
+
+    streams.stop_all();
+    writer.abort();
+}
+
+fn send_json(out: &mpsc::UnboundedSender<String>, value: &impl serde::Serialize) {
+    match serde_json::to_string(value) {
+        Ok(text) => {
+            let _ = out.send(text);
+        },
+        Err(e) => log::error!("could not serialize an outbound frame: {}", e),
+    }
+}
+
+async fn dispatch(
+    command: Command,
+    state: &ApiState,
+    out: &mpsc::UnboundedSender<String>,
+    streams: &mut Streams,
+) -> Result<serde_json::Value, String> {
+    match command {
+        // ---- sessions ---------------------------------------------------
+        Command::SessionList => Ok(json!({ "sessions": state.sessions.list() })),
+        Command::SessionCreate {
+            name,
+            layout,
+            cwd,
+            rows,
+            cols,
+        } => {
+            let sessions = state.sessions.clone();
+            // Session creation spawns a process and blocks on IPC, so keep it
+            // off the async runtime's worker threads.
+            //
+            // `sessions.create` has its own internal startup deadline, but
+            // that deadline is only checked *between* messages from the
+            // spawned session server — a peer that fails before sending
+            // anything at all (found live: an overlong session name causing
+            // a silent `bind()` failure, since fixed at the validation
+            // layer) never gives it the chance to run, so the blocking call
+            // could hang past its own supposed timeout. This outer bound is
+            // the backstop: if that inner logic ever fails to return for a
+            // reason not yet found, the caller still gets an answer instead
+            // of hanging forever. The blocked OS thread itself is abandoned,
+            // not killed — Tokio has no way to force that — but the caller
+            // is unblocked either way, which is what actually matters here.
+            let outcome = tokio::time::timeout(
+                CALL_TIMEOUT,
+                tokio::task::spawn_blocking(move || sessions.create(name, layout, cwd, rows, cols)),
+            )
+            .await
+            .map_err(|_| "timed out creating the session".to_string())?
+            .map_err(|e| format!("session creation panicked: {}", e))??;
+            Ok(json!({ "session": outcome }))
+        },
+        Command::SessionKill { name } => {
+            let sessions = state.sessions.clone();
+            let target = name.clone();
+            // Same backstop as `SessionCreate` above: `sessions.kill` blocks
+            // on the session server acknowledging the kill, with no timeout
+            // of its own — if the server is wedged mid-shutdown and never
+            // closes the connection or replies, this bounds how long the
+            // caller waits instead of leaving it hanging indefinitely.
+            tokio::time::timeout(
+                CALL_TIMEOUT,
+                tokio::task::spawn_blocking(move || sessions.kill(&target)),
+            )
+            .await
+            .map_err(|_| "timed out killing the session".to_string())?
+            .map_err(|e| format!("session kill panicked: {}", e))??;
+            streams.stop(&name);
+            Ok(json!({ "killed": name }))
+        },
+        Command::SessionRename { name, new_name } => {
+            // Upstream's rename handler does `ZELLIJ_SOCK_DIR.join(&name)` and
+            // renames the socket file to it, with no validation at all — a
+            // `new_name` of `../evil` renames the socket *out of* the
+            // directory session discovery scans, orphaning the session, and a
+            // longer `../../..` reaches further still. `validate_session_name`
+            // is what `session.create` already runs a name through; run the
+            // rename target through the same gate before it ever reaches the
+            // server.
+            zellij_utils::sessions::validate_session_name(&new_name)?;
+            let link = link_for(state, &name).await?;
+            link.run_action(Action::RenameSession {
+                name: new_name.clone(),
+            })
+            .await?;
+            // The socket is named after the session, so the old link is stale.
+            streams.stop(&name);
+            state.sessions.drop_link(&name);
+            Ok(json!({ "session": new_name }))
+        },
+
+        // ---- tabs -------------------------------------------------------
+        Command::TabList { session } => {
+            let link = link_for(state, &session).await?;
+            let tabs = link.list_tabs().await?;
+            Ok(json!({ "tabs": tabs }))
+        },
+        Command::TabCreate { session, name, cwd } => {
+            let link = link_for(state, &session).await?;
+            link.run_action(Action::NewTab {
+                tiled_layout: None,
+                floating_layouts: vec![],
+                swap_tiled_layouts: None,
+                swap_floating_layouts: None,
+                tab_name: name,
+                should_change_focus_to_new_tab: true,
+                cwd: cwd.map(Into::into),
+                initial_panes: None,
+                first_pane_unblock_condition: None,
+            })
+            .await?;
+            let tab = link.active_tab().await?;
+            Ok(json!({ "tab_id": tab.tab_id, "name": tab.name }))
+        },
+        Command::TabClose { session, tab_id } => {
+            let link = link_for(state, &session).await?;
+            link.require_tab(tab_id as usize).await?;
+            link.run_action(Action::CloseTabById { id: tab_id }).await?;
+            Ok(json!({ "closed": tab_id }))
+        },
+        Command::TabFocus { session, tab_id } => {
+            let link = link_for(state, &session).await?;
+            // Focus belongs to a client, so this goes through the session's
+            // attached client — and we confirm it actually took, rather than
+            // reporting a focus change the session did not make.
+            link.require_tab(tab_id as usize).await?;
+            let focused = link
+                .focus_tab(tab_id as usize)
+                .await
+                .map_err(|e| format!("could not focus tab {}: {}", tab_id, e))?;
+            Ok(json!({ "focused": focused }))
+        },
+        Command::TabRename {
+            session,
+            tab_id,
+            name,
+        } => {
+            let link = link_for(state, &session).await?;
+            link.require_tab(tab_id as usize).await?;
+            link.run_action(Action::RenameTabById {
+                id: tab_id,
+                name: name.clone(),
+            })
+            .await?;
+            Ok(json!({ "tab_id": tab_id, "name": name }))
+        },
+
+        // ---- panes ------------------------------------------------------
+        Command::PaneList { session } => {
+            let link = link_for(state, &session).await?;
+            let panes = link.list_panes().await?;
+            Ok(json!({ "panes": panes }))
+        },
+        Command::PaneCreate {
+            session,
+            command,
+            plugin,
+            plugin_config,
+            args,
+            cwd,
+            floating,
+            direction,
+            name,
+            tab_id,
+        } => {
+            let link = link_for(state, &session).await?;
+            let direction = parse_direction(direction.as_deref())?;
+            if command.is_some() && plugin.is_some() {
+                return Err("give either `command` or `plugin`, not both".to_string());
+            }
+            if command.is_none() && !args.is_empty() {
+                return Err("`args` only applies to `command`".to_string());
+            }
+            if plugin.is_some() && !floating && direction.is_some() {
+                // Upstream deliberately refuses a direction for tiled plugin
+                // panes: the pane is placed only once the plugin has loaded, by
+                // which time the reference pane may have moved.
+                return Err(
+                    "`direction` is not supported for tiled plugin panes; use `floating` \
+                     or omit `direction`"
+                        .to_string(),
+                );
+            }
+            // Target a tab explicitly. Left unset, the server places the pane
+            // in whatever tab the *last active client* is focused on — and a
+            // session driven over the API usually has no attached client, so
+            // that resolves to nothing and the pane is silently never created.
+            let tab_id = match tab_id {
+                Some(tab_id) => tab_id as usize,
+                None => link.active_tab().await?.tab_id,
+            };
+            let run_command = command.map(|command| RunCommandAction {
+                command: command.into(),
+                args,
+                cwd: cwd.clone().map(Into::into),
+                direction,
+                hold_on_close: true,
+                hold_on_start: false,
+                originating_plugin: None,
+                use_terminal_title: false,
+            });
+            // Create the pane the way a person would: put focus where the pane
+            // should go, then ask for it. Placement is resolved against the
+            // focused pane of the focused tab, so this is what makes a
+            // directional split land where the caller asked.
+            link.focus_tab(tab_id).await?;
+            if direction.is_some() {
+                // A split needs a *terminal* pane to split away from. A fresh
+                // session focuses a floating plugin pane (the welcome screen),
+                // which cannot be split — so move focus to a real one first.
+                let reference = link.reference_pane_in_tab(tab_id).await?;
+                link.focus_pane(PaneId::Terminal(reference)).await?;
+            }
+
+            let action = match plugin {
+                Some(plugin) => {
+                    let plugin = RunPluginOrAlias::from_url(
+                        &plugin,
+                        &plugin_config,
+                        None, // aliases are resolved by the session
+                        cwd.clone().map(Into::into),
+                    )
+                    .map_err(|e| format!("invalid plugin '{}': {}", plugin, e))?;
+                    if floating {
+                        Action::NewFloatingPluginPane {
+                            plugin,
+                            pane_name: name,
+                            skip_cache: false,
+                            cwd: cwd.map(Into::into),
+                            coordinates: None,
+                            no_focus: false,
+                            tab_id: None,
+                        }
+                    } else {
+                        Action::NewTiledPluginPane {
+                            plugin,
+                            pane_name: name,
+                            skip_cache: false,
+                            cwd: cwd.map(Into::into),
+                            no_focus: false,
+                            tab_id: None,
+                        }
+                    }
+                },
+                None if floating => Action::NewFloatingPane {
+                    command: run_command,
+                    pane_name: name,
+                    coordinates: None,
+                    near_current_pane: false,
+                    no_focus: false,
+                    tab_id: None,
+                },
+                None => Action::NewTiledPane {
+                    direction,
+                    command: run_command,
+                    pane_name: name,
+                    near_current_pane: false,
+                    no_focus: false,
+                    borderless: None,
+                    tab_id: None,
+                },
+            };
+
+            // The server reports a new pane's id before placing it, and drops
+            // a placement it cannot resolve without an error — so identify the
+            // pane by watching it appear instead of trusting that report.
+            let before = link.pane_ids_now().await?;
+            link.run_as_client(action);
+            let pane_id = link.await_new_pane(&before).await?;
+            Ok(json!({ "pane_id": pane_id }))
+        },
+        Command::PaneClose { session, pane_id } => {
+            let link = link_for(state, &session).await?;
+            let pane = parse_pane_id(&pane_id)?;
+            if !link.pane_exists(pane).await? {
+                return Err(format!("session '{}' has no pane {}", session, pane_id));
+            }
+            let action = match pane {
+                PaneId::Terminal(id) => Action::CloseTerminalPane { pane_id: id },
+                PaneId::Plugin(id) => Action::ClosePluginPane { pane_id: id },
+            };
+            link.run_action(action).await?;
+            Ok(json!({ "closed": pane_id }))
+        },
+        Command::PaneFocus { session, pane_id } => {
+            let link = link_for(state, &session).await?;
+            let pane = parse_pane_id(&pane_id)?;
+            if !link.pane_exists(pane).await? {
+                return Err(format!("session '{}' has no pane {}", session, pane_id));
+            }
+            link.focus_pane(pane)
+                .await
+                .map_err(|e| format!("could not focus pane {}: {}", pane_id, e))?;
+            Ok(json!({ "focused": pane_id }))
+        },
+        Command::PaneRename {
+            session,
+            pane_id,
+            name,
+        } => {
+            let link = link_for(state, &session).await?;
+            let pane = parse_pane_id(&pane_id)?;
+            if !link.pane_exists(pane).await? {
+                return Err(format!("session '{}' has no pane {}", session, pane_id));
+            }
+            link.run_action(Action::RenamePaneByPaneId {
+                pane_id: Some(pane),
+                name: name.clone().into_bytes(),
+            })
+            .await?;
+            Ok(json!({ "pane_id": pane_id, "name": name }))
+        },
+        Command::PaneResize {
+            session,
+            pane_id,
+            resize,
+            direction,
+        } => {
+            let link = link_for(state, &session).await?;
+            let pane = parse_pane_id(&pane_id)?;
+            if !link.pane_exists(pane).await? {
+                return Err(format!("session '{}' has no pane {}", session, pane_id));
+            }
+            let resize = Resize::from_str(&resize)?;
+            link.run_action(Action::ResizeByPaneId {
+                pane_id: pane,
+                resize,
+                direction: parse_direction(direction.as_deref())?,
+            })
+            .await?;
+            Ok(json!({ "pane_id": pane_id }))
+        },
+
+        // ---- input ------------------------------------------------------
+        Command::InputText {
+            session,
+            pane_id,
+            text,
+        } => {
+            let link = link_for(state, &session).await?;
+            let pane = resolve_pane(&link, pane_id).await?;
+            let bytes = text.len();
+            link.run_action(Action::WriteCharsToPaneId {
+                chars: text,
+                pane_id: pane,
+            })
+            .await?;
+            Ok(json!({ "pane_id": pane.to_string(), "bytes": bytes }))
+        },
+        Command::InputKeys {
+            session,
+            pane_id,
+            keys,
+        } => {
+            let link = link_for(state, &session).await?;
+            let pane = resolve_pane(&link, pane_id).await?;
+            let bytes = keys_to_bytes(&keys)?;
+            let written = bytes.len();
+            link.run_action(Action::WriteToPaneId {
+                bytes,
+                pane_id: pane,
+            })
+            .await?;
+            Ok(json!({ "pane_id": pane.to_string(), "bytes": written }))
+        },
+        Command::InputMouse {
+            session,
+            kind,
+            x,
+            y,
+            button,
+            alt,
+            ctrl,
+            shift,
+        } => {
+            let link = link_for(state, &session).await?;
+            let event = build_mouse_event(&kind, x, y, button.as_deref(), alt, ctrl, shift)?;
+            link.run_action(Action::MouseEvent { event }).await?;
+            Ok(json!({ "x": x, "y": y, "kind": kind }))
+        },
+
+        // ---- screen -----------------------------------------------------
+        Command::ScreenSnapshot { session, pane_id } => {
+            let link = link_for(state, &session).await?;
+            let pane = resolve_pane(&link, pane_id).await?;
+            let pane_id = pane.to_string();
+            let (version, lines) = link.snapshot(&pane_id).ok_or_else(|| {
+                format!(
+                    "no canvas for pane '{}' — subscribe to it first",
+                    pane_id
+                )
+            })?;
+            Ok(json!({ "pane_id": pane_id, "version": version, "lines": lines }))
+        },
+        Command::ScreenHistory {
+            session,
+            pane_id,
+            since,
+            limit,
+        } => {
+            let link = link_for(state, &session).await?;
+            let pane = resolve_pane(&link, pane_id).await?;
+            let pane_id = pane.to_string();
+            let history = link.history(&pane_id, since, limit);
+            Ok(json!({ "pane_id": pane_id, "diffs": history }))
+        },
+        Command::ScreenSubscribe { session, pane_ids } => {
+            let link = link_for(state, &session).await?;
+            let targets = match pane_ids {
+                Some(ids) => Some(
+                    ids.iter()
+                        .map(|id| parse_pane_id(id))
+                        .collect::<Result<Vec<_>, _>>()?,
+                ),
+                None => None,
+            };
+            let follow_all = targets.is_none();
+            let subscribed = link.subscribe(targets).await?;
+
+            streams.stop(&session);
+            let mut handles = vec![forward_events(link.clone(), out.clone())];
+            if follow_all {
+                handles.push(poll_pane_set(link.clone()));
+            }
+            streams.tasks.insert(session.clone(), handles);
+
+            Ok(json!({
+                "session": session,
+                "panes": subscribed.iter().map(|p| p.to_string()).collect::<Vec<_>>(),
+                "following_new_panes": follow_all,
+            }))
+        },
+        Command::ScreenUnsubscribe { session } => {
+            if let Some(link) = state.sessions.existing_link(&session) {
+                link.unsubscribe();
+            }
+            streams.stop(&session);
+            Ok(json!({ "session": session }))
+        },
+    }
+}
+
+/// Pump one session's events into this connection's outbound channel.
+fn forward_events(
+    link: Arc<SessionLink>,
+    out: mpsc::UnboundedSender<String>,
+) -> JoinHandle<()> {
+    let mut events = link.events();
+    tokio::spawn(async move {
+        loop {
+            match events.recv().await {
+                Ok(event) => send_json(&out, &event),
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    // Tell the caller rather than silently dropping screen
+                    // changes: they can resync with screen.snapshot.
+                    log::warn!("api client lagged, dropped {} events", skipped);
+                    send_json(
+                        &out,
+                        &json!({
+                            "event": "stream.lagged",
+                            "session": link.name,
+                            "dropped": skipped,
+                        }),
+                    );
+                },
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    })
+}
+
+/// While following a whole session, keep the subscribed pane set current.
+fn poll_pane_set(link: Arc<SessionLink>) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(PANE_POLL_INTERVAL);
+        loop {
+            ticker.tick().await;
+            if let Err(e) = link.refresh_pane_set().await {
+                // Only a session that has gone away ends the follow. A single
+                // failed query used to stop it for good, silently: the caller
+                // kept its subscription but new panes were never picked up
+                // again.
+                if !link.is_alive() {
+                    log::debug!("stopped following panes of '{}': {}", link.name, e);
+                    break;
+                }
+                log::debug!("could not refresh panes of '{}': {}", link.name, e);
+            }
+        }
+    })
+}
+
+/// Open (or reuse) a session link, ready to serve focus-dependent commands.
+async fn link_for(state: &ApiState, session: &str) -> Result<Arc<SessionLink>, String> {
+    // `SessionManager::link` is synchronous and, the first time it links a
+    // given session (or relinks after the old link died), does real
+    // blocking work: three socket connects plus handshakes, and
+    // `learn_own_client_id`'s poll loop (up to 10 attempts, 100ms apart —
+    // up to a full second). Called directly from this `async fn` with no
+    // `spawn_blocking`, that work would run straight on a Tokio worker
+    // thread, blocking it — and every other task scheduled on that same
+    // thread — for the same duration. `spawn_blocking` moves it to the
+    // blocking thread pool instead, the same treatment already given
+    // `sessions.create`/`sessions.kill` for the same reason.
+    let sessions = state.sessions.clone();
+    let session_name = session.to_string();
+    let link = tokio::time::timeout(
+        CALL_TIMEOUT,
+        tokio::task::spawn_blocking(move || sessions.link(&session_name)),
+    )
+    .await
+    .map_err(|_| format!("timed out linking to session '{}'", session))?
+    .map_err(|e| format!("linking to session panicked: {}", e))??;
+    link.ensure_focus_ready().await?;
+    Ok(link)
+}
+
+/// Work out which pane an input command is aimed at.
+///
+/// A named pane is checked for existence first. Writing to a pane id the
+/// session does not have is silently discarded by the server — and a pane can
+/// disappear at any moment (closing a plugin's UI closes its pane), so a caller
+/// that keeps typing at a stale id would otherwise get a stream of successful
+/// replies and no effect at all.
+async fn resolve_pane(link: &Arc<SessionLink>, pane_id: Option<String>) -> Result<PaneId, String> {
+    match pane_id {
+        Some(id) => {
+            let pane = parse_pane_id(&id)?;
+            if !link.pane_exists(pane).await? {
+                return Err(format!("session '{}' has no pane {}", link.name, id));
+            }
+            Ok(pane)
+        },
+        None => link.focused_pane().await,
+    }
+}
+
+fn parse_pane_id(raw: &str) -> Result<PaneId, String> {
+    PaneId::from_str(raw).map_err(|e| format!("invalid pane id '{}': {}", raw, e))
+}
+
+fn parse_direction(raw: Option<&str>) -> Result<Option<Direction>, String> {
+    match raw {
+        Some(value) => Direction::from_str(value).map(Some),
+        None => Ok(None),
+    }
+}
+
+fn build_mouse_event(
+    kind: &str,
+    x: u16,
+    y: u16,
+    button: Option<&str>,
+    alt: bool,
+    ctrl: bool,
+    shift: bool,
+) -> Result<MouseEvent, String> {
+    let event_type = match kind.to_lowercase().as_str() {
+        "press" | "down" | "click" => MouseEventType::Press,
+        "release" | "up" => MouseEventType::Release,
+        "motion" | "move" | "drag" => MouseEventType::Motion,
+        other => return Err(format!("unknown mouse event kind '{}'", other)),
+    };
+
+    let mut event = MouseEvent::new();
+    event.event_type = event_type;
+    // Zellij positions are (line, column), and both are 0-based like the
+    // coordinates a caller reads out of a pane's geometry.
+    event.position = Position::new(y as i32, x);
+    event.alt = alt;
+    event.ctrl = ctrl;
+    event.shift = shift;
+
+    match button.unwrap_or("left").to_lowercase().as_str() {
+        "left" => event.left = true,
+        "right" => event.right = true,
+        "middle" => event.middle = true,
+        "wheel_up" | "scroll_up" => event.wheel_up = true,
+        "wheel_down" | "scroll_down" => event.wheel_down = true,
+        "none" => {},
+        other => return Err(format!("unknown mouse button '{}'", other)),
+    }
+
+    Ok(event)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_comparison_accepts_only_the_exact_token() {
+        assert!(tokens_match("s3cret", "s3cret"));
+        assert!(!tokens_match("s3cret", "s3creT"));
+        assert!(!tokens_match("s3cret", ""));
+        assert!(!tokens_match("s3cret", "s3cre"), "a prefix is not enough");
+        assert!(
+            !tokens_match("s3cret", "s3cretx"),
+            "a longer string is not enough"
+        );
+        assert!(tokens_match("", ""));
+    }
+
+    #[test]
+    fn mouse_coordinates_map_to_line_and_column() {
+        let event = build_mouse_event("press", 12, 5, Some("left"), false, false, false).unwrap();
+        assert_eq!(event.event_type, MouseEventType::Press);
+        assert!(event.left);
+        assert_eq!(event.position.column.0, 12, "x is the column");
+        assert_eq!(event.position.line.0, 5, "y is the line");
+    }
+
+    #[test]
+    fn mouse_defaults_to_the_left_button() {
+        let event = build_mouse_event("press", 0, 0, None, false, false, false).unwrap();
+        assert!(event.left);
+        assert!(!event.right && !event.middle);
+    }
+
+    #[test]
+    fn mouse_supports_wheel_and_modifiers() {
+        let event =
+            build_mouse_event("motion", 1, 2, Some("wheel_down"), true, true, false).unwrap();
+        assert!(event.wheel_down);
+        assert!(event.alt && event.ctrl && !event.shift);
+        assert_eq!(event.event_type, MouseEventType::Motion);
+    }
+
+    #[test]
+    fn unknown_mouse_input_is_rejected() {
+        assert!(build_mouse_event("wiggle", 0, 0, None, false, false, false).is_err());
+        assert!(build_mouse_event("press", 0, 0, Some("pinky"), false, false, false).is_err());
+    }
+
+    #[test]
+    fn pane_ids_accept_both_forms() {
+        assert_eq!(parse_pane_id("terminal_2").unwrap(), PaneId::Terminal(2));
+        assert_eq!(parse_pane_id("plugin_9").unwrap(), PaneId::Plugin(9));
+        // A bare number is a terminal pane, matching the CLI.
+        assert_eq!(parse_pane_id("4").unwrap(), PaneId::Terminal(4));
+        assert!(parse_pane_id("banana").is_err());
+    }
+
+    #[test]
+    fn directions_are_optional_but_validated() {
+        assert_eq!(parse_direction(None).unwrap(), None);
+        assert_eq!(parse_direction(Some("left")).unwrap(), Some(Direction::Left));
+        assert!(parse_direction(Some("sideways")).is_err());
+    }
+
+    #[test]
+    fn resize_accepts_the_documented_spellings() {
+        assert_eq!(Resize::from_str("increase").unwrap(), Resize::Increase);
+        assert_eq!(Resize::from_str("decrease").unwrap(), Resize::Decrease);
+        assert!(Resize::from_str("bigger").is_err());
+    }
+}

--- a/zellij-api/src/server.rs
+++ b/zellij-api/src/server.rs
@@ -157,7 +157,10 @@ async fn handle_connection(socket: WebSocket, state: ApiState) {
             Message::Binary(bytes) => match String::from_utf8(bytes.to_vec()) {
                 Ok(text) => text,
                 Err(_) => {
-                    send_json(&out_tx, &Reply::err(None, "binary frames must be UTF-8 JSON"));
+                    send_json(
+                        &out_tx,
+                        &Reply::err(None, "binary frames must be UTF-8 JSON"),
+                    );
                     continue;
                 },
             },
@@ -587,10 +590,7 @@ async fn dispatch(
             let pane = resolve_pane(&link, pane_id).await?;
             let pane_id = pane.to_string();
             let (version, lines) = link.snapshot(&pane_id).ok_or_else(|| {
-                format!(
-                    "no canvas for pane '{}' — subscribe to it first",
-                    pane_id
-                )
+                format!("no canvas for pane '{}' — subscribe to it first", pane_id)
             })?;
             Ok(json!({ "pane_id": pane_id, "version": version, "lines": lines }))
         },
@@ -643,10 +643,7 @@ async fn dispatch(
 }
 
 /// Pump one session's events into this connection's outbound channel.
-fn forward_events(
-    link: Arc<SessionLink>,
-    out: mpsc::UnboundedSender<String>,
-) -> JoinHandle<()> {
+fn forward_events(link: Arc<SessionLink>, out: mpsc::UnboundedSender<String>) -> JoinHandle<()> {
     let mut events = link.events();
     tokio::spawn(async move {
         loop {
@@ -846,7 +843,10 @@ mod tests {
     #[test]
     fn directions_are_optional_but_validated() {
         assert_eq!(parse_direction(None).unwrap(), None);
-        assert_eq!(parse_direction(Some("left")).unwrap(), Some(Direction::Left));
+        assert_eq!(
+            parse_direction(Some("left")).unwrap(),
+            Some(Direction::Left)
+        );
         assert!(parse_direction(Some("sideways")).is_err());
     }
 

--- a/zellij-api/src/session_link.rs
+++ b/zellij-api/src/session_link.rs
@@ -1,0 +1,1213 @@
+//! A live link to one running Zellij session.
+//!
+//! Two IPC connections are opened per session, each with its own reader thread
+//! (`ClientOsApi` is blocking, so it cannot live on the async runtime):
+//!
+//! - the **control** connection dispatches `Action`s one at a time and reads
+//!   back the server's reply (`Log` for queries, `UnblockInputThread` for
+//!   fire-and-forget commands);
+//! - the **observer** connection carries only the `SubscribeToPaneRenders`
+//!   stream, so unsolicited screen updates never interleave with command
+//!   replies.
+
+use std::collections::HashSet;
+use std::str::FromStr;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc as std_mpsc;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::sync::{broadcast, oneshot};
+
+use zellij_client::os_input_output::{get_cli_client_os_input, ClientOsApi};
+use zellij_utils::data::{ClientId, ListPanesResponse, ListTabsResponse, PaneId, TabInfo};
+use zellij_utils::input::actions::Action;
+use zellij_utils::input::cli_assets::CliAssets;
+use zellij_utils::ipc::{ClientToServerMsg, ServerToClientMsg};
+use zellij_utils::pane_size::Size;
+
+use crate::canvas::{CanvasStore, CanvasUpdate, HistoryEntry};
+use crate::protocol::Event;
+
+/// How long a caller waits for a command reply before giving up.
+pub const ACTION_TIMEOUT: Duration = Duration::from_secs(10);
+/// How often we re-check which panes exist, so that panes opened after a
+/// subscription are picked up automatically.
+pub const PANE_POLL_INTERVAL: Duration = Duration::from_millis(750);
+/// Buffered events per subscriber before the slowest one starts losing frames.
+const EVENT_BUFFER: usize = 4096;
+
+type ActionReply = Result<Vec<String>, String>;
+
+enum LinkRequest {
+    Run {
+        action: Action,
+        reply: oneshot::Sender<ActionReply>,
+    },
+    Shutdown,
+}
+
+#[derive(Debug, Default)]
+struct Subscription {
+    /// When true, every pane in the session is followed, including new ones.
+    follow_all: bool,
+    pane_ids: HashSet<PaneId>,
+}
+
+pub struct SessionLink {
+    pub name: String,
+    requests: std_mpsc::Sender<LinkRequest>,
+    canvas: Arc<Mutex<CanvasStore>>,
+    subscription: Arc<Mutex<Subscription>>,
+    /// Clone of the observer connection, used to (re)send subscription requests.
+    observer: Arc<Box<dyn ClientOsApi>>,
+    /// A real attached client, so the session has somewhere to hold focus.
+    focus: Arc<Box<dyn ClientOsApi>>,
+    /// Whether that client has been seen holding focus.
+    focus_ready: AtomicBool,
+    /// Cleared by the reader threads when the session goes away.
+    alive: Arc<AtomicBool>,
+    /// The last pane we focused. Used as a fallback for picking our client out
+    /// among several attached ones, when `own_client_id` could not be
+    /// determined.
+    last_focused: Mutex<Option<PaneId>>,
+    /// The focus client's own id, learned once at connect time (see
+    /// `learn_own_client_id`) by diffing the attached-client list before and
+    /// after attaching. `None` if that could not be determined — commands
+    /// depending on it fall back to `last_focused`-based heuristics.
+    own_client_id: Option<ClientId>,
+    events: broadcast::Sender<Event>,
+}
+
+impl std::fmt::Debug for SessionLink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SessionLink").field("name", &self.name).finish()
+    }
+}
+
+pub fn session_socket_path(session_name: &str) -> PathBuf {
+    let mut sock_dir = zellij_utils::consts::ZELLIJ_SOCK_DIR.clone();
+    let _ = std::fs::create_dir_all(&sock_dir);
+    let _ = zellij_utils::shared::set_permissions(&sock_dir, 0o700);
+    sock_dir.push(session_name);
+    sock_dir
+}
+
+/// Whether a session's socket is up, tolerating the moment right after a
+/// rename.
+///
+/// `session_exists` scans the socket directory and, for each entry, connects
+/// and round-trips a status message — and just after `RenameSession` finishes
+/// on the server (the directory entry is already renamed; that part is
+/// synchronous), a probe aimed at the new name can still see it as absent. It
+/// resolves within about a second in practice. Reproduced directly: creating a
+/// session, renaming it, and killing it immediately by the new name fails
+/// roughly one time in three without this retry, even though the session is
+/// verifiably running the whole time. Five short attempts is comfortably past
+/// what was needed to stop reproducing it, while staying well under what a
+/// caller would notice as a hang.
+pub fn session_exists_settled(session_name: &str) -> Result<bool, String> {
+    use std::time::Duration;
+    for attempt in 0..5 {
+        if attempt > 0 {
+            std::thread::sleep(Duration::from_millis(150));
+        }
+        match zellij_utils::sessions::session_exists(session_name) {
+            Ok(true) => return Ok(true),
+            Ok(false) => continue,
+            Err(e) => return Err(format!("could not check session '{}': {:?}", session_name, e)),
+        }
+    }
+    Ok(false)
+}
+
+fn connect(session_name: &str) -> Result<Box<dyn ClientOsApi>, String> {
+    // `connect_to_server` retries forever, so refuse up front rather than
+    // wedging a thread on a session that is not there.
+    if !session_exists_settled(session_name)? {
+        return Err(format!("session '{}' is not running", session_name));
+    }
+    let os_input =
+        get_cli_client_os_input().map_err(|e| format!("could not open client IPC: {}", e))?;
+    let path = session_socket_path(session_name);
+    os_input.connect_to_server(&path);
+    Ok(Box::new(os_input))
+}
+
+/// Parse `ListClients`' table into `(client_id, pane_id)` pairs.
+///
+/// ```text
+/// CLIENT_ID ZELLIJ_PANE_ID RUNNING_COMMAND
+/// 3         terminal_1     N/A
+/// ```
+fn parse_client_table(lines: &[String]) -> Vec<(ClientId, PaneId)> {
+    lines
+        .iter()
+        .flat_map(|line| line.lines())
+        .skip_while(|line| line.trim_start().starts_with("CLIENT_ID"))
+        .filter_map(|line| {
+            let mut columns = line.split_whitespace();
+            let client_id: ClientId = columns.next()?.parse().ok()?;
+            let pane_id = PaneId::from_str(columns.next()?).ok()?;
+            Some((client_id, pane_id))
+        })
+        .collect()
+}
+
+/// The attached client ids of a session, via a disposable connection.
+///
+/// Used only to learn the focus client's own id (see
+/// `SessionLink::connect`): open, ask, close. Not folded into `SessionLink`
+/// itself because it is needed *before* one exists — this is how the focus
+/// client's own id is discovered in the first place.
+fn list_client_ids(session_name: &str) -> Result<HashSet<ClientId>, String> {
+    let os_input = connect(session_name)?;
+    os_input.send_to_server(ClientToServerMsg::Action {
+        action: Action::ListClients,
+        terminal_id: None,
+        client_id: None,
+        is_cli_client: true,
+    });
+    let lines = read_action_reply(&*os_input, ReplyShape::Text)?;
+    os_input.send_to_server(ClientToServerMsg::ClientExited);
+    Ok(parse_client_table(&lines).into_iter().map(|(id, _)| id).collect())
+}
+
+/// Learn the focus client's own id by elimination: after attaching, exactly
+/// one new client id should appear that was not in `before_attach`.
+///
+/// If a real client attaches in that same narrow window — a genuine race,
+/// not one we can fully close — more than one new id can appear at once. We
+/// do not guess in that case: we give up and leave the id unknown, and focus
+/// resolution falls back to the `last_focused`-based heuristic instead of
+/// risking attribution to the wrong client.
+fn learn_own_client_id(session_name: &str, before_attach: &HashSet<ClientId>) -> Option<ClientId> {
+    for attempt in 0..10 {
+        if attempt > 0 {
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        let Ok(after_attach) = list_client_ids(session_name) else {
+            continue;
+        };
+        let new_ids: Vec<ClientId> = after_attach.difference(before_attach).copied().collect();
+        if let [only] = new_ids.as_slice() {
+            return Some(*only);
+        }
+    }
+    None
+}
+
+impl SessionLink {
+    /// Open the connections to `session_name` and start their reader threads.
+    pub fn connect(session_name: &str) -> Result<Arc<Self>, String> {
+        // Snapshotted before we attach our own focus client, so that client's
+        // id can be learned by elimination once it appears (see below) — the
+        // protocol never tells a client its own id directly.
+        let before_attach = list_client_ids(session_name).unwrap_or_default();
+
+        let control = connect(session_name)?;
+        let observer = connect(session_name)?;
+        let focus = connect(session_name)?;
+
+        let (requests_tx, requests_rx) = std_mpsc::channel::<LinkRequest>();
+        let (events_tx, _) = broadcast::channel(EVENT_BUFFER);
+        let canvas = Arc::new(Mutex::new(CanvasStore::default()));
+        let subscription = Arc::new(Mutex::new(Subscription::default()));
+        let alive = Arc::new(AtomicBool::new(true));
+
+        spawn_control_thread(
+            session_name.to_string(),
+            control,
+            requests_rx,
+            events_tx.clone(),
+            alive.clone(),
+        );
+        let observer = Arc::new(observer);
+        spawn_observer_thread(
+            session_name.to_string(),
+            observer.clone(),
+            canvas.clone(),
+            events_tx.clone(),
+            alive.clone(),
+        );
+
+        let focus = Arc::new(focus);
+        attach_focus_client(&**focus);
+        spawn_focus_thread(session_name.to_string(), focus.clone());
+        let own_client_id = learn_own_client_id(session_name, &before_attach);
+
+        Ok(Arc::new(SessionLink {
+            name: session_name.to_string(),
+            requests: requests_tx,
+            canvas,
+            subscription,
+            observer,
+            focus,
+            focus_ready: AtomicBool::new(false),
+            alive,
+            last_focused: Mutex::new(None),
+            own_client_id,
+            events: events_tx,
+        }))
+    }
+
+    /// Run an action *as the session's attached client*.
+    ///
+    /// Client-relative operations — focusing a tab or pane, splitting next to
+    /// the current pane — are resolved by the server against the requesting
+    /// client. Sending them over the CLI connection does not work: a CLI
+    /// message is attributed to the *last active client*, which is only ever
+    /// set by a keystroke, so on an API-driven session it is nobody. Sent over
+    /// the attached connection with `is_cli_client: false`, the server
+    /// attributes the action to that client, and focus behaves exactly as it
+    /// does for a human.
+    ///
+    /// The reply is not read here: this socket also carries the render stream,
+    /// and callers that need certainty verify the resulting state with a query
+    /// instead of trusting an acknowledgement.
+    pub fn run_as_client(&self, action: Action) {
+        self.focus.send_to_server(ClientToServerMsg::Action {
+            action,
+            terminal_id: None,
+            client_id: None,
+            is_cli_client: false,
+        });
+    }
+
+    /// Subscribe to this session's event stream.
+    pub fn events(&self) -> broadcast::Receiver<Event> {
+        self.events.subscribe()
+    }
+
+    /// Dispatch an action and wait for the server's reply.
+    ///
+    /// The reply is whatever the server logged back, which for the `List*`
+    /// actions is a single JSON document.
+    pub async fn run_action(&self, action: Action) -> Result<Vec<String>, String> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.requests
+            .send(LinkRequest::Run {
+                action,
+                reply: reply_tx,
+            })
+            .map_err(|_| format!("session '{}' link is closed", self.name))?;
+
+        match tokio::time::timeout(ACTION_TIMEOUT, reply_rx).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(_)) => Err(format!("session '{}' link dropped the reply", self.name)),
+            Err(_) => {
+                // The control thread is still blocked reading a reply that has
+                // not come, and it reads replies in order — so every later
+                // command on this link would time out too. Retire the link:
+                // the next caller opens a fresh one, and closing this one
+                // unblocks the stuck thread.
+                self.alive.store(false, Ordering::Relaxed);
+                Err(format!(
+                    "timed out after {:?} waiting for session '{}'",
+                    ACTION_TIMEOUT, self.name
+                ))
+            },
+        }
+    }
+
+    /// Run an action whose reply is a JSON document, and deserialize it.
+    pub async fn query<T: serde::de::DeserializeOwned>(&self, action: Action) -> Result<T, String> {
+        let lines = self.run_action(action).await?;
+        let body = lines.join("\n");
+        if body.trim().is_empty() {
+            return Err("server returned an empty response".to_string());
+        }
+        serde_json::from_str(&body)
+            .map_err(|e| format!("could not parse server response: {} (was: {})", e, body))
+    }
+
+    pub async fn list_tabs(&self) -> Result<ListTabsResponse, String> {
+        self.query(Action::ListTabs {
+            show_state: true,
+            show_dimensions: false,
+            show_panes: true,
+            show_layout: false,
+            show_all: false,
+            output_json: true,
+        })
+        .await
+    }
+
+    pub async fn list_panes(&self) -> Result<ListPanesResponse, String> {
+        self.query(Action::ListPanes {
+            show_tab: true,
+            show_command: true,
+            show_state: true,
+            show_geometry: true,
+            show_all: false,
+            output_json: true,
+        })
+        .await
+    }
+
+    /// Which pane each attached client is focused on.
+    ///
+    /// This is the only authoritative answer to "what is focused": the
+    /// `is_focused` flag on a pane means "focused within its layer", so several
+    /// panes carry it at once (a tiled pane and a floating one, in every tab).
+    /// `ListClients` reports the single pane each client actually sits on.
+    ///
+    /// It answers with a table rather than JSON, hence the parsing:
+    ///
+    /// ```text
+    /// CLIENT_ID ZELLIJ_PANE_ID RUNNING_COMMAND
+    /// 3         terminal_1     N/A
+    /// ```
+    pub async fn attached_clients(&self) -> Result<Vec<(ClientId, PaneId)>, String> {
+        let lines = self.run_action(Action::ListClients).await?;
+        Ok(parse_client_table(&lines))
+    }
+
+    /// The pane the session considers focused — the default target for input.
+    ///
+    /// Prefers what a *real* client is actually on — a human who attached
+    /// with `zellij attach`, distinguished from our own focus client by
+    /// `own_client_id` (see `learn_own_client_id`). This is what makes
+    /// unaddressed input follow a person who is interacting live, rather than
+    /// staying wherever the API last pointed its own client: if you switch
+    /// panes yourself, the next `input.text` with no `pane_id` goes where you
+    /// are, not where we last put things.
+    ///
+    /// Falls back to reading the pane flags, which is ambiguous but better
+    /// than nothing if the client listing is unavailable.
+    pub async fn focused_pane(&self) -> Result<PaneId, String> {
+        if let Ok(clients) = self.attached_clients().await {
+            let focused = match clients.len() {
+                1 => Some(clients[0].1),
+                0 => None,
+                _ => {
+                    // More than one client: prefer a real one — anyone whose
+                    // id is not ours — over our own client's last known
+                    // position. If our own id was never resolved (see
+                    // `learn_own_client_id`), fall back to the old heuristic
+                    // rather than guessing which client is "the human".
+                    match self.own_client_id {
+                        Some(own) => clients
+                            .iter()
+                            .find(|(id, _)| *id != own)
+                            .map(|(_, pane)| *pane)
+                            .or_else(|| clients.iter().find(|(id, _)| *id == own).map(|(_, p)| *p)),
+                        None => {
+                            let ours = *self.last_focused.lock().unwrap();
+                            ours.filter(|ours| clients.iter().any(|(_, p)| p == ours))
+                        },
+                    }
+                },
+            };
+            if let Some(focused) = focused {
+                return Ok(focused);
+            }
+        }
+        self.focused_pane_from_flags().await
+    }
+
+    async fn focused_pane_from_flags(&self) -> Result<PaneId, String> {
+        let active_tab_id = self.active_tab().await?.tab_id;
+        let panes = self.list_panes().await?;
+        let in_active_tab: Vec<_> = panes
+            .iter()
+            .filter(|p| p.tab_id == active_tab_id && !p.pane_info.is_suppressed)
+            .collect();
+
+        in_active_tab
+            .iter()
+            .find(|p| p.pane_info.is_focused && !p.pane_info.is_plugin)
+            .or_else(|| in_active_tab.iter().find(|p| !p.pane_info.is_plugin))
+            .or_else(|| in_active_tab.iter().find(|p| p.pane_info.is_focused))
+            .map(|p| pane_id_of(&p.pane_info.id, p.pane_info.is_plugin))
+            .ok_or_else(|| {
+                format!(
+                    "session '{}' has no focused pane in its active tab",
+                    self.name
+                )
+            })
+    }
+
+    /// The tab commands act on by default.
+    ///
+    /// A tab is `active` relative to a *client*, and a session driven purely
+    /// over the API usually has no client attached — so no tab is marked
+    /// active. In that case the first tab is the only sensible target, and it
+    /// is what a caller means by "the session's tab".
+    pub async fn active_tab(&self) -> Result<TabInfo, String> {
+        let tabs = self.list_tabs().await?;
+        tabs.iter()
+            .find(|t| t.active)
+            .or_else(|| tabs.iter().min_by_key(|t| t.position))
+            .cloned()
+            .ok_or_else(|| format!("session '{}' has no tabs", self.name))
+    }
+
+    /// Wait until the session's attached client holds focus.
+    ///
+    /// Attaching is asynchronous, and until the server has registered the
+    /// client no tab is focused — so a command issued in that window (a
+    /// directional split, say) has nothing to resolve against. Focus appearing
+    /// on some tab is the signal that the client is live.
+    pub async fn ensure_focus_ready(&self) -> Result<(), String> {
+        if self.focus_ready.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+        for attempt in 0..20 {
+            if attempt > 0 {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            if let Ok(tabs) = self.list_tabs().await {
+                if tabs.iter().any(|t| t.active) {
+                    self.focus_ready.store(true, Ordering::Relaxed);
+                    return Ok(());
+                }
+            }
+        }
+        // Not fatal on its own — commands that do not depend on focus still
+        // work, and those that do report their own, more specific failure.
+        log::warn!(
+            "session '{}' never reported a focused tab; focus-dependent commands may fail",
+            self.name
+        );
+        Ok(())
+    }
+
+    /// Poll `check` against fresh session state until it holds.
+    ///
+    /// Focus changes are applied asynchronously inside the session, so a
+    /// command that sets focus confirms the result rather than assuming it.
+    async fn settle<T, F>(&self, what: &str, mut check: F) -> Result<T, String>
+    where
+        F: FnMut(&ListTabsResponse, &ListPanesResponse) -> Option<T>,
+    {
+        let mut last_error = None;
+        for attempt in 0..12 {
+            if attempt > 0 {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            match (self.list_tabs().await, self.list_panes().await) {
+                (Ok(tabs), Ok(panes)) => {
+                    if let Some(found) = check(&tabs, &panes) {
+                        return Ok(found);
+                    }
+                },
+                (Err(e), _) | (_, Err(e)) => last_error = Some(e),
+            }
+        }
+        Err(match last_error {
+            Some(e) => format!("{} (last error: {})", what, e),
+            None => what.to_string(),
+        })
+    }
+
+    /// Check a tab exists, so acting on a tab id that is not there fails at
+    /// once and by name — rather than after waiting for a focus change that was
+    /// never going to happen.
+    pub async fn require_tab(&self, tab_id: usize) -> Result<(), String> {
+        let tabs = self.list_tabs().await?;
+        if tabs.iter().any(|t| t.tab_id == tab_id) {
+            return Ok(());
+        }
+        let known: Vec<String> = tabs.iter().map(|t| t.tab_id.to_string()).collect();
+        Err(format!(
+            "session '{}' has no tab {} (known tab ids: {})",
+            self.name,
+            tab_id,
+            if known.is_empty() { "none".to_string() } else { known.join(", ") }
+        ))
+    }
+
+    /// Focus a tab and wait until the session agrees it is focused.
+    pub async fn focus_tab(&self, tab_id: usize) -> Result<usize, String> {
+        let tabs = self.list_tabs().await?;
+        if !tabs.iter().any(|t| t.tab_id == tab_id) {
+            return self.require_tab(tab_id).await.map(|_| tab_id);
+        }
+        if tabs.iter().any(|t| t.tab_id == tab_id && t.active) {
+            return Ok(tab_id);
+        }
+        self.run_as_client(Action::GoToTabById { id: tab_id as u64 });
+        self.await_tab_focus(tab_id).await
+    }
+
+    /// Focus a pane and wait until the session agrees it is focused.
+    pub async fn focus_pane(&self, pane_id: PaneId) -> Result<(), String> {
+        self.run_as_client(Action::FocusPaneByPaneId { pane_id });
+        self.await_pane_focus(pane_id).await?;
+        *self.last_focused.lock().unwrap() = Some(pane_id);
+        Ok(())
+    }
+
+    /// Wait until `tab_id` is the session's focused tab.
+    pub async fn await_tab_focus(&self, tab_id: usize) -> Result<usize, String> {
+        self.settle("the session did not focus the tab", |tabs, _| {
+            tabs.iter()
+                .find(|t| t.tab_id == tab_id && t.active)
+                .map(|t| t.tab_id)
+        })
+        .await
+    }
+
+    /// Wait until the attached client is sitting on `pane_id`.
+    pub async fn await_pane_focus(&self, pane_id: PaneId) -> Result<(), String> {
+        for attempt in 0..12 {
+            if attempt > 0 {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            if let Ok(clients) = self.attached_clients().await {
+                // `focus_pane` moves only our own client — `run_as_client`
+                // sends `FocusPaneByPaneId` as that client specifically — so
+                // this should confirm *our* client reached `pane_id`, not
+                // merely that some client (possibly a human, already sitting
+                // there by coincidence) is present. When our id is unknown,
+                // fall back to "any client", matching the old behavior.
+                let reached = match self.own_client_id {
+                    Some(own) => clients.iter().any(|(id, p)| *id == own && *p == pane_id),
+                    None => clients.iter().any(|(_, p)| *p == pane_id),
+                };
+                if reached {
+                    return Ok(());
+                }
+            }
+        }
+        Err(format!(
+            "the session did not focus pane {} (no attached client moved to it)",
+            pane_id
+        ))
+    }
+
+    /// The ids of every pane currently in the session.
+    pub async fn pane_ids_now(&self) -> Result<HashSet<String>, String> {
+        Ok(self
+            .list_panes()
+            .await?
+            .iter()
+            .map(|p| pane_id_of(&p.pane_info.id, p.pane_info.is_plugin).to_string())
+            .collect())
+    }
+
+    /// Wait for a pane that was not in `before` to appear, and return its id.
+    pub async fn await_new_pane(&self, before: &HashSet<String>) -> Result<String, String> {
+        for attempt in 0..12 {
+            if attempt > 0 {
+                tokio::time::sleep(Duration::from_millis(150)).await;
+            }
+            let now = self.pane_ids_now().await?;
+            if let Some(created) = now.difference(before).next() {
+                return Ok(created.clone());
+            }
+        }
+        Err("the session did not create the pane".to_string())
+    }
+
+    /// Whether the session has this pane right now.
+    ///
+    /// A single check — for a pane that may still be on its way, see
+    /// [`Self::await_new_pane`].
+    pub async fn pane_exists(&self, pane_id: PaneId) -> Result<bool, String> {
+        Ok(self
+            .list_panes()
+            .await?
+            .iter()
+            .any(|p| pane_id_of(&p.pane_info.id, p.pane_info.is_plugin) == pane_id))
+    }
+
+    /// A terminal pane in `tab_id` to use as the reference for a positional
+    /// action, preferring the tab's focused one.
+    pub async fn reference_pane_in_tab(&self, tab_id: usize) -> Result<u32, String> {
+        let panes = self.list_panes().await?;
+        let in_tab: Vec<_> = panes
+            .iter()
+            .filter(|p| {
+                p.tab_id == tab_id && !p.pane_info.is_plugin && !p.pane_info.is_suppressed
+            })
+            .collect();
+        in_tab
+            .iter()
+            .find(|p| p.pane_info.is_focused)
+            .or_else(|| in_tab.first())
+            .map(|p| p.pane_info.id)
+            .ok_or_else(|| {
+                format!(
+                    "tab {} of session '{}' has no terminal pane to place a pane next to",
+                    tab_id, self.name
+                )
+            })
+    }
+
+    /// Start following pane renders. `pane_ids` of `None` means every pane in
+    /// the session, now and in future.
+    pub async fn subscribe(&self, pane_ids: Option<Vec<PaneId>>) -> Result<Vec<PaneId>, String> {
+        let targets = match pane_ids {
+            Some(ids) => {
+                // Check the panes exist before asking to follow them. The
+                // server answers an unknown pane with an error on the observer
+                // socket — which carries no replies, so nothing would surface
+                // it — and installs no subscription at all if none of the panes
+                // were found, leaving any previous subscription in place while
+                // we believe we replaced it.
+                let live: HashSet<PaneId> = self
+                    .list_panes()
+                    .await?
+                    .iter()
+                    .map(|p| pane_id_of(&p.pane_info.id, p.pane_info.is_plugin))
+                    .collect();
+                let unknown: Vec<String> = ids
+                    .iter()
+                    .filter(|id| !live.contains(id))
+                    .map(|id| id.to_string())
+                    .collect();
+                if !unknown.is_empty() {
+                    return Err(format!(
+                        "session '{}' has no pane {}",
+                        self.name,
+                        unknown.join(", ")
+                    ));
+                }
+                let mut sub = self.subscription.lock().unwrap();
+                sub.follow_all = false;
+                sub.pane_ids = ids.iter().copied().collect();
+                ids
+            },
+            None => {
+                let panes = self.list_panes().await?;
+                let ids: Vec<PaneId> = panes
+                    .iter()
+                    .map(|p| pane_id_of(&p.pane_info.id, p.pane_info.is_plugin))
+                    .collect();
+                let mut sub = self.subscription.lock().unwrap();
+                sub.follow_all = true;
+                sub.pane_ids = ids.iter().copied().collect();
+                ids
+            },
+        };
+
+        if targets.is_empty() {
+            return Err("no panes to subscribe to".to_string());
+        }
+        self.send_subscription(&targets);
+        Ok(targets)
+    }
+
+    pub fn unsubscribe(&self) {
+        let mut sub = self.subscription.lock().unwrap();
+        sub.follow_all = false;
+        sub.pane_ids.clear();
+        // The server drops a subscription when its panes close; there is no
+        // explicit unsubscribe message, so we simply stop tracking and let the
+        // observer discard what still arrives.
+    }
+
+    fn send_subscription(&self, pane_ids: &[PaneId]) {
+        self.observer
+            .send_to_server(ClientToServerMsg::SubscribeToPaneRenders {
+                pane_ids: pane_ids.to_vec(),
+                scrollback: None,
+                ansi: false,
+            });
+    }
+
+    /// Refresh the followed pane set. Called periodically while following all
+    /// panes, so panes opened after `subscribe` are picked up.
+    pub async fn refresh_pane_set(&self) -> Result<(), String> {
+        let follow_all = self.subscription.lock().unwrap().follow_all;
+        if !follow_all {
+            return Ok(());
+        }
+        let panes = self.list_panes().await?;
+        let current: HashSet<PaneId> = panes
+            .iter()
+            .map(|p| pane_id_of(&p.pane_info.id, p.pane_info.is_plugin))
+            .collect();
+
+        let (added, removed) = {
+            let sub = self.subscription.lock().unwrap();
+            let added: Vec<PaneId> = current.difference(&sub.pane_ids).copied().collect();
+            let removed: Vec<PaneId> = sub.pane_ids.difference(&current).copied().collect();
+            (added, removed)
+        };
+
+        if added.is_empty() && removed.is_empty() {
+            return Ok(());
+        }
+
+        for pane_id in &added {
+            let _ = self.events.send(Event::PaneOpened {
+                session: self.name.clone(),
+                pane_id: pane_id.to_string(),
+            });
+        }
+        for pane_id in &removed {
+            self.canvas.lock().unwrap().forget(&pane_id.to_string());
+            let _ = self.events.send(Event::PaneClosed {
+                session: self.name.clone(),
+                pane_id: pane_id.to_string(),
+            });
+        }
+
+        {
+            let mut sub = self.subscription.lock().unwrap();
+            sub.pane_ids = current.clone();
+        }
+        let targets: Vec<PaneId> = current.into_iter().collect();
+        if !targets.is_empty() {
+            self.send_subscription(&targets);
+        }
+        Ok(())
+    }
+
+    pub fn snapshot(&self, pane_id: &str) -> Option<(u64, Vec<String>)> {
+        self.canvas.lock().unwrap().snapshot(pane_id)
+    }
+
+    pub fn history(
+        &self,
+        pane_id: &str,
+        since: Option<u64>,
+        limit: Option<usize>,
+    ) -> Vec<HistoryEntry> {
+        self.canvas.lock().unwrap().history(pane_id, since, limit)
+    }
+
+    /// Whether the session behind this link is still there.
+    ///
+    /// The reader threads clear this when the server sends `Exit` or the socket
+    /// closes, so a link to a session that has ended is not handed out again.
+    pub fn is_alive(&self) -> bool {
+        self.alive.load(Ordering::Relaxed)
+    }
+
+    /// Close this link and stop its threads.
+    ///
+    /// The observer and focus threads sit blocked in `recv_from_server`, so
+    /// they cannot be asked to stop — telling the server we have exited closes
+    /// those connections from the other end, which unblocks them. Without this
+    /// they would outlive the link, and the focus client would stay attached to
+    /// a session we no longer drive.
+    pub fn shutdown(&self) {
+        self.alive.store(false, Ordering::Relaxed);
+        let _ = self.requests.send(LinkRequest::Shutdown);
+        self.observer.send_to_server(ClientToServerMsg::ClientExited);
+        self.focus.send_to_server(ClientToServerMsg::ClientExited);
+    }
+}
+
+pub fn pane_id_of(id: &u32, is_plugin: bool) -> PaneId {
+    if is_plugin {
+        PaneId::Plugin(*id)
+    } else {
+        PaneId::Terminal(*id)
+    }
+}
+
+fn spawn_control_thread(
+    session_name: String,
+    os_input: Box<dyn ClientOsApi>,
+    requests: std_mpsc::Receiver<LinkRequest>,
+    events: broadcast::Sender<Event>,
+    alive: Arc<AtomicBool>,
+) {
+    std::thread::Builder::new()
+        .name(format!("zellij-api-control-{}", session_name))
+        .spawn(move || {
+            while let Ok(request) = requests.recv() {
+                let LinkRequest::Run { action, reply } = request else {
+                    break;
+                };
+
+                let shape = reply_shape(&action);
+                os_input.send_to_server(ClientToServerMsg::Action {
+                    action,
+                    terminal_id: None,
+                    client_id: None,
+                    is_cli_client: true,
+                });
+
+                let result = read_action_reply(&*os_input, shape);
+                let session_ended = matches!(&result, Err(e) if e == SESSION_GONE);
+                let _ = reply.send(result);
+
+                if session_ended {
+                    alive.store(false, Ordering::Relaxed);
+                    let _ = events.send(Event::SessionEnded {
+                        session: session_name.clone(),
+                    });
+                    break;
+                }
+            }
+            os_input.send_to_server(ClientToServerMsg::ClientExited);
+        })
+        .expect("could not spawn the session control thread");
+}
+
+const SESSION_GONE: &str = "session ended";
+
+/// What a given action's reply looks like on the wire.
+///
+/// The IPC stream carries no request ids, so replies are matched by position —
+/// and two server behaviours break naive positional matching:
+///
+/// - `UnblockInputThread` is not one-per-action: the server emits extra ones
+///   (a broadcast unblock reaches every client, ours included), so counting
+///   them shifts every later reply by one;
+/// - some actions log more than once (`NewTab` reports both the new tab's id
+///   and the new pane's id), leaving a spare `Log` in the stream.
+///
+/// So each action declares the shape of its answer, and the reader skips
+/// anything that cannot be it. Queries ask for JSON, which no stray line from
+/// another action ever parses as — that makes them self-resynchronising.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ReplyShape {
+    /// A `Log` whose body is a JSON document.
+    Json,
+    /// A `Log` of plain text (an id, for example).
+    Text,
+    /// No output — the action just has to complete.
+    Ack,
+}
+
+fn reply_shape(action: &Action) -> ReplyShape {
+    match action {
+        Action::ListPanes { .. }
+        | Action::ListTabs { .. }
+        | Action::CurrentTabInfo { .. }
+        | Action::DumpLayout => ReplyShape::Json,
+        // `ListClients` has no JSON form — it answers with a table.
+        Action::ListClients => ReplyShape::Text,
+        Action::NewTiledPane { .. }
+        | Action::NewFloatingPane { .. }
+        | Action::NewStackedPane { .. }
+        | Action::NewInPlacePane { .. } => ReplyShape::Text,
+        // `NewTab` does log ids, but we re-query the tab list afterwards
+        // rather than depend on which of its two logs arrives first.
+        _ => ReplyShape::Ack,
+    }
+}
+
+/// Read the server's reply to the action we just sent.
+///
+/// `UnblockInputThread` cannot be treated as a per-action terminator — the
+/// server emits more of them than there are actions, and counting them shifts
+/// every later reply by one. So:
+///
+/// - an action that produces output is read until its `Log` (or `LogError`)
+///   arrives, ignoring unblocks;
+/// - an action that only completes returns at the first unblock, and ignores a
+///   stray `Log` left over from an earlier action.
+fn read_action_reply(os_input: &dyn ClientOsApi, shape: ReplyShape) -> ActionReply {
+    loop {
+        match os_input.recv_from_server() {
+            Some((ServerToClientMsg::Log { lines }, _)) => match shape {
+                ReplyShape::Text => return Ok(lines),
+                ReplyShape::Json => {
+                    // Skip leftovers from an earlier action. Every query
+                    // answers with a JSON array or object, so a bare scalar —
+                    // `NewTab` logging a tab id of `1`, say — is not it.
+                    let is_query_result = serde_json::from_str::<serde_json::Value>(
+                        &lines.join("\n"),
+                    )
+                    .map(|value| value.is_array() || value.is_object())
+                    .unwrap_or(false);
+                    if is_query_result {
+                        return Ok(lines);
+                    }
+                    log::debug!("skipping a stale log line while awaiting a query result");
+                },
+                ReplyShape::Ack => {},
+            },
+            Some((ServerToClientMsg::LogError { lines }, _)) => return Err(lines.join("\n")),
+            Some((ServerToClientMsg::UnblockInputThread, _)) => {
+                if shape == ReplyShape::Ack {
+                    return Ok(Vec::new());
+                }
+            },
+            Some((ServerToClientMsg::Exit { .. }, _)) | None => {
+                return Err(SESSION_GONE.to_string())
+            },
+            // Anything else on this connection is not a reply to our action.
+            Some(_) => continue,
+        }
+    }
+}
+
+/// The size the focus client declares itself as, both on attach and whenever
+/// the server asks.
+///
+/// Zellij shares one rendered size per tab across every client on it: it
+/// takes the *minimum* rows and the *minimum* columns reported by any client
+/// currently viewing that tab (`Screen::recompute_tab_size`) — the same model
+/// tmux uses. The focus client is not a real terminal and has no viewport of
+/// its own, but it is a genuine attached client (not a watcher, which the
+/// server excludes from this computation but also from focus — see
+/// `attach_focus_client`), so whatever size it declares participates in that
+/// minimum for whichever tab it is on.
+///
+/// A small declared size (this used to be 24×80, matching a typical
+/// default) meant that attaching a real terminal to the same tab clamped the
+/// *real* terminal down to 24×80 — visibly: content already rendered at the
+/// real terminal's native size was still on screen when Zellij redrew a
+/// smaller frame over it, leaving a corrupted double-image until a full
+/// clear. Declaring a size far larger than any real terminal will ever be
+/// keeps the focus client from ever being the constraining minimum, so the
+/// tab always renders at whatever size the real client(s) actually are.
+const FOCUS_CLIENT_ROWS: usize = 999;
+const FOCUS_CLIENT_COLS: usize = 999;
+
+/// Attach as a real client, giving the session a place to hold focus.
+///
+/// This is a genuine attachment, not a watcher: watchers are excluded from
+/// focus handling, which is the whole point of this connection.
+fn attach_focus_client(os_input: &dyn ClientOsApi) {
+    let cli_assets = CliAssets {
+        config_file_path: None,
+        config_dir: None,
+        should_ignore_config: false,
+        configuration_options: None,
+        layout: None,
+        terminal_window_size: Size {
+            rows: FOCUS_CLIENT_ROWS,
+            cols: FOCUS_CLIENT_COLS,
+        },
+        data_dir: None,
+        is_debug: false,
+        max_panes: None,
+        force_run_layout_commands: false,
+        cwd: None,
+    };
+    os_input.send_to_server(ClientToServerMsg::AttachClient {
+        cli_assets,
+        tab_position_to_focus: None,
+        pane_to_focus: None,
+        is_web_client: false,
+    });
+}
+
+/// Drain the attached client's stream.
+///
+/// An attached client is sent the full render stream. If nothing reads it the
+/// socket buffer fills and the server blocks writing to us, which would stall
+/// the whole session — so this thread reads and discards, and answers the one
+/// question the server asks of a client.
+fn spawn_focus_thread(session_name: String, os_input: Arc<Box<dyn ClientOsApi>>) {
+    std::thread::Builder::new()
+        .name(format!("zellij-api-focus-{}", session_name))
+        .spawn(move || loop {
+            match os_input.recv_from_server() {
+                Some((ServerToClientMsg::QueryTerminalSize, _)) => {
+                    os_input.send_to_server(ClientToServerMsg::TerminalResize {
+                        new_size: Size {
+                            rows: FOCUS_CLIENT_ROWS,
+                            cols: FOCUS_CLIENT_COLS,
+                        },
+                    });
+                },
+                Some((ServerToClientMsg::Exit { .. }, _)) | None => break,
+                // Renders and everything else are of no interest here — the
+                // screen is observed through the pane subscription instead.
+                Some(_) => {},
+            }
+        })
+        .expect("could not spawn the session focus thread");
+}
+
+fn spawn_observer_thread(
+    session_name: String,
+    os_input: Arc<Box<dyn ClientOsApi>>,
+    canvas: Arc<Mutex<CanvasStore>>,
+    events: broadcast::Sender<Event>,
+    alive: Arc<AtomicBool>,
+) {
+    std::thread::Builder::new()
+        .name(format!("zellij-api-observer-{}", session_name))
+        .spawn(move || loop {
+            match os_input.recv_from_server() {
+                Some((
+                    ServerToClientMsg::PaneRenderUpdate {
+                        pane_id,
+                        viewport,
+                        is_initial,
+                        ..
+                    },
+                    _,
+                )) => {
+                    let pane_key = pane_id.to_string();
+                    let update = canvas
+                        .lock()
+                        .unwrap()
+                        .apply(&pane_key, viewport, is_initial);
+                    match update {
+                        CanvasUpdate::Changed { ts, diff } => {
+                            let _ =
+                                events.send(Event::from_diff(&session_name, &pane_key, ts, &diff));
+                        },
+                        CanvasUpdate::Reset { seq, ts, lines } => {
+                            let _ = events.send(Event::ScreenReset {
+                                session: session_name.clone(),
+                                pane_id: pane_key,
+                                seq,
+                                ts,
+                                lines,
+                            });
+                        },
+                        CanvasUpdate::Unchanged => {},
+                    }
+                },
+                Some((ServerToClientMsg::SubscribedPaneClosed { pane_id }, _)) => {
+                    let pane_key = pane_id.to_string();
+                    canvas.lock().unwrap().forget(&pane_key);
+                    let _ = events.send(Event::PaneClosed {
+                        session: session_name.clone(),
+                        pane_id: pane_key,
+                    });
+                },
+                Some((ServerToClientMsg::Exit { .. }, _)) | None => {
+                    alive.store(false, Ordering::Relaxed);
+                    let _ = events.send(Event::SessionEnded {
+                        session: session_name.clone(),
+                    });
+                    break;
+                },
+                Some(_) => {},
+            }
+        })
+        .expect("could not spawn the session observer thread");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pane_ids_round_trip_through_their_string_form() {
+        assert_eq!(pane_id_of(&3, false), PaneId::Terminal(3));
+        assert_eq!(pane_id_of(&3, true), PaneId::Plugin(3));
+        assert_eq!(PaneId::Terminal(3).to_string(), "terminal_3");
+        assert_eq!(PaneId::Plugin(3).to_string(), "plugin_3");
+    }
+
+    #[test]
+    fn connecting_to_a_missing_session_fails_fast() {
+        // Guards against `connect_to_server`'s infinite retry loop.
+        let result = SessionLink::connect("zellij-api-definitely-not-a-session");
+        assert!(result.is_err(), "expected a missing session to be refused");
+        let message = result.err().unwrap();
+        assert!(
+            message.contains("not running") || message.contains("could not check"),
+            "unhelpful error: {}",
+            message
+        );
+    }
+
+    #[test]
+    fn queries_declare_a_json_reply() {
+        assert_eq!(
+            reply_shape(&Action::ListTabs {
+                show_state: false,
+                show_dimensions: false,
+                show_panes: false,
+                show_layout: false,
+                show_all: false,
+                output_json: true,
+            }),
+            ReplyShape::Json
+        );
+        // ListClients is the exception: it has no JSON form, it answers with a
+        // table.
+        assert_eq!(reply_shape(&Action::ListClients), ReplyShape::Text);
+    }
+
+    #[test]
+    fn pane_creation_declares_a_text_reply() {
+        assert_eq!(
+            reply_shape(&Action::NewTiledPane {
+                direction: None,
+                command: None,
+                pane_name: None,
+                near_current_pane: false,
+                no_focus: false,
+                borderless: None,
+                tab_id: None,
+            }),
+            ReplyShape::Text
+        );
+    }
+
+    #[test]
+    fn commands_without_output_declare_an_ack() {
+        assert_eq!(reply_shape(&Action::GoToTabById { id: 1 }), ReplyShape::Ack);
+        assert_eq!(
+            reply_shape(&Action::WriteCharsToPaneId {
+                chars: "hi".into(),
+                pane_id: PaneId::Terminal(0),
+            }),
+            ReplyShape::Ack
+        );
+        // NewTab logs both a tab id and a pane id; we deliberately do not try
+        // to read either, and re-query instead.
+        assert_eq!(
+            reply_shape(&Action::NewTab {
+                tiled_layout: None,
+                floating_layouts: vec![],
+                swap_tiled_layouts: None,
+                swap_floating_layouts: None,
+                tab_name: None,
+                should_change_focus_to_new_tab: true,
+                cwd: None,
+                initial_panes: None,
+                first_pane_unblock_condition: None,
+            }),
+            ReplyShape::Ack
+        );
+    }
+
+    #[test]
+    fn reads_the_focused_pane_out_of_the_client_table() {
+        let table = vec![
+            "CLIENT_ID ZELLIJ_PANE_ID RUNNING_COMMAND".to_string(),
+            "3         terminal_1     N/A".to_string(),
+        ];
+        assert_eq!(
+            super::parse_client_table(&table),
+            vec![(3, PaneId::Terminal(1))]
+        );
+    }
+
+    #[test]
+    fn reads_every_attached_client() {
+        let table = vec![[
+            "CLIENT_ID ZELLIJ_PANE_ID RUNNING_COMMAND",
+            "1         terminal_0     zsh",
+            "2         plugin_4       N/A",
+        ]
+        .join("\n")];
+        assert_eq!(
+            super::parse_client_table(&table),
+            vec![(1, PaneId::Terminal(0)), (2, PaneId::Plugin(4))]
+        );
+    }
+
+    #[test]
+    fn an_empty_client_table_yields_no_clients() {
+        let table = vec!["CLIENT_ID ZELLIJ_PANE_ID RUNNING_COMMAND".to_string()];
+        assert!(super::parse_client_table(&table).is_empty());
+    }
+
+    #[test]
+    fn learning_our_own_id_ignores_a_client_that_was_already_there() {
+        // `before_attach` simulates a human who was already attached before
+        // our focus client connects — their id must not be mistaken for ours.
+        let before_attach: HashSet<ClientId> = [7].into_iter().collect();
+        let after_attach: HashSet<ClientId> = [7, 9].into_iter().collect();
+        let new_ids: Vec<ClientId> = after_attach.difference(&before_attach).copied().collect();
+        assert_eq!(new_ids, vec![9]);
+    }
+
+    #[test]
+    fn socket_path_lands_in_the_zellij_socket_dir() {
+        let path = session_socket_path("some-session");
+        assert!(path.ends_with("some-session"));
+        assert!(path.starts_with(&*zellij_utils::consts::ZELLIJ_SOCK_DIR));
+    }
+}

--- a/zellij-api/src/session_link.rs
+++ b/zellij-api/src/session_link.rs
@@ -11,8 +11,8 @@
 //!   replies.
 
 use std::collections::HashSet;
-use std::str::FromStr;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc as std_mpsc;
 use std::sync::{Arc, Mutex};
@@ -82,7 +82,9 @@ pub struct SessionLink {
 
 impl std::fmt::Debug for SessionLink {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SessionLink").field("name", &self.name).finish()
+        f.debug_struct("SessionLink")
+            .field("name", &self.name)
+            .finish()
     }
 }
 
@@ -116,7 +118,12 @@ pub fn session_exists_settled(session_name: &str) -> Result<bool, String> {
         match zellij_utils::sessions::session_exists(session_name) {
             Ok(true) => return Ok(true),
             Ok(false) => continue,
-            Err(e) => return Err(format!("could not check session '{}': {:?}", session_name, e)),
+            Err(e) => {
+                return Err(format!(
+                    "could not check session '{}': {:?}",
+                    session_name, e
+                ))
+            },
         }
     }
     Ok(false)
@@ -171,7 +178,10 @@ fn list_client_ids(session_name: &str) -> Result<HashSet<ClientId>, String> {
     });
     let lines = read_action_reply(&*os_input, ReplyShape::Text)?;
     os_input.send_to_server(ClientToServerMsg::ClientExited);
-    Ok(parse_client_table(&lines).into_iter().map(|(id, _)| id).collect())
+    Ok(parse_client_table(&lines)
+        .into_iter()
+        .map(|(id, _)| id)
+        .collect())
 }
 
 /// Learn the focus client's own id by elimination: after attaching, exactly
@@ -515,7 +525,11 @@ impl SessionLink {
             "session '{}' has no tab {} (known tab ids: {})",
             self.name,
             tab_id,
-            if known.is_empty() { "none".to_string() } else { known.join(", ") }
+            if known.is_empty() {
+                "none".to_string()
+            } else {
+                known.join(", ")
+            }
         ))
     }
 
@@ -620,9 +634,7 @@ impl SessionLink {
         let panes = self.list_panes().await?;
         let in_tab: Vec<_> = panes
             .iter()
-            .filter(|p| {
-                p.tab_id == tab_id && !p.pane_info.is_plugin && !p.pane_info.is_suppressed
-            })
+            .filter(|p| p.tab_id == tab_id && !p.pane_info.is_plugin && !p.pane_info.is_suppressed)
             .collect();
         in_tab
             .iter()
@@ -789,7 +801,8 @@ impl SessionLink {
     pub fn shutdown(&self) {
         self.alive.store(false, Ordering::Relaxed);
         let _ = self.requests.send(LinkRequest::Shutdown);
-        self.observer.send_to_server(ClientToServerMsg::ClientExited);
+        self.observer
+            .send_to_server(ClientToServerMsg::ClientExited);
         self.focus.send_to_server(ClientToServerMsg::ClientExited);
     }
 }
@@ -905,11 +918,10 @@ fn read_action_reply(os_input: &dyn ClientOsApi, shape: ReplyShape) -> ActionRep
                     // Skip leftovers from an earlier action. Every query
                     // answers with a JSON array or object, so a bare scalar —
                     // `NewTab` logging a tab id of `1`, say — is not it.
-                    let is_query_result = serde_json::from_str::<serde_json::Value>(
-                        &lines.join("\n"),
-                    )
-                    .map(|value| value.is_array() || value.is_object())
-                    .unwrap_or(false);
+                    let is_query_result =
+                        serde_json::from_str::<serde_json::Value>(&lines.join("\n"))
+                            .map(|value| value.is_array() || value.is_object())
+                            .unwrap_or(false);
                     if is_query_result {
                         return Ok(lines);
                     }

--- a/zellij-api/src/sessions.rs
+++ b/zellij-api/src/sessions.rs
@@ -280,8 +280,7 @@ fn wait_until_started(os_input: &dyn ClientOsApi) -> Result<(), String> {
 /// would be told the session was created — with no hint that the layout it
 /// asked for was never applied.
 fn layout_info_from(layout: &str) -> Result<LayoutInfo, String> {
-    let looks_like_a_path =
-        layout.contains(std::path::MAIN_SEPARATOR) || layout.ends_with(".kdl");
+    let looks_like_a_path = layout.contains(std::path::MAIN_SEPARATOR) || layout.ends_with(".kdl");
     if looks_like_a_path {
         if !std::path::Path::new(layout).exists() {
             return Err(format!("no layout file at '{}'", layout));

--- a/zellij-api/src/sessions.rs
+++ b/zellij-api/src/sessions.rs
@@ -1,0 +1,349 @@
+//! Session lifecycle: listing, creating, killing, and keeping one live
+//! [`SessionLink`] per session that the API is driving.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde::Serialize;
+
+use zellij_client::os_input_output::{get_cli_client_os_input, ClientOsApi};
+use zellij_client::spawn_server;
+use zellij_utils::data::LayoutInfo;
+use zellij_utils::envs;
+use zellij_utils::input::cli_assets::CliAssets;
+use zellij_utils::input::options::Options;
+use zellij_utils::ipc::{ClientToServerMsg, ServerToClientMsg};
+use zellij_utils::pane_size::Size;
+use zellij_utils::sessions::{
+    generate_unique_session_name, get_resurrectable_session_names, get_sessions, session_exists,
+    validate_session_name,
+};
+
+use crate::session_link::{session_socket_path, SessionLink};
+
+/// Terminal geometry used for sessions created through the API. There is no
+/// real terminal behind them, but panes still need a size — and it is the size
+/// the canvas diffs are computed against.
+pub const DEFAULT_ROWS: usize = 24;
+pub const DEFAULT_COLS: usize = 80;
+
+/// How long we wait for a freshly spawned session to accept a connection.
+const SESSION_START_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionSummary {
+    pub name: String,
+    /// Seconds since the session was created.
+    pub age_secs: u64,
+    /// A dead session that can be resurrected rather than a running one.
+    pub resurrectable: bool,
+}
+
+#[derive(Default)]
+pub struct SessionManager {
+    links: Mutex<HashMap<String, Arc<SessionLink>>>,
+    /// Session creation writes a process-wide env var that the spawned server
+    /// inherits, so only one creation may be in flight at a time.
+    creation: Mutex<()>,
+}
+
+impl SessionManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn list(&self) -> Vec<SessionSummary> {
+        let mut summaries: Vec<SessionSummary> = get_sessions()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(name, age)| SessionSummary {
+                name,
+                age_secs: age.as_secs(),
+                resurrectable: false,
+            })
+            .collect();
+
+        let running: Vec<String> = summaries.iter().map(|s| s.name.clone()).collect();
+        for name in get_resurrectable_session_names() {
+            if !running.contains(&name) {
+                summaries.push(SessionSummary {
+                    name,
+                    age_secs: 0,
+                    resurrectable: true,
+                });
+            }
+        }
+        summaries.sort_by(|a, b| a.name.cmp(&b.name));
+        summaries
+    }
+
+    /// Get (or open) the link to a session.
+    ///
+    /// The map is held for the whole operation, not just the lookup. Two
+    /// commands arriving together for a session that is not linked yet would
+    /// otherwise each open one — and since a link attaches a client, the
+    /// session would end up with two of them, which quietly breaks focus
+    /// resolution (it identifies our client by being the only one attached).
+    ///
+    /// A link whose session has ended is replaced rather than handed out, so a
+    /// caller gets a clear "is not running" instead of commands timing out
+    /// against a dead socket.
+    ///
+    /// Note that opening a link connects three sockets while the map is locked.
+    /// `SessionLink::connect` proves the session is alive first (that check
+    /// connects and round-trips a status message), because the underlying
+    /// connect retries forever against a socket that is not answering — and
+    /// with the map held, a wedged connect would block every session.
+    pub fn link(&self, session_name: &str) -> Result<Arc<SessionLink>, String> {
+        let mut links = self.links.lock().unwrap();
+        match links.get(session_name) {
+            Some(existing) if existing.is_alive() => return Ok(existing.clone()),
+            Some(_) => {
+                if let Some(dead) = links.remove(session_name) {
+                    dead.shutdown();
+                }
+            },
+            None => {},
+        }
+        let link = SessionLink::connect(session_name)?;
+        links.insert(session_name.to_string(), link.clone());
+        Ok(link)
+    }
+
+    /// The link to a session, if one is already open.
+    ///
+    /// Unlike [`Self::link`] this never opens one — for commands that only
+    /// tidy up local state, opening three sockets and attaching a client would
+    /// be a strange side effect.
+    pub fn existing_link(&self, session_name: &str) -> Option<Arc<SessionLink>> {
+        self.links.lock().unwrap().get(session_name).cloned()
+    }
+
+    /// Drop our link to a session (after it ended, or on unsubscribe).
+    pub fn drop_link(&self, session_name: &str) {
+        if let Some(link) = self.links.lock().unwrap().remove(session_name) {
+            link.shutdown();
+        }
+    }
+
+    pub fn linked_sessions(&self) -> Vec<String> {
+        self.links.lock().unwrap().keys().cloned().collect()
+    }
+
+    /// Create a new session with no terminal attached to it.
+    ///
+    /// This is the same handshake the bundled web client uses: spawn the server
+    /// process, then send `FirstClientConnected` to initialise it. We disconnect
+    /// once the session is up — Zellij keeps a session alive with no clients
+    /// attached, which is exactly the detached session we want to drive.
+    pub fn create(
+        &self,
+        name: Option<String>,
+        layout: Option<String>,
+        cwd: Option<String>,
+        rows: Option<usize>,
+        cols: Option<usize>,
+    ) -> Result<String, String> {
+        let _guard = self.creation.lock().unwrap();
+
+        let session_name = match name {
+            Some(name) => name,
+            None => generate_unique_session_name()
+                .ok_or_else(|| "could not generate a session name".to_string())?,
+        };
+        validate_session_name(&session_name)?;
+        if session_exists(&session_name).unwrap_or(false) {
+            return Err(format!("session '{}' already exists", session_name));
+        }
+
+        let socket_path = session_socket_path(&session_name);
+        // Note: `validate_session_name` above already rejects a name whose
+        // socket path would exceed the OS's Unix-socket path limit — this
+        // matters more here than it would interactively, since
+        // `wait_until_started` below can't tell "still starting" from
+        // "never going to start" if the daemonized server never gets far
+        // enough to send anything back, and would otherwise just block for
+        // the full timeout instead of failing immediately with a message
+        // that says why.
+        // The spawned server inherits this and uses it to identify itself.
+        envs::set_session_name(session_name.clone());
+        spawn_server(&socket_path, false)
+            .map_err(|e| format!("could not spawn the session server: {}", e))?;
+
+        let os_input =
+            get_cli_client_os_input().map_err(|e| format!("could not open client IPC: {}", e))?;
+        os_input.connect_to_server(&socket_path);
+
+        let cli_assets = CliAssets {
+            config_file_path: None,
+            config_dir: None,
+            should_ignore_config: false,
+            configuration_options: Some(api_session_options()),
+            layout: layout.as_deref().map(layout_info_from).transpose()?,
+            terminal_window_size: Size {
+                rows: rows.unwrap_or(DEFAULT_ROWS),
+                cols: cols.unwrap_or(DEFAULT_COLS),
+            },
+            data_dir: None,
+            is_debug: false,
+            max_panes: None,
+            force_run_layout_commands: false,
+            cwd: cwd.map(PathBuf::from),
+        };
+        os_input.send_to_server(ClientToServerMsg::FirstClientConnected {
+            cli_assets,
+            is_web_client: false,
+        });
+
+        // Wait for the server to come up before handing the session back, so a
+        // caller can immediately issue commands against it.
+        wait_until_started(&os_input)?;
+        os_input.send_to_server(ClientToServerMsg::ClientExited);
+
+        Ok(session_name)
+    }
+
+    pub fn kill(&self, session_name: &str) -> Result<(), String> {
+        // See `session_exists_settled`: a plain `session_exists` can still
+        // report false right after this session was renamed into
+        // `session_name`, even though it is definitely running.
+        if !crate::session_link::session_exists_settled(session_name).unwrap_or(false) {
+            return Err(format!("session '{}' is not running", session_name));
+        }
+        self.drop_link(session_name);
+
+        let os_input =
+            get_cli_client_os_input().map_err(|e| format!("could not open client IPC: {}", e))?;
+        os_input.connect_to_server(&session_socket_path(session_name));
+        os_input.send_to_server(ClientToServerMsg::KillSession);
+        // The server acknowledges by closing the connection or sending Exit.
+        let _ = os_input.recv_from_server();
+        Ok(())
+    }
+}
+
+/// Options for sessions the API creates.
+///
+/// Zellij greets a new session with the release notes and a startup tip. Both
+/// are floating plugin panes, and a floating pane takes focus — so a session
+/// created for a program to drive would start with focus on a welcome screen
+/// rather than on a shell, and input sent without naming a pane would go to
+/// that welcome screen.
+///
+/// These are the supported switches for exactly this, so the greeting is simply
+/// never created. Only the fields set here are applied; everything else still
+/// comes from the user's config, because `Options` merges field by field.
+fn api_session_options() -> Options {
+    Options {
+        show_release_notes: Some(false),
+        show_startup_tips: Some(false),
+        ..Default::default()
+    }
+}
+
+/// Wait for the first message from a freshly created session.
+fn wait_until_started(os_input: &dyn ClientOsApi) -> Result<(), String> {
+    let deadline = std::time::Instant::now() + SESSION_START_TIMEOUT;
+    // `recv_from_server` blocks, so this thread parks until the server speaks.
+    // The server always sends something once it has initialised the session.
+    loop {
+        match os_input.recv_from_server() {
+            Some((ServerToClientMsg::Exit { exit_reason }, _)) => {
+                return Err(format!("session exited during startup: {}", exit_reason));
+            },
+            Some((ServerToClientMsg::LogError { lines }, _)) => {
+                return Err(lines.join("\n"));
+            },
+            // A render means the session has laid out its panes and is live.
+            // `UnblockInputThread` only means our message was routed, which
+            // happens before the session finishes coming up — so it is not
+            // enough to report success on.
+            Some((ServerToClientMsg::Connected, _))
+            | Some((ServerToClientMsg::Render { .. }, _)) => return Ok(()),
+            Some(_) => {
+                if std::time::Instant::now() > deadline {
+                    return Err("timed out waiting for the session to start".to_string());
+                }
+            },
+            None => return Err("lost the connection while starting the session".to_string()),
+        }
+    }
+}
+
+/// Interpret the `layout` parameter: a bare name is a built-in layout, anything
+/// that looks like a path is a layout file.
+///
+/// A layout file that is not there is rejected here. The session would
+/// otherwise start perfectly happily with the default layout, and the caller
+/// would be told the session was created — with no hint that the layout it
+/// asked for was never applied.
+fn layout_info_from(layout: &str) -> Result<LayoutInfo, String> {
+    let looks_like_a_path =
+        layout.contains(std::path::MAIN_SEPARATOR) || layout.ends_with(".kdl");
+    if looks_like_a_path {
+        if !std::path::Path::new(layout).exists() {
+            return Err(format!("no layout file at '{}'", layout));
+        }
+        Ok(LayoutInfo::File(layout.to_string(), Default::default()))
+    } else {
+        Ok(LayoutInfo::BuiltIn(layout.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_layout_names_are_built_ins() {
+        assert!(matches!(
+            layout_info_from("compact"),
+            Ok(LayoutInfo::BuiltIn(name)) if name == "compact"
+        ));
+    }
+
+    #[test]
+    fn layout_paths_are_files() {
+        let existing = std::env::current_exe().expect("test binary path");
+        let path = existing.display().to_string();
+        assert!(matches!(
+            layout_info_from(&path),
+            Ok(LayoutInfo::File(found, _)) if found == path
+        ));
+    }
+
+    #[test]
+    fn a_layout_file_that_is_not_there_is_refused() {
+        // Otherwise the session starts with the default layout and reports
+        // success, having quietly ignored what was asked for.
+        let result = layout_info_from("/nonexistent/definitely/not/here.kdl");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("no layout file"));
+    }
+
+    #[test]
+    fn creating_a_session_with_an_invalid_name_is_refused() {
+        let manager = SessionManager::new();
+        // Session names may not contain path separators — that would escape
+        // the socket directory.
+        let result = manager.create(Some("../evil".to_string()), None, None, None, None);
+        assert!(result.is_err(), "expected an invalid name to be refused");
+    }
+
+    #[test]
+    fn killing_a_session_that_is_not_running_is_an_error() {
+        let manager = SessionManager::new();
+        let result = manager.kill("zellij-api-definitely-not-a-session");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not running"));
+    }
+
+    #[test]
+    fn linking_to_a_missing_session_does_not_cache_anything() {
+        let manager = SessionManager::new();
+        assert!(manager.link("zellij-api-definitely-not-a-session").is_err());
+        assert!(manager.linked_sessions().is_empty());
+    }
+}

--- a/zellij-api/tests/e2e.rs
+++ b/zellij-api/tests/e2e.rs
@@ -194,7 +194,8 @@ impl Client {
             .map(|e| match e["event"].as_str() {
                 Some("screen.diff") => format!(
                     "screen.diff pane={} seq={}\n{}",
-                    e["pane_id"], e["seq"],
+                    e["pane_id"],
+                    e["seq"],
                     e["unified"].as_str().unwrap_or("")
                 ),
                 _ => e.to_string(),
@@ -260,7 +261,10 @@ async fn drives_a_real_session_over_the_websocket() {
         .await;
     assert_eq!(bad_layout["ok"], json!(false));
     assert!(
-        bad_layout["error"].as_str().unwrap().contains("no layout file"),
+        bad_layout["error"]
+            .as_str()
+            .unwrap()
+            .contains("no layout file"),
         "unhelpful error: {}",
         bad_layout["error"]
     );
@@ -327,7 +331,9 @@ async fn drives_a_real_session_over_the_websocket() {
         ("tab.rename", json!({"name": "x"})),
     ] {
         let mut body = json!({"cmd": cmd, "session": session, "tab_id": bogus_tab});
-        body.as_object_mut().unwrap().extend(extra.as_object().unwrap().clone());
+        body.as_object_mut()
+            .unwrap()
+            .extend(extra.as_object().unwrap().clone());
         let result = client.call_raw(body).await;
         assert_eq!(
             result["ok"],
@@ -371,7 +377,10 @@ async fn drives_a_real_session_over_the_websocket() {
         .await;
     assert_eq!(subscribed["following_new_panes"], json!(true));
     let followed = subscribed["panes"].as_array().unwrap().clone();
-    assert!(!followed.is_empty(), "should be following at least one pane");
+    assert!(
+        !followed.is_empty(),
+        "should be following at least one pane"
+    );
 
     // Every subscribed pane sends a baseline first.
     client
@@ -712,7 +721,9 @@ async fn manages_panes_and_accepts_mouse_input() {
 
     // A malformed mouse event must be refused rather than silently ignored.
     let bad = client
-        .call_raw(json!({"cmd": "input.mouse", "session": session, "kind": "wiggle", "x": 0, "y": 0}))
+        .call_raw(
+            json!({"cmd": "input.mouse", "session": session, "kind": "wiggle", "x": 0, "y": 0}),
+        )
         .await;
     assert_eq!(bad["ok"], json!(false), "unknown mouse kind must fail");
 
@@ -726,7 +737,11 @@ async fn manages_panes_and_accepts_mouse_input() {
             "cmd": "screen.subscribe", "session": session, "pane_ids": ["terminal_4242"],
         }))
         .await;
-    assert_eq!(bad["ok"], json!(false), "subscribing to a missing pane must fail");
+    assert_eq!(
+        bad["ok"],
+        json!(false),
+        "subscribing to a missing pane must fail"
+    );
     assert!(
         bad["error"].as_str().unwrap().contains("no pane"),
         "unhelpful error: {}",
@@ -775,7 +790,12 @@ async fn manages_panes_and_accepts_mouse_input() {
     ] {
         let cmd = body["cmd"].as_str().unwrap().to_string();
         let result = client.call_raw(body).await;
-        assert_eq!(result["ok"], json!(false), "{} on a missing pane must fail", cmd);
+        assert_eq!(
+            result["ok"],
+            json!(false),
+            "{} on a missing pane must fail",
+            cmd
+        );
         assert!(
             result["error"].as_str().unwrap().contains("no pane"),
             "{}: unhelpful error: {}",
@@ -904,7 +924,10 @@ async fn pane_create_rejects_args_without_a_command() {
             "cmd": "pane.create", "session": session, "args": ["--flag"],
         }))
         .await;
-    assert_eq!(reply["ok"], false, "args without command should be rejected");
+    assert_eq!(
+        reply["ok"], false,
+        "args without command should be rejected"
+    );
     assert!(
         reply["error"].as_str().unwrap_or_default().contains("args"),
         "expected an error mentioning `args`, got: {}",
@@ -964,7 +987,10 @@ async fn screen_history_rejects_a_pane_that_does_not_exist() {
         "screen.history on a nonexistent pane should fail, not report empty history"
     );
     assert!(
-        reply["error"].as_str().unwrap_or_default().contains("has no pane"),
+        reply["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("has no pane"),
         "expected a specific 'has no pane' error, got: {}",
         reply["error"]
     );
@@ -1105,7 +1131,11 @@ async fn drives_a_plugin_pane() {
             "pane_id": "plugin_9999", "text": "x",
         }))
         .await;
-    assert_eq!(stale["ok"], json!(false), "writing to a missing pane must fail");
+    assert_eq!(
+        stale["ok"],
+        json!(false),
+        "writing to a missing pane must fail"
+    );
     assert!(
         stale["error"].as_str().unwrap().contains("no pane"),
         "unhelpful error: {}",
@@ -1179,7 +1209,8 @@ async fn concurrent_callers_share_one_attached_client() {
         .filter(|l| !l.trim().is_empty() && !l.trim_start().starts_with("CLIENT_ID"))
         .count();
     assert_eq!(
-        rows, 1,
+        rows,
+        1,
         "the API should hold exactly one attached client, found {}:\n{}",
         rows,
         String::from_utf8_lossy(&listing.stdout)
@@ -1532,7 +1563,9 @@ async fn focus_and_size_follow_a_real_client_that_attaches_alongside_the_api() {
         .as_array()
         .unwrap()
         .iter()
-        .find(|p| p["is_plugin"] == json!(false) && p["id"].as_u64() != Some(second_pane_num as u64))
+        .find(|p| {
+            p["is_plugin"] == json!(false) && p["id"].as_u64() != Some(second_pane_num as u64)
+        })
         .expect("the session's original pane should still exist")["id"]
         .as_u64()
         .unwrap();
@@ -1646,7 +1679,11 @@ async fn typing_with_no_other_client_attached_does_not_duplicate_characters() {
             "cmd": "input.text", "session": session, "pane_id": "terminal_0", "text": "Z",
         }))
         .await;
-    assert_eq!(reply["bytes"], json!(1), "writing 'Z' should report 1 byte written");
+    assert_eq!(
+        reply["bytes"],
+        json!(1),
+        "writing 'Z' should report 1 byte written"
+    );
 
     tokio::time::sleep(Duration::from_millis(1000)).await;
     client
@@ -1738,7 +1775,11 @@ async fn typing_without_a_term_environment_variable_does_not_duplicate_character
             "cmd": "input.text", "session": session, "pane_id": "terminal_0", "text": "Z",
         }))
         .await;
-    assert_eq!(reply["bytes"], json!(1), "writing 'Z' should report 1 byte written");
+    assert_eq!(
+        reply["bytes"],
+        json!(1),
+        "writing 'Z' should report 1 byte written"
+    );
 
     tokio::time::sleep(Duration::from_millis(1000)).await;
     client
@@ -1790,7 +1831,10 @@ async fn rejects_connections_without_the_token() {
     // Wait for it to come up.
     let health = format!("http://127.0.0.1:{}/health", port);
     for _ in 0..50 {
-        if tokio::net::TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .is_ok()
+        {
             break;
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -1805,7 +1849,9 @@ async fn rejects_connections_without_the_token() {
 
     let wrong_token = format!("ws://127.0.0.1:{}/api?token=nope", port);
     assert!(
-        tokio_tungstenite::connect_async(&wrong_token).await.is_err(),
+        tokio_tungstenite::connect_async(&wrong_token)
+            .await
+            .is_err(),
         "connecting with the wrong token must be refused"
     );
 }

--- a/zellij-api/tests/e2e.rs
+++ b/zellij-api/tests/e2e.rs
@@ -1,0 +1,1811 @@
+//! End-to-end test: drives a real Zellij session entirely over the WebSocket
+//! API — creating it, typing into it, and reading back the screen diffs.
+//!
+//! This needs the built `zellij` binary (the API server spawns session servers
+//! by re-executing it), so it is opt-in:
+//!
+//! ```sh
+//! cargo xtask build
+//! ZELLIJ_API_E2E=target/dev-opt/zellij cargo test -p zellij-api --test e2e -- --nocapture
+//! ```
+
+use std::process::{Child, Command, Stdio};
+use std::str::FromStr;
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use tokio_tungstenite::tungstenite::Message;
+
+const TOKEN: &str = "e2e-secret";
+const PORT: u16 = 8799;
+
+struct ServerProcess(Child);
+
+impl Drop for ServerProcess {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Makes sure a test session is torn down even if the test panics — otherwise a
+/// failed run leaves a real Zellij server behind.
+struct SessionGuard {
+    binary: String,
+    session: String,
+}
+
+impl Drop for SessionGuard {
+    fn drop(&mut self) {
+        let _ = Command::new(&self.binary)
+            .args(["delete-session", &self.session, "--force"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+}
+
+fn zellij_binary() -> Option<String> {
+    std::env::var("ZELLIJ_API_E2E").ok().filter(|p| {
+        let exists = std::path::Path::new(p).exists();
+        if !exists {
+            eprintln!("ZELLIJ_API_E2E points at '{}', which does not exist", p);
+        }
+        exists
+    })
+}
+
+struct Client {
+    socket: tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+    next_id: u64,
+    /// Every event observed, kept so failures can show what did arrive.
+    seen: Vec<Value>,
+}
+
+impl Client {
+    async fn connect() -> Self {
+        Self::connect_to(PORT).await
+    }
+
+    async fn connect_to(port: u16) -> Self {
+        let url = format!("ws://127.0.0.1:{}/api?token={}", port, TOKEN);
+        for attempt in 0..50 {
+            match tokio_tungstenite::connect_async(&url).await {
+                Ok((socket, _)) => {
+                    return Client {
+                        socket,
+                        next_id: 1,
+                        seen: Vec::new(),
+                    }
+                },
+                Err(e) if attempt == 49 => panic!("could not connect to the API server: {}", e),
+                Err(_) => tokio::time::sleep(Duration::from_millis(100)).await,
+            }
+        }
+        unreachable!()
+    }
+
+    /// Send a command and return its `result`, asserting that it succeeded.
+    async fn call(&mut self, command: Value) -> Value {
+        let described = command.to_string();
+        let reply = self.call_raw(command).await;
+        assert_eq!(
+            reply["ok"], true,
+            "command {} failed: {}",
+            described, reply["error"]
+        );
+        reply["result"].clone()
+    }
+
+    /// Send a command and return the whole reply, successful or not.
+    async fn call_raw(&mut self, mut command: Value) -> Value {
+        let id = self.next_id.to_string();
+        self.next_id += 1;
+        command["id"] = json!(id);
+
+        self.socket
+            .send(Message::Text(command.to_string().into()))
+            .await
+            .expect("send failed");
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        loop {
+            let frame = tokio::time::timeout_at(deadline, self.socket.next())
+                .await
+                .unwrap_or_else(|_| panic!("timed out waiting for a reply to {}", command))
+                .expect("socket closed")
+                .expect("websocket error");
+            let Message::Text(text) = frame else { continue };
+            let value: Value = serde_json::from_str(&text).expect("reply was not JSON");
+            if value["id"] == json!(id) {
+                return value;
+            }
+            if value.get("event").is_some() {
+                self.seen.push(value);
+            }
+        }
+    }
+
+    /// Collect events until `predicate` matches one, or we time out.
+    async fn wait_for_event(
+        &mut self,
+        timeout: Duration,
+        mut predicate: impl FnMut(&Value) -> bool,
+    ) -> Option<Value> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let frame = match tokio::time::timeout_at(deadline, self.socket.next()).await {
+                Ok(Some(Ok(frame))) => frame,
+                Ok(Some(Err(e))) => panic!("websocket error: {}", e),
+                Ok(None) => return None,
+                Err(_) => return None,
+            };
+            let Message::Text(text) = frame else { continue };
+            let value: Value = serde_json::from_str(&text).expect("event was not JSON");
+            if value.get("event").is_some() {
+                self.seen.push(value.clone());
+                if predicate(&value) {
+                    return Some(value);
+                }
+            }
+        }
+    }
+
+    /// Wait until no screen change has arrived for `idle`, giving up after
+    /// `max`.
+    ///
+    /// A remote driver cannot know when a freshly started shell is ready to
+    /// accept input — a shell discards anything typed before it finishes
+    /// initialising. Watching the diff stream go quiet is the signal, and it is
+    /// the same technique any API consumer would use.
+    async fn wait_until_quiet(&mut self, idle: Duration, max: Duration) {
+        let give_up = tokio::time::Instant::now() + max;
+        loop {
+            let next_idle = tokio::time::Instant::now() + idle;
+            let until = next_idle.min(give_up);
+            match tokio::time::timeout_at(until, self.socket.next()).await {
+                Ok(Some(Ok(Message::Text(text)))) => {
+                    if let Ok(value) = serde_json::from_str::<Value>(&text) {
+                        if value.get("event").is_some() {
+                            self.seen.push(value);
+                        }
+                    }
+                },
+                Ok(Some(Ok(_))) => continue,
+                Ok(Some(Err(e))) => panic!("websocket error: {}", e),
+                Ok(None) => return,
+                // Timed out: either the screen went quiet, or we ran out of
+                // patience. Either way, stop waiting.
+                Err(_) => return,
+            }
+            if tokio::time::Instant::now() >= give_up {
+                return;
+            }
+        }
+    }
+
+    /// A readable dump of the events observed so far, for failure messages.
+    fn event_log(&self) -> String {
+        self.seen
+            .iter()
+            .map(|e| match e["event"].as_str() {
+                Some("screen.diff") => format!(
+                    "screen.diff pane={} seq={}\n{}",
+                    e["pane_id"], e["seq"],
+                    e["unified"].as_str().unwrap_or("")
+                ),
+                _ => e.to_string(),
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn drives_a_real_session_over_the_websocket() {
+    let Some(binary) = zellij_binary() else {
+        eprintln!("skipping: set ZELLIJ_API_E2E=<path to zellij binary> to run this test");
+        return;
+    };
+
+    let server = ServerProcess(
+        Command::new(&binary)
+            .arg("api-server")
+            .arg("--port")
+            .arg(PORT.to_string())
+            .arg("--token")
+            .arg(TOKEN)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("could not start the api server"),
+    );
+
+    let mut client = Client::connect().await;
+    let session = format!("zellij-api-e2e-{}", std::process::id());
+    let _guard = SessionGuard {
+        binary: binary.clone(),
+        session: session.clone(),
+    };
+
+    // --- sessions ---------------------------------------------------------
+    let created = client
+        .call(json!({"cmd": "session.create", "name": session, "rows": 24, "cols": 80}))
+        .await;
+    assert_eq!(created["session"], json!(session));
+
+    let listed = client.call(json!({"cmd": "session.list"})).await;
+    let names: Vec<String> = listed["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["name"].as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        names.contains(&session),
+        "created session missing from session.list: {:?}",
+        names
+    );
+
+    // A layout file that is not on disk must be refused, not silently ignored
+    // in favour of the default layout.
+    let bad_layout = client
+        .call_raw(json!({
+            "cmd": "session.create", "name": format!("{}-bad-layout", session),
+            "layout": "/nonexistent/definitely/not/here.kdl",
+        }))
+        .await;
+    assert_eq!(bad_layout["ok"], json!(false));
+    assert!(
+        bad_layout["error"].as_str().unwrap().contains("no layout file"),
+        "unhelpful error: {}",
+        bad_layout["error"]
+    );
+
+    // --- tabs -------------------------------------------------------------
+    let tabs = client
+        .call(json!({"cmd": "tab.list", "session": session}))
+        .await;
+    let initial_tab_count = tabs["tabs"].as_array().unwrap().len();
+    assert!(initial_tab_count >= 1, "a new session should have a tab");
+
+    client
+        .call(json!({"cmd": "tab.create", "session": session, "name": "second"}))
+        .await;
+    let tabs = client
+        .call(json!({"cmd": "tab.list", "session": session}))
+        .await;
+    let tab_list = tabs["tabs"].as_array().unwrap();
+
+    // Focus is controllable through the API: focusing a tab makes it the
+    // session's active tab, which is what every "current tab" behaviour and
+    // unaddressed input then follows.
+    let first_tab = tab_list
+        .iter()
+        .find(|t| t["name"] == json!("Tab #1"))
+        .expect("the original tab should still exist")["tab_id"]
+        .as_u64()
+        .unwrap();
+    let second_tab = tab_list
+        .iter()
+        .find(|t| t["name"] == json!("second"))
+        .expect("the created tab should exist")["tab_id"]
+        .as_u64()
+        .unwrap();
+
+    for target in [first_tab, second_tab, first_tab] {
+        let focused = client
+            .call(json!({"cmd": "tab.focus", "session": session, "tab_id": target}))
+            .await;
+        assert_eq!(focused["focused"], json!(target));
+
+        let active: Vec<u64> = client
+            .call(json!({"cmd": "tab.list", "session": session}))
+            .await["tabs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|t| t["active"] == json!(true))
+            .map(|t| t["tab_id"].as_u64().unwrap())
+            .collect();
+        assert_eq!(
+            active,
+            vec![target],
+            "tab.focus should leave exactly tab {} active",
+            target
+        );
+    }
+    // A tab id that does not exist must fail fast and by name, not after
+    // waiting out a focus-change timeout that was never going to resolve.
+    let bogus_tab = second_tab + 1000;
+    for (cmd, extra) in [
+        ("tab.focus", json!({})),
+        ("tab.close", json!({})),
+        ("tab.rename", json!({"name": "x"})),
+    ] {
+        let mut body = json!({"cmd": cmd, "session": session, "tab_id": bogus_tab});
+        body.as_object_mut().unwrap().extend(extra.as_object().unwrap().clone());
+        let result = client.call_raw(body).await;
+        assert_eq!(
+            result["ok"],
+            json!(false),
+            "{} on a missing tab must fail",
+            cmd
+        );
+        assert!(
+            result["error"].as_str().unwrap().contains("no tab"),
+            "{}: unhelpful error: {}",
+            cmd,
+            result["error"]
+        );
+    }
+
+    // Leave the newest tab focused for the rest of the scenario.
+    client
+        .call(json!({"cmd": "tab.focus", "session": session, "tab_id": second_tab}))
+        .await;
+    assert_eq!(
+        tab_list.len(),
+        initial_tab_count + 1,
+        "tab.create should have added a tab"
+    );
+    assert!(
+        tab_list.iter().any(|t| t["name"] == json!("second")),
+        "named tab missing: {:?}",
+        tab_list
+    );
+
+    // --- panes ------------------------------------------------------------
+    let panes = client
+        .call(json!({"cmd": "pane.list", "session": session}))
+        .await;
+    let pane_list = panes["panes"].as_array().unwrap();
+    assert!(!pane_list.is_empty(), "session should have panes");
+
+    // --- screen subscription + input --------------------------------------
+    let subscribed = client
+        .call(json!({"cmd": "screen.subscribe", "session": session}))
+        .await;
+    assert_eq!(subscribed["following_new_panes"], json!(true));
+    let followed = subscribed["panes"].as_array().unwrap().clone();
+    assert!(!followed.is_empty(), "should be following at least one pane");
+
+    // Every subscribed pane sends a baseline first.
+    client
+        .wait_for_event(Duration::from_secs(10), |e| e["event"] == "screen.reset")
+        .await
+        .expect("expected a screen.reset baseline");
+
+    // Zellij greets a new session with release notes and a startup tip, as
+    // floating plugin panes — and a floating pane takes focus, which would put
+    // a welcome screen in the way of everything the API does. Sessions the API
+    // creates switch the greeting off, so nothing floats over the shell.
+    let panes = client
+        .call(json!({"cmd": "pane.list", "session": session}))
+        .await;
+    let floating: Vec<String> = panes["panes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|p| p["is_floating"] == json!(true))
+        .map(|p| p["title"].as_str().unwrap_or_default().to_string())
+        .collect();
+    assert!(
+        floating.is_empty(),
+        "an API-created session should have no floating greeting panes, found {:?}",
+        floating
+    );
+
+    // With nothing stealing focus, unaddressed input reaches the shell.
+    let probe = client
+        .call(json!({"cmd": "input.text", "session": session, "text": ""}))
+        .await;
+    assert!(
+        probe["pane_id"].as_str().unwrap().starts_with("terminal_"),
+        "unaddressed input should reach a terminal pane, got {}",
+        probe["pane_id"]
+    );
+
+    // Let the shell in the newly created tab finish starting before typing;
+    // anything sent before it is ready is discarded as typeahead.
+    client
+        .wait_until_quiet(Duration::from_millis(1500), Duration::from_secs(20))
+        .await;
+
+    // Type a command into the focused pane and watch the screen change.
+    let marker = "zellij_api_e2e_marker";
+    let typed = client
+        .call(json!({
+            "cmd": "input.text",
+            "session": session,
+            "text": format!("echo {}\n", marker),
+        }))
+        .await;
+    // With no pane_id given, input goes to the focused pane of the active tab
+    // — which is the tab we just created.
+    let typed_into = typed["pane_id"].as_str().unwrap().to_string();
+    assert_eq!(typed["bytes"], json!(format!("echo {}\n", marker).len()));
+
+    let diff = match client
+        .wait_for_event(Duration::from_secs(20), |e| {
+            e["event"] == "screen.diff"
+                && e["unified"]
+                    .as_str()
+                    .map(|u| u.contains(marker))
+                    .unwrap_or(false)
+        })
+        .await
+    {
+        Some(diff) => diff,
+        None => panic!(
+            "no screen.diff contained the typed command. Events seen:\n{}",
+            client.event_log()
+        ),
+    };
+
+    let unified = diff["unified"].as_str().unwrap();
+    assert!(
+        unified.contains(&format!("+{}", marker)) || unified.contains(marker),
+        "diff should show the added text as an addition:\n{}",
+        unified
+    );
+    assert!(
+        unified.starts_with("--- pane/"),
+        "diff should be in unified format:\n{}",
+        unified
+    );
+    assert!(diff["seq"].as_u64().unwrap() >= 1, "diffs are versioned");
+    // The change was reported against the pane we typed into.
+    let pane_id = diff["pane_id"].as_str().unwrap().to_string();
+    assert_eq!(pane_id, typed_into);
+
+    // --- history + snapshot -----------------------------------------------
+    let history = client
+        .call(json!({"cmd": "screen.history", "session": session, "pane_id": pane_id}))
+        .await;
+    let diffs = history["diffs"].as_array().unwrap();
+    assert!(!diffs.is_empty(), "history should have recorded the change");
+    assert!(
+        diffs
+            .iter()
+            .any(|d| d["unified"].as_str().unwrap().contains(marker)),
+        "history should contain the change we caused"
+    );
+    // Sequence numbers are monotonic, so a caller can resume from one.
+    let seqs: Vec<u64> = diffs.iter().map(|d| d["seq"].as_u64().unwrap()).collect();
+    assert!(
+        seqs.windows(2).all(|w| w[0] < w[1]),
+        "history sequence numbers must increase: {:?}",
+        seqs
+    );
+
+    let resumed = client
+        .call(json!({
+            "cmd": "screen.history", "session": session, "pane_id": pane_id,
+            "since": seqs[seqs.len() - 1],
+        }))
+        .await;
+    assert!(
+        resumed["diffs"].as_array().unwrap().len() < diffs.len(),
+        "resuming from the newest version should return fewer entries"
+    );
+
+    let snapshot = client
+        .call(json!({"cmd": "screen.snapshot", "session": session, "pane_id": pane_id}))
+        .await;
+    let lines: Vec<String> = snapshot["lines"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|l| l.as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        lines.iter().any(|l| l.contains(marker)),
+        "the pane's canvas should show what we typed:\n{:?}",
+        lines
+    );
+
+    // --- keys -------------------------------------------------------------
+    client
+        .call(json!({
+            "cmd": "input.keys", "session": session, "keys": ["c", "l", "e", "a", "r", "enter"],
+        }))
+        .await;
+    client
+        .wait_for_event(Duration::from_secs(10), |e| e["event"] == "screen.diff")
+        .await
+        .expect("clearing the screen should produce a diff");
+
+    // --- teardown ---------------------------------------------------------
+    client
+        .call(json!({"cmd": "session.kill", "name": session}))
+        .await;
+    let listed = client.call(json!({"cmd": "session.list"})).await;
+    let still_running: Vec<String> = listed["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|s| s["resurrectable"] == json!(false))
+        .map(|s| s["name"].as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        !still_running.contains(&session),
+        "session should be gone after session.kill: {:?}",
+        still_running
+    );
+
+    drop(server);
+}
+
+/// The API's string form of a pane in a `pane.list` entry.
+fn pane_id_of(pane: &Value) -> String {
+    let kind = if pane["is_plugin"] == json!(true) {
+        "plugin"
+    } else {
+        "terminal"
+    };
+    format!("{}_{}", kind, pane["id"])
+}
+
+async fn pane_ids(client: &mut Client, session: &str) -> Vec<String> {
+    client
+        .call(json!({"cmd": "pane.list", "session": session}))
+        .await["panes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(pane_id_of)
+        .collect()
+}
+
+/// Covers the parts of the surface the main scenario does not touch: the pane
+/// lifecycle, mouse input, and unsubscribing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn manages_panes_and_accepts_mouse_input() {
+    let Some(binary) = zellij_binary() else {
+        eprintln!("skipping: set ZELLIJ_API_E2E=<path to zellij binary> to run this test");
+        return;
+    };
+
+    let port = PORT + 2;
+    let _server = ServerProcess(
+        Command::new(&binary)
+            .arg("api-server")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--token")
+            .arg(TOKEN)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("could not start the api server"),
+    );
+
+    let mut client = Client::connect_to(port).await;
+    let session = format!("zellij-api-panes-{}", std::process::id());
+    let _guard = SessionGuard {
+        binary: binary.clone(),
+        session: session.clone(),
+    };
+    client
+        .call(json!({"cmd": "session.create", "name": session, "rows": 24, "cols": 80}))
+        .await;
+
+    // --- create -----------------------------------------------------------
+    // A directional split is resolved against the requesting client's focused
+    // pane. The API attaches a client to each session precisely so this works
+    // without a human at a terminal.
+    let split = client
+        .call(json!({
+            "cmd": "pane.create", "session": session, "direction": "right",
+        }))
+        .await;
+    let split_pane = split["pane_id"].as_str().unwrap().to_string();
+    assert!(
+        pane_ids(&mut client, &session).await.contains(&split_pane),
+        "a directional split should actually create the pane"
+    );
+
+    let created = client
+        .call(json!({"cmd": "pane.create", "session": session, "name": "worker"}))
+        .await;
+    let new_pane = created["pane_id"].as_str().unwrap().to_string();
+    assert!(
+        new_pane.starts_with("terminal_"),
+        "pane.create should report the new pane's id, got '{}'",
+        new_pane
+    );
+
+    let listed = pane_ids(&mut client, &session).await;
+    assert!(
+        listed.contains(&new_pane),
+        "the created pane '{}' should appear in pane.list, which has {:?}",
+        new_pane,
+        listed
+    );
+
+    // --- focus, rename, resize -------------------------------------------
+    // Focusing must actually move focus, not just be accepted: the reply is
+    // only sent once the session reports the pane as focused.
+    client
+        .call(json!({"cmd": "pane.focus", "session": session, "pane_id": new_pane}))
+        .await;
+    // Unaddressed input follows focus — this is the observable consequence of
+    // pane.focus, and the reply names the pane that was written to.
+    let typed = client
+        .call(json!({"cmd": "input.text", "session": session, "text": "# focused\n"}))
+        .await;
+    assert_eq!(
+        typed["pane_id"],
+        json!(new_pane),
+        "input with no pane_id should go to the focused pane"
+    );
+
+    // Focus the other pane and confirm input moves with it.
+    client
+        .call(json!({"cmd": "pane.focus", "session": session, "pane_id": split_pane}))
+        .await;
+    let typed = client
+        .call(json!({"cmd": "input.text", "session": session, "text": "# moved\n"}))
+        .await;
+    assert_eq!(
+        typed["pane_id"],
+        json!(split_pane),
+        "input should follow focus to the other pane"
+    );
+
+    // Put focus back for the rest of the scenario.
+    client
+        .call(json!({"cmd": "pane.focus", "session": session, "pane_id": new_pane}))
+        .await;
+    client
+        .call(json!({
+            "cmd": "pane.rename", "session": session, "pane_id": new_pane, "name": "renamed",
+        }))
+        .await;
+    client
+        .call(json!({
+            "cmd": "pane.resize", "session": session, "pane_id": new_pane,
+            "resize": "increase", "direction": "left",
+        }))
+        .await;
+
+    let panes = client
+        .call(json!({"cmd": "pane.list", "session": session}))
+        .await;
+    let renamed = panes["panes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|p| pane_id_of(p) == new_pane)
+        .expect("the created pane should still be listed")
+        .clone();
+    assert!(
+        renamed["title"].as_str().unwrap().contains("renamed"),
+        "pane.rename should be reflected in the title, got {}",
+        renamed["title"]
+    );
+
+    // --- mouse ------------------------------------------------------------
+    client
+        .call(json!({
+            "cmd": "input.mouse", "session": session,
+            "kind": "press", "button": "left", "x": 2, "y": 2,
+        }))
+        .await;
+    client
+        .call(json!({
+            "cmd": "input.mouse", "session": session,
+            "kind": "release", "button": "left", "x": 2, "y": 2,
+        }))
+        .await;
+    // Scrolling is a mouse event too, and takes no button.
+    client
+        .call(json!({
+            "cmd": "input.mouse", "session": session,
+            "kind": "press", "button": "wheel_up", "x": 2, "y": 2,
+        }))
+        .await;
+
+    // A malformed mouse event must be refused rather than silently ignored.
+    let bad = client
+        .call_raw(json!({"cmd": "input.mouse", "session": session, "kind": "wiggle", "x": 0, "y": 0}))
+        .await;
+    assert_eq!(bad["ok"], json!(false), "unknown mouse kind must fail");
+
+    // --- subscribe / unsubscribe -----------------------------------------
+    // Following a pane that is not there must fail. The server reports an
+    // unknown pane on the observer socket, which carries no replies, so a
+    // caller would otherwise be told it was following something and then wait
+    // forever for events that never come.
+    let bad = client
+        .call_raw(json!({
+            "cmd": "screen.subscribe", "session": session, "pane_ids": ["terminal_4242"],
+        }))
+        .await;
+    assert_eq!(bad["ok"], json!(false), "subscribing to a missing pane must fail");
+    assert!(
+        bad["error"].as_str().unwrap().contains("no pane"),
+        "unhelpful error: {}",
+        bad["error"]
+    );
+
+    // A partly-valid list is refused too, naming only what is missing.
+    let partly = client
+        .call_raw(json!({
+            "cmd": "screen.subscribe", "session": session,
+            "pane_ids": [new_pane, "plugin_4242"],
+        }))
+        .await;
+    assert_eq!(partly["ok"], json!(false));
+    assert!(
+        partly["error"].as_str().unwrap().contains("plugin_4242")
+            && !partly["error"].as_str().unwrap().contains(&new_pane),
+        "the error should name only the missing pane: {}",
+        partly["error"]
+    );
+
+    // Unsubscribing from a session we never linked is a no-op, not a reason to
+    // open one.
+    client
+        .call(json!({"cmd": "screen.unsubscribe", "session": "zellij-api-never-linked"}))
+        .await;
+
+    client
+        .call(json!({"cmd": "screen.subscribe", "session": session}))
+        .await;
+    client
+        .wait_for_event(Duration::from_secs(10), |e| e["event"] == "screen.reset")
+        .await
+        .expect("subscribing should deliver a baseline");
+    client
+        .call(json!({"cmd": "screen.unsubscribe", "session": session}))
+        .await;
+
+    // --- validation on a pane that is not there ----------------------------
+    // pane.close/rename/resize used to report success against a made-up pane
+    // id — the server silently drops the action, and nothing told the caller.
+    for body in [
+        json!({"cmd": "pane.close", "session": session, "pane_id": "terminal_777777"}),
+        json!({"cmd": "pane.rename", "session": session, "pane_id": "terminal_777777", "name": "x"}),
+        json!({"cmd": "pane.resize", "session": session, "pane_id": "terminal_777777", "resize": "increase"}),
+    ] {
+        let cmd = body["cmd"].as_str().unwrap().to_string();
+        let result = client.call_raw(body).await;
+        assert_eq!(result["ok"], json!(false), "{} on a missing pane must fail", cmd);
+        assert!(
+            result["error"].as_str().unwrap().contains("no pane"),
+            "{}: unhelpful error: {}",
+            cmd,
+            result["error"]
+        );
+    }
+
+    // --- close ------------------------------------------------------------
+    client
+        .call(json!({"cmd": "pane.close", "session": session, "pane_id": new_pane}))
+        .await;
+    // Closing a pane is asynchronous; give the session a moment to settle.
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+    assert!(
+        !pane_ids(&mut client, &session).await.contains(&new_pane),
+        "pane.close should have removed the pane again"
+    );
+
+    client
+        .call(json!({"cmd": "session.kill", "name": session}))
+        .await;
+}
+
+/// `pane.focus` on a pane id that doesn't exist should fail fast with a
+/// specific message, the same way `pane.close`/`pane.rename`/`pane.resize`
+/// already do — it originally skipped the existence check and instead ran
+/// the full ~1.2s focus-confirmation retry loop before failing with a vaguer
+/// "the session did not focus pane ... (no attached client moved to it)".
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn focusing_a_missing_pane_fails_fast_with_a_specific_message() {
+    let Some(binary) = zellij_binary() else {
+        eprintln!("skipping: set ZELLIJ_API_E2E=<path to zellij binary> to run this test");
+        return;
+    };
+
+    let port = PORT + 8;
+    let _server = ServerProcess(
+        Command::new(&binary)
+            .arg("api-server")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--token")
+            .arg(TOKEN)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("could not start the api server"),
+    );
+
+    let mut client = Client::connect_to(port).await;
+    let session = format!("zellij-api-focus-missing-{}", std::process::id());
+    let _guard = SessionGuard {
+        binary: binary.clone(),
+        session: session.clone(),
+    };
+    client
+        .call(json!({"cmd": "session.create", "name": session, "rows": 24, "cols": 80}))
+        .await;
+
+    let started = tokio::time::Instant::now();
+    let reply = client
+        .call_raw(json!({
+            "cmd": "pane.focus", "session": session, "pane_id": "terminal_999",
+        }))
+        .await;
+    let elapsed = started.elapsed();
+
+    assert_eq!(reply["ok"], false, "focusing a missing pane should fail");
+    let error = reply["error"].as_str().unwrap_or_default();
+    assert!(
+        error.contains("has no pane"),
+        "expected a specific 'has no pane' error, got: {}",
+        error
+    );
+    assert!(
+        elapsed < Duration::from_millis(1000),
+        "should fail fast via the existence check, not after the ~1.2s focus-confirmation \
+         retry loop; took {:?}",
+        elapsed
+    );
+
+    client
+        .call(json!({"cmd": "session.kill", "name": session}))
+        .await;
+}
+
+/// `args` only means something alongside `command` (it becomes the shell
+/// command's argv). Giving it with `plugin`, or with neither, used to be
+/// silently accepted and just as silently ignored — no error, no effect,
+/// same "quiet no-op" class of bug as the missing existence checks elsewhere
+/// in this file.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pane_create_rejects_args_without_a_command() {
+    let Some(binary) = zellij_binary() else {
+        eprintln!("skipping: set ZELLIJ_API_E2E=<path to zellij binary> to run this test");
+        return;
+    };
+
+    let port = PORT + 9;
+    let _server = ServerProcess(
+        Command::new(&binary)
+            .arg("api-server")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--token")
+            .arg(TOKEN)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("could not start the api server"),
+    );
+
+    let mut client = Client::connect_to(port).await;
+    let session = format!("zellij-api-args-no-command-{}", std::process::id());
+    let _guard = SessionGuard {
+        binary: binary.clone(),
+        session: session.clone(),
+    };
+    client
+        .call(json!({"cmd": "session.create", "name": session, "rows": 24, "cols": 80}))
+        .await;
+
+    let reply = client
+        .call_raw(json!({
+            "cmd": "pane.create", "session": session, "args": ["--flag"],
+        }))
+        .await;
+    assert_eq!(reply["ok"], false, "args without command should be rejected");
+    assert!(
+        reply["error"].as_str().unwrap_or_default().contains("args"),
+        "expected an error mentioning `args`, got: {}",
+        reply["error"]
+    );
+
+    client
+        .call(json!({"cmd": "session.kill", "name": session}))
+        .await;
+}
+
+/// `screen.history` on a pane that was never subscribed, and one that never
+/// existed at all, look identical from the canvas store's point of view —
+/// both are just an absent key, and the history lookup returns an empty
+/// list either way. That is correct for the first case but wrong for the
+/// second: unlike every pane-targeting mutation (`pane.close`, `pane.focus`,
+/// ...), `screen.history` had no existence check, so a typo'd pane id
+/// silently came back as "no history yet" instead of "no such pane".
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn screen_history_rejects_a_pane_that_does_not_exist() {
+    let Some(binary) = zellij_binary() else {
+        eprintln!("skipping: set ZELLIJ_API_E2E=<path to zellij binary> to run this test");
+        return;
+    };
+
+    let port = PORT + 10;
+    let _server = ServerProcess(
+        Command::new(&binary)
+            .arg("api-server")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--token")
+            .arg(TOKEN)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("could not start the api server"),
+    );
+
+    let mut client = Client::connect_to(port).await;
+    let session = format!("zellij-api-history-missing-{}", std::process::id());
+    let _guard = SessionGuard {
+        binary: binary.clone(),
+        session: session.clone(),
+    };
+    client
+        .call(json!({"cmd": "session.create", "name": session, "rows": 24, "cols": 80}))
+        .await;
+
+    let reply = client
+        .call_raw(json!({
+            "cmd": "screen.history", "session": session, "pane_id": "terminal_999",
+        }))
+        .await;
+    assert_eq!(
+        reply["ok"], false,
+        "screen.history on a nonexistent pane should fail, not report empty history"
+    );
+    assert!(
+        reply["error"].as_str().unwrap_or_default().contains("has no pane"),
+        "expected a specific 'has no pane' error, got: {}",
+        reply["error"]
+    );
+
+    // The real (existing, never-subscribed) pane should still cleanly report
+    // an empty history rather than erroring — this is not a regression of
+    // that case.
+    let real = client
+        .call(json!({
+            "cmd": "screen.history", "session": session, "pane_id": "terminal_0",
+        }))
+        .await;
+    assert_eq!(
+        real["diffs"].as_array().map(|d| d.is_empty()),
+        Some(true),
+        "an existing, never-subscribed pane should report empty history, not error: {real:?}"
+    );
+
+    client
+        .call(json!({"cmd": "session.kill", "name": session}))
+        .await;
+}
+
+/// Plugin panes are driven the same way terminal panes are: open one, address
+/// it by id, and its UI reacts. Zellij delivers the bytes to a plugin as key
+/// events rather than writing them to a pty, but that is invisible from here.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn drives_a_plugin_pane() {
+    let Some(binary) = zellij_binary() else {
+        eprintln!("skipping: set ZELLIJ_API_E2E=<path to zellij binary> to run this test");
+        return;
+    };
+
+    let port = PORT + 3;
+    let _server = ServerProcess(
+        Command::new(&binary)
+            .arg("api-server")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--token")
+            .arg(TOKEN)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("could not start the api server"),
+    );
+
+    let mut client = Client::connect_to(port).await;
+    let session = format!("zellij-api-plugin-{}", std::process::id());
+    let _guard = SessionGuard {
+        binary: binary.clone(),
+        session: session.clone(),
+    };
+    client
+        .call(json!({"cmd": "session.create", "name": session, "rows": 24, "cols": 80}))
+        .await;
+
+    // A plugin pane, opened through the API by alias.
+    let created = client
+        .call(json!({
+            "cmd": "pane.create", "session": session,
+            "plugin": "session-manager", "floating": true,
+        }))
+        .await;
+    let plugin_pane = created["pane_id"].as_str().unwrap().to_string();
+    assert!(
+        plugin_pane.starts_with("plugin_"),
+        "expected a plugin pane, got {}",
+        plugin_pane
+    );
+
+    client
+        .call(json!({"cmd": "screen.subscribe", "session": session}))
+        .await;
+    client
+        .wait_until_quiet(Duration::from_millis(1000), Duration::from_secs(15))
+        .await;
+
+    // Typing at the plugin reaches its UI — the session manager echoes what is
+    // typed into its "Session:" field.
+    client
+        .call(json!({
+            "cmd": "input.text", "session": session,
+            "pane_id": plugin_pane, "text": "abc",
+        }))
+        .await;
+    let typed = client
+        .wait_for_event(Duration::from_secs(15), |e| {
+            e["event"] == "screen.diff"
+                && e["pane_id"] == json!(plugin_pane)
+                // Match the added side of the diff: the field now reads "abc".
+                && e["unified"]
+                    .as_str()
+                    .map(|u| u.lines().any(|l| l.starts_with('+') && l.contains("Session: abc")))
+                    .unwrap_or(false)
+        })
+        .await;
+    assert!(
+        typed.is_some(),
+        "the plugin should have reacted to typing. Events seen:\n{}",
+        client.event_log()
+    );
+
+    // Named keys reach it too — backspace removes the last character.
+    client
+        .call(json!({
+            "cmd": "input.keys", "session": session,
+            "pane_id": plugin_pane, "keys": ["backspace"],
+        }))
+        .await;
+    let edited = client
+        .wait_for_event(Duration::from_secs(15), |e| {
+            e["event"] == "screen.diff"
+                && e["pane_id"] == json!(plugin_pane)
+                // The added side now reads "ab" — a diff also carries the old
+                // "abc" on its removed side, so match the added line only.
+                && e["unified"]
+                    .as_str()
+                    .map(|u| {
+                        u.lines()
+                            .any(|l| l.starts_with('+') && l.contains("Session: ab_"))
+                    })
+                    .unwrap_or(false)
+        })
+        .await;
+    assert!(
+        edited.is_some(),
+        "backspace should have reached the plugin. Events seen:\n{}",
+        client.event_log()
+    );
+
+    // A pane that is not there must fail rather than swallow the input: a
+    // plugin's pane vanishes when its UI is dismissed, and a caller still
+    // typing at that id would otherwise get success replies and no effect.
+    let stale = client
+        .call_raw(json!({
+            "cmd": "input.text", "session": session,
+            "pane_id": "plugin_9999", "text": "x",
+        }))
+        .await;
+    assert_eq!(stale["ok"], json!(false), "writing to a missing pane must fail");
+    assert!(
+        stale["error"].as_str().unwrap().contains("no pane"),
+        "unhelpful error: {}",
+        stale["error"]
+    );
+
+    client
+        .call(json!({"cmd": "session.kill", "name": session}))
+        .await;
+}
+
+/// Two callers hitting the same session at once must not each open a link.
+///
+/// A link attaches a client, and focus resolution identifies our client by it
+/// being the only one attached — so a second attachment would not fail loudly,
+/// it would quietly degrade every focus-dependent command.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_callers_share_one_attached_client() {
+    let Some(binary) = zellij_binary() else {
+        eprintln!("skipping: set ZELLIJ_API_E2E=<path to zellij binary> to run this test");
+        return;
+    };
+
+    let port = PORT + 4;
+    let _server = ServerProcess(
+        Command::new(&binary)
+            .arg("api-server")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--token")
+            .arg(TOKEN)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("could not start the api server"),
+    );
+
+    let session = format!("zellij-api-race-{}", std::process::id());
+    let _guard = SessionGuard {
+        binary: binary.clone(),
+        session: session.clone(),
+    };
+    Client::connect_to(port)
+        .await
+        .call(json!({"cmd": "session.create", "name": session, "rows": 24, "cols": 80}))
+        .await;
+
+    // Six callers on separate connections, all touching the session for the
+    // first time together.
+    let mut callers = Vec::new();
+    for _ in 0..6 {
+        let session = session.clone();
+        callers.push(tokio::spawn(async move {
+            let mut client = Client::connect_to(port).await;
+            client
+                .call(json!({"cmd": "pane.list", "session": session}))
+                .await;
+        }));
+    }
+    for caller in callers {
+        caller.await.expect("caller panicked");
+    }
+
+    // `list-clients` reports one row per attached client.
+    let listing = Command::new(&binary)
+        .args(["--session", &session, "action", "list-clients"])
+        .output()
+        .expect("could not list clients");
+    let rows = String::from_utf8_lossy(&listing.stdout)
+        .lines()
+        .filter(|l| !l.trim().is_empty() && !l.trim_start().starts_with("CLIENT_ID"))
+        .count();
+    assert_eq!(
+        rows, 1,
+        "the API should hold exactly one attached client, found {}:\n{}",
+        rows,
+        String::from_utf8_lossy(&listing.stdout)
+    );
+
+    Client::connect_to(port)
+        .await
+        .call(json!({"cmd": "session.kill", "name": session}))
+        .await;
+}
+
+/// Upstream's `RenameSession` handler builds the socket path with
+/// `ZELLIJ_SOCK_DIR.join(&name)` and renames the file there — with no
+/// validation of `name` at all. A `new_name` of `../evil` renames the socket
+/// *out of* the directory session discovery scans (orphaning the session,
+/// invisibly to `session.list`), and a longer `../../..` reaches further
+/// still. This is reachable specifically through a wire API in a way it is not
+/// through the interactive rename UI, so the API validates the name itself
+/// before ever sending the action.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn session_rename_rejects_a_path_traversal_name() {
+    let Some(binary) = zellij_binary() else {
+        eprintln!("skipping: set ZELLIJ_API_E2E=<path to zellij binary> to run this test");
+        return;
+    };
+
+    let port = PORT + 5;
+    let _server = ServerProcess(
+        Command::new(&binary)
+            .arg("api-server")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--token")
+            .arg(TOKEN)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("could not start the api server"),
+    );
+
+    let mut client = Client::connect_to(port).await;
+    let session = format!("zellij-api-rename-{}", std::process::id());
+    let _guard = SessionGuard {
+        binary: binary.clone(),
+        session: session.clone(),
+    };
+    client
+        .call(json!({"cmd": "session.create", "name": session, "rows": 24, "cols": 80}))
+        .await;
+
+    for bad_name in ["../evil", "..", "a/b", "", "/etc/passwd"] {
+        let result = client
+            .call_raw(json!({
+                "cmd": "session.rename", "name": session, "new_name": bad_name,
+            }))
+            .await;
+        assert_eq!(
+            result["ok"],
+            json!(false),
+            "renaming to '{}' must be refused",
+            bad_name
+        );
+    }
+
+    // The traversal attempts must not have renamed anything on disk — the
+    // session is still reachable under its original name.
+    let listed = client.call(json!({"cmd": "session.list"})).await;
+    let names: Vec<String> = listed["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["name"].as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        names.contains(&session),
+        "the session should still exist under its original name after refused renames: {:?}",
+        names
+    );
+
+    // An ordinary name still works.
+    let renamed_to = format!("{}-renamed", session);
+    let ok = client
+        .call(json!({
+            "cmd": "session.rename", "name": session, "new_name": renamed_to,
+        }))
+        .await;
+    assert_eq!(ok["session"], json!(renamed_to));
+
+    client
+        .call(json!({"cmd": "session.kill", "name": renamed_to}))
+        .await;
+}
+
+/// Regression test for a real bug: a session name long enough that its
+/// socket path exceeds the OS's Unix-domain-socket path limit
+/// (`sockaddr_un.sun_path`, ~104-108 bytes depending on platform) used to
+/// hang `session.create` for the full startup timeout instead of failing
+/// immediately. The daemonized session server fails silently at `bind()`
+/// and never sends anything back; `wait_until_started`
+/// (`zellij-api/src/sessions.rs`) can't distinguish "still starting" from
+/// "never going to start" if the peer never speaks at all — its deadline
+/// check only runs *after* receiving some message, so a peer that sends
+/// nothing blocks the call for the whole timeout. The interactive CLI
+/// already checks this once it has a full socket path in hand
+/// (`zellij_client::check_ipc_pipe_length`), but that check is never
+/// reached from this API, which spawns the session server directly.
+///
+/// Fixed by teaching `validate_session_name`
+/// (`zellij-utils/src/sessions.rs`) — already called from both
+/// `session.create` and `session.rename` — to compute the real socket path
+/// and reject it upfront if it's too long, the same way the CLI's checker
+/// does, just returning a `Result` instead of exiting the process.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_overlong_session_name_fails_fast_instead_of_hanging() {
+    let Some(binary) = zellij_binary() else {
+        eprintln!("skipping: set ZELLIJ_API_E2E=<path to zellij binary> to run this test");
+        return;
+    };
+
+    let port = PORT + 14;
+    let _server = ServerProcess(
+        Command::new(&binary)
+            .arg("api-server")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--token")
+            .arg(TOKEN)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("could not start the api server"),
+    );
+
+    let mut client = Client::connect_to(port).await;
+    let overlong_name = "a".repeat(300);
+
+    let started = tokio::time::Instant::now();
+    let reply = client
+        .call_raw(json!({
+            "cmd": "session.create", "name": overlong_name, "rows": 24, "cols": 80,
+        }))
+        .await;
+    let elapsed = started.elapsed();
+
+    assert_eq!(
+        reply["ok"],
+        json!(false),
+        "an overlong session name should be refused, not created: {reply:?}"
+    );
+    let error = reply["error"].as_str().unwrap_or_default();
+    assert!(
+        error.contains("too long"),
+        "expected an error explaining the name is too long, got: {}",
+        error
+    );
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "should fail fast via upfront validation, not after the multi-second startup \
+         timeout the old bug produced; took {:?}",
+        elapsed
+    );
+}
+
+/// A raw, non-watcher attach — deliberately built the same way a real
+/// `zellij attach` connects, so tests can exercise "what happens when a human
+/// also attaches" without needing an actual terminal.
+struct SimulatedHuman {
+    os_input: std::sync::Arc<Box<dyn zellij_client::os_input_output::ClientOsApi>>,
+}
+
+impl SimulatedHuman {
+    /// Attach to `session` with the given terminal size and start draining its
+    /// render stream in the background — an attached client that never reads
+    /// its stream stalls the server, the same concern the API's own focus
+    /// client has (see `session_link::spawn_focus_thread`).
+    fn attach(session: &str, rows: usize, cols: usize) -> Self {
+        use zellij_client::os_input_output::get_cli_client_os_input;
+        use zellij_utils::input::cli_assets::CliAssets;
+        use zellij_utils::ipc::{ClientToServerMsg, ServerToClientMsg};
+        use zellij_utils::pane_size::Size;
+
+        let os_input: Box<dyn zellij_client::os_input_output::ClientOsApi> =
+            Box::new(get_cli_client_os_input().expect("could not open client IPC"));
+        os_input.connect_to_server(&zellij_api::session_link::session_socket_path(session));
+
+        let cli_assets = CliAssets {
+            config_file_path: None,
+            config_dir: None,
+            should_ignore_config: false,
+            configuration_options: None,
+            layout: None,
+            terminal_window_size: Size { rows, cols },
+            data_dir: None,
+            is_debug: false,
+            max_panes: None,
+            force_run_layout_commands: false,
+            cwd: None,
+        };
+        os_input.send_to_server(ClientToServerMsg::AttachClient {
+            cli_assets,
+            tab_position_to_focus: None,
+            pane_to_focus: None,
+            is_web_client: false,
+        });
+
+        let os_input: std::sync::Arc<Box<dyn zellij_client::os_input_output::ClientOsApi>> =
+            std::sync::Arc::new(os_input);
+        let reader = os_input.clone();
+        std::thread::spawn(move || loop {
+            match reader.recv_from_server() {
+                Some((ServerToClientMsg::QueryTerminalSize, _)) => {
+                    reader.send_to_server(ClientToServerMsg::TerminalResize {
+                        new_size: Size { rows, cols },
+                    });
+                },
+                Some((ServerToClientMsg::Exit { .. }, _)) | None => break,
+                Some(_) => {},
+            }
+        });
+
+        // Give the server a moment to fully register the attach before the
+        // caller does anything that depends on it (e.g. counts this client as
+        // already present).
+        std::thread::sleep(Duration::from_millis(300));
+
+        SimulatedHuman { os_input }
+    }
+
+    /// Move this client's own focus — mirrors exactly what a real keypress
+    /// (or `session_link::run_as_client`) does: an `Action` sent as a
+    /// non-CLI client is attributed to the client that sent it.
+    ///
+    /// Takes `Arc<Box<dyn ClientOsApi>>` (clone `.connection()` first) rather
+    /// than `&self`, so callers can move it into `spawn_blocking`, whose
+    /// closure must be `'static` and cannot borrow across the await.
+    fn focus_pane_as(
+        connection: &std::sync::Arc<Box<dyn zellij_client::os_input_output::ClientOsApi>>,
+        pane_id: zellij_utils::data::PaneId,
+    ) {
+        use zellij_utils::input::actions::Action;
+        use zellij_utils::ipc::ClientToServerMsg;
+        connection.send_to_server(ClientToServerMsg::Action {
+            action: Action::FocusPaneByPaneId { pane_id },
+            terminal_id: None,
+            client_id: None,
+            is_cli_client: false,
+        });
+    }
+
+    fn connection(&self) -> std::sync::Arc<Box<dyn zellij_client::os_input_output::ClientOsApi>> {
+        self.os_input.clone()
+    }
+}
+
+/// The two bugs this covers, both only visible with a *second* real client
+/// attached alongside the API's own:
+///
+/// 1. Zellij shares one rendered size per tab: the minimum rows and minimum
+///    columns across every client on it. The API's own focus client used to
+///    declare a small fixed size, which clamped a real terminal attached to
+///    the same tab down to that size — visible as a corrupted, doubled render
+///    when the real terminal was actually much bigger.
+/// 2. Unaddressed input used to keep following wherever the API itself had
+///    last set focus, even after a human attached and moved elsewhere by
+///    hand.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn focus_and_size_follow_a_real_client_that_attaches_alongside_the_api() {
+    let Some(binary) = zellij_binary() else {
+        eprintln!("skipping: set ZELLIJ_API_E2E=<path to zellij binary> to run this test");
+        return;
+    };
+
+    let port = PORT + 6;
+    let _server = ServerProcess(
+        Command::new(&binary)
+            .arg("api-server")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--token")
+            .arg(TOKEN)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("could not start the api server"),
+    );
+
+    let mut client = Client::connect_to(port).await;
+    let session = format!("zellij-api-focus-{}", std::process::id());
+    let _guard = SessionGuard {
+        binary: binary.clone(),
+        session: session.clone(),
+    };
+    client
+        .call(json!({"cmd": "session.create", "name": session, "rows": 24, "cols": 80}))
+        .await;
+
+    // Attach a "human" with a real, distinct terminal size *before* any API
+    // command touches this session — so when the API's own focus client
+    // attaches moments later (triggered by the first command below), the
+    // human is already counted and cleanly excluded from "whose id is new".
+    let human = tokio::task::spawn_blocking({
+        let session = session.clone();
+        move || SimulatedHuman::attach(&session, 50, 200)
+    })
+    .await
+    .expect("attaching the simulated human panicked");
+
+    // --- sizing: the tab must render at the human's size, not clamp it -----
+    // `display_area_*` is the raw negotiated client size (the direct output of
+    // the min-across-clients computation this test exists to check);
+    // `viewport_*` is that minus Zellij's own UI chrome (tab bar, status bar),
+    // so it is always a couple of rows smaller and not what this is testing.
+    let tabs = client
+        .call(json!({"cmd": "tab.list", "session": session}))
+        .await;
+    let tab = &tabs["tabs"].as_array().unwrap()[0];
+    assert_eq!(
+        (
+            tab["display_area_rows"].as_u64(),
+            tab["display_area_columns"].as_u64()
+        ),
+        (Some(50), Some(200)),
+        "the tab should render at the real client's size, not be clamped by \
+         the API's own focus client; got {}",
+        tab
+    );
+
+    // --- focus: unaddressed input must follow the human, not stay where the
+    // API last put things --------------------------------------------------
+    let created = client
+        .call(json!({"cmd": "pane.create", "session": session, "name": "second"}))
+        .await;
+    let second_pane = created["pane_id"].as_str().unwrap().to_string();
+    let second_pane_id = zellij_utils::data::PaneId::from_str(&second_pane).unwrap();
+
+    // The API explicitly focuses the *original* pane first — this is what
+    // makes the test meaningful: it pins `last_focused` to a real, different
+    // pane, so "follow the human" and "stay where the API last put things"
+    // give different, checkable answers. Without this the two coincide (the
+    // API never focused anything, so the old code's fallback path can drift
+    // into a right answer by coincidence rather than by tracking the human).
+    let panes = client
+        .call(json!({"cmd": "pane.list", "session": session}))
+        .await;
+    let second_pane_num = match second_pane_id {
+        zellij_utils::data::PaneId::Terminal(id) => id,
+        zellij_utils::data::PaneId::Plugin(id) => id,
+    };
+    let original_pane = panes["panes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|p| p["is_plugin"] == json!(false) && p["id"].as_u64() != Some(second_pane_num as u64))
+        .expect("the session's original pane should still exist")["id"]
+        .as_u64()
+        .unwrap();
+    client
+        .call(json!({
+            "cmd": "pane.focus", "session": session,
+            "pane_id": format!("terminal_{}", original_pane),
+        }))
+        .await;
+
+    // The human moves their own focus by hand — nothing routed through the API.
+    let human_connection = human.connection();
+    tokio::task::spawn_blocking(move || {
+        SimulatedHuman::focus_pane_as(&human_connection, second_pane_id)
+    })
+    .await
+    .expect("focusing as the simulated human panicked");
+
+    // Poll: this is a real, independently-timed state change on the server,
+    // not something the API caused, so there is nothing to await except the
+    // session settling.
+    let mut followed = String::new();
+    for attempt in 0..20 {
+        if attempt > 0 {
+            tokio::time::sleep(Duration::from_millis(150)).await;
+        }
+        let typed = client
+            .call(json!({"cmd": "input.text", "session": session, "text": ""}))
+            .await;
+        followed = typed["pane_id"].as_str().unwrap().to_string();
+        if followed == second_pane {
+            break;
+        }
+    }
+    assert_eq!(
+        followed, second_pane,
+        "unaddressed input should follow the human's live focus, not stay on \
+         wherever the API last set it"
+    );
+
+    let _ = human; // keep alive until here
+    client
+        .call(json!({"cmd": "session.kill", "name": session}))
+        .await;
+}
+
+/// Regression test for a real bug: typing into a session with no other
+/// client attached (the ordinary case for pure API/MCP usage — the API's
+/// own always-attached "focus" client is the only one there) was observed
+/// to duplicate every character on screen (`input.text "A"` → `AA`) when
+/// deployed as a systemd service — never in an ad-hoc foreground process.
+///
+/// This uncovered a real, independent correctness bug along the way, which
+/// this test exercises: `Action::WriteCharsToPaneId`/`WriteToPaneId` sent a
+/// preceding `ScreenInstruction::ClearScroll(client_id)` that resolves a
+/// *client*-relative "active pane" — even though the action already names
+/// an explicit `pane_id` and has no reason to go through client-focus
+/// resolution to find it. Fixed by adding `ClearScrollForPaneId`, which
+/// clears scroll for the pane the write already targets directly, with no
+/// client_id resolution involved — `zellij-server/src/route.rs`'s
+/// `WriteToPaneId`/`WriteCharsToPaneId` arms now use it instead of
+/// `ClearScroll`. Correct either way, but on its own this did **not**
+/// eliminate the character-duplication bug — see
+/// `typing_without_a_term_environment_variable_does_not_duplicate_characters`
+/// below for the actual root cause and fix, found afterward.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn typing_with_no_other_client_attached_does_not_duplicate_characters() {
+    let Some(binary) = zellij_binary() else {
+        eprintln!("skipping: set ZELLIJ_API_E2E=<path to zellij binary> to run this test");
+        return;
+    };
+
+    let port = PORT + 11;
+    let _server = ServerProcess(
+        Command::new(&binary)
+            .arg("api-server")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--token")
+            .arg(TOKEN)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("could not start the api server"),
+    );
+
+    let mut client = Client::connect_to(port).await;
+    let session = format!("zellij-api-no-dup-{}", std::process::id());
+    let _guard = SessionGuard {
+        binary: binary.clone(),
+        session: session.clone(),
+    };
+    client
+        .call(json!({"cmd": "session.create", "name": session, "rows": 24, "cols": 80}))
+        .await;
+    // Give the shell prompt time to fully settle before typing — this
+    // matters: the original bug raced against the shell's own initial
+    // prompt redraw, and typing too soon after creation dodges the race.
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    // Deliberately no SimulatedHuman here — this is the exact condition
+    // that reproduced the bug: only the API's own focus client attached.
+    // A single character, not a word — the original repro used one
+    // character at a time (each `input.text` call races the shell's own
+    // async re-render of what it just echoed, e.g. zsh-syntax-highlighting
+    // recoloring the line); writing multiple characters per call, or many
+    // calls back to back without settling time, didn't reliably reproduce
+    // it, since each character races independently rather than compounding.
+    let reply = client
+        .call(json!({
+            "cmd": "input.text", "session": session, "pane_id": "terminal_0", "text": "Z",
+        }))
+        .await;
+    assert_eq!(reply["bytes"], json!(1), "writing 'Z' should report 1 byte written");
+
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+    client
+        .call(json!({
+            "cmd": "screen.subscribe", "session": session, "pane_ids": ["terminal_0"],
+        }))
+        .await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let snapshot = client
+        .call(json!({"cmd": "screen.snapshot", "session": session, "pane_id": "terminal_0"}))
+        .await;
+    let lines = snapshot["lines"].as_array().cloned().unwrap_or_default();
+    let joined: String = lines
+        .iter()
+        .map(|l| l.as_str().unwrap_or_default())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !joined.contains("ZZ"),
+        "expected a single 'Z' with no duplicated character, got:\n{joined}"
+    );
+
+    client
+        .call(json!({"cmd": "session.kill", "name": session}))
+        .await;
+}
+
+/// Regression test for the actual root cause of the character-duplication
+/// bug: `TERM` was empty in every environment that reproduced it (deployed
+/// as a systemd service — a daemon with no controlling terminal to inherit
+/// `TERM` from) and never reproduced in any environment where `TERM` was
+/// present (an ad-hoc process launched from an interactive shell, which
+/// always has `TERM` set). With `TERM` unset, the spawned shell's syntax
+/// highlighting redraw came back malformed — missing a cursor-repositioning
+/// backspace before the recolored redraw of what it had just echoed — so
+/// applying it landed the colored character in a new cell instead of
+/// overwriting the plain one, producing two visible characters from one
+/// keystroke. Confirmed with instrumented logging against the deployed
+/// service (30/30 reproductions with `TERM` empty; 0/50 across two
+/// independent large batches once fixed), a signal strong enough that no
+/// further theory explained the two states better.
+///
+/// Fixed in `src/commands.rs`'s `start_api_server`: default `TERM` to
+/// `xterm-256color` at startup if empty or unset, the same way tmux/screen
+/// default it for their own panes — every session this server creates is a
+/// fork of this process (`zellij_server::spawn_server`), so whatever `TERM`
+/// this process has at startup is what every pane's shell inherits.
+///
+/// This test reproduces the exact condition directly, with `Command`'s own
+/// `env_remove` rather than relying on the ambient shell (which — as this
+/// investigation discovered the hard way — may or may not have `TERM` set
+/// for reasons entirely outside this test's control, e.g. how the parent
+/// process's own session was activated).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn typing_without_a_term_environment_variable_does_not_duplicate_characters() {
+    let Some(binary) = zellij_binary() else {
+        eprintln!("skipping: set ZELLIJ_API_E2E=<path to zellij binary> to run this test");
+        return;
+    };
+
+    let port = PORT + 13;
+    let _server = ServerProcess(
+        Command::new(&binary)
+            .arg("api-server")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--token")
+            .arg(TOKEN)
+            .env_remove("TERM")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("could not start the api server"),
+    );
+
+    let mut client = Client::connect_to(port).await;
+    let session = format!("zellij-api-no-term-{}", std::process::id());
+    let _guard = SessionGuard {
+        binary: binary.clone(),
+        session: session.clone(),
+    };
+    client
+        .call(json!({"cmd": "session.create", "name": session, "rows": 24, "cols": 80}))
+        .await;
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    let reply = client
+        .call(json!({
+            "cmd": "input.text", "session": session, "pane_id": "terminal_0", "text": "Z",
+        }))
+        .await;
+    assert_eq!(reply["bytes"], json!(1), "writing 'Z' should report 1 byte written");
+
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+    client
+        .call(json!({
+            "cmd": "screen.subscribe", "session": session, "pane_ids": ["terminal_0"],
+        }))
+        .await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let snapshot = client
+        .call(json!({"cmd": "screen.snapshot", "session": session, "pane_id": "terminal_0"}))
+        .await;
+    let lines = snapshot["lines"].as_array().cloned().unwrap_or_default();
+    let joined: String = lines
+        .iter()
+        .map(|l| l.as_str().unwrap_or_default())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !joined.contains("ZZ"),
+        "expected a single 'Z' with no duplicated character even with TERM unset, got:\n{joined}"
+    );
+
+    client
+        .call(json!({"cmd": "session.kill", "name": session}))
+        .await;
+}
+
+#[tokio::test]
+async fn rejects_connections_without_the_token() {
+    let Some(binary) = zellij_binary() else {
+        eprintln!("skipping: set ZELLIJ_API_E2E=<path to zellij binary> to run this test");
+        return;
+    };
+
+    let port = PORT + 1;
+    let _server = ServerProcess(
+        Command::new(&binary)
+            .arg("api-server")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--token")
+            .arg(TOKEN)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("could not start the api server"),
+    );
+
+    // Wait for it to come up.
+    let health = format!("http://127.0.0.1:{}/health", port);
+    for _ in 0..50 {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port)).await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    let _ = health;
+
+    let no_token = format!("ws://127.0.0.1:{}/api", port);
+    assert!(
+        tokio_tungstenite::connect_async(&no_token).await.is_err(),
+        "connecting without a token must be refused"
+    );
+
+    let wrong_token = format!("ws://127.0.0.1:{}/api?token=nope", port);
+    assert!(
+        tokio_tungstenite::connect_async(&wrong_token).await.is_err(),
+        "connecting with the wrong token must be refused"
+    );
+}

--- a/zellij-mcp/Cargo.toml
+++ b/zellij-mcp/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "zellij-mcp"
+version.workspace = true
+edition.workspace = true
+description = "MCP server exposing the Zellij remote-control WebSocket API as tools"
+license.workspace = true
+
+[dependencies]
+rmcp = { version = "3.1", default-features = false, features = [
+  "server",
+  "macros",
+  "schemars",
+  "transport-streamable-http-server",
+] }
+tokio = { workspace = true, features = ["rt-multi-thread", "net", "signal", "macros"] }
+tokio-tungstenite = "0.28"
+futures-util = "0.3"
+axum = { version = "0.8" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+schemars = "1"
+anyhow = { workspace = true }
+log = { workspace = true }
+uuid = { workspace = true }
+clap = { workspace = true }
+
+[[bin]]
+name = "zellij-mcp"
+path = "src/main.rs"
+
+[dev-dependencies]
+rmcp = { version = "3.1", default-features = false, features = [
+  "client",
+  "transport-streamable-http-client-reqwest",
+] }
+tempfile = "3"

--- a/zellij-mcp/src/main.rs
+++ b/zellij-mcp/src/main.rs
@@ -1,0 +1,134 @@
+//! MCP server exposing the Zellij remote-control WebSocket API (`zellij-api`)
+//! as tools an MCP client (an LLM agent) can call — list sessions, attach to
+//! one, drive it, read its screen. See `tools.rs` for the tool surface and
+//! `REMOTE_API.md` at the repository root for the underlying protocol this
+//! wraps.
+//!
+//! This process is a *client* of that WebSocket API, not a reimplementation
+//! of it — it talks to an already-running `zellij api-server` the same way
+//! `zellij-api/examples/drive.rs` does, and adds nothing to the session/pane
+//! control surface itself.
+
+mod tools;
+mod ws_client;
+
+use std::net::{IpAddr, SocketAddr};
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::IntoResponse;
+use clap::Parser;
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
+
+use tools::ZellijTools;
+use ws_client::ApiClient;
+
+/// MCP server exposing Zellij remote-control tools.
+#[derive(Parser, Debug)]
+struct Args {
+    /// Address to bind the MCP server to.
+    #[clap(long, default_value = "127.0.0.1")]
+    bind: String,
+
+    /// Port to listen on.
+    #[clap(short, long, default_value = "8788")]
+    port: u16,
+
+    /// Token MCP clients must present as `Authorization: Bearer <token>`.
+    /// Without it the server is open to anyone who can reach the port.
+    #[clap(long, env = "ZELLIJ_MCP_TOKEN")]
+    token: Option<String>,
+
+    /// WebSocket URL of the underlying zellij-api server this MCP server
+    /// drives.
+    #[clap(long, default_value = "ws://127.0.0.1:8787/api", env = "ZELLIJ_API_URL")]
+    api_url: String,
+
+    /// Token for the underlying zellij-api server.
+    #[clap(long, env = "ZELLIJ_API_TOKEN")]
+    api_token: String,
+}
+
+#[derive(Clone)]
+struct AuthState {
+    token: Option<String>,
+}
+
+/// Constant-time bearer-token check — see `zellij-api`'s `tokens_match` for
+/// why a plain `==` on the presented token would leak timing information
+/// about how much of it was correct.
+fn tokens_match(expected: &str, presented: &str) -> bool {
+    let (expected, presented) = (expected.as_bytes(), presented.as_bytes());
+    if expected.len() != presented.len() {
+        return false;
+    }
+    expected
+        .iter()
+        .zip(presented)
+        .fold(0u8, |differences, (a, b)| differences | (a ^ b))
+        == 0
+}
+
+async fn require_token(
+    State(state): State<AuthState>,
+    headers: HeaderMap,
+    request: axum::extract::Request,
+    next: Next,
+) -> axum::response::Response {
+    let Some(expected) = &state.token else {
+        return next.run(request).await;
+    };
+    let presented = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "));
+    match presented {
+        Some(presented) if tokens_match(expected, presented) => next.run(request).await,
+        _ => (StatusCode::UNAUTHORIZED, "invalid or missing bearer token").into_response(),
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+
+    if args.token.is_none() {
+        eprintln!(
+            "WARNING: starting without a token. Anyone who can reach the MCP port can drive your \
+             Zellij sessions through it."
+        );
+        eprintln!("         Pass --token <secret> (or set ZELLIJ_MCP_TOKEN) to require one.");
+    }
+
+    let api = ApiClient::new(&args.api_url, &args.api_token);
+
+    let session_manager = std::sync::Arc::new(LocalSessionManager::default());
+    let service = StreamableHttpService::new(
+        move || Ok(ZellijTools::new(api.clone())),
+        session_manager,
+        StreamableHttpServerConfig::default(),
+    );
+
+    let auth_state = AuthState { token: args.token };
+    let router = axum::Router::new()
+        .nest_service("/mcp", service)
+        .route_layer(middleware::from_fn_with_state(auth_state, require_token))
+        .route("/health", axum::routing::get(|| async { "ok" }));
+
+    let ip: IpAddr = args
+        .bind
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid --bind address '{}': {}", args.bind, e))?;
+    let addr = SocketAddr::new(ip, args.port);
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    log::info!("zellij mcp server listening on http://{}/mcp", addr);
+
+    axum::serve(listener, router)
+        .with_graceful_shutdown(async {
+            let _ = tokio::signal::ctrl_c().await;
+        })
+        .await?;
+    Ok(())
+}

--- a/zellij-mcp/src/main.rs
+++ b/zellij-mcp/src/main.rs
@@ -43,7 +43,11 @@ struct Args {
 
     /// WebSocket URL of the underlying zellij-api server this MCP server
     /// drives.
-    #[clap(long, default_value = "ws://127.0.0.1:8787/api", env = "ZELLIJ_API_URL")]
+    #[clap(
+        long,
+        default_value = "ws://127.0.0.1:8787/api",
+        env = "ZELLIJ_API_URL"
+    )]
     api_url: String,
 
     /// Token for the underlying zellij-api server.

--- a/zellij-mcp/src/tools.rs
+++ b/zellij-mcp/src/tools.rs
@@ -11,10 +11,9 @@
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{
-    CallToolResult, ContentBlock, Implementation, ProtocolVersion, ServerCapabilities,
-    ServerInfo,
+    CallToolResult, ContentBlock, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo,
 };
-use rmcp::{ErrorData as McpError, ServerHandler, schemars, tool, tool_handler, tool_router};
+use rmcp::{schemars, tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler};
 use serde_json::{json, Value};
 
 use crate::ws_client::ApiClient;
@@ -248,7 +247,8 @@ impl ZellijTools {
         &self,
         Parameters(p): Parameters<SessionNameParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.run(json!({"cmd": "session.kill", "name": p.session})).await
+        self.run(json!({"cmd": "session.kill", "name": p.session}))
+            .await
     }
 
     #[tool(description = "Rename a session.")]
@@ -307,7 +307,9 @@ impl ZellijTools {
                 if is_plugin || suppressed {
                     continue;
                 }
-                let Some(id) = pane["id"].as_u64() else { continue };
+                let Some(id) = pane["id"].as_u64() else {
+                    continue;
+                };
                 let pane_id = format!("terminal_{id}");
                 let command = json!({
                     "cmd": "screen.snapshot", "session": p.session, "pane_id": pane_id,
@@ -351,7 +353,8 @@ impl ZellijTools {
         &self,
         Parameters(p): Parameters<SessionParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.run(json!({"cmd": "tab.list", "session": p.session})).await
+        self.run(json!({"cmd": "tab.list", "session": p.session}))
+            .await
     }
 
     #[tool(description = "Create a new tab in a session.")]
@@ -403,7 +406,8 @@ impl ZellijTools {
         &self,
         Parameters(p): Parameters<SessionParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.run(json!({"cmd": "pane.list", "session": p.session})).await
+        self.run(json!({"cmd": "pane.list", "session": p.session}))
+            .await
     }
 
     #[tool(

--- a/zellij-mcp/src/tools.rs
+++ b/zellij-mcp/src/tools.rs
@@ -1,0 +1,614 @@
+//! MCP tools, one per command in the Zellij remote-control WebSocket API (see
+//! `REMOTE_API.md`). Each tool is a thin translation: build the JSON command,
+//! send it over `ApiClient`, hand the result back as text.
+//!
+//! `attach_session` is the one composite tool — it is what "attach" means for
+//! an MCP caller, which has no terminal to draw into. A human running
+//! `zellij attach` gets oriented by *looking at the screen*; this tool gives
+//! an agent the same orientation in one call: every tab, every pane, and the
+//! current on-screen content of each terminal pane.
+
+use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{
+    CallToolResult, ContentBlock, Implementation, ProtocolVersion, ServerCapabilities,
+    ServerInfo,
+};
+use rmcp::{ErrorData as McpError, ServerHandler, schemars, tool, tool_handler, tool_router};
+use serde_json::{json, Value};
+
+use crate::ws_client::ApiClient;
+
+#[derive(Clone)]
+pub struct ZellijTools {
+    api: ApiClient,
+    tool_router: ToolRouter<ZellijTools>,
+}
+
+fn ok_json(value: Value) -> Result<CallToolResult, McpError> {
+    let text = serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
+    Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
+}
+
+/// A tool-level error: the request was valid and reached the tool, but the
+/// operation it represents failed (the session doesn't exist, the pane is
+/// gone, a bad key name — anything the *caller* got wrong or that failed for
+/// an ordinary reason). Returned as `Ok(CallToolResult::error(...))`, per
+/// rmcp's own guidance on `CallToolResult::error`: MCP clients render this
+/// content back to the model, which is what lets it see the failure and react
+/// — a protocol-level `Err(McpError)` is for when the *server* cannot proceed
+/// at all, not for "this Zellij command failed".
+fn err_result(message: impl Into<String>) -> Result<CallToolResult, McpError> {
+    Ok(CallToolResult::error(vec![ContentBlock::text(
+        message.into(),
+    )]))
+}
+
+// --- parameter types --------------------------------------------------------
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct CreateSessionParams {
+    /// Name for the new session. Omit to get an auto-generated one.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// A built-in layout name, or a path to a layout file.
+    #[serde(default)]
+    pub layout: Option<String>,
+    /// Working directory for the session's initial pane.
+    #[serde(default)]
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub rows: Option<usize>,
+    #[serde(default)]
+    pub cols: Option<usize>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SessionNameParams {
+    pub session: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct RenameSessionParams {
+    pub session: String,
+    pub new_name: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SessionParams {
+    pub session: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct CreateTabParams {
+    pub session: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub cwd: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct TabIdParams {
+    pub session: String,
+    pub tab_id: u64,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct RenameTabParams {
+    pub session: String,
+    pub tab_id: u64,
+    pub name: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct CreatePaneParams {
+    pub session: String,
+    /// A shell command to run in the new pane.
+    #[serde(default)]
+    pub command: Option<String>,
+    /// A plugin URL or alias to run instead of a command (e.g.
+    /// `session-manager`). Give either `command` or `plugin`, not both.
+    #[serde(default)]
+    pub plugin: Option<String>,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub floating: bool,
+    /// `right`, `left`, `up`, or `down`. Not supported for tiled plugin panes.
+    #[serde(default)]
+    pub direction: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Which tab to create the pane in. Defaults to the session's active tab.
+    #[serde(default)]
+    pub tab_id: Option<u64>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct PaneIdParams {
+    pub session: String,
+    pub pane_id: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct RenamePaneParams {
+    pub session: String,
+    pub pane_id: String,
+    pub name: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ResizePaneParams {
+    pub session: String,
+    pub pane_id: String,
+    /// `increase` or `decrease`.
+    pub resize: String,
+    #[serde(default)]
+    pub direction: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SendTextParams {
+    pub session: String,
+    /// Which pane to type into. Omit to target the focused pane.
+    #[serde(default)]
+    pub pane_id: Option<String>,
+    pub text: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SendKeysParams {
+    pub session: String,
+    #[serde(default)]
+    pub pane_id: Option<String>,
+    /// Key names in order, e.g. `["ctrl-c"]`, `["down", "down", "enter"]`,
+    /// `["a"]`. Named keys: enter, tab, esc, space, backspace, delete,
+    /// insert, home, end, pageup, pagedown, up/down/left/right, f1–f12.
+    /// Modifiers: ctrl-, alt-, shift- (combinable: ctrl-alt-c).
+    pub keys: Vec<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SendMouseParams {
+    pub session: String,
+    /// `press`, `release`, or `motion`.
+    pub kind: String,
+    /// Column, 0-based.
+    pub x: u16,
+    /// Row, 0-based.
+    pub y: u16,
+    /// `left`, `right`, `middle`, `wheel_up`, `wheel_down`. Defaults to `left`.
+    #[serde(default)]
+    pub button: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ReadScreenParams {
+    pub session: String,
+    /// Which pane to read. Omit to target the focused pane.
+    #[serde(default)]
+    pub pane_id: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ScreenHistoryParams {
+    pub session: String,
+    /// Which pane's history to read. Omit to target the focused pane.
+    #[serde(default)]
+    pub pane_id: Option<String>,
+    /// Only diffs newer than this version.
+    #[serde(default)]
+    pub since: Option<u64>,
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+// --- tools -------------------------------------------------------------
+
+#[tool_router]
+impl ZellijTools {
+    pub fn new(api: ApiClient) -> Self {
+        Self {
+            api,
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    async fn run(&self, command: Value) -> Result<CallToolResult, McpError> {
+        match self.api.call(command).await {
+            Ok(result) => ok_json(result),
+            Err(e) => err_result(e),
+        }
+    }
+
+    // --- sessions ---------------------------------------------------------
+
+    #[tool(description = "List every Zellij session this API can see, running or resurrectable.")]
+    async fn list_sessions(&self) -> Result<CallToolResult, McpError> {
+        self.run(json!({"cmd": "session.list"})).await
+    }
+
+    #[tool(description = "Create a new detached Zellij session.")]
+    async fn create_session(
+        &self,
+        Parameters(p): Parameters<CreateSessionParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.run(json!({
+            "cmd": "session.create", "name": p.name, "layout": p.layout,
+            "cwd": p.cwd, "rows": p.rows, "cols": p.cols,
+        }))
+        .await
+    }
+
+    #[tool(description = "Kill a session and every pane in it.")]
+    async fn kill_session(
+        &self,
+        Parameters(p): Parameters<SessionNameParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.run(json!({"cmd": "session.kill", "name": p.session})).await
+    }
+
+    #[tool(description = "Rename a session.")]
+    async fn rename_session(
+        &self,
+        Parameters(p): Parameters<RenameSessionParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.run(json!({"cmd": "session.rename", "name": p.session, "new_name": p.new_name}))
+            .await
+    }
+
+    /// The composite "attach" tool: everything a caller needs to get
+    /// oriented in one call, since there is no terminal to draw into.
+    #[tool(
+        description = "Attach to a session: returns its tabs, its panes, and the current on-screen \
+                        content of every terminal pane. This is the tool to call first when picking \
+                        up a session — the MCP equivalent of `zellij attach` for an agent that has no \
+                        screen to look at. Subscribes the session for you if it wasn't already."
+    )]
+    async fn attach_session(
+        &self,
+        Parameters(p): Parameters<SessionParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let tabs = match self
+            .api
+            .call(json!({"cmd": "tab.list", "session": p.session}))
+            .await
+        {
+            Ok(tabs) => tabs,
+            Err(e) => return err_result(e),
+        };
+        let panes = match self
+            .api
+            .call(json!({"cmd": "pane.list", "session": p.session}))
+            .await
+        {
+            Ok(panes) => panes,
+            Err(e) => return err_result(e),
+        };
+
+        // Following every pane is required before any of them can be
+        // snapshotted; already-followed panes are unaffected. This only
+        // requests the subscription — the first render event that actually
+        // populates the snapshot arrives asynchronously afterward, which is
+        // why the snapshot loop below retries rather than reading once.
+        let _ = self
+            .api
+            .call(json!({"cmd": "screen.subscribe", "session": p.session}))
+            .await;
+
+        let mut screens = Vec::new();
+        if let Some(pane_list) = panes["panes"].as_array() {
+            for pane in pane_list {
+                let is_plugin = pane["is_plugin"].as_bool().unwrap_or(false);
+                let suppressed = pane["is_suppressed"].as_bool().unwrap_or(false);
+                if is_plugin || suppressed {
+                    continue;
+                }
+                let Some(id) = pane["id"].as_u64() else { continue };
+                let pane_id = format!("terminal_{id}");
+                let command = json!({
+                    "cmd": "screen.snapshot", "session": p.session, "pane_id": pane_id,
+                });
+                // The subscription's baseline can take a moment to arrive;
+                // a handful of short retries covers that without the tool
+                // call itself hanging noticeably.
+                let mut snapshot = self.api.call(command.clone()).await;
+                for _ in 0..8 {
+                    if snapshot.is_ok() {
+                        break;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    snapshot = self.api.call(command.clone()).await;
+                }
+                match snapshot {
+                    Ok(snapshot) => screens.push(snapshot),
+                    Err(e) => {
+                        // Report the miss in the result itself, not just the
+                        // log — a caller reading `screens` should not have
+                        // fewer entries than `panes` with no way to tell why.
+                        log::warn!("attach_session: could not snapshot {pane_id}: {e}");
+                        screens.push(json!({"pane_id": pane_id, "error": e}));
+                    },
+                }
+            }
+        }
+
+        ok_json(json!({
+            "session": p.session,
+            "tabs": tabs["tabs"],
+            "panes": panes["panes"],
+            "screens": screens,
+        }))
+    }
+
+    // --- tabs ---------------------------------------------------------------
+
+    #[tool(description = "List a session's tabs.")]
+    async fn list_tabs(
+        &self,
+        Parameters(p): Parameters<SessionParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.run(json!({"cmd": "tab.list", "session": p.session})).await
+    }
+
+    #[tool(description = "Create a new tab in a session.")]
+    async fn create_tab(
+        &self,
+        Parameters(p): Parameters<CreateTabParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.run(json!({"cmd": "tab.create", "session": p.session, "name": p.name, "cwd": p.cwd}))
+            .await
+    }
+
+    #[tool(description = "Close a tab by id.")]
+    async fn close_tab(
+        &self,
+        Parameters(p): Parameters<TabIdParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.run(json!({"cmd": "tab.close", "session": p.session, "tab_id": p.tab_id}))
+            .await
+    }
+
+    #[tool(
+        description = "Focus a tab by id — actually moves focus, unlike send_text/send_keys/ \
+                        send_mouse, which only write. Confirmed before returning: fails if it never \
+                        takes."
+    )]
+    async fn focus_tab(
+        &self,
+        Parameters(p): Parameters<TabIdParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.run(json!({"cmd": "tab.focus", "session": p.session, "tab_id": p.tab_id}))
+            .await
+    }
+
+    #[tool(description = "Rename a tab by id.")]
+    async fn rename_tab(
+        &self,
+        Parameters(p): Parameters<RenameTabParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.run(json!({
+            "cmd": "tab.rename", "session": p.session, "tab_id": p.tab_id, "name": p.name,
+        }))
+        .await
+    }
+
+    // --- panes ------------------------------------------------------------
+
+    #[tool(description = "List a session's panes, across every tab.")]
+    async fn list_panes(
+        &self,
+        Parameters(p): Parameters<SessionParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.run(json!({"cmd": "pane.list", "session": p.session})).await
+    }
+
+    #[tool(
+        description = "Create a pane: a shell command, or a plugin (session-manager, about, ...). \
+                        Returns the new pane's id."
+    )]
+    async fn create_pane(
+        &self,
+        Parameters(p): Parameters<CreatePaneParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.run(json!({
+            "cmd": "pane.create", "session": p.session, "command": p.command,
+            "plugin": p.plugin, "args": p.args, "cwd": p.cwd, "floating": p.floating,
+            "direction": p.direction, "name": p.name, "tab_id": p.tab_id,
+        }))
+        .await
+    }
+
+    #[tool(description = "Close a pane by id.")]
+    async fn close_pane(
+        &self,
+        Parameters(p): Parameters<PaneIdParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.run(json!({"cmd": "pane.close", "session": p.session, "pane_id": p.pane_id}))
+            .await
+    }
+
+    #[tool(
+        description = "Focus a pane by id (and its tab) — actually moves focus, unlike \
+                        send_text/send_keys/send_mouse, which only write. Unaddressed input.* then \
+                        targets it, unless a real client has taken focus back."
+    )]
+    async fn focus_pane(
+        &self,
+        Parameters(p): Parameters<PaneIdParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.run(json!({"cmd": "pane.focus", "session": p.session, "pane_id": p.pane_id}))
+            .await
+    }
+
+    #[tool(description = "Rename a pane by id.")]
+    async fn rename_pane(
+        &self,
+        Parameters(p): Parameters<RenamePaneParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.run(json!({
+            "cmd": "pane.rename", "session": p.session, "pane_id": p.pane_id, "name": p.name,
+        }))
+        .await
+    }
+
+    #[tool(description = "Resize a pane: grow or shrink it, optionally in a direction.")]
+    async fn resize_pane(
+        &self,
+        Parameters(p): Parameters<ResizePaneParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.run(json!({
+            "cmd": "pane.resize", "session": p.session, "pane_id": p.pane_id,
+            "resize": p.resize, "direction": p.direction,
+        }))
+        .await
+    }
+
+    // --- input --------------------------------------------------------------
+
+    #[tool(
+        description = "Type text into a pane, as if pasted. Writes bytes only — never changes which \
+                        pane or tab is focused, whether addressed by pane_id or left to default to \
+                        the currently focused pane. Use focus_pane/focus_tab first if you need focus \
+                        itself to move. For an interactive TUI (a plugin pane, or an app driven by \
+                        arrow keys), use send_keys instead — this delivers keystrokes, not pasted text."
+    )]
+    async fn send_text(
+        &self,
+        Parameters(p): Parameters<SendTextParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.run(json!({
+            "cmd": "input.text", "session": p.session, "pane_id": p.pane_id, "text": p.text,
+        }))
+        .await
+    }
+
+    #[tool(
+        description = "Send named keys to a pane in order, e.g. [\"ctrl-c\"] or [\"down\", \"enter\"]. \
+                        Writes bytes only — never changes which pane or tab is focused. Use \
+                        focus_pane/focus_tab first if you need focus itself to move."
+    )]
+    async fn send_keys(
+        &self,
+        Parameters(p): Parameters<SendKeysParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.run(json!({
+            "cmd": "input.keys", "session": p.session, "pane_id": p.pane_id, "keys": p.keys,
+        }))
+        .await
+    }
+
+    #[tool(
+        description = "Send a mouse event at (x, y) — column, row, both 0-based, within the \
+                        session's currently focused tab. Unlike send_text/send_keys there is no \
+                        pane_id to target directly, since a mouse position is inherently relative \
+                        to whatever is currently visible — a click can itself change pane focus or \
+                        selection, the same way it would for a person clicking with a real mouse."
+    )]
+    async fn send_mouse(
+        &self,
+        Parameters(p): Parameters<SendMouseParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.run(json!({
+            "cmd": "input.mouse", "session": p.session, "kind": p.kind,
+            "x": p.x, "y": p.y, "button": p.button,
+        }))
+        .await
+    }
+
+    // --- screen ---------------------------------------------------------------
+
+    #[tool(
+        description = "Read a pane's current on-screen content. Auto-subscribes to it first if it \
+                        was not already followed."
+    )]
+    async fn read_screen(
+        &self,
+        Parameters(p): Parameters<ReadScreenParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let snapshot_command = json!({
+            "cmd": "screen.snapshot", "session": p.session, "pane_id": p.pane_id,
+        });
+        let mut snapshot = self.api.call(snapshot_command.clone()).await;
+        if snapshot.is_err() {
+            // Not yet followed — subscribe, then retry. The subscription's
+            // baseline arrives asynchronously (a render event, not part of
+            // the subscribe reply), so give it a few short beats rather than
+            // trying once and giving up.
+            //
+            // A subscribe failure (e.g. no such pane) is usually more
+            // specific than whatever the snapshot attempt above returned —
+            // surface it directly rather than falling through to a vaguer
+            // "still couldn't snapshot" error.
+            //
+            // With no `pane_id` given, the target is "whichever pane is
+            // focused" — that can only be resolved session-side, so follow
+            // every pane instead of naming one.
+            let subscribe_command = match &p.pane_id {
+                Some(pane_id) => json!({
+                    "cmd": "screen.subscribe", "session": p.session,
+                    "pane_ids": [pane_id],
+                }),
+                None => json!({"cmd": "screen.subscribe", "session": p.session}),
+            };
+            if let Err(e) = self.api.call(subscribe_command).await {
+                return err_result(e);
+            }
+            for _ in 0..8 {
+                snapshot = self.api.call(snapshot_command.clone()).await;
+                if snapshot.is_ok() {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+        }
+        match snapshot {
+            Ok(value) => ok_json(value),
+            Err(e) => err_result(e),
+        }
+    }
+
+    #[tool(
+        description = "A pane's recorded screen changes as git-style unified diffs, oldest first. \
+                        Pass `since` (a version from a previous call) to resume from where you left off."
+    )]
+    async fn screen_history(
+        &self,
+        Parameters(p): Parameters<ScreenHistoryParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.run(json!({
+            "cmd": "screen.history", "session": p.session, "pane_id": p.pane_id,
+            "since": p.since, "limit": p.limit,
+        }))
+        .await
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for ZellijTools {
+    fn get_info(&self) -> ServerInfo {
+        // Not `Implementation::from_build_env()`: that reads `env!()` at the
+        // point it is *defined*, inside rmcp's own source — so it always
+        // reports rmcp's own name and version, not the crate calling it.
+        let server_info = Implementation::new(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))
+            .with_description("Zellij remote-control API exposed as MCP tools");
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(server_info)
+            .with_protocol_version(ProtocolVersion::V_2025_03_26)
+            .with_instructions(
+                "Tools for driving Zellij terminal sessions through the zellij-api WebSocket \
+                 control plane. Call `attach_session` first to see what's on screen — there is no \
+                 real terminal here, so that is how you get oriented. `list_sessions` to see what \
+                 exists, `create_session`/`create_pane` to start something, `send_text`/`send_keys` \
+                 to drive it, `read_screen`/`screen_history` to see what happened. \
+                 `send_text`/`send_keys`/`send_mouse` only write — they never move focus, even when \
+                 addressed to a pane_id in a different tab than the one currently focused. Only \
+                 `focus_pane`/`focus_tab` actually change what's focused; call one of those first if \
+                 focus itself needs to move, not just the pane a write lands in."
+                    .to_string(),
+            )
+    }
+}

--- a/zellij-mcp/src/ws_client.rs
+++ b/zellij-mcp/src/ws_client.rs
@@ -33,13 +33,11 @@ impl ApiClient {
         let id = uuid::Uuid::new_v4().to_string();
         command["id"] = json!(id);
 
-        let (mut socket, _) = tokio::time::timeout(
-            CALL_TIMEOUT,
-            tokio_tungstenite::connect_async(&self.url),
-        )
-        .await
-        .map_err(|_| "timed out connecting to the zellij remote API".to_string())?
-        .map_err(|e| format!("could not connect to the zellij remote API: {e}"))?;
+        let (mut socket, _) =
+            tokio::time::timeout(CALL_TIMEOUT, tokio_tungstenite::connect_async(&self.url))
+                .await
+                .map_err(|_| "timed out connecting to the zellij remote API".to_string())?
+                .map_err(|e| format!("could not connect to the zellij remote API: {e}"))?;
 
         socket
             .send(Message::Text(command.to_string().into()))
@@ -96,9 +94,6 @@ mod tests {
     #[test]
     fn an_existing_query_string_is_extended_not_overwritten() {
         let client = ApiClient::new("ws://127.0.0.1:8787/api?debug=1", "s3cret");
-        assert_eq!(
-            client.url,
-            "ws://127.0.0.1:8787/api?debug=1&token=s3cret"
-        );
+        assert_eq!(client.url, "ws://127.0.0.1:8787/api?debug=1&token=s3cret");
     }
 }

--- a/zellij-mcp/src/ws_client.rs
+++ b/zellij-mcp/src/ws_client.rs
@@ -1,0 +1,104 @@
+//! A minimal client for the Zellij remote-control WebSocket API
+//! (`zellij-api`; see `REMOTE_API.md` at the repository root).
+//!
+//! Opens one connection per call rather than pooling. This is a low-volume,
+//! loopback control plane and tool calls from an MCP client can be minutes
+//! apart — a fresh connection per call means no reconnect logic, no stale
+//! sockets, and nothing that can drift out of sync between calls.
+
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use tokio_tungstenite::tungstenite::Message;
+
+const CALL_TIMEOUT: Duration = Duration::from_secs(15);
+
+#[derive(Clone)]
+pub struct ApiClient {
+    url: String,
+}
+
+impl ApiClient {
+    pub fn new(ws_url: &str, token: &str) -> Self {
+        let separator = if ws_url.contains('?') { "&" } else { "?" };
+        Self {
+            url: format!("{ws_url}{separator}token={token}"),
+        }
+    }
+
+    /// Send one command (a JSON object without `id` — one is added here) and
+    /// return its `result` on success, or the server's error message.
+    pub async fn call(&self, mut command: Value) -> Result<Value, String> {
+        let id = uuid::Uuid::new_v4().to_string();
+        command["id"] = json!(id);
+
+        let (mut socket, _) = tokio::time::timeout(
+            CALL_TIMEOUT,
+            tokio_tungstenite::connect_async(&self.url),
+        )
+        .await
+        .map_err(|_| "timed out connecting to the zellij remote API".to_string())?
+        .map_err(|e| format!("could not connect to the zellij remote API: {e}"))?;
+
+        socket
+            .send(Message::Text(command.to_string().into()))
+            .await
+            .map_err(|e| format!("could not send command: {e}"))?;
+
+        let deadline = tokio::time::Instant::now() + CALL_TIMEOUT;
+        let result = loop {
+            let frame = match tokio::time::timeout_at(deadline, socket.next()).await {
+                Ok(Some(Ok(frame))) => frame,
+                Ok(Some(Err(e))) => break Err(format!("websocket error: {e}")),
+                Ok(None) => break Err("the zellij remote API closed the connection".to_string()),
+                Err(_) => break Err(format!("timed out waiting for a reply to {command}")),
+            };
+            let Message::Text(text) = frame else { continue };
+            let value: Value = match serde_json::from_str(&text) {
+                Ok(value) => value,
+                Err(e) => break Err(format!("the zellij remote API sent invalid JSON: {e}")),
+            };
+            // A fresh, single-purpose connection should only ever see the one
+            // reply it is waiting for — an `event` frame here would mean the
+            // server pushed something unsolicited, which is harmless to skip
+            // rather than treat as fatal.
+            if value.get("event").is_some() {
+                continue;
+            }
+            if value["id"] == json!(id) {
+                break if value["ok"] == json!(true) {
+                    Ok(value["result"].clone())
+                } else {
+                    Err(value["error"]
+                        .as_str()
+                        .unwrap_or("unknown error")
+                        .to_string())
+                };
+            }
+        };
+
+        let _ = socket.close(None).await;
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_is_appended_as_a_query_parameter() {
+        let client = ApiClient::new("ws://127.0.0.1:8787/api", "s3cret");
+        assert_eq!(client.url, "ws://127.0.0.1:8787/api?token=s3cret");
+    }
+
+    #[test]
+    fn an_existing_query_string_is_extended_not_overwritten() {
+        let client = ApiClient::new("ws://127.0.0.1:8787/api?debug=1", "s3cret");
+        assert_eq!(
+            client.url,
+            "ws://127.0.0.1:8787/api?debug=1&token=s3cret"
+        );
+    }
+}

--- a/zellij-mcp/tests/e2e.rs
+++ b/zellij-mcp/tests/e2e.rs
@@ -1,0 +1,517 @@
+//! End-to-end test: a real MCP client (rmcp's own) talks to a real
+//! `zellij-mcp` server, which drives a real `zellij api-server`, which drives
+//! a real Zellij session.
+//!
+//! This crate is a thin translation layer over `zellij-api` — the underlying
+//! session/tab/pane/input logic is already exhaustively tested there. What is
+//! specific to *this* crate, and therefore what this test focuses on, is the
+//! MCP wiring itself: does the tool list come through correctly, does a tool
+//! call actually reach a real session, and does the bearer-token auth work.
+//!
+//! Needs both binaries built:
+//!
+//! ```sh
+//! cargo xtask build          # for target/dev-opt/zellij (zellij-api)
+//! cargo build -p zellij-mcp  # for target/debug/zellij-mcp
+//! ZELLIJ_API_E2E=target/dev-opt/zellij ZELLIJ_MCP_E2E=target/debug/zellij-mcp \
+//!   cargo test -p zellij-mcp --test e2e -- --nocapture
+//! ```
+
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+use rmcp::model::{CallToolRequestParams, ClientCapabilities, ClientInfo, Implementation};
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::ServiceExt;
+
+const API_TOKEN: &str = "e2e-api-secret";
+const MCP_TOKEN: &str = "e2e-mcp-secret";
+const API_PORT: u16 = 8791;
+const MCP_PORT: u16 = 8792;
+
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+struct SessionGuard {
+    binary: String,
+    session: String,
+}
+
+impl Drop for SessionGuard {
+    fn drop(&mut self) {
+        let _ = Command::new(&self.binary)
+            .args(["delete-session", &self.session, "--force"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+}
+
+fn env_binary(var: &str) -> Option<String> {
+    std::env::var(var).ok().filter(|p| {
+        let exists = std::path::Path::new(p).exists();
+        if !exists {
+            eprintln!("{var} points at '{p}', which does not exist");
+        }
+        exists
+    })
+}
+
+/// Starts both servers and returns a connected, initialized MCP client.
+/// Returns `None` (callers should skip) if the required binaries are not set.
+async fn start_stack() -> Option<(
+    ChildGuard,
+    ChildGuard,
+    rmcp::service::RunningService<rmcp::RoleClient, ClientInfo>,
+)> {
+    let zellij_binary = env_binary("ZELLIJ_API_E2E")?;
+    let mcp_binary = env_binary("ZELLIJ_MCP_E2E")?;
+
+    let api_server = ChildGuard(
+        Command::new(&zellij_binary)
+            .arg("api-server")
+            .arg("--port")
+            .arg(API_PORT.to_string())
+            .arg("--token")
+            .arg(API_TOKEN)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("could not start zellij api-server"),
+    );
+
+    let mcp_server = ChildGuard(
+        Command::new(&mcp_binary)
+            .arg("--port")
+            .arg(MCP_PORT.to_string())
+            .arg("--token")
+            .arg(MCP_TOKEN)
+            .arg("--api-url")
+            .arg(format!("ws://127.0.0.1:{API_PORT}/api"))
+            .arg("--api-token")
+            .arg(API_TOKEN)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("could not start zellij-mcp"),
+    );
+
+    // Give both servers a moment to bind their ports.
+    tokio::time::sleep(Duration::from_millis(800)).await;
+
+    let config = StreamableHttpClientTransportConfig::with_uri(format!(
+        "http://127.0.0.1:{MCP_PORT}/mcp"
+    ))
+    .auth_header(MCP_TOKEN);
+    let transport = StreamableHttpClientTransport::from_config(config);
+    let client_info = ClientInfo::new(
+        ClientCapabilities::default(),
+        Implementation::new("zellij-mcp-e2e", "0.0.1"),
+    );
+    let client = client_info
+        .serve(transport)
+        .await
+        .expect("could not connect to the mcp server");
+
+    Some((api_server, mcp_server, client))
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn lists_every_tool() {
+    let Some((_api, _mcp, client)) = start_stack().await else {
+        eprintln!("skipping: set ZELLIJ_API_E2E and ZELLIJ_MCP_E2E to run this test");
+        return;
+    };
+
+    let tools = client
+        .list_all_tools()
+        .await
+        .expect("could not list tools");
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+
+    for expected in [
+        "list_sessions",
+        "create_session",
+        "kill_session",
+        "rename_session",
+        "attach_session",
+        "list_tabs",
+        "create_tab",
+        "focus_tab",
+        "close_tab",
+        "rename_tab",
+        "list_panes",
+        "create_pane",
+        "focus_pane",
+        "close_pane",
+        "rename_pane",
+        "resize_pane",
+        "send_text",
+        "send_keys",
+        "send_mouse",
+        "read_screen",
+        "screen_history",
+    ] {
+        assert!(
+            names.contains(&expected),
+            "missing tool '{expected}', got {names:?}"
+        );
+    }
+
+    client.cancel().await.ok();
+}
+
+/// Every tool that operates on an *existing* session must name that
+/// parameter `session` — the same name every other tool in the surface
+/// uses. `create_session` is the one legitimate exception: its `name` names
+/// the session being brought into existence, not one being looked up.
+///
+/// Regression test for a real inconsistency: `kill_session` and
+/// `rename_session` originally took `name` instead of `session`, so an
+/// agent that had just learned the convention from any of the other 19
+/// tools would get a confusing "missing field `session`" on exactly these
+/// two — undiscoverable without reading the schema for each tool
+/// individually.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn every_tool_names_its_session_parameter_consistently() {
+    let Some((_api, _mcp, client)) = start_stack().await else {
+        eprintln!("skipping: set ZELLIJ_API_E2E and ZELLIJ_MCP_E2E to run this test");
+        return;
+    };
+
+    let tools = client
+        .list_all_tools()
+        .await
+        .expect("could not list tools");
+
+    for tool in &tools {
+        if tool.name == "create_session" || tool.name == "list_sessions" {
+            continue;
+        }
+        let properties = tool
+            .input_schema
+            .get("properties")
+            .and_then(|p| p.as_object());
+        let has_session_field = properties.is_some_and(|p| p.contains_key("session"));
+        assert!(
+            has_session_field,
+            "tool '{}' takes a session but doesn't name the parameter 'session': {:?}",
+            tool.name, tool.input_schema
+        );
+    }
+
+    client.cancel().await.ok();
+}
+
+/// MCP distinguishes two failure modes: a *tool-level* error
+/// (`CallToolResult.is_error = true`, content the calling model can see and
+/// react to) for "the request was valid but the operation failed", versus a
+/// *protocol-level* error (a JSON-RPC `error` object) for "the server cannot
+/// even route this". Every Zellij command failure — a missing session, a bad
+/// key name — is the former: the tool ran, the underlying operation just
+/// didn't succeed. Getting this backwards (returning every failure as a
+/// protocol error) would mean the calling model often never sees why its
+/// request failed, only that something broke.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn business_failures_are_tool_errors_not_protocol_errors() {
+    let Some((_api, _mcp, client)) = start_stack().await else {
+        eprintln!("skipping: set ZELLIJ_API_E2E and ZELLIJ_MCP_E2E to run this test");
+        return;
+    };
+
+    // A well-formed request naming a session that does not exist: the tool
+    // runs, the operation fails. Must come back as a *tool* error.
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("list_tabs").with_arguments(
+                serde_json::json!({"session": "definitely-not-a-real-session"})
+                    .as_object()
+                    .cloned()
+                    .unwrap(),
+            ),
+        )
+        .await
+        .expect("call_tool itself should not fail — the failure belongs in the result");
+    assert_eq!(
+        result.is_error,
+        Some(true),
+        "a missing session should be a tool-level error: {result:?}"
+    );
+    assert!(
+        tool_result_text(&result).contains("not running"),
+        "the error content should explain what went wrong: {result:?}"
+    );
+
+    // A request naming a tool that does not exist at all: the server cannot
+    // route it. This one genuinely is a protocol error.
+    let routing_error = client
+        .call_tool(CallToolRequestParams::new("this_tool_does_not_exist"))
+        .await;
+    assert!(
+        routing_error.is_err(),
+        "an unknown tool name should be a protocol-level error, not a tool result"
+    );
+
+    client.cancel().await.ok();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn drives_a_real_session_end_to_end() {
+    let Some((_api, _mcp, client)) = start_stack().await else {
+        eprintln!("skipping: set ZELLIJ_API_E2E and ZELLIJ_MCP_E2E to run this test");
+        return;
+    };
+
+    let zellij_binary = env_binary("ZELLIJ_API_E2E").unwrap();
+    let session = format!("zellij-mcp-e2e-{}", std::process::id());
+    let _guard = SessionGuard {
+        binary: zellij_binary,
+        session: session.clone(),
+    };
+
+    // --- create_session -----------------------------------------------------
+    let created = client
+        .call_tool(
+            CallToolRequestParams::new("create_session")
+                .with_arguments(
+                    serde_json::json!({"name": session, "rows": 24, "cols": 80})
+                        .as_object()
+                        .cloned()
+                        .unwrap(),
+                ),
+        )
+        .await
+        .expect("create_session failed");
+    assert_ne!(created.is_error, Some(true), "create_session reported an error: {created:?}");
+
+    // --- attach_session: the composite "get oriented" tool ------------------
+    let attached = client
+        .call_tool(
+            CallToolRequestParams::new("attach_session").with_arguments(
+                serde_json::json!({"session": session})
+                    .as_object()
+                    .cloned()
+                    .unwrap(),
+            ),
+        )
+        .await
+        .expect("attach_session failed");
+    assert_ne!(attached.is_error, Some(true), "attach_session reported an error: {attached:?}");
+    let attached_text = tool_result_text(&attached);
+    let attached_json: serde_json::Value =
+        serde_json::from_str(&attached_text).expect("attach_session did not return JSON");
+    assert!(
+        attached_json["tabs"].as_array().is_some_and(|t| !t.is_empty()),
+        "attach_session should report at least one tab: {attached_json}"
+    );
+    assert!(
+        attached_json["screens"].as_array().is_some_and(|s| !s.is_empty()),
+        "attach_session should include at least one screen: {attached_json}"
+    );
+
+    // --- send_text + read_screen: drive it and see what happened ------------
+    let marker = "zellij_mcp_e2e_marker";
+    let typed = client
+        .call_tool(
+            CallToolRequestParams::new("send_text").with_arguments(
+                serde_json::json!({"session": session, "text": format!("echo {marker}\n")})
+                    .as_object()
+                    .cloned()
+                    .unwrap(),
+            ),
+        )
+        .await
+        .expect("send_text failed");
+    assert_ne!(typed.is_error, Some(true), "send_text reported an error: {typed:?}");
+
+    // Poll for the shell to echo and run the command — a fixed sleep here was
+    // flaky under load (render lands asynchronously after the write
+    // completes), so retry instead of gambling on one delay being long enough.
+    let mut screen_text = String::new();
+    for _ in 0..10 {
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        let screen = client
+            .call_tool(
+                CallToolRequestParams::new("read_screen").with_arguments(
+                    serde_json::json!({"session": session, "pane_id": "terminal_0"})
+                        .as_object()
+                        .cloned()
+                        .unwrap(),
+                ),
+            )
+            .await
+            .expect("read_screen failed");
+        assert_ne!(screen.is_error, Some(true), "read_screen reported an error: {screen:?}");
+        screen_text = tool_result_text(&screen);
+        if screen_text.contains(marker) {
+            break;
+        }
+    }
+    assert!(
+        screen_text.contains(marker),
+        "read_screen should show what was typed; got:\n{screen_text}"
+    );
+
+    // --- kill_session ---------------------------------------------------------
+    let killed = client
+        .call_tool(
+            CallToolRequestParams::new("kill_session").with_arguments(
+                serde_json::json!({"session": session}).as_object().cloned().unwrap(),
+            ),
+        )
+        .await
+        .expect("kill_session failed");
+    assert_ne!(killed.is_error, Some(true), "kill_session reported an error: {killed:?}");
+
+    client.cancel().await.ok();
+}
+
+/// `send_text`/`send_keys` default to the focused pane when `pane_id` is
+/// omitted; `read_screen`/`screen_history` originally didn't offer that same
+/// default and required `pane_id` even though there's exactly one sensible
+/// thing "the pane" means with nothing else specified. Regression test for
+/// making them symmetric with the input tools.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn read_screen_and_screen_history_default_to_the_focused_pane() {
+    let Some((_api, _mcp, client)) = start_stack().await else {
+        eprintln!("skipping: set ZELLIJ_API_E2E and ZELLIJ_MCP_E2E to run this test");
+        return;
+    };
+
+    let zellij_binary = env_binary("ZELLIJ_API_E2E").unwrap();
+    let session = format!("zellij-mcp-e2e-focused-pane-{}", std::process::id());
+    let _guard = SessionGuard {
+        binary: zellij_binary,
+        session: session.clone(),
+    };
+
+    let created = client
+        .call_tool(
+            CallToolRequestParams::new("create_session").with_arguments(
+                serde_json::json!({"name": session, "rows": 24, "cols": 80})
+                    .as_object()
+                    .cloned()
+                    .unwrap(),
+            ),
+        )
+        .await
+        .expect("create_session failed");
+    assert_ne!(created.is_error, Some(true), "create_session failed: {created:?}");
+
+    let read_without_pane_id = client
+        .call_tool(
+            CallToolRequestParams::new("read_screen").with_arguments(
+                serde_json::json!({"session": session}).as_object().cloned().unwrap(),
+            ),
+        )
+        .await
+        .expect("read_screen failed");
+    assert_ne!(
+        read_without_pane_id.is_error,
+        Some(true),
+        "read_screen with no pane_id should default to the focused pane, not error: \
+         {read_without_pane_id:?}"
+    );
+
+    let history_without_pane_id = client
+        .call_tool(
+            CallToolRequestParams::new("screen_history").with_arguments(
+                serde_json::json!({"session": session}).as_object().cloned().unwrap(),
+            ),
+        )
+        .await
+        .expect("screen_history failed");
+    assert_ne!(
+        history_without_pane_id.is_error,
+        Some(true),
+        "screen_history with no pane_id should default to the focused pane, not error: \
+         {history_without_pane_id:?}"
+    );
+
+    client
+        .call_tool(
+            CallToolRequestParams::new("kill_session").with_arguments(
+                serde_json::json!({"session": session}).as_object().cloned().unwrap(),
+            ),
+        )
+        .await
+        .ok();
+    client.cancel().await.ok();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn rejects_the_wrong_token() {
+    let Some(zellij_binary) = env_binary("ZELLIJ_API_E2E") else {
+        eprintln!("skipping: set ZELLIJ_API_E2E and ZELLIJ_MCP_E2E to run this test");
+        return;
+    };
+    let Some(mcp_binary) = env_binary("ZELLIJ_MCP_E2E") else {
+        eprintln!("skipping: set ZELLIJ_API_E2E and ZELLIJ_MCP_E2E to run this test");
+        return;
+    };
+
+    let port = MCP_PORT + 1;
+    let api_port = API_PORT + 1;
+    let _api = ChildGuard(
+        Command::new(&zellij_binary)
+            .arg("api-server")
+            .arg("--port")
+            .arg(api_port.to_string())
+            .arg("--token")
+            .arg(API_TOKEN)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("could not start zellij api-server"),
+    );
+    let _mcp = ChildGuard(
+        Command::new(&mcp_binary)
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--token")
+            .arg(MCP_TOKEN)
+            .arg("--api-url")
+            .arg(format!("ws://127.0.0.1:{api_port}/api"))
+            .arg("--api-token")
+            .arg(API_TOKEN)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("could not start zellij-mcp"),
+    );
+    tokio::time::sleep(Duration::from_millis(800)).await;
+
+    let config = StreamableHttpClientTransportConfig::with_uri(format!(
+        "http://127.0.0.1:{port}/mcp"
+    ))
+    .auth_header("not-the-right-token");
+    let transport = StreamableHttpClientTransport::from_config(config);
+    let client_info = ClientInfo::new(
+        ClientCapabilities::default(),
+        Implementation::new("zellij-mcp-e2e", "0.0.1"),
+    );
+    let result = client_info.serve(transport).await;
+    assert!(
+        result.is_err(),
+        "connecting with the wrong bearer token must be refused"
+    );
+}
+
+fn tool_result_text(result: &rmcp::model::CallToolResult) -> String {
+    result
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            rmcp::model::ContentBlock::Text(text) => Some(text.text.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/zellij-mcp/tests/e2e.rs
+++ b/zellij-mcp/tests/e2e.rs
@@ -106,10 +106,9 @@ async fn start_stack() -> Option<(
     // Give both servers a moment to bind their ports.
     tokio::time::sleep(Duration::from_millis(800)).await;
 
-    let config = StreamableHttpClientTransportConfig::with_uri(format!(
-        "http://127.0.0.1:{MCP_PORT}/mcp"
-    ))
-    .auth_header(MCP_TOKEN);
+    let config =
+        StreamableHttpClientTransportConfig::with_uri(format!("http://127.0.0.1:{MCP_PORT}/mcp"))
+            .auth_header(MCP_TOKEN);
     let transport = StreamableHttpClientTransport::from_config(config);
     let client_info = ClientInfo::new(
         ClientCapabilities::default(),
@@ -130,10 +129,7 @@ async fn lists_every_tool() {
         return;
     };
 
-    let tools = client
-        .list_all_tools()
-        .await
-        .expect("could not list tools");
+    let tools = client.list_all_tools().await.expect("could not list tools");
     let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
 
     for expected in [
@@ -186,10 +182,7 @@ async fn every_tool_names_its_session_parameter_consistently() {
         return;
     };
 
-    let tools = client
-        .list_all_tools()
-        .await
-        .expect("could not list tools");
+    let tools = client.list_all_tools().await.expect("could not list tools");
 
     for tool in &tools {
         if tool.name == "create_session" || tool.name == "list_sessions" {
@@ -279,17 +272,20 @@ async fn drives_a_real_session_end_to_end() {
     // --- create_session -----------------------------------------------------
     let created = client
         .call_tool(
-            CallToolRequestParams::new("create_session")
-                .with_arguments(
-                    serde_json::json!({"name": session, "rows": 24, "cols": 80})
-                        .as_object()
-                        .cloned()
-                        .unwrap(),
-                ),
+            CallToolRequestParams::new("create_session").with_arguments(
+                serde_json::json!({"name": session, "rows": 24, "cols": 80})
+                    .as_object()
+                    .cloned()
+                    .unwrap(),
+            ),
         )
         .await
         .expect("create_session failed");
-    assert_ne!(created.is_error, Some(true), "create_session reported an error: {created:?}");
+    assert_ne!(
+        created.is_error,
+        Some(true),
+        "create_session reported an error: {created:?}"
+    );
 
     // --- attach_session: the composite "get oriented" tool ------------------
     let attached = client
@@ -303,16 +299,24 @@ async fn drives_a_real_session_end_to_end() {
         )
         .await
         .expect("attach_session failed");
-    assert_ne!(attached.is_error, Some(true), "attach_session reported an error: {attached:?}");
+    assert_ne!(
+        attached.is_error,
+        Some(true),
+        "attach_session reported an error: {attached:?}"
+    );
     let attached_text = tool_result_text(&attached);
     let attached_json: serde_json::Value =
         serde_json::from_str(&attached_text).expect("attach_session did not return JSON");
     assert!(
-        attached_json["tabs"].as_array().is_some_and(|t| !t.is_empty()),
+        attached_json["tabs"]
+            .as_array()
+            .is_some_and(|t| !t.is_empty()),
         "attach_session should report at least one tab: {attached_json}"
     );
     assert!(
-        attached_json["screens"].as_array().is_some_and(|s| !s.is_empty()),
+        attached_json["screens"]
+            .as_array()
+            .is_some_and(|s| !s.is_empty()),
         "attach_session should include at least one screen: {attached_json}"
     );
 
@@ -329,7 +333,11 @@ async fn drives_a_real_session_end_to_end() {
         )
         .await
         .expect("send_text failed");
-    assert_ne!(typed.is_error, Some(true), "send_text reported an error: {typed:?}");
+    assert_ne!(
+        typed.is_error,
+        Some(true),
+        "send_text reported an error: {typed:?}"
+    );
 
     // Poll for the shell to echo and run the command — a fixed sleep here was
     // flaky under load (render lands asynchronously after the write
@@ -348,7 +356,11 @@ async fn drives_a_real_session_end_to_end() {
             )
             .await
             .expect("read_screen failed");
-        assert_ne!(screen.is_error, Some(true), "read_screen reported an error: {screen:?}");
+        assert_ne!(
+            screen.is_error,
+            Some(true),
+            "read_screen reported an error: {screen:?}"
+        );
         screen_text = tool_result_text(&screen);
         if screen_text.contains(marker) {
             break;
@@ -363,12 +375,19 @@ async fn drives_a_real_session_end_to_end() {
     let killed = client
         .call_tool(
             CallToolRequestParams::new("kill_session").with_arguments(
-                serde_json::json!({"session": session}).as_object().cloned().unwrap(),
+                serde_json::json!({"session": session})
+                    .as_object()
+                    .cloned()
+                    .unwrap(),
             ),
         )
         .await
         .expect("kill_session failed");
-    assert_ne!(killed.is_error, Some(true), "kill_session reported an error: {killed:?}");
+    assert_ne!(
+        killed.is_error,
+        Some(true),
+        "kill_session reported an error: {killed:?}"
+    );
 
     client.cancel().await.ok();
 }
@@ -403,12 +422,19 @@ async fn read_screen_and_screen_history_default_to_the_focused_pane() {
         )
         .await
         .expect("create_session failed");
-    assert_ne!(created.is_error, Some(true), "create_session failed: {created:?}");
+    assert_ne!(
+        created.is_error,
+        Some(true),
+        "create_session failed: {created:?}"
+    );
 
     let read_without_pane_id = client
         .call_tool(
             CallToolRequestParams::new("read_screen").with_arguments(
-                serde_json::json!({"session": session}).as_object().cloned().unwrap(),
+                serde_json::json!({"session": session})
+                    .as_object()
+                    .cloned()
+                    .unwrap(),
             ),
         )
         .await
@@ -423,7 +449,10 @@ async fn read_screen_and_screen_history_default_to_the_focused_pane() {
     let history_without_pane_id = client
         .call_tool(
             CallToolRequestParams::new("screen_history").with_arguments(
-                serde_json::json!({"session": session}).as_object().cloned().unwrap(),
+                serde_json::json!({"session": session})
+                    .as_object()
+                    .cloned()
+                    .unwrap(),
             ),
         )
         .await
@@ -438,7 +467,10 @@ async fn read_screen_and_screen_history_default_to_the_focused_pane() {
     client
         .call_tool(
             CallToolRequestParams::new("kill_session").with_arguments(
-                serde_json::json!({"session": session}).as_object().cloned().unwrap(),
+                serde_json::json!({"session": session})
+                    .as_object()
+                    .cloned()
+                    .unwrap(),
             ),
         )
         .await
@@ -488,10 +520,9 @@ async fn rejects_the_wrong_token() {
     );
     tokio::time::sleep(Duration::from_millis(800)).await;
 
-    let config = StreamableHttpClientTransportConfig::with_uri(format!(
-        "http://127.0.0.1:{port}/mcp"
-    ))
-    .auth_header("not-the-right-token");
+    let config =
+        StreamableHttpClientTransportConfig::with_uri(format!("http://127.0.0.1:{port}/mcp"))
+            .auth_header("not-the-right-token");
     let transport = StreamableHttpClientTransport::from_config(config);
     let client_info = ClientInfo::new(
         ClientCapabilities::default(),

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -295,7 +295,7 @@ pub(crate) fn route_action(
         },
         Action::WriteToPaneId { bytes, pane_id } => {
             senders
-                .send_to_screen(ScreenInstruction::ClearScroll(client_id))
+                .send_to_screen(ScreenInstruction::ClearScrollForPaneId(pane_id.into()))
                 .with_context(err_context)?;
             senders
                 .send_to_screen(ScreenInstruction::WriteToPaneId(
@@ -307,7 +307,7 @@ pub(crate) fn route_action(
         },
         Action::WriteCharsToPaneId { chars, pane_id } => {
             senders
-                .send_to_screen(ScreenInstruction::ClearScroll(client_id))
+                .send_to_screen(ScreenInstruction::ClearScrollForPaneId(pane_id.into()))
                 .with_context(err_context)?;
             let bytes = chars.into_bytes();
             senders

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -435,6 +435,10 @@ pub enum ScreenInstruction {
     HalfPageScrollUp(ClientId, Option<NotificationEnd>),
     HalfPageScrollDown(ClientId, Option<NotificationEnd>),
     ClearScroll(ClientId),
+    /// Same as `ClearScroll`, but for a specific pane rather than whichever
+    /// pane a client_id's focus resolves to — used by pane-id-addressed
+    /// writes, which already know exactly which pane they're targeting.
+    ClearScrollForPaneId(PaneId),
     CloseFocusedPane(ClientId, Option<NotificationEnd>),
     ToggleActiveTerminalFullscreen(ClientId, Option<NotificationEnd>),
     ToggleActiveTerminalNoUiFullscreen(ClientId, Option<NotificationEnd>),
@@ -1010,6 +1014,7 @@ impl From<&ScreenInstruction> for ScreenContext {
             ScreenInstruction::HalfPageScrollUp(..) => ScreenContext::HalfPageScrollUp,
             ScreenInstruction::HalfPageScrollDown(..) => ScreenContext::HalfPageScrollDown,
             ScreenInstruction::ClearScroll(..) => ScreenContext::ClearScroll,
+            ScreenInstruction::ClearScrollForPaneId(..) => ScreenContext::ClearScrollForPaneId,
             ScreenInstruction::CloseFocusedPane(..) => ScreenContext::CloseFocusedPane,
             ScreenInstruction::ToggleActiveTerminalFullscreen(..) => {
                 ScreenContext::ToggleActiveTerminalFullscreen
@@ -8824,6 +8829,16 @@ pub(crate) fn screen_thread_main(
                     |tab: &mut Tab, client_id: ClientId| tab
                         .clear_active_terminal_scroll(client_id), ?
                 );
+                screen.render(None)?;
+            },
+            ScreenInstruction::ClearScrollForPaneId(pane_id) => {
+                let all_tabs = screen.get_tabs_mut();
+                for tab in all_tabs.values_mut() {
+                    if tab.has_pane_with_pid(&pane_id) {
+                        tab.clear_scroll_for_pane_id(pane_id)?;
+                        break;
+                    }
+                }
                 screen.render(None)?;
             },
             ScreenInstruction::CloseFocusedPane(client_id, completion_tx) => {

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -6299,6 +6299,30 @@ impl Tab {
         }
         Ok(())
     }
+    /// Same as `clear_active_terminal_scroll`, but for a specific pane
+    /// rather than whichever pane a client_id's focus happens to resolve
+    /// to. Used by pane-id-addressed writes (`WriteToPaneId`), which
+    /// already know exactly which pane they're targeting and have no
+    /// business going through client-focus resolution to find it.
+    pub fn clear_scroll_for_pane_id(&mut self, pane_id: PaneId) -> Result<()> {
+        let err_context = || format!("failed to clear scroll in pane {pane_id:?}");
+
+        let active_pane = self
+            .floating_panes
+            .get_mut(&pane_id)
+            .or_else(|| self.tiled_panes.get_pane_mut(pane_id))
+            .or_else(|| self.suppressed_panes.get_mut(&pane_id).map(|p| &mut p.1));
+        if let Some(active_pane) = active_pane {
+            active_pane.clear_scroll();
+            if !active_pane.is_scrolled() {
+                if let PaneId::Terminal(raw_fd) = active_pane.pid() {
+                    self.process_pending_vte_events(raw_fd)
+                        .with_context(err_context)?;
+                }
+            }
+        }
+        Ok(())
+    }
 
     pub fn handle_scrollwheel_up(
         &mut self,

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -154,6 +154,26 @@ pub enum Command {
         "zellij [--session <OTHER SESSION NAME>] subscribe [OPTIONS] --pane-id..."
     ))]
     Subscribe(SubscribeCli),
+
+    /// Start the WebSocket remote-control API server
+    #[clap(name = "api-server")]
+    ApiServer(ApiServerCli),
+}
+
+#[derive(Debug, Parser, Clone, Serialize, Deserialize)]
+pub struct ApiServerCli {
+    /// Address to bind the API server to
+    #[clap(long, default_value = "127.0.0.1")]
+    pub bind: String,
+
+    /// Port to listen on
+    #[clap(short, long, default_value = "8787")]
+    pub port: u16,
+
+    /// Require this token as a `?token=` query parameter on connect.
+    /// Without it the API is open to anyone who can reach the port.
+    #[clap(long, env = "ZELLIJ_API_TOKEN")]
+    pub token: Option<String>,
 }
 
 #[derive(Debug, Parser, Clone, Serialize, Deserialize)]

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -278,6 +278,7 @@ pub enum ScreenContext {
     HalfPageScrollUp,
     HalfPageScrollDown,
     ClearScroll,
+    ClearScrollForPaneId,
     CloseFocusedPane,
     ToggleActiveSyncTab,
     ToggleActiveTerminalFullscreen,

--- a/zellij-utils/src/sessions.rs
+++ b/zellij-utils/src/sessions.rs
@@ -530,6 +530,22 @@ pub fn validate_session_name(name: &str) -> Result<(), String> {
     if name.contains('/') {
         return Err("Session name cannot contain '/'.".to_string());
     }
+    // Unix domain socket paths have a hard OS limit (`sockaddr_un.sun_path`).
+    // The interactive CLI checks this once it has a full socket path in hand
+    // (`zellij_client::check_ipc_pipe_length`) and exits cleanly if it's too
+    // long; callers that only ever see the bare name — like this function's
+    // — would otherwise let an overlong name straight through, and the
+    // session server fails silently at `bind()` far downstream, with no
+    // clean error anywhere near the caller.
+    let socket_path_len = crate::consts::ZELLIJ_SOCK_DIR.join(name).as_os_str().len();
+    if socket_path_len >= crate::consts::ZELLIJ_SOCK_MAX_LENGTH {
+        return Err(format!(
+            "session name \"{}\" is too long: the socket path would be {} bytes, over the OS limit of {}",
+            name,
+            socket_path_len,
+            crate::consts::ZELLIJ_SOCK_MAX_LENGTH - 1,
+        ));
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Heads up

This is an unsolicited contribution — I know from CONTRIBUTING.md that large
feature work is normally expected to be pre-discussed against the
[Roadmap](https://zellij.dev/roadmap) before a PR like this lands, and I
didn't do that first. I'm opening it anyway as a concrete suggestion/starting
point for discussion, fully expecting it may not fit your current plans —
please feel free to close or ignore it with no hard feelings if so. Happy to
discuss on Discord/Matrix if there's interest in the direction.

## Summary

Adds a `zellij api-server` subcommand exposing session/tab/pane/input control
over a token-authenticated WebSocket API (new `zellij-api` crate), and a thin
MCP server on top of it (new `zellij-mcp` crate) so an LLM agent (Claude, or
anything else that speaks [MCP](https://modelcontextprotocol.io)) can list,
create, and drive Zellij sessions directly — creating sessions/tabs/panes,
typing into them, reading back what's on screen, and moving focus, all
without a real terminal attached.

Full protocol docs, the tool list, and the deployment model (systemd user
services, two independent auth tokens) are in the two new top-level docs:
- [`REMOTE_API.md`](../REMOTE_API.md) — the WebSocket API itself
- [`MCP.md`](../MCP.md) — the MCP server built on top of it

Built and adversarially tested against real deployed instances (not just unit
tests) over a few days, including concurrent access from a live human client
attached to the same session the API was driving.

### Also included: a few independently-useful correctness fixes

Found while building and testing the above, kept because they're real bugs
regardless of whether the rest of this PR is wanted:

- **`src/commands.rs`**: default `TERM` when unset before spawning the
  server. Daemonized/service-launched processes (no controlling terminal)
  start with `TERM` empty, which every session forked from them then
  inherits — with `TERM` empty, terminal-aware line editors (e.g. zsh's ZLE)
  emit redraws that assume capabilities they never confirmed, causing every
  keystroke sent to the shell to appear doubled. Defaulted to
  `xterm-256color` the way tmux/screen do for their own panes. Only takes
  effect for sessions started via the new `api-server` command, so it's a
  no-op for anyone not using this feature.
- **`zellij-utils/src/sessions.rs`**: `validate_session_name` now rejects
  session names whose Unix domain socket path would exceed
  `ZELLIJ_SOCK_MAX_LENGTH`, instead of the `bind()` call silently failing
  later and the client hanging indefinitely waiting for a server that never
  came up.
- **`zellij-server/src/route.rs`** + **`screen.rs`** + **`tab/mod.rs`**:
  writing to an explicitly-addressed `pane_id` was clearing scroll for the
  *client's currently focused pane* (`ClearScroll(client_id)`) rather than
  the pane actually written to. Added a pane-id-scoped
  `ClearScrollForPaneId` that targets the right pane regardless of what the
  client currently has focused.

Each has a regression test in `zellij-api/tests/e2e.rs`, proven against a
pre-fix binary first per the usual revert-then-retest discipline.

## Testing

- `cargo fmt --check` clean
- `cargo test --workspace` (excluding the two new e2e suites, which need a
  live built binary and are run separately per their own docs) — passing,
  modulo `nested_fullscreen` failures that reproduce identically against a
  clean checkout of `main` in this environment and are unrelated to this
  change
- `zellij-api` and `zellij-mcp` each have their own e2e suite exercising a
  real `zellij api-server` / `zellij-mcp` process end-to-end; instructions in
  their respective docs

## Notes on scope

This is deliberately proposed as one PR covering the whole feature rather
than splitting the bug fixes out, since they were found in service of
building this and are easiest to review with that context. Glad to split
them out into a separate, smaller PR if that's preferred.