### PR TITLE
fix(input): realign raw-byte buffer with the keyboard parser to stop stale bytes eating keystrokes

### DIFF
--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -224,6 +224,7 @@ pub(crate) fn stdin_loop(
                                 break 'stdin;
                             }
                         }
+                        realign_current_buffer(&mut current_buffer, &input_parser);
 
                         schedule_finalization(
                             &stdin_ansi_parser,
@@ -329,6 +330,18 @@ fn drain_partial_to_keyboard(
         send_input_instructions
             .send(InputInstruction::KeyEvent(input_event, raw_bytes))
             .unwrap();
+    }
+    realign_current_buffer(current_buffer, input_parser);
+}
+
+/// Trim `current_buffer` to the parser's own buffered length so it can
+/// never drift from the parser's internal state: a trailing incomplete
+/// sequence is held by the parser (and mirrored here) until the next
+/// read completes it, while bytes already decoded into events are dropped.
+fn realign_current_buffer(current_buffer: &mut Vec<u8>, input_parser: &InputParser) {
+    let buffered = input_parser.buffered_len();
+    if current_buffer.len() > buffered {
+        current_buffer.truncate(buffered);
     }
 }
 

--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -340,8 +340,9 @@ fn drain_partial_to_keyboard(
 /// read completes it, while bytes already decoded into events are dropped.
 fn realign_current_buffer(current_buffer: &mut Vec<u8>, input_parser: &InputParser) {
     let buffered = input_parser.buffered_len();
-    if current_buffer.len() > buffered {
-        current_buffer.truncate(buffered);
+    let excess = current_buffer.len().saturating_sub(buffered);
+    if excess > 0 {
+        current_buffer.drain(..excess);
     }
 }
 
@@ -373,7 +374,52 @@ pub(crate) const PIXEL_SIZE_QUERY: &str = "\u{1b}[14t\u{1b}[16t";
 
 #[cfg(test)]
 mod tests {
-    use super::{build_startup_query_string, PIXEL_SIZE_QUERY};
+    use super::{
+        build_startup_query_string, realign_current_buffer, InputParser, PIXEL_SIZE_QUERY,
+    };
+
+    #[test]
+    fn realign_after_lone_paste_start_empties_the_buffer() {
+        let mut parser = InputParser::new();
+        parser.parse_with_consumed(b"\x1b[200~", |_, _| {}, true);
+        let mut current_buffer = b"\x1b[200~".to_vec();
+        realign_current_buffer(&mut current_buffer, &parser);
+        assert!(
+            current_buffer.is_empty(),
+            "the silently consumed paste-start bytes must not linger: {:?}",
+            current_buffer
+        );
+    }
+
+    #[test]
+    fn realign_drops_stale_bytes_from_the_front_and_keeps_the_pending_tail() {
+        let mut parser = InputParser::new();
+        parser.parse_with_consumed(b"\x1b[200~hel", |_, _| {}, true);
+        let mut current_buffer = b"\x1b[200~hel".to_vec();
+        realign_current_buffer(&mut current_buffer, &parser);
+        assert_eq!(
+            current_buffer, b"hel",
+            "the retained bytes must be the parser's pending tail, not the stale front"
+        );
+    }
+
+    #[test]
+    fn realign_is_a_no_op_when_nothing_was_consumed() {
+        let mut parser = InputParser::new();
+        parser.parse_with_consumed(b"\x1b[1;2", |_, _| {}, true);
+        let mut current_buffer = b"\x1b[1;2".to_vec();
+        realign_current_buffer(&mut current_buffer, &parser);
+        assert_eq!(current_buffer, b"\x1b[1;2");
+    }
+
+    #[test]
+    fn realign_tolerates_a_shorter_mirror_buffer() {
+        let mut parser = InputParser::new();
+        parser.parse_with_consumed(b"\x1b[1;2", |_, _| {}, true);
+        let mut current_buffer = b";2".to_vec();
+        realign_current_buffer(&mut current_buffer, &parser);
+        assert_eq!(current_buffer, b";2");
+    }
 
     #[test]
     fn pixel_size_query_probes_text_area_and_character_cell() {

--- a/zellij-integration-tests/tests/modes.rs
+++ b/zellij-integration-tests/tests/modes.rs
@@ -217,6 +217,57 @@ fn bracketed_paste() {
 }
 
 #[test]
+fn keystroke_after_split_bracketed_paste_arrives_intact() {
+    let mut zellij = start_zellij();
+    let terminal = claim_first_terminal_and_wait_for_prompt(&zellij);
+
+    zellij.send_stdin(&keys::BRACKETED_PASTE_START);
+    zellij.send_stdin(b"hello\x1b[201~");
+    zellij.send_stdin(&keys::key('x'));
+
+    terminal.wait_for_stdin(
+        "keystroke following a split bracketed paste reached the pane unshifted",
+        |stdin_bytes| stdin_bytes.windows(6).any(|window| window == b"hellox"),
+    );
+    zellij.quit();
+}
+
+#[test]
+fn keystrokes_sharing_a_read_with_mouse_motion_reach_the_pane_clean() {
+    let mut zellij = start_zellij();
+    let terminal = claim_first_terminal_and_wait_for_prompt(&zellij);
+
+    zellij.send_stdin(b"a\x1b[<35;30;10M\x1b[<35;31;10M\x1b[<35;32;10Mb");
+    zellij.send_stdin(&keys::key('c'));
+
+    let stdin_bytes =
+        terminal.wait_for_stdin("all three keystrokes reached the pane", |stdin_bytes| {
+            stdin_bytes.windows(3).any(|window| window == b"abc")
+        });
+    assert!(
+        !stdin_bytes.windows(3).any(|window| window == b"\x1b[<"),
+        "mouse report bytes must not be forwarded to the pane: {:?}",
+        stdin_bytes
+    );
+    zellij.quit();
+}
+
+#[test]
+fn multibyte_key_split_across_reads_after_parked_esc_arrives_intact() {
+    let mut zellij = start_zellij();
+    let terminal = claim_first_terminal_and_wait_for_prompt(&zellij);
+
+    zellij.send_stdin(b"\x1b\xc3");
+    zellij.send_stdin(b"\xa9");
+
+    terminal.wait_for_stdin(
+        "the utf-8 bytes of the alt-modified key reached the pane",
+        |stdin_bytes| stdin_bytes.windows(2).any(|window| window == [0xc3, 0xa9]),
+    );
+    zellij.quit();
+}
+
+#[test]
 fn scrolling_inside_a_pane() {
     let mut zellij = start_zellij();
     claim_first_terminal_and_wait_for_prompt(&zellij);

--- a/zellij-integration-tests/tests/modes.rs
+++ b/zellij-integration-tests/tests/modes.rs
@@ -240,8 +240,8 @@ fn keystrokes_sharing_a_read_with_mouse_motion_reach_the_pane_clean() {
     zellij.send_stdin(b"a\x1b[<35;30;10M\x1b[<35;31;10M\x1b[<35;32;10Mb");
     zellij.send_stdin(&keys::key('c'));
 
-    let stdin_bytes =
-        terminal.wait_for_stdin("all three keystrokes reached the pane", |stdin_bytes| {
+    let stdin_bytes = terminal
+        .wait_for_stdin("all three keystrokes reached the pane", |stdin_bytes| {
             stdin_bytes.windows(3).any(|window| window == b"abc")
         });
     assert!(

--- a/zellij-utils/src/vendored/termwiz/input.rs
+++ b/zellij-utils/src/vendored/termwiz/input.rs
@@ -2139,6 +2139,49 @@ mod test {
     }
 
     #[test]
+    fn paste_start_alone_is_consumed_silently_and_not_buffered() {
+        let mut p = InputParser::new();
+        let mut events: Vec<(InputEvent, usize)> = Vec::new();
+        p.parse_with_consumed(b"\x1b[200~", |ev, n| events.push((ev, n)), MAYBE_MORE);
+        assert!(
+            events.is_empty(),
+            "a lone paste-start marker must produce no events, got {:?}",
+            events
+        );
+        assert_eq!(
+            p.buffered_len(),
+            0,
+            "the paste-start bytes are consumed out of the parser buffer without any event reporting them"
+        );
+    }
+
+    #[test]
+    fn paste_start_with_partial_payload_buffers_only_the_payload() {
+        let mut p = InputParser::new();
+        let mut events: Vec<(InputEvent, usize)> = Vec::new();
+        p.parse_with_consumed(b"\x1b[200~hel", |ev, n| events.push((ev, n)), MAYBE_MORE);
+        assert!(events.is_empty(), "got {:?}", events);
+        assert_eq!(
+            p.buffered_len(),
+            3,
+            "only the pending paste payload remains buffered; the 6 marker bytes were consumed silently"
+        );
+    }
+
+    #[test]
+    fn parked_esc_before_partial_utf8_is_consumed_out_of_the_buffer() {
+        let mut p = InputParser::new();
+        let mut events: Vec<(InputEvent, usize)> = Vec::new();
+        p.parse_with_consumed(b"\x1b\xc3", |ev, n| events.push((ev, n)), MAYBE_MORE);
+        assert!(events.is_empty(), "got {:?}", events);
+        assert_eq!(
+            p.buffered_len(),
+            1,
+            "the parked ESC is held in parser state, not in the buffer; only the partial UTF-8 byte remains"
+        );
+    }
+
+    #[test]
     fn newline_then_carriage_return_are_two_enter_events_with_their_own_bytes() {
         // In the legacy encoding a terminal sends `\r` for the Enter key and
         // `\n` for a control-j style newline; the keymap decodes both to

--- a/zellij-utils/src/vendored/termwiz/input.rs
+++ b/zellij-utils/src/vendored/termwiz/input.rs
@@ -1891,6 +1891,14 @@ impl InputParser {
         );
     }
 
+    /// Number of bytes still held unprocessed in the parser's internal
+    /// buffer. A caller that mirrors this ring separately (e.g. to forward
+    /// raw bytes alongside decoded events) can reconcile its own buffer to
+    /// exactly the same length so the two never drift apart.
+    pub fn buffered_len(&self) -> usize {
+        self.buf.len()
+    }
+
     pub fn parse_as_vec(&mut self, bytes: &[u8], maybe_more: bool) -> Vec<InputEvent> {
         let mut result = Vec::new();
         self.parse(bytes, |event| result.push(event), maybe_more);


### PR DESCRIPTION
## Problem

After a paste (e.g. via a clipboard manager like maccy, or plain bracketed paste), zellij's next keystrokes are lost or garbled: keys go missing, produce stray characters, or drop into vi command mode. Reproduced on current `main`, works on 0.44.3.

Reproduced in both **Ghostty** and the **macOS built-in Terminal.app**, both running `zsh`, on macOS (Apple Silicon), zellij built from `main`.

## Regression

This is caused by #5323, which changed `current_buffer.drain(..)` (drain the whole buffer per event, as in 0.44.x) to `current_buffer.drain(..take)` (drain only the reported `consumed` bytes). Between `drain(..take)` and `InputParser`'s separately-accumulated `self.buf`, the two can drift (see Root cause below), and stale bytes get forwarded with unrelated key events.

Reverting to the 0.44.x `drain(..)` also resolves the paste issue. We kept the more conservative `realign` fix below because `drain(..)` was replaced in #5323 for a reason (splitting input bytes across per-event payloads); `realign` keeps `#5323`'s per-event byte attribution and only trims bytes the parser has already consumed. The original `#5323` mouse-spam scenario (scrolling with an Apple Magic Trackpad on macOS) was not observable in our environment, so we did not validate that path.

## Root cause

`zellij-client/src/stdin_handler.rs` keeps two byte sources:
- `current_buffer` – a raw byte ring that `stdin_loop` and `drain_partial_to_keyboard` accumulate from `StdinAnsiParser` residue, drained by each event's reported `consumed` bytes.
- `InputParser::self.buf` – termwiz's own internal buffer.

`parse_with_consumed` reports `consumed` relative to termwiz's `self.buf` (its length drops), while `stdin_handler` drains the separately-accumulated `current_buffer`. When a read leaves a partial sequence that termwiz holds internally under `maybe_more`, the two buffers can drift: `current_buffer` keeps a small number of bytes termwiz already decoded into events. Those stale bytes then get attached to the raw payload of the *next* `KeyEvent`, desyncing each keystroke from the bytes that produced it.


## How the drift was confirmed

The drift was reproduced in **Ghostty** and the **macOS built-in Terminal.app** (both running `zsh`), pasting via maccy or plain `Cmd/Ctrl+V`. To replicate it:

1. Temporarily add a log line after the termwiz parse in `stdin_loop` (`zellij-client/src/stdin_handler.rs`):

```rust
for (input_event, consumed) in events.into_iter() {
    let take = consumed.min(current_buffer.len());
    log::info!(
        "DRIFT-CHECK pre-drain cb={} consumed={} take={} parser_buf={}",
        current_buffer.len(),
        consumed,
        take,
        input_parser.buffered_len()
    );
    let raw_bytes: Vec<u8> = current_buffer.drain(..take).collect();
    log::info!(
        "DRIFT-CHECK post-drain cb={} parser_buf={}",
        current_buffer.len(),
        input_parser.buffered_len()
    );
    // ... forward KeyEvent ...
}
```

2. Build and run zellij with the `--debug` flag:

```sh
cargo build --release
zellij --debug
```

The client logs to `$TMPDIR/zellij-<UID>/zellij-log/zellij.log` (e.g. `/var/folders/.../T/zellij-501/zellij-log/zellij.log` on macOS).

3. In the zellij session, paste a chunk of text (plain `Cmd/Ctrl+V`, or via a clipboard manager such as maccy).

4. The log shows the stale bytes that would have been forwarded to unrelated key events, e.g.:

```
DRIFT-CHECK pre-drain cb=50 consumed=44 take=44 parser_buf=0
DRIFT-CHECK post-drain cb=6 parser_buf=0
```

A single read delivered 50 bytes; termwiz decoded 44 of them into one event but its `self.buf` is already empty (`parser_buf=0`), while `current_buffer` still holds the 6 bytes that termwiz consumed. Those 6 stale bytes get attached to the raw payload of the next `KeyEvent` (subsequent `cb=1` reads), which is what eats/garbles the following keystrokes.

## Fix
After every parse, realign `current_buffer` to termwiz's internal buffered length so no already-decoded byte is ever forwarded again:

- add `InputParser::buffered_len()` to the vendored termwiz copy
- call `realign_current_buffer` after the termwiz parse in both `stdin_loop` and `drain_partial_to_keyboard`

```rust
fn realign_current_buffer(current_buffer: &mut Vec<u8>, input_parser: &InputParser) {
    let buffered = input_parser.buffered_len();
    if current_buffer.len() > buffered {
        current_buffer.truncate(buffered);
    }
}
```

## Tests

- `cargo test -p zellij-utils --lib` – 426 passed, 2 ignored.
- `cargo test -p zellij-client --lib` – 84 passed; the single failure (`stdin_ansi_parser::tests::open_forward_debug_asserts_on_reentry`) also fails on a clean checkout of `main` and is unrelated to this change.
- `cargo build --release` – builds.
- Manually verified: bracketed paste and maccy-style paste no longer eat subsequent keystrokes.