### PR TITLE
NestedListItem: forward the remaining Text methods

### DIFF
--- a/zellij-tile/src/ui_components/nested_list.rs
+++ b/zellij-tile/src/ui_components/nested_list.rs
@@ -90,6 +90,82 @@ impl NestedListItem {
         self.content = self.content.success_color_all();
         self
     }
+    pub fn success_color_last_substring<S: AsRef<str>>(mut self, substr: S) -> Self {
+        self.content = self.content.success_color_last_substring(substr);
+        self
+    }
+    pub fn error_color_last_substring<S: AsRef<str>>(mut self, substr: S) -> Self {
+        self.content = self.content.error_color_last_substring(substr);
+        self
+    }
+    pub fn color_all(mut self, index_level: usize) -> Self {
+        self.content = self.content.color_all(index_level);
+        self
+    }
+    pub fn color_substring<S: AsRef<str>>(mut self, index_level: usize, substr: S) -> Self {
+        self.content = self.content.color_substring(index_level, substr);
+        self
+    }
+    pub fn color_nth_substring<S: AsRef<str>>(
+        mut self,
+        index_level: usize,
+        substr: S,
+        occurrence_index: usize,
+    ) -> Self {
+        self.content = self
+            .content
+            .color_nth_substring(index_level, substr, occurrence_index);
+        self
+    }
+    pub fn color_last_substring<S: AsRef<str>>(mut self, index_level: usize, substr: S) -> Self {
+        self.content = self.content.color_last_substring(index_level, substr);
+        self
+    }
+    pub fn dim_all(mut self) -> Self {
+        self.content = self.content.dim_all();
+        self
+    }
+    pub fn dim_indices(mut self, indices: Vec<usize>) -> Self {
+        self.content = self.content.dim_indices(indices);
+        self
+    }
+    pub fn dim_range<R: RangeBounds<usize>>(mut self, indices: R) -> Self {
+        self.content = self.content.dim_range(indices);
+        self
+    }
+    pub fn dim_substring<S: AsRef<str>>(mut self, substr: S) -> Self {
+        self.content = self.content.dim_substring(substr);
+        self
+    }
+    pub fn unbold_all(mut self) -> Self {
+        self.content = self.content.unbold_all();
+        self
+    }
+    pub fn unbold_indices(mut self, indices: Vec<usize>) -> Self {
+        self.content = self.content.unbold_indices(indices);
+        self
+    }
+    pub fn unbold_range<R: RangeBounds<usize>>(mut self, indices: R) -> Self {
+        self.content = self.content.unbold_range(indices);
+        self
+    }
+    pub fn unbold_substring<S: AsRef<str>>(mut self, substr: S) -> Self {
+        self.content = self.content.unbold_substring(substr);
+        self
+    }
+    pub fn disabled(mut self) -> Self {
+        self.content = self.content.disabled();
+        self
+    }
+    pub fn content(&self) -> &str {
+        self.content.content()
+    }
+    pub fn len(&self) -> usize {
+        self.content.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.content.len() == 0
+    }
     pub fn serialize(&self) -> String {
         let mut serialized = String::new();
         for _ in 0..self.indentation_level {


### PR DESCRIPTION
Fixes #5411

`NestedListItem` wraps `Text` and forwards its builders one at a time, so a method that was never forwarded does not exist on it. `color_substring` is one of seventeen in that state, which is why its `success_` and `error_` variants are there and it is not.

Diffing the public API of the two files: `Text` has 37 public methods, `NestedListItem` had 21, and four of the difference are the free print/serialize functions that have their own nested-list counterparts. The rest:

```
color_all              dim_all           unbold_all        content
color_substring        dim_indices       unbold_indices    len
color_nth_substring    dim_range         unbold_range
color_last_substring   dim_substring     unbold_substring
success_color_last_substring   error_color_last_substring   disabled
```

All seventeen forwarded here, in the same one-line style as the existing ones. Added `is_empty` next to `len` since clippy asks for the pair.

Nothing else in the type changes: `indent` stays its only own behaviour, and `Ribbon` needs no equivalent work -- `print_ribbon` takes a `Text` directly, so the asymmetry was only here.

`cargo build`, `cargo test -p zellij-tile` and `cargo fmt --check` pass. `cargo clippy` reports the same single pre-existing warning on this file before and after.
