### PR TITLE
fix(grid): preserve scroll regions across CSI 2J and alt-screen changes

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -4387,7 +4387,6 @@ impl Perform for Grid {
                 } else if clear_type == 1 {
                     self.clear_all_before_cursor(char_to_replace);
                 } else if clear_type == 2 {
-                    self.set_scroll_region_to_viewport_size();
                     self.fill_viewport(char_to_replace);
                     if let Some(images_to_reap) = self.sixel_grid.clear() {
                         self.sixel_grid.reap_images(images_to_reap);
@@ -4436,9 +4435,14 @@ impl Perform for Grid {
                             self.bracketed_paste_mode = false;
                         },
                         1049 => {
+                            let mut main_screen_scroll_region = None;
                             if let Some(mut alternate_screen_state) =
                                 self.alternate_screen_state.take()
                             {
+                                main_screen_scroll_region = Some((
+                                    alternate_screen_state.scroll_region,
+                                    alternate_screen_state.screen_height,
+                                ));
                                 if let Some(image_ids_to_reap) = self.sixel_grid.clear() {
                                     // reap images before dropping the alternate_screen_state contents
                                     // - we can't implement a drop method for this because the store is
@@ -4458,6 +4462,23 @@ impl Perform for Grid {
                             self.alternate_screen_state = None;
                             self.clear_viewport_before_rendering = true;
                             self.force_change_size(self.height, self.width); // the alternative_viewport might have been of a different size...
+                            if let Some(((saved_top, saved_bottom), saved_height)) =
+                                main_screen_scroll_region
+                            {
+                                let saved_viewport_bottom = saved_height.saturating_sub(1);
+                                let saved_bottom_margin =
+                                    saved_viewport_bottom.saturating_sub(saved_bottom);
+                                let current_viewport_bottom = self.height.saturating_sub(1);
+                                if current_viewport_bottom == 0 {
+                                    self.scroll_region = (0, 0);
+                                } else {
+                                    let restored_bottom = current_viewport_bottom
+                                        .saturating_sub(saved_bottom_margin)
+                                        .max(1);
+                                    let restored_top = saved_top.min(restored_bottom - 1);
+                                    self.scroll_region = (restored_top, restored_bottom);
+                                }
+                            }
                             self.mark_for_rerender();
                         },
                         25 => {
@@ -4569,6 +4590,8 @@ impl Perform for Grid {
                                 current_lines_above,
                                 current_viewport,
                                 current_cursor,
+                                self.scroll_region,
+                                self.height,
                                 alternate_sixelgrid,
                                 alternate_kittygrid,
                                 current_supports_kitty_keyboard_protocol,
@@ -5096,6 +5119,8 @@ pub struct AlternateScreenState {
     lines_above: VecDeque<Row>,
     viewport: VecDeque<Row>,
     cursor: Cursor,
+    scroll_region: (usize, usize),
+    screen_height: usize,
     sixel_grid: SixelGrid,
     kitty_grid: KittyGrid,
     supports_kitty_keyboard_protocol: bool,
@@ -5105,6 +5130,8 @@ impl AlternateScreenState {
         lines_above: VecDeque<Row>,
         viewport: VecDeque<Row>,
         cursor: Cursor,
+        scroll_region: (usize, usize),
+        screen_height: usize,
         sixel_grid: SixelGrid,
         kitty_grid: KittyGrid,
         supports_kitty_keyboard_protocol: bool,
@@ -5113,6 +5140,8 @@ impl AlternateScreenState {
             lines_above,
             viewport,
             cursor,
+            scroll_region,
+            screen_height,
             sixel_grid,
             kitty_grid,
             supports_kitty_keyboard_protocol,

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -2126,6 +2126,63 @@ pub fn clear_scroll_region() {
 }
 
 #[test]
+fn erase_display_preserves_scroll_region() {
+    let mut grid = create_grid_with_content("\u{1b}[1;19r");
+    assert_eq!(grid.scroll_region, (0, 18));
+
+    // ED 2 clears the display without changing the DECSTBM scroll region.
+    let mut vte_parser = vte::Parser::new();
+    vte_parser.advance(&mut grid, "\u{1b}[2J".as_bytes());
+
+    assert_eq!(grid.scroll_region, (0, 18));
+}
+
+#[test]
+fn alternate_screen_restores_main_screen_scroll_region() {
+    let mut grid = create_grid_with_content("\u{1b}[1;19r");
+    let mut vte_parser = vte::Parser::new();
+
+    assert_eq!(grid.scroll_region, (0, 18));
+
+    vte_parser.advance(&mut grid, b"\x1b[?1049h");
+    vte_parser.advance(&mut grid, b"\x1b[?1049l");
+
+    assert_eq!(grid.scroll_region, (0, 18));
+}
+
+#[test]
+fn alternate_screen_restores_scroll_region_after_shrinking() {
+    let mut grid = create_grid_with_content("\u{1b}[1;19r");
+    let mut vte_parser = vte::Parser::new();
+
+    assert_eq!(grid.scroll_region, (0, 18));
+
+    vte_parser.advance(&mut grid, b"\x1b[?1049h");
+
+    grid.change_size(10, 20);
+
+    vte_parser.advance(&mut grid, b"\x1b[?1049l");
+
+    assert_eq!(grid.scroll_region, (0, 8));
+}
+
+#[test]
+fn alternate_screen_restores_scroll_region_after_growing() {
+    let mut grid = create_grid_with_content("\u{1b}[1;19r");
+    let mut vte_parser = vte::Parser::new();
+
+    assert_eq!(grid.scroll_region, (0, 18));
+
+    vte_parser.advance(&mut grid, b"\x1b[?1049h");
+
+    grid.change_size(30, 20);
+
+    vte_parser.advance(&mut grid, b"\x1b[?1049l");
+
+    assert_eq!(grid.scroll_region, (0, 28));
+}
+
+#[test]
 pub fn display_tab_characters_properly() {
     let mut vte_parser = vte::Parser::new();
     let sixel_image_store = Rc::new(RefCell::new(SixelImageStore::default()));

--- a/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__vttest2_6.snap
+++ b/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__vttest2_6.snap
@@ -2,44 +2,44 @@
 source: zellij-server/src/panes/./unit/grid_tests.rs
 expression: "format!(\"{:?}\", grid)"
 ---
-00 (C): Push <RETURN>
-01 (C): Soft scroll down region [12..13] size 2 Line 29
-02 (C): Soft scroll down region [12..13] size 2 Line 28
-03 (C): Soft scroll down region [12..13] size 2 Line 27
-04 (C): Soft scroll down region [12..13] size 2 Line 26
-05 (C): Soft scroll down region [12..13] size 2 Line 25
-06 (C): Soft scroll down region [12..13] size 2 Line 24
-07 (C): Soft scroll down region [12..13] size 2 Line 23
-08 (C): Soft scroll down region [12..13] size 2 Line 22
-09 (C): Soft scroll down region [12..13] size 2 Line 21
-10 (C): Soft scroll down region [12..13] size 2 Line 20
-11 (C): Soft scroll down region [12..13] size 2 Line 19
-12 (C): Soft scroll down region [12..13] size 2 Line 18
-13 (C): Soft scroll down region [12..13] size 2 Line 17                                                               
-14 (C): Soft scroll down region [12..13] size 2 Line 16                                                               
-15 (C): Soft scroll down region [12..13] size 2 Line 15                                                               
-16 (C): Soft scroll down region [12..13] size 2 Line 14                                                               
-17 (C): Soft scroll down region [12..13] size 2 Line 13                                                               
-18 (C): Soft scroll down region [12..13] size 2 Line 12                                                               
-19 (C): Soft scroll down region [12..13] size 2 Line 11                                                               
-20 (C): Soft scroll down region [12..13] size 2 Line 10                                                               
-21 (C): Soft scroll down region [12..13] size 2 Line 9                                                                
-22 (C): Soft scroll down region [12..13] size 2 Line 8                                                                
-23 (C): Soft scroll down region [12..13] size 2 Line 7                                                                
-24 (C): Soft scroll down region [12..13] size 2 Line 6                                                                
-25 (C): Soft scroll down region [12..13] size 2 Line 5                                                                
-26 (C): Soft scroll down region [12..13] size 2 Line 4                                                                
-27 (C): Soft scroll down region [12..13] size 2 Line 3                                                                
-28 (C): Soft scroll down region [12..13] size 2 Line 2                                                                
-29 (C): Soft scroll down region [12..13] size 2 Line 1                                                                
-30 (C): Soft scroll up region [12..13] size 2 Line 7
-31 (C): Soft scroll up region [12..13] size 2 Line 8
-32 (C): Soft scroll up region [12..13] size 2 Line 9
-33 (C): Soft scroll up region [12..13] size 2 Line 10
-34 (C): Soft scroll up region [12..13] size 2 Line 11
-35 (C): Soft scroll up region [12..13] size 2 Line 12
-36 (C): Soft scroll up region [12..13] size 2 Line 13
-37 (C): Soft scroll up region [12..13] size 2 Line 14
-38 (C): Soft scroll up region [12..13] size 2 Line 15
-39 (C): Soft scroll up region [12..13] size 2 Line 16
-40 (C): Soft scroll up region [12..13] size 2 Line 17
+00 (C):                                                                                                               
+01 (C):                                                                                                               
+02 (C):                                                                                                               
+03 (C):                                                                                                               
+04 (C):                                                                                                               
+05 (C):                                                                                                               
+06 (C):                                                                                                               
+07 (C):                                                                                                               
+08 (C):                                                                                                               
+09 (C):                                                                                                               
+10 (C):                                                                                                               
+11 (C): Push <RETURN>
+12 (C): Soft scroll down region [12..13] size 2 Line 29
+13 (C):                                                                                                               
+14 (C):                                                                                                               
+15 (C):                                                                                                               
+16 (C):                                                                                                               
+17 (C):                                                                                                               
+18 (C):                                                                                                               
+19 (C):                                                                                                               
+20 (C):                                                                                                               
+21 (C):                                                                                                               
+22 (C):                                                                                                               
+23 (C):                                                                                                               
+24 (C):                                                                                                               
+25 (C):                                                                                                               
+26 (C):                                                                                                               
+27 (C):                                                                                                               
+28 (C):                                                                                                               
+29 (C):                                                                                                               
+30 (C):                                                                                                               
+31 (C):                                                                                                               
+32 (C):                                                                                                               
+33 (C):                                                                                                               
+34 (C):                                                                                                               
+35 (C):                                                                                                               
+36 (C):                                                                                                               
+37 (C):                                                                                                               
+38 (C):                                                                                                               
+39 (C):                                                                                                               
+40 (C):

--- a/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__vttest2_7.snap
+++ b/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__vttest2_7.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-server/src/panes/./unit/grid_tests.rs
-assertion_line: 327
 expression: "format!(\"{:?}\", grid)"
 ---
 00 (C): Push <RETURN>
@@ -16,32 +15,31 @@ expression: "format!(\"{:?}\", grid)"
 10 (C): Soft scroll down region [1..24] size 24 Line 20
 11 (C): Soft scroll down region [1..24] size 24 Line 19
 12 (C): Soft scroll down region [1..24] size 24 Line 18
-13 (C): Soft scroll down region [1..24] size 24 Line 17                                                               
-14 (C): Soft scroll down region [1..24] size 24 Line 16                                                               
-15 (C): Soft scroll down region [1..24] size 24 Line 15                                                               
-16 (C): Soft scroll down region [1..24] size 24 Line 14                                                               
-17 (C): Soft scroll down region [1..24] size 24 Line 13                                                               
-18 (C): Soft scroll down region [1..24] size 24 Line 12                                                               
-19 (C): Soft scroll down region [1..24] size 24 Line 11                                                               
-20 (C): Soft scroll down region [1..24] size 24 Line 10                                                               
-21 (C): Soft scroll down region [1..24] size 24 Line 9                                                                
-22 (C): Soft scroll down region [1..24] size 24 Line 8                                                                
-23 (C): Soft scroll down region [1..24] size 24 Line 7                                                                
-24 (C): Soft scroll down region [1..24] size 24 Line 6                                                                
-25 (C): Soft scroll down region [1..24] size 24 Line 5                                                                
-26 (C): Soft scroll down region [1..24] size 24 Line 4                                                                
-27 (C): Soft scroll down region [1..24] size 24 Line 3                                                                
-28 (C): Soft scroll down region [1..24] size 24 Line 2                                                                
-29 (C): Soft scroll down region [1..24] size 24 Line 1                                                                
-30 (C): Soft scroll up region [1..24] size 24 Line 7                                                                  
-31 (C): Soft scroll up region [1..24] size 24 Line 8                                                                  
-32 (C): Soft scroll up region [1..24] size 24 Line 9                                                                  
-33 (C): Soft scroll up region [1..24] size 24 Line 10                                                                 
-34 (C): Soft scroll up region [1..24] size 24 Line 11                                                                 
-35 (C): Soft scroll up region [1..24] size 24 Line 12                                                                 
-36 (C): Soft scroll up region [1..24] size 24 Line 13                                                                 
-37 (C): Soft scroll up region [1..24] size 24 Line 14                                                                 
-38 (C): Soft scroll up region [1..24] size 24 Line 15                                                                 
-39 (C): Soft scroll up region [1..24] size 24 Line 16                                                                 
-40 (C): Soft scroll up region [1..24] size 24 Line 17                                                                 
-
+13 (C): Soft scroll down region [1..24] size 24 Line 17
+14 (C): Soft scroll down region [1..24] size 24 Line 16
+15 (C): Soft scroll down region [1..24] size 24 Line 15
+16 (C): Soft scroll down region [1..24] size 24 Line 14
+17 (C): Soft scroll down region [1..24] size 24 Line 13
+18 (C): Soft scroll down region [1..24] size 24 Line 12
+19 (C): Soft scroll down region [1..24] size 24 Line 11
+20 (C): Soft scroll down region [1..24] size 24 Line 10
+21 (C): Soft scroll down region [1..24] size 24 Line 9
+22 (C): Soft scroll down region [1..24] size 24 Line 8
+23 (C): Soft scroll down region [1..24] size 24 Line 7
+24 (C):                                                                                                               
+25 (C):                                                                                                               
+26 (C):                                                                                                               
+27 (C):                                                                                                               
+28 (C):                                                                                                               
+29 (C):                                                                                                               
+30 (C):                                                                                                               
+31 (C):                                                                                                               
+32 (C):                                                                                                               
+33 (C):                                                                                                               
+34 (C):                                                                                                               
+35 (C):                                                                                                               
+36 (C):                                                                                                               
+37 (C):                                                                                                               
+38 (C):                                                                                                               
+39 (C):                                                                                                               
+40 (C):

--- a/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__vttest2_8.snap
+++ b/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__vttest2_8.snap
@@ -2,44 +2,44 @@
 source: zellij-server/src/panes/./unit/grid_tests.rs
 expression: "format!(\"{:?}\", grid)"
 ---
-00 (C): Push <RETURN>
-01 (C): Jump scroll down region [12..13] size 2 Line 29
-02 (C): Jump scroll down region [12..13] size 2 Line 28
-03 (C): Jump scroll down region [12..13] size 2 Line 27
-04 (C): Jump scroll down region [12..13] size 2 Line 26
-05 (C): Jump scroll down region [12..13] size 2 Line 25
-06 (C): Jump scroll down region [12..13] size 2 Line 24
-07 (C): Jump scroll down region [12..13] size 2 Line 23
-08 (C): Jump scroll down region [12..13] size 2 Line 22
-09 (C): Jump scroll down region [12..13] size 2 Line 21
-10 (C): Jump scroll down region [12..13] size 2 Line 20
-11 (C): Jump scroll down region [12..13] size 2 Line 19
-12 (C): Jump scroll down region [12..13] size 2 Line 18
-13 (C): Jump scroll down region [12..13] size 2 Line 17                                                               
-14 (C): Jump scroll down region [12..13] size 2 Line 16                                                               
-15 (C): Jump scroll down region [12..13] size 2 Line 15                                                               
-16 (C): Jump scroll down region [12..13] size 2 Line 14                                                               
-17 (C): Jump scroll down region [12..13] size 2 Line 13                                                               
-18 (C): Jump scroll down region [12..13] size 2 Line 12                                                               
-19 (C): Jump scroll down region [12..13] size 2 Line 11                                                               
-20 (C): Jump scroll down region [12..13] size 2 Line 10                                                               
-21 (C): Jump scroll down region [12..13] size 2 Line 9                                                                
-22 (C): Jump scroll down region [12..13] size 2 Line 8                                                                
-23 (C): Jump scroll down region [12..13] size 2 Line 7                                                                
-24 (C): Jump scroll down region [12..13] size 2 Line 6                                                                
-25 (C): Jump scroll down region [12..13] size 2 Line 5                                                                
-26 (C): Jump scroll down region [12..13] size 2 Line 4                                                                
-27 (C): Jump scroll down region [12..13] size 2 Line 3                                                                
-28 (C): Jump scroll down region [12..13] size 2 Line 2                                                                
-29 (C): Jump scroll down region [12..13] size 2 Line 1                                                                
-30 (C): Jump scroll up region [12..13] size 2 Line 7
-31 (C): Jump scroll up region [12..13] size 2 Line 8
-32 (C): Jump scroll up region [12..13] size 2 Line 9
-33 (C): Jump scroll up region [12..13] size 2 Line 10
-34 (C): Jump scroll up region [12..13] size 2 Line 11
-35 (C): Jump scroll up region [12..13] size 2 Line 12
-36 (C): Jump scroll up region [12..13] size 2 Line 13
-37 (C): Jump scroll up region [12..13] size 2 Line 14
-38 (C): Jump scroll up region [12..13] size 2 Line 15
-39 (C): Jump scroll up region [12..13] size 2 Line 16
-40 (C): Jump scroll up region [12..13] size 2 Line 17
+00 (C):                                                                                                               
+01 (C):                                                                                                               
+02 (C):                                                                                                               
+03 (C):                                                                                                               
+04 (C):                                                                                                               
+05 (C):                                                                                                               
+06 (C):                                                                                                               
+07 (C):                                                                                                               
+08 (C):                                                                                                               
+09 (C):                                                                                                               
+10 (C):                                                                                                               
+11 (C): Push <RETURN>
+12 (C): Jump scroll down region [12..13] size 2 Line 29
+13 (C):                                                                                                               
+14 (C):                                                                                                               
+15 (C):                                                                                                               
+16 (C):                                                                                                               
+17 (C):                                                                                                               
+18 (C):                                                                                                               
+19 (C):                                                                                                               
+20 (C):                                                                                                               
+21 (C):                                                                                                               
+22 (C):                                                                                                               
+23 (C):                                                                                                               
+24 (C):                                                                                                               
+25 (C):                                                                                                               
+26 (C):                                                                                                               
+27 (C):                                                                                                               
+28 (C):                                                                                                               
+29 (C):                                                                                                               
+30 (C):                                                                                                               
+31 (C):                                                                                                               
+32 (C):                                                                                                               
+33 (C):                                                                                                               
+34 (C):                                                                                                               
+35 (C):                                                                                                               
+36 (C):                                                                                                               
+37 (C):                                                                                                               
+38 (C):                                                                                                               
+39 (C):                                                                                                               
+40 (C):

--- a/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__vttest2_9.snap
+++ b/zellij-server/src/panes/unit/snapshots/zellij_server__panes__grid__grid_tests__vttest2_9.snap
@@ -1,6 +1,5 @@
 ---
 source: zellij-server/src/panes/./unit/grid_tests.rs
-assertion_line: 371
 expression: "format!(\"{:?}\", grid)"
 ---
 00 (C): Push <RETURN>
@@ -16,32 +15,31 @@ expression: "format!(\"{:?}\", grid)"
 10 (C): Jump scroll down region [1..24] size 24 Line 20
 11 (C): Jump scroll down region [1..24] size 24 Line 19
 12 (C): Jump scroll down region [1..24] size 24 Line 18
-13 (C): Jump scroll down region [1..24] size 24 Line 17                                                               
-14 (C): Jump scroll down region [1..24] size 24 Line 16                                                               
-15 (C): Jump scroll down region [1..24] size 24 Line 15                                                               
-16 (C): Jump scroll down region [1..24] size 24 Line 14                                                               
-17 (C): Jump scroll down region [1..24] size 24 Line 13                                                               
-18 (C): Jump scroll down region [1..24] size 24 Line 12                                                               
-19 (C): Jump scroll down region [1..24] size 24 Line 11                                                               
-20 (C): Jump scroll down region [1..24] size 24 Line 10                                                               
-21 (C): Jump scroll down region [1..24] size 24 Line 9                                                                
-22 (C): Jump scroll down region [1..24] size 24 Line 8                                                                
-23 (C): Jump scroll down region [1..24] size 24 Line 7                                                                
-24 (C): Jump scroll down region [1..24] size 24 Line 6                                                                
-25 (C): Jump scroll down region [1..24] size 24 Line 5                                                                
-26 (C): Jump scroll down region [1..24] size 24 Line 4                                                                
-27 (C): Jump scroll down region [1..24] size 24 Line 3                                                                
-28 (C): Jump scroll down region [1..24] size 24 Line 2                                                                
-29 (C): Jump scroll down region [1..24] size 24 Line 1                                                                
-30 (C): Jump scroll up region [1..24] size 24 Line 7                                                                  
-31 (C): Jump scroll up region [1..24] size 24 Line 8                                                                  
-32 (C): Jump scroll up region [1..24] size 24 Line 9                                                                  
-33 (C): Jump scroll up region [1..24] size 24 Line 10                                                                 
-34 (C): Jump scroll up region [1..24] size 24 Line 11                                                                 
-35 (C): Jump scroll up region [1..24] size 24 Line 12                                                                 
-36 (C): Jump scroll up region [1..24] size 24 Line 13                                                                 
-37 (C): Jump scroll up region [1..24] size 24 Line 14                                                                 
-38 (C): Jump scroll up region [1..24] size 24 Line 15                                                                 
-39 (C): Jump scroll up region [1..24] size 24 Line 16                                                                 
-40 (C): Jump scroll up region [1..24] size 24 Line 17                                                                 
-
+13 (C): Jump scroll down region [1..24] size 24 Line 17
+14 (C): Jump scroll down region [1..24] size 24 Line 16
+15 (C): Jump scroll down region [1..24] size 24 Line 15
+16 (C): Jump scroll down region [1..24] size 24 Line 14
+17 (C): Jump scroll down region [1..24] size 24 Line 13
+18 (C): Jump scroll down region [1..24] size 24 Line 12
+19 (C): Jump scroll down region [1..24] size 24 Line 11
+20 (C): Jump scroll down region [1..24] size 24 Line 10
+21 (C): Jump scroll down region [1..24] size 24 Line 9
+22 (C): Jump scroll down region [1..24] size 24 Line 8
+23 (C): Jump scroll down region [1..24] size 24 Line 7
+24 (C):                                                                                                               
+25 (C):                                                                                                               
+26 (C):                                                                                                               
+27 (C):                                                                                                               
+28 (C):                                                                                                               
+29 (C):                                                                                                               
+30 (C):                                                                                                               
+31 (C):                                                                                                               
+32 (C):                                                                                                               
+33 (C):                                                                                                               
+34 (C):                                                                                                               
+35 (C):                                                                                                               
+36 (C):                                                                                                               
+37 (C):                                                                                                               
+38 (C):                                                                                                               
+39 (C):                                                                                                               
+40 (C):


### PR DESCRIPTION
## Summary

Fixes #5449.

Zellij was resetting the active DECSTBM scroll region when processing
`CSI 2J` and when returning from the alternate screen.

## Changes

- Stop resetting the scroll region when handling `CSI 2J` (ED 2).
- Save the main screen's scroll region when entering the alternate screen.
- Restore the saved scroll region when leaving the alternate screen.
- Preserve the corresponding scroll-region boundaries when the screen
  dimensions differ during the alternate-screen transition.

## Tests

Added regression tests covering:

- `CSI 2J` preserving the active scroll region.
- Alternate-screen transitions with unchanged dimensions.
- Restoring the scroll region after the screen becomes smaller.
- Restoring the scroll region after the screen becomes larger.

Updated the existing `vttest2_6`, `vttest2_7`, `vttest2_8`, and `vttest2_9`
snapshots to reflect the corrected scroll-region behavior. The grid test
module passes with the updated snapshots.