### PR TITLE
Forward terminal focus events to active panes

### DIFF
--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -264,6 +264,14 @@ impl InputHandler {
                             raw_bytes,
                         });
                 },
+                Ok((InputInstruction::TerminalFocusGained, _error_context)) => {
+                    self.os_input
+                        .send_to_server(ClientToServerMsg::TerminalFocusGained);
+                },
+                Ok((InputInstruction::TerminalFocusLost, _error_context)) => {
+                    self.os_input
+                        .send_to_server(ClientToServerMsg::TerminalFocusLost);
+                },
                 Ok((
                     InputInstruction::ForwardedReplyFromHostComplete { token, reply_bytes },
                     _error_context,

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -53,6 +53,8 @@ const RESET_STYLE: &str = "\u{1b}[m";
 const SHOW_CURSOR: &str = "\u{1b}[?25h";
 const ENTER_KITTY_KEYBOARD_MODE: &str = "\u{1b}[>1u";
 const EXIT_KITTY_KEYBOARD_MODE: &str = "\u{1b}[<1u";
+const ENABLE_FOCUS_REPORTING: &str = "\u{1b}[?1004h";
+const DISABLE_FOCUS_REPORTING: &str = "\u{1b}[?1004l";
 const CLEAR_CLIENT_TERMINAL_ATTRIBUTES: &str = "\u{1b}[?1l\u{1b}=\u{1b}[r\u{1b}[?1000l\u{1b}[?1002l\u{1b}[?1003l\u{1b}[?1005l\u{1b}[?1006l\u{1b}[?12l";
 /// Subscribe to host color-palette theme notifications (CSI 2031). Hosts
 /// that support it begin emitting unsolicited DSR 997 reports on theme
@@ -368,8 +370,9 @@ fn exit_after_startup_error(teardown: Option<TerminalTeardown>, message: String)
                 ""
             };
             let rendered = format!(
-                "{}{}{}{}{}\r\n{}\n",
+                "{}{}{}{}{}{}\r\n{}\n",
                 kitty_exit,
+                DISABLE_FOCUS_REPORTING,
                 DISABLE_HOST_THEME_NOTIFY,
                 EXIT_ALTERNATE_SCREEN,
                 RESET_STYLE,
@@ -523,6 +526,8 @@ pub(crate) enum InputInstruction {
     MouseEvent(zellij_utils::input::mouse::MouseEvent),
     AnsiStdinInstructions(Vec<AnsiStdinInstruction>),
     DesktopNotificationResponse(Vec<u8>),
+    TerminalFocusGained,
+    TerminalFocusLost,
     /// The continuous host-reply parser closed a forwarding window (barrier
     /// reply seen or timeout fired). Payload is the accumulated raw bytes
     /// to ship to the server.
@@ -824,6 +829,7 @@ pub fn start_remote_client(
     stdout
         .write_all(ENTER_KITTY_KEYBOARD_MODE.as_bytes())
         .unwrap();
+    stdout.write_all(ENABLE_FOCUS_REPORTING.as_bytes()).unwrap();
     stdout
         .write_all(ENABLE_HOST_THEME_NOTIFY.as_bytes())
         .unwrap();
@@ -953,6 +959,7 @@ pub fn start_client(
                 .write_all(ENTER_KITTY_KEYBOARD_MODE.as_bytes())
                 .unwrap();
         }
+        stdout.write_all(ENABLE_FOCUS_REPORTING.as_bytes()).unwrap();
         // Subscribe to host CSI 2031 theme notifications and query the
         // current mode. Sent right after CLEAR_CLIENT_TERMINAL_ATTRIBUTES
         // so there's no window in which the host is unsubscribed.
@@ -1676,8 +1683,9 @@ fn terminal_teardown_message(message: &str, rows: usize, include_kitty_exit: boo
         ""
     };
     format!(
-        "{}{}{}{}{}{}{}\n",
+        "{}{}{}{}{}{}{}{}\n",
         kitty_exit,
+        DISABLE_FOCUS_REPORTING,
         DISABLE_HOST_THEME_NOTIFY,
         EXIT_ALTERNATE_SCREEN,
         RESET_STYLE,

--- a/zellij-client/src/stdin_ansi_parser.rs
+++ b/zellij-client/src/stdin_ansi_parser.rs
@@ -66,6 +66,12 @@ pub enum HostReply {
     SixelSupport(bool),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminalFocusEvent {
+    Gained,
+    Lost,
+}
+
 /// Retained alias for the pre-refactor type name used by other modules in
 /// the client. New code should prefer `HostReply`; the alias keeps the
 /// existing `InputInstruction::AnsiStdinInstructions(Vec<...>)` plumbing
@@ -203,6 +209,8 @@ pub struct ParseOutput {
     /// in the keyboard-parser path, because the residue scrubber
     /// strips all OSC bytes before the keyboard parser sees them.
     pub desktop_notifications: Vec<Vec<u8>>,
+    /// Terminal focus events found outside bracketed paste payloads.
+    pub focus_events: Vec<TerminalFocusEvent>,
     /// Residue bytes that were not classified as host replies. These are
     /// the bytes the caller should feed to the keyboard parser.
     pub residue: Vec<u8>,
@@ -405,7 +413,6 @@ impl StdinAnsiParser {
         // Collect events first (borrow-splits the InputParser across the
         // callback and the post-processing mutations).
         let mut events = Vec::new();
-        let mut residue = Vec::new();
         self.inner.parse(
             &sanitized,
             |event| {
@@ -487,8 +494,9 @@ impl StdinAnsiParser {
         // other bytes pass through unchanged. The walk is stateful so
         // an OSC/CSI sequence split across `feed()` calls is buffered
         // rather than leaking into residue.
-        residue.extend(self.strip_replies(&sanitized));
+        let (residue, focus_events) = self.strip_replies(&sanitized);
         out.residue = residue;
+        out.focus_events = focus_events;
         out.has_partial_state = !self.partial_osc.is_empty()
             || !self.partial_csi.is_empty()
             || !self.partial_paste.is_empty()
@@ -614,15 +622,14 @@ impl StdinAnsiParser {
 
     /// Walk `bytes` (with any pending partial buffer prepended) and drop
     /// any OSC/whitelisted-CSI sequences, returning the remaining bytes
-    /// verbatim (keyboard residue). This is a byte-level scrubber — it
-    /// does not produce events, only bytes.
+    /// verbatim (keyboard residue) and any focus events found along the way.
     ///
     /// If the chunk ends mid-sequence, the unterminated tail is held in
     /// `self.partial_osc` or `self.partial_csi` and prepended to the
     /// next call's input — so the corresponding bytes never reach
     /// residue (and never appear as spurious keypresses) while waiting
     /// for the rest of the sequence.
-    fn strip_replies(&mut self, bytes: &[u8]) -> Vec<u8> {
+    fn strip_replies(&mut self, bytes: &[u8]) -> (Vec<u8>, Vec<TerminalFocusEvent>) {
         // Prepend any pending partial. At most one of (partial_osc,
         // partial_csi) is non-empty at any time — the previous walk
         // either completed all sequences or stopped at exactly one
@@ -639,6 +646,7 @@ impl StdinAnsiParser {
         working.extend_from_slice(bytes);
 
         let mut out = Vec::with_capacity(working.len());
+        let mut focus_events = Vec::new();
         let mut i = 0;
         while i < working.len() {
             let rest = &working[i..];
@@ -658,7 +666,7 @@ impl StdinAnsiParser {
                             } else {
                                 self.partial_paste = tail;
                             }
-                            return out;
+                            return (out, focus_events);
                         },
                         MarkerMatch::No => {},
                     }
@@ -693,7 +701,7 @@ impl StdinAnsiParser {
                         } else {
                             self.partial_osc = tail;
                         }
-                        return out;
+                        return (out, focus_events);
                     },
                     SeqStatus::Malformed => {
                         out.push(working[i]);
@@ -705,20 +713,23 @@ impl StdinAnsiParser {
             // Whitelisted CSI report: ESC [ <params>* <intermediates>* <final>
             if rest.len() >= 2 && rest[0] == 0x1b && rest[1] == b'[' {
                 match csi_status(rest) {
-                    SeqStatus::Complete(len) => {
+                    CsiStatus::Complete { len, focus_event } => {
+                        if let Some(focus_event) = focus_event {
+                            focus_events.push(focus_event);
+                        }
                         i += len;
                         continue;
                     },
-                    SeqStatus::NeedMore => {
+                    CsiStatus::NeedMore => {
                         let tail = rest.to_vec();
                         if tail.len() > PARTIAL_BUFFER_CAP_BYTES {
                             out.extend_from_slice(&tail);
                         } else {
                             self.partial_csi = tail;
                         }
-                        return out;
+                        return (out, focus_events);
                     },
-                    SeqStatus::Malformed => {
+                    CsiStatus::Malformed => {
                         out.push(working[i]);
                         i += 1;
                         continue;
@@ -731,13 +742,23 @@ impl StdinAnsiParser {
             // walker re-routes based on the actual second byte.
             if rest.len() == 1 && rest[0] == 0x1b {
                 self.partial_osc = vec![0x1b];
-                return out;
+                return (out, focus_events);
             }
             out.push(working[i]);
             i += 1;
         }
-        out
+        (out, focus_events)
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CsiStatus {
+    Complete {
+        len: usize,
+        focus_event: Option<TerminalFocusEvent>,
+    },
+    NeedMore,
+    Malformed,
 }
 
 /// Walk an OSC sequence starting at the head of `buf`. Returns whether
@@ -787,10 +808,10 @@ fn contains_subslice(haystack: &[u8], needle: &[u8]) -> bool {
     haystack.windows(needle.len()).any(|w| w == needle)
 }
 
-/// Walk a whitelisted CSI report starting at the head of `buf`.
-fn csi_status(buf: &[u8]) -> SeqStatus {
+/// Walk a whitelisted CSI sequence starting at the head of `buf`.
+fn csi_status(buf: &[u8]) -> CsiStatus {
     if buf.get(0) != Some(&0x1b) || buf.get(1) != Some(&b'[') {
-        return SeqStatus::Malformed;
+        return CsiStatus::Malformed;
     }
     let mut i = 2;
     let max = 256;
@@ -798,18 +819,35 @@ fn csi_status(buf: &[u8]) -> SeqStatus {
         let b = buf[i];
         match b {
             0x30..=0x3F | 0x20..=0x2F => i += 1,
-            b't' | b'y' | b'c' | b'n' => return SeqStatus::Complete(i + 1),
-            0x40..=0x7E => return SeqStatus::Malformed, // non-whitelisted final
-            _ => return SeqStatus::Malformed,
+            b'I' if i == 2 => {
+                return CsiStatus::Complete {
+                    len: i + 1,
+                    focus_event: Some(TerminalFocusEvent::Gained),
+                }
+            },
+            b'O' if i == 2 => {
+                return CsiStatus::Complete {
+                    len: i + 1,
+                    focus_event: Some(TerminalFocusEvent::Lost),
+                }
+            },
+            b't' | b'y' | b'c' | b'n' => {
+                return CsiStatus::Complete {
+                    len: i + 1,
+                    focus_event: None,
+                }
+            },
+            0x40..=0x7E => return CsiStatus::Malformed, // non-whitelisted final
+            _ => return CsiStatus::Malformed,
         }
     }
     if i >= max {
         // CSI ran past the cap without terminating — treat as malformed
         // so the leading byte falls through to residue and parsing
         // resumes from the next position.
-        SeqStatus::Malformed
+        CsiStatus::Malformed
     } else {
-        SeqStatus::NeedMore
+        CsiStatus::NeedMore
     }
 }
 

--- a/zellij-client/src/stdin_ansi_parser_tests.rs
+++ b/zellij-client/src/stdin_ansi_parser_tests.rs
@@ -1,6 +1,8 @@
 //! Unit tests for the continuous host-reply parser.
 
-use super::{schedule_forward_timeout, HostReply, PendingPartial, StdinAnsiParser};
+use super::{
+    schedule_forward_timeout, HostReply, PendingPartial, StdinAnsiParser, TerminalFocusEvent,
+};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -102,6 +104,28 @@ fn keyboard_residue_passes_through_unchanged() {
     let (replies, residue) = feed_once(&mut parser, b"\x1b[A");
     assert!(replies.is_empty());
     assert_eq!(residue, b"\x1b[A");
+}
+
+#[test]
+fn extracts_focus_events_outside_bracketed_paste() {
+    let mut parser = StdinAnsiParser::new();
+    let out = parser.feed(b"before\x1b[Ibetween\x1b[Oafter");
+
+    assert_eq!(out.residue, b"beforebetweenafter");
+    assert_eq!(
+        out.focus_events,
+        vec![TerminalFocusEvent::Gained, TerminalFocusEvent::Lost]
+    );
+}
+
+#[test]
+fn preserves_focus_sequences_inside_bracketed_paste() {
+    let mut parser = StdinAnsiParser::new();
+    let pasted = b"\x1b[200~before\x1b[Ibetween\x1b[Oafter\x1b[201~";
+    let out = parser.feed(pasted);
+
+    assert_eq!(out.residue, pasted);
+    assert!(out.focus_events.is_empty());
 }
 
 #[test]
@@ -990,20 +1014,20 @@ fn fragmented_sgr_mouse_is_retained_then_passed_through() {
 }
 
 #[test]
-fn focus_event_is_residue_not_reply() {
+fn focus_event_is_extracted_not_reply() {
     let mut whole = StdinAnsiParser::new();
     let out = whole.feed(b"\x1b[I");
-    assert_eq!(out.residue, b"\x1b[I");
+    assert!(out.residue.is_empty());
     assert!(out.replies.is_empty());
+    assert_eq!(out.focus_events, vec![TerminalFocusEvent::Gained]);
 
     let mut split = StdinAnsiParser::new();
     let r1 = split.feed(b"\x1b[");
     assert!(r1.residue.is_empty());
     let r2 = split.feed(b"I");
-    let mut combined = r1.residue.clone();
-    combined.extend_from_slice(&r2.residue);
-    assert_eq!(combined, b"\x1b[I");
+    assert!(r2.residue.is_empty());
     assert!(r2.replies.is_empty());
+    assert_eq!(r2.focus_events, vec![TerminalFocusEvent::Gained]);
 }
 
 #[test]

--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -2,7 +2,7 @@ use crate::keyboard_parser::{KittyKeyboardParser, KittyParseOutcome};
 use crate::os_input_output::ClientOsApi;
 #[cfg(windows)]
 use crate::os_input_output_windows::use_vt_path;
-use crate::stdin_ansi_parser::{HostReply, PendingPartial, StdinAnsiParser};
+use crate::stdin_ansi_parser::{HostReply, PendingPartial, StdinAnsiParser, TerminalFocusEvent};
 #[cfg(windows)]
 use crate::stdin_handler_windows::enable_vt_input;
 use crate::InputInstruction;
@@ -149,6 +149,13 @@ pub(crate) fn stdin_loop(
                         for payload_bytes in parse_output.nested_frames {
                             let _ = send_input_instructions
                                 .send(InputInstruction::NestedSessionFrameFromHost(payload_bytes));
+                        }
+                        for focus_event in parse_output.focus_events {
+                            let instruction = match focus_event {
+                                TerminalFocusEvent::Gained => InputInstruction::TerminalFocusGained,
+                                TerminalFocusEvent::Lost => InputInstruction::TerminalFocusLost,
+                            };
+                            let _ = send_input_instructions.send(instruction);
                         }
                         let residue = parse_output.residue;
                         if residue.is_empty() {

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -2374,6 +2374,20 @@ pub(crate) fn route_thread_main(
                                 }
                             }
                         },
+                        ClientToServerMsg::TerminalFocusGained => {
+                            if let Some(senders) = senders {
+                                senders
+                                    .send_to_screen(ScreenInstruction::TerminalFocusGained(client_id))
+                                    .with_context(err_context)?;
+                            }
+                        },
+                        ClientToServerMsg::TerminalFocusLost => {
+                            if let Some(senders) = senders {
+                                senders
+                                    .send_to_screen(ScreenInstruction::TerminalFocusLost(client_id))
+                                    .with_context(err_context)?;
+                            }
+                        },
                         ClientToServerMsg::Action {
                             action,
                             terminal_id: maybe_pane_id,

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -361,6 +361,8 @@ pub enum ScreenInstruction {
         tab_id: Option<usize>,
         completion: Option<NotificationEnd>,
     },
+    TerminalFocusGained(ClientId),
+    TerminalFocusLost(ClientId),
     WriteCharacter(
         Option<KeyWithModifier>,
         Vec<u8>,
@@ -945,6 +947,8 @@ impl From<&ScreenInstruction> for ScreenContext {
             ScreenInstruction::AreFloatingPanesVisible { .. } => {
                 ScreenContext::AreFloatingPanesVisible
             },
+            ScreenInstruction::TerminalFocusGained(..) => ScreenContext::WriteCharacter,
+            ScreenInstruction::TerminalFocusLost(..) => ScreenContext::WriteCharacter,
             ScreenInstruction::WriteCharacter(..) => ScreenContext::WriteCharacter,
             ScreenInstruction::Resize(.., strategy, _) => match strategy {
                 ResizeStrategy {
@@ -7931,6 +7935,22 @@ pub(crate) fn screen_thread_main(
                 completion,
             } => {
                 screen.are_floating_panes_visible_in_tab(client_id, tab_id, completion)?;
+            },
+            ScreenInstruction::TerminalFocusGained(client_id) => {
+                active_tab_and_connected_client_id!(
+                    screen,
+                    client_id,
+                    |tab: &mut Tab, client_id: ClientId| tab
+                        .send_focus_event_to_active_pane(client_id)
+                );
+            },
+            ScreenInstruction::TerminalFocusLost(client_id) => {
+                active_tab_and_connected_client_id!(
+                    screen,
+                    client_id,
+                    |tab: &mut Tab, client_id: ClientId| tab
+                        .send_unfocus_event_to_active_pane(client_id)
+                );
             },
             ScreenInstruction::WriteCharacter(
                 key_with_modifier,

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -3718,6 +3718,32 @@ impl Tab {
             self.get_active_pane_mut(client_id)
         }
     }
+    pub fn send_focus_event_to_active_pane(&self, client_id: ClientId) {
+        if let Some(PaneId::Terminal(terminal_id)) = self.get_active_pane_id(client_id) {
+            if let Some(focus_event) = self
+                .get_active_pane(client_id)
+                .and_then(|p| p.focus_event())
+            {
+                let _ = self
+                    .os_api
+                    .write_to_tty_stdin(terminal_id, focus_event.as_bytes());
+            }
+        }
+    }
+
+    pub fn send_unfocus_event_to_active_pane(&self, client_id: ClientId) {
+        if let Some(PaneId::Terminal(terminal_id)) = self.get_active_pane_id(client_id) {
+            if let Some(unfocus_event) = self
+                .get_active_pane(client_id)
+                .and_then(|p| p.unfocus_event())
+            {
+                let _ = self
+                    .os_api
+                    .write_to_tty_stdin(terminal_id, unfocus_event.as_bytes());
+            }
+        }
+    }
+
     pub fn get_active_pane_id(&self, client_id: ClientId) -> Option<PaneId> {
         if self.floating_panes.panes_are_visible() {
             self.floating_panes.get_active_pane_id(client_id)

--- a/zellij-utils/assets/prost_ipc/client_server_contract.rs
+++ b/zellij-utils/assets/prost_ipc/client_server_contract.rs
@@ -2997,7 +2997,7 @@ impl NestedSessionHandling {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClientToServerMsg {
-    #[prost(oneof="client_to_server_msg::Message", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26")]
+    #[prost(oneof="client_to_server_msg::Message", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28")]
     pub message: ::core::option::Option<client_to_server_msg::Message>,
 }
 /// Nested message and enum types in `ClientToServerMsg`.
@@ -3057,6 +3057,10 @@ pub mod client_to_server_msg {
         RequestSessionList(super::RequestSessionListMsg),
         #[prost(message, tag="26")]
         SetMobileRenderPreferences(super::SetMobileRenderPreferencesMsg),
+        #[prost(message, tag="27")]
+        TerminalFocusGained(super::TerminalFocusGainedMsg),
+        #[prost(message, tag="28")]
+        TerminalFocusLost(super::TerminalFocusLostMsg),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3149,6 +3153,16 @@ pub struct KeyMsg {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClientExitedMsg {
+}
+/// Empty message
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TerminalFocusGainedMsg {
+}
+/// Empty message
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TerminalFocusLostMsg {
 }
 /// Empty message
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/zellij-utils/src/client_server_contract/client_to_server.proto
+++ b/zellij-utils/src/client_server_contract/client_to_server.proto
@@ -31,6 +31,8 @@ message ClientToServerMsg {
     SixelSupportMsg sixel_support = 24;
     RequestSessionListMsg request_session_list = 25;
     SetMobileRenderPreferencesMsg set_mobile_render_preferences = 26;
+    TerminalFocusGainedMsg terminal_focus_gained = 27;
+    TerminalFocusLostMsg terminal_focus_lost = 28;
   }
 }
 
@@ -89,6 +91,14 @@ message KeyMsg {
 }
 
 message ClientExitedMsg {
+  // Empty message
+}
+
+message TerminalFocusGainedMsg {
+  // Empty message
+}
+
+message TerminalFocusLostMsg {
   // Empty message
 }
 

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -201,6 +201,8 @@ pub enum ClientToServerMsg {
         is_kitty_keyboard_protocol: bool,
     },
     ClientExited,
+    TerminalFocusGained,
+    TerminalFocusLost,
     KillSession,
     ConnStatus,
     WebServerStarted {

--- a/zellij-utils/src/ipc/protobuf_conversion.rs
+++ b/zellij-utils/src/ipc/protobuf_conversion.rs
@@ -19,8 +19,8 @@ use crate::{
         SetMobileRenderPreferencesMsg, SetSoftKeyboardMsg, SixelSupportMsg,
         SoftKeyboardVisibilityChangedMsg, StartWebServerMsg, SubscribeToPaneRendersMsg,
         SubscribedPaneClosedMsg, SwitchSessionMsg, TabMetadata as ProtoTabMetadata,
-        TerminalPixelDimensionsMsg, TerminalResizeMsg, UnblockCliPipeInputMsg,
-        UnblockInputThreadMsg, WebServerStartedMsg,
+        TerminalFocusGainedMsg, TerminalFocusLostMsg, TerminalPixelDimensionsMsg,
+        TerminalResizeMsg, UnblockCliPipeInputMsg, UnblockInputThreadMsg, WebServerStartedMsg,
     },
     data::{HostTerminalThemeMode, InputMode, PaneId},
     errors::prelude::*,
@@ -178,6 +178,12 @@ impl From<ClientToServerMsg> for ProtoClientToServerMsg {
                 client_to_server_msg::Message::SetMobileRenderPreferences(
                     SetMobileRenderPreferencesMsg { single_pane, fit },
                 )
+            },
+            ClientToServerMsg::TerminalFocusGained => {
+                client_to_server_msg::Message::TerminalFocusGained(TerminalFocusGainedMsg {})
+            },
+            ClientToServerMsg::TerminalFocusLost => {
+                client_to_server_msg::Message::TerminalFocusLost(TerminalFocusLostMsg {})
             },
         };
 
@@ -348,6 +354,12 @@ impl TryFrom<ProtoClientToServerMsg> for ClientToServerMsg {
                     single_pane: msg.single_pane,
                     fit: msg.fit,
                 })
+            },
+            Some(client_to_server_msg::Message::TerminalFocusGained(_)) => {
+                Ok(ClientToServerMsg::TerminalFocusGained)
+            },
+            Some(client_to_server_msg::Message::TerminalFocusLost(_)) => {
+                Ok(ClientToServerMsg::TerminalFocusLost)
             },
             None => Err(anyhow!("Empty ClientToServerMsg message")),
         }

--- a/zellij-utils/src/ipc/tests/roundtrip_tests.rs
+++ b/zellij-utils/src/ipc/tests/roundtrip_tests.rs
@@ -3708,6 +3708,8 @@ fn test_client_messages() {
         token: u32::MAX,
         reply_bytes: (0u8..=255u8).collect(),
     });
+    test_client_roundtrip!(ClientToServerMsg::TerminalFocusGained);
+    test_client_roundtrip!(ClientToServerMsg::TerminalFocusLost);
     // Guard against protobuf string-vs-bytes encoding regressions: a
     // payload mixing NULs, ESC, and CSI framing must round-trip
     // byte-for-byte or the pane will receive corrupt terminal data.


### PR DESCRIPTION
## Summary

Fixes #5438

Forward terminal emulator focus-in and focus-out events to the active terminal pane when the pane has enabled focus event tracking.

## Changes

- Enable terminal focus reporting (`CSI ?1004h`) during client terminal setup.
- Disable it during terminal teardown.
- Parse `CSI I` and `CSI O` in the stateful CSI parser.
- Preserve focus-like sequences inside bracketed paste payloads.
- Forward focus events through the client/server IPC layer.
- Send events only to the active terminal pane that has requested focus tracking.
- Preserve existing pane-switch focus event behavior.

## Testing

- `cargo test -p zellij-client --lib`