### PR TITLE
fix(pty): prefer OSC 7 working directories

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -432,6 +432,12 @@ pub fn parse_osc7_path(raw: &[u8]) -> Option<std::path::PathBuf> {
         }
     }
     let decoded = String::from_utf8(out).ok()?;
+    #[cfg(windows)]
+    let decoded = decoded
+        .strip_prefix('/')
+        .filter(|path| path.as_bytes().get(1) == Some(&b':'))
+        .map(str::to_owned)
+        .unwrap_or(decoded);
     Some(std::path::PathBuf::from(decoded))
 }
 
@@ -5609,5 +5615,15 @@ mod osc7_parser_tests {
     fn osc7_parser_rejects_non_utf8_input() {
         let raw = &[0xFFu8, 0xFE, 0xFD];
         assert_eq!(parse_osc7_path(raw), None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn osc7_parser_normalizes_windows_drive_path() {
+        let raw = b"file://host/C:/Users/user/project";
+        assert_eq!(
+            parse_osc7_path(raw),
+            Some(PathBuf::from("C:/Users/user/project"))
+        );
     }
 }

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -204,8 +204,9 @@ pub(crate) struct Pty {
     task_handles: HashMap<u32, JoinHandle<()>>, // terminal_id to join-handle
     default_editor: Option<PathBuf>,
     post_command_discovery_hook: Option<String>,
-    plugin_cwds: HashMap<u32, PathBuf>,   // plugin_id -> cwd
-    terminal_cwds: HashMap<u32, PathBuf>, // terminal_id -> cwd
+    plugin_cwds: HashMap<u32, PathBuf>,        // plugin_id -> cwd
+    terminal_cwds: HashMap<u32, PathBuf>,      // terminal_id -> cwd discovered from the OS
+    osc7_terminal_cwds: HashMap<u32, PathBuf>, // terminal_id -> cwd reported by OSC 7
     pane_activity_flags: HashMap<u32, std::sync::Arc<std::sync::atomic::AtomicBool>>,
     terminal_cmds: HashMap<u32, Vec<String>>,
     terminal_foreground_cmds: HashMap<u32, Vec<String>>,
@@ -924,6 +925,7 @@ impl Pty {
             post_command_discovery_hook,
             plugin_cwds: HashMap::new(),
             terminal_cwds: HashMap::new(),
+            osc7_terminal_cwds: HashMap::new(),
             pane_activity_flags: HashMap::new(),
             terminal_cmds: HashMap::new(),
             terminal_foreground_cmds: HashMap::new(),
@@ -968,6 +970,21 @@ impl Pty {
             },
         }
     }
+    fn preferred_terminal_cwd(&self, terminal_id: &u32) -> Option<PathBuf> {
+        self.osc7_terminal_cwds
+            .get(terminal_id)
+            .cloned()
+            .or_else(|| {
+                self.id_to_child_pid.get(terminal_id).and_then(|&pid| {
+                    self.bus
+                        .os_input
+                        .as_ref()
+                        .and_then(|input| input.get_cwd(pid))
+                })
+            })
+            .or_else(|| self.terminal_cwds.get(terminal_id).cloned())
+    }
+
     fn fill_cwd(&self, terminal_action: &mut TerminalAction, client_id: ClientId) {
         let cwd = match terminal_action {
             TerminalAction::RunCommand(run_command) => &mut run_command.cwd,
@@ -979,18 +996,7 @@ impl Pty {
                 .get(&client_id)
                 .and_then(|pane| match pane {
                     PaneId::Plugin(plugin_id) => self.plugin_cwds.get(plugin_id).cloned(),
-                    PaneId::Terminal(id) => {
-                        // Try to get CWD from OS, fall back to cached value
-                        self.id_to_child_pid
-                            .get(id)
-                            .and_then(|&pid| {
-                                self.bus
-                                    .os_input
-                                    .as_ref()
-                                    .and_then(|input| input.get_cwd(pid))
-                            })
-                            .or_else(|| self.terminal_cwds.get(id).cloned())
-                    },
+                    PaneId::Terminal(id) => self.preferred_terminal_cwd(id),
                 })
         };
     }
@@ -1001,18 +1007,7 @@ impl Pty {
         };
         if cwd.is_none() {
             *cwd = match pane_id {
-                PaneId::Terminal(terminal_pane_id) => {
-                    // Try to get CWD from OS, fall back to cached value
-                    self.id_to_child_pid
-                        .get(terminal_pane_id)
-                        .and_then(|&pid| {
-                            self.bus
-                                .os_input
-                                .as_ref()
-                                .and_then(|input| input.get_cwd(pid))
-                        })
-                        .or_else(|| self.terminal_cwds.get(terminal_pane_id).cloned())
-                },
+                PaneId::Terminal(terminal_pane_id) => self.preferred_terminal_cwd(terminal_pane_id),
                 PaneId::Plugin(plugin_id) => self.plugin_cwds.get(plugin_id).cloned(),
             };
         };
@@ -1818,6 +1813,7 @@ impl Pty {
                 }
                 self.pane_activity_flags.remove(&id);
                 self.terminal_cwds.remove(&id);
+                self.osc7_terminal_cwds.remove(&id);
                 self.terminal_cmds.remove(&id);
                 self.terminal_foreground_cmds.remove(&id);
                 self.bus
@@ -1956,7 +1952,7 @@ impl Pty {
             .filter_map(|id| self.id_to_child_pid.get(&id))
             .copied()
             .collect();
-        let (pids_to_cwds, pids_to_cmds) = self
+        let (_pids_to_cwds, pids_to_cmds) = self
             .bus
             .os_input
             .as_ref()
@@ -1975,7 +1971,7 @@ impl Pty {
 
         for terminal_id in terminal_ids {
             let process_id = self.id_to_child_pid.get(&terminal_id);
-            let cwd = process_id.and_then(|pid| pids_to_cwds.get(pid));
+            let cwd = self.preferred_terminal_cwd(&terminal_id);
             let cmd_sysinfo = process_id.and_then(|pid| pids_to_cmds.get(pid));
             let cmd_foreground = foreground_cmds.get(&terminal_id);
             if let Some(cmd) = cmd_foreground {
@@ -2015,18 +2011,7 @@ impl Pty {
                 .get(&client_id)
                 .and_then(|pane| match pane {
                     PaneId::Plugin(plugin_id) => self.plugin_cwds.get(plugin_id).cloned(),
-                    PaneId::Terminal(id) => {
-                        // Try to get CWD from OS, fall back to cached value
-                        self.id_to_child_pid
-                            .get(id)
-                            .and_then(|&pid| {
-                                self.bus
-                                    .os_input
-                                    .as_ref()
-                                    .and_then(|input| input.get_cwd(pid))
-                            })
-                            .or_else(|| self.terminal_cwds.get(id).cloned())
-                    },
+                    PaneId::Terminal(id) => self.preferred_terminal_cwd(id),
                 })
         };
 
@@ -2107,7 +2092,9 @@ impl Pty {
             let cwd = process_id.and_then(|pid| pids_to_cwds.get(pid));
 
             if let Some(cwd) = cwd {
-                if self.terminal_cwds.get(terminal_id) != Some(cwd) {
+                if !self.osc7_terminal_cwds.contains_key(terminal_id)
+                    && self.terminal_cwds.get(terminal_id) != Some(cwd)
+                {
                     let pane_id = PaneId::Terminal(*terminal_id);
                     let focused_client_ids: Vec<ClientId> = self
                         .active_panes
@@ -2199,7 +2186,7 @@ impl Pty {
     pub fn notify_cwd_from_osc7(&mut self, terminal_id: u32, path: PathBuf) {
         use std::sync::atomic::Ordering;
 
-        if self.terminal_cwds.get(&terminal_id) != Some(&path) {
+        if self.osc7_terminal_cwds.get(&terminal_id) != Some(&path) {
             let pane_id = PaneId::Terminal(terminal_id);
             let focused_client_ids: Vec<ClientId> = self
                 .active_panes
@@ -2215,7 +2202,7 @@ impl Pty {
                     None,
                     Event::CwdChanged(pane_id.into(), path.clone(), focused_client_ids),
                 )]));
-            self.terminal_cwds.insert(terminal_id, path);
+            self.osc7_terminal_cwds.insert(terminal_id, path);
         }
         if let Some(flag) = self.pane_activity_flags.get(&terminal_id) {
             flag.store(false, Ordering::Relaxed);
@@ -2331,21 +2318,8 @@ impl Pty {
     pub fn get_pane_cwd(&self, pane_id: PaneId) -> GetPaneCwdResponse {
         match pane_id {
             PaneId::Terminal(terminal_id) => {
-                if let Some(&child_pid) = self.id_to_child_pid.get(&terminal_id) {
-                    // Query OS for current working directory
-                    if let Some(os_input) = self.bus.os_input.as_ref() {
-                        let (cwds, _cmds) = os_input.get_cwds(vec![child_pid]);
-                        if let Some(cwd) = cwds.get(&child_pid) {
-                            GetPaneCwdResponse::Ok(cwd.clone())
-                        } else {
-                            GetPaneCwdResponse::Err(format!(
-                                "Could not retrieve CWD for terminal pane {}",
-                                terminal_id
-                            ))
-                        }
-                    } else {
-                        GetPaneCwdResponse::Err("OS input not available".to_string())
-                    }
+                if let Some(cwd) = self.preferred_terminal_cwd(&terminal_id) {
+                    GetPaneCwdResponse::Ok(cwd)
                 } else {
                     GetPaneCwdResponse::Err(format!(
                         "Terminal pane {} not found or not running",

--- a/zellij-server/src/unit/pty_tests.rs
+++ b/zellij-server/src/unit/pty_tests.rs
@@ -436,9 +436,9 @@ fn osc7_emits_cwd_changed() {
     assert_eq!(events[0].0, PaneId::Terminal(1));
     assert_eq!(events[0].1, PathBuf::from("/tmp/new"));
     assert_eq!(
-        pty.terminal_cwds.get(&1),
+        pty.osc7_terminal_cwds.get(&1),
         Some(&PathBuf::from("/tmp/new")),
-        "cache should be updated"
+        "OSC 7 cache should be updated"
     );
 }
 
@@ -447,12 +447,15 @@ fn osc7_no_event_when_unchanged() {
     let mock = MockOsApi::new();
     let (mut pty, rx) = make_pty_with_plugin_receiver(mock);
     pty.id_to_child_pid.insert(1, 100);
-    pty.terminal_cwds.insert(1, PathBuf::from("/same"));
+    pty.osc7_terminal_cwds.insert(1, PathBuf::from("/same"));
 
     pty.notify_cwd_from_osc7(1, PathBuf::from("/same"));
 
     let events = collect_cwd_changed_events(&rx);
-    assert!(events.is_empty(), "no event when osc7 path matches cache");
+    assert!(
+        events.is_empty(),
+        "no event when osc7 path matches OSC 7 cache"
+    );
 }
 
 #[test]
@@ -491,4 +494,82 @@ fn osc7_then_poll_skips_terminal() {
         cwd_events.is_empty() && cmd_events.is_empty(),
         "poll after osc7 should skip terminal since flag was cleared"
     );
+}
+
+#[test]
+fn osc7_cache_is_not_overwritten_by_os_cwd_poll() {
+    let mock = MockOsApi::new();
+    let child_pid = 100;
+    mock.set_cwd(child_pid, PathBuf::from("/from-proc"));
+    let (mut pty, rx) = make_pty_with_plugin_receiver(mock);
+    set_active_terminal(&mut pty, 1, child_pid);
+
+    pty.notify_cwd_from_osc7(1, PathBuf::from("/from-osc7"));
+    let _ = collect_cwd_changed_events(&rx);
+
+    pty.pane_activity_flags
+        .get(&1)
+        .unwrap()
+        .store(true, Ordering::Relaxed);
+    pty.update_and_report_cwds();
+
+    assert_eq!(
+        pty.osc7_terminal_cwds.get(&1),
+        Some(&PathBuf::from("/from-osc7")),
+        "OS cwd polling must not overwrite the OSC 7 cache"
+    );
+    assert_eq!(
+        pty.terminal_cwds.get(&1),
+        Some(&PathBuf::from("/from-proc")),
+        "OS cwd should still be tracked separately"
+    );
+    assert!(
+        collect_cwd_changed_events(&rx).is_empty(),
+        "OS cwd polling must not report a different cwd while OSC 7 is authoritative"
+    );
+}
+
+#[test]
+fn preferred_terminal_cwd_uses_osc7_before_os_cwd() {
+    let mock = MockOsApi::new();
+    let child_pid = 100;
+    mock.set_cwd(child_pid, PathBuf::from("/from-proc"));
+    let (mut pty, _rx) = make_pty_with_plugin_receiver(mock);
+    set_active_terminal(&mut pty, 1, child_pid);
+    pty.terminal_cwds.insert(1, PathBuf::from("/cached-proc"));
+    pty.osc7_terminal_cwds
+        .insert(1, PathBuf::from("/from-osc7"));
+
+    assert_eq!(
+        pty.preferred_terminal_cwd(&1),
+        Some(PathBuf::from("/from-osc7"))
+    );
+}
+
+#[test]
+fn preferred_terminal_cwd_falls_back_to_os_cwd_without_osc7() {
+    let mock = MockOsApi::new();
+    let child_pid = 100;
+    mock.set_cwd(child_pid, PathBuf::from("/from-proc"));
+    let (mut pty, _rx) = make_pty_with_plugin_receiver(mock);
+    set_active_terminal(&mut pty, 1, child_pid);
+    pty.terminal_cwds.insert(1, PathBuf::from("/cached-proc"));
+
+    assert_eq!(
+        pty.preferred_terminal_cwd(&1),
+        Some(PathBuf::from("/from-proc"))
+    );
+}
+
+#[test]
+fn close_pane_removes_osc7_cwd_cache() {
+    let mock = MockOsApi::new();
+    let (mut pty, _rx) = make_pty_with_plugin_receiver(mock);
+    set_active_terminal(&mut pty, 1, 100);
+    pty.osc7_terminal_cwds
+        .insert(1, PathBuf::from("/from-osc7"));
+
+    pty.close_pane(PaneId::Terminal(1)).unwrap();
+
+    assert!(!pty.osc7_terminal_cwds.contains_key(&1));
 }


### PR DESCRIPTION
## Description

Fixes #3184
Fixes #3512
Related to #5052
Related to #3811

CWD reporting can be incorrect when the shell reports its working directory through OSC 7 but the process working directory remains stale. This is especially visible with PowerShell on Windows, where a later OS-based CWD poll could overwrite the correct OSC 7 value.

For #5052, PowerShell must be configured to emit OSC 7 working-directory notifications.

## Changes

- Keep OSC 7-reported CWDs separate from OS-discovered CWDs.
- Prefer OSC 7 CWDs for pane creation, command execution, session metadata, and pane CWD queries.
- Suppress conflicting OS-derived `CwdChanged` events after OSC 7 has reported a CWD.
- Remove OSC 7 CWD entries when panes are closed.
- Normalize Windows OSC 7 paths such as `/C:/Users/...` to `C:/Users/...`.
- Add regression tests for CWD precedence, polling behavior, cache cleanup, and Windows path normalization.

## Testing

- Linux: `cargo test -p zellij-server --lib`
- Windows: `cargo test --no-default-features -p zellij-server --lib`