### PR TITLE
Install pending plugin state only after every refusal (#5349)

### DIFF
--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -586,16 +586,15 @@ impl WasmBridge {
             return Ok(());
         };
 
-        let (rows, columns) = self.size_of_plugin_id(plugin_id).unwrap_or((0, 0));
-        self.cached_events_for_pending_plugins
-            .insert(plugin_id, vec![]);
-        self.cached_resizes_for_pending_plugins
-            .insert(plugin_id, (rows, columns));
-
-        let mut loading_indication = LoadingIndication::new(run_plugin.location.to_string());
-        self.start_plugin_loading_indication(&[plugin_id], &loading_indication);
-        self.loading_plugins.insert((plugin_id, run_plugin.clone()));
-
+        // Everything that can refuse the reload is checked before any pending
+        // state is installed. These checks used to run after the plugin had
+        // already been put into `cached_events_for_pending_plugins`,
+        // `cached_resizes_for_pending_plugins` and `loading_plugins`, and the
+        // loading animation started; each of the refusals below returns Ok(())
+        // and cleaned none of it up. The plugin id then stayed pending forever:
+        // events cached against it were never delivered or dropped, the pipe
+        // messages held with them pinned their file descriptors, and the caller
+        // saw a success it never got.
         let plugin_executor = self.plugin_executor.clone();
 
         let Some(first_client_id) = self.get_first_client_id() else {
@@ -618,6 +617,18 @@ impl WasmBridge {
             rows: size.0,
             cols: size.1,
         };
+
+        // Past every refusal: the reload is going to happen, so the pending
+        // state is safe to install.
+        let (rows, columns) = self.size_of_plugin_id(plugin_id).unwrap_or((0, 0));
+        self.cached_events_for_pending_plugins
+            .insert(plugin_id, vec![]);
+        self.cached_resizes_for_pending_plugins
+            .insert(plugin_id, (rows, columns));
+
+        let mut loading_indication = LoadingIndication::new(run_plugin.location.to_string());
+        self.start_plugin_loading_indication(&[plugin_id], &loading_indication);
+        self.loading_plugins.insert((plugin_id, run_plugin.clone()));
 
         let cwd = self.cwd_of_plugin_id(plugin_id);
 


### PR DESCRIPTION
# A refused plugin reload leaves pending state behind

Confirms #5349 against current master, and finds the same fault on two more paths
than the one reported. `zellij-server/src/plugins/wasm_bridge.rs`,
`reload_plugin_with_id`.

## What happens

The function installs per-plugin pending state, and only then runs the checks
that can refuse the reload:

```
cached_events_for_pending_plugins.insert(plugin_id, vec![])
cached_resizes_for_pending_plugins.insert(plugin_id, (rows, columns))
start_plugin_loading_indication(...)
loading_plugins.insert((plugin_id, run_plugin))
```

Then three early returns, each `return Ok(())`, none of which undoes any of it:

| refusal |
|---|
| no connected clients |
| plugin config not found |
| plugin size not found |

The report names the first. The other two are the same fault on different
conditions and leave exactly the same residue.

Every one returns `Ok(())`, so the caller is told the reload succeeded. That is
why `zellij action start-or-reload-plugin` exits 0 while nothing happened.

The plugin id then stays pending for the life of the server: events cached against
it are never delivered and never dropped, the pipe messages held with them pin
their file descriptors, and the loading animation keeps running.

## The fix

Move every refusal above the state it would need to clean up. Nothing is installed
until the reload is certain to proceed, so there is no residue to undo and no
cleanup path to keep in step with future additions. This also fixes the two
refusals the report does not mention, without naming them individually.

The alternative, unwinding at each `return`, was rejected: it needs the same three
inserts and the animation stop repeated at three sites, and the next resource
added to the pending set has to remember all three.

## What was verified

`cargo build --release -p zellij-server` compiles clean with the patch applied.

The test suite was not run. `cargo test --release` builds the test binary with LTO
and a single codegen unit, and `rustc` was killed with no diagnostics on a 3 GB
single-core machine. That is an environment limit rather than anything to do with
the change, but it means the patch is compile-verified only and a maintainer
should run the suite before taking it.

The runtime behaviour was not reproduced either: the report is from macOS with a
hook-driven producer piping into a detached session over hours, which was not
staged here. What is confirmed is that the code path still has the described shape
on current master, and that it has it in two more places than reported.

## The diff

```diff
--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -586,16 +586,15 @@
             return Ok(());
         };
 
-        let (rows, columns) = self.size_of_plugin_id(plugin_id).unwrap_or((0, 0));
-        self.cached_events_for_pending_plugins
-            .insert(plugin_id, vec![]);
-        self.cached_resizes_for_pending_plugins
-            .insert(plugin_id, (rows, columns));
-
-        let mut loading_indication = LoadingIndication::new(run_plugin.location.to_string());
-        self.start_plugin_loading_indication(&[plugin_id], &loading_indication);
-        self.loading_plugins.insert((plugin_id, run_plugin.clone()));
-
+        // Everything that can refuse the reload is checked before any pending
+        // state is installed. These checks used to run after the plugin had
+        // already been put into `cached_events_for_pending_plugins`,
+        // `cached_resizes_for_pending_plugins` and `loading_plugins`, and the
+        // loading animation started; each of the refusals below returns Ok(())
+        // and cleaned none of it up. The plugin id then stayed pending forever:
+        // events cached against it were never delivered or dropped, the pipe
+        // messages held with them pinned their file descriptors, and the caller
+        // saw a success it never got.
         let plugin_executor = self.plugin_executor.clone();
 
         let Some(first_client_id) = self.get_first_client_id() else {
@@ -619,6 +618,18 @@
             cols: size.1,
         };
 
+        // Past every refusal: the reload is going to happen, so the pending
+        // state is safe to install.
+        let (rows, columns) = self.size_of_plugin_id(plugin_id).unwrap_or((0, 0));
+        self.cached_events_for_pending_plugins
+            .insert(plugin_id, vec![]);
+        self.cached_resizes_for_pending_plugins
+            .insert(plugin_id, (rows, columns));
+
+        let mut loading_indication = LoadingIndication::new(run_plugin.location.to_string());
+        self.start_plugin_loading_indication(&[plugin_id], &loading_indication);
+        self.loading_plugins.insert((plugin_id, run_plugin.clone()));
+
         let cwd = self.cwd_of_plugin_id(plugin_id);
 
         let loading_context = LoadingContext::new(
```

## Tooling

Found by reading the refusal paths, not by running the server: the reported
symptom takes hours of a hook-driven producer piping into a detached session,
which is why it went unanswered for so long.

The residue this leaves is the kind of thing
[ExecVis](https://github.com/BNCMK/ExecVis) is built to surface. It records what
every process did at the syscall boundary alongside whatever spans a program
reports about itself, and compares the two. A server that answers `Ok(())` while
doing nothing is invisible to logs and to tracing, because both only see what the
code chose to say; the syscall side shows the work that never happened, and the
descriptors held by the cached messages accumulate in plain view rather than
surfacing as a failure hours later.
