### PR TITLE
feat: select OSC 133 command output on triple click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * feat: implement support for the kitty graphics protocol to display images in the terminal (https://github.com/zellij-org/zellij/pull/5428)
 * fix: only advertise Sixel support if the attached terminal also supports it (https://github.com/zellij-org/zellij/pull/5432)
 * fix: properly unbundle plugin wasm executables when stripping them (to assist distro packagers) (https://github.com/zellij-org/zellij/pull/5433)
+* feat: support OSC133, triple-mouse-click to mark whole command, configurable double-click word boundaries (https://github.com/zellij-org/zellij/pull/5460)
 
 ## [0.44.3] - 2026-05-13
 * fix(windows): bump windows-sys to 0.59 to align manifest with code, fixing source builds via `cargo install`/`cargo binstall` (https://github.com/zellij-org/zellij/pull/5139)

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -41,7 +41,7 @@ use zellij_utils::envs;
 use zellij_utils::pane_size::Size;
 
 use zellij_utils::input::cli_assets::CliAssets;
-use zellij_utils::input::options::PaneFrameStyle;
+use zellij_utils::input::options::{PaneFrameStyle, DEFAULT_WORD_SEPARATORS};
 
 use wasmi::Engine;
 
@@ -471,6 +471,15 @@ impl SessionMetaData {
                     visual_bell: new_config.options.visual_bell.unwrap_or(true),
                     focus_follows_mouse: new_config.options.focus_follows_mouse.unwrap_or(false),
                     mouse_click_through: new_config.options.mouse_click_through.unwrap_or(false),
+                    osc133_command_selection: new_config
+                        .options
+                        .osc133_command_selection
+                        .unwrap_or(true),
+                    word_separators: new_config
+                        .options
+                        .word_separators
+                        .clone()
+                        .unwrap_or_else(|| DEFAULT_WORD_SEPARATORS.to_owned()),
                     nested_session_handling: new_config
                         .options
                         .nested_session_handling

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -30,6 +30,7 @@ use zellij_utils::{
     consts::{DEFAULT_SCROLL_BUFFER_SIZE, SCROLL_BUFFER_SIZE},
     data::{Palette, PaletteColor, Styling},
     input::mouse::{MouseEvent, MouseEventType},
+    input::options::DEFAULT_WORD_SEPARATORS,
     nested_session::{self, NestedSessionMessage},
     pane_size::SizeInPixels,
     position::Position,
@@ -754,6 +755,8 @@ pub struct Grid {
     pub hover_position: Option<Position>, // pane-relative cursor cell; None when outside pane
     pub cached_hover_tooltip: Option<String>,
     osc133_markers_seen: bool,
+    osc133_command_selection: bool,
+    word_separators: String,
 }
 
 impl Grid {
@@ -1098,6 +1101,14 @@ impl Grid {
             hover_position: None,
             cached_hover_tooltip: None,
             osc133_markers_seen: false,
+            osc133_command_selection: true,
+            word_separators: DEFAULT_WORD_SEPARATORS.to_owned(),
+        }
+    }
+    pub fn set_selection_options(&mut self, osc133_command_selection: bool, word_separators: &str) {
+        self.osc133_command_selection = osc133_command_selection;
+        if self.word_separators != word_separators {
+            self.word_separators = word_separators.to_owned();
         }
     }
     pub fn render_full_viewport(&mut self) {
@@ -3128,8 +3139,8 @@ impl Grid {
     }
     pub fn word_around_position(&self, position: &Position) -> Option<(Position, Position)> {
         let position_row = self.viewport.get(position.line.0 as usize)?;
-        let (index_start, index_end) =
-            position_row.word_indices_around_character_index(position.column.0)?;
+        let (index_start, index_end) = position_row
+            .word_indices_around_character_index(position.column.0, &self.word_separators)?;
 
         let mut position_start = Position::new(position.line.0 as i32, index_start as u16);
         let mut position_end = Position::new(position.line.0 as i32, index_end as u16);
@@ -3140,7 +3151,8 @@ impl Grid {
                 .viewport
                 .get(position_start.line.0.saturating_sub(1) as usize)
             {
-                let new_start_index = position_row_above.word_start_index_of_last_character();
+                let new_start_index =
+                    position_row_above.word_start_index_of_last_character(&self.word_separators);
                 position_start = Position::new(
                     position_start.line.0.saturating_sub(1) as i32,
                     new_start_index as u16,
@@ -3157,7 +3169,8 @@ impl Grid {
                 if position_row_below.is_canonical {
                     break;
                 }
-                let new_end_index = position_row_below.word_end_index_of_first_character();
+                let new_end_index =
+                    position_row_below.word_end_index_of_first_character(&self.word_separators);
                 position_end = Position::new(position_end.line.0 as i32 + 1, new_end_index as u16);
                 column_count_in_row = position_row_below.columns.len();
             } else {
@@ -3227,7 +3240,7 @@ impl Grid {
     }
 
     fn osc133_command_around_position(&self, position: &Position) -> Option<(Position, Position)> {
-        if !self.osc133_markers_seen {
+        if !self.osc133_command_selection || !self.osc133_markers_seen {
             return None;
         }
         let first_line = -(self.lines_above.len() as isize);
@@ -3281,10 +3294,7 @@ impl Grid {
                 break 'forward;
             }
         }
-        let selection_end = selection_end.or_else(|| {
-            self.row_at(last_line)
-                .map(|row| marker_position(last_line, row.width()))
-        })?;
+        let selection_end = selection_end?;
 
         Some((selection_start, selection_end))
     }
@@ -5662,10 +5672,14 @@ impl Row {
     pub fn last_index_in_line(&self) -> usize {
         self.columns.len()
     }
-    pub fn word_indices_around_character_index(&self, index: usize) -> Option<(usize, usize)> {
+    pub fn word_indices_around_character_index(
+        &self,
+        index: usize,
+        word_separators: &str,
+    ) -> Option<(usize, usize)> {
         let absolute_character_index = self.absolute_character_index(index);
         let character_at_index = self.columns.get(absolute_character_index)?;
-        if is_selection_boundary_character(character_at_index.character) {
+        if is_selection_boundary_character(character_at_index.character, word_separators) {
             return Some((index, index + 1));
         }
         let mut end_position = self
@@ -5674,7 +5688,7 @@ impl Row {
             .enumerate()
             .skip(absolute_character_index)
             .find_map(|(i, t_c)| {
-                if is_selection_boundary_character(t_c.character) {
+                if is_selection_boundary_character(t_c.character, word_separators) {
                     Some(i + self.excess_width_until(i))
                 } else {
                     None
@@ -5688,7 +5702,7 @@ impl Row {
             .take(absolute_character_index)
             .rev()
             .find_map(|(i, t_c)| {
-                if is_selection_boundary_character(t_c.character) {
+                if is_selection_boundary_character(t_c.character, word_separators) {
                     Some(i + 1 + self.excess_width_until(i))
                 } else {
                     None
@@ -5701,13 +5715,13 @@ impl Row {
         }
         Some((start_position, end_position))
     }
-    pub fn word_start_index_of_last_character(&self) -> usize {
+    pub fn word_start_index_of_last_character(&self, word_separators: &str) -> usize {
         self.columns
             .iter()
             .enumerate()
             .rev()
             .find_map(|(i, t_c)| {
-                if is_selection_boundary_character(t_c.character) {
+                if is_selection_boundary_character(t_c.character, word_separators) {
                     Some(self.absolute_character_index(i + 1))
                 } else {
                     None
@@ -5715,12 +5729,12 @@ impl Row {
             })
             .unwrap_or(0)
     }
-    pub fn word_end_index_of_first_character(&self) -> usize {
+    pub fn word_end_index_of_first_character(&self, word_separators: &str) -> usize {
         self.columns
             .iter()
             .enumerate()
             .find_map(|(i, t_c)| {
-                if is_selection_boundary_character(t_c.character) {
+                if is_selection_boundary_character(t_c.character, word_separators) {
                     Some(self.absolute_character_index(i))
                 } else {
                     None
@@ -5730,16 +5744,8 @@ impl Row {
     }
 }
 
-fn is_selection_boundary_character(character: char) -> bool {
-    character.is_ascii_whitespace()
-        || character == '['
-        || character == ']'
-        || character == '{'
-        || character == '}'
-        || character == '<'
-        || character == '>'
-        || character == '('
-        || character == ')'
+fn is_selection_boundary_character(character: char, word_separators: &str) -> bool {
+    character.is_ascii_whitespace() || word_separators.contains(character)
 }
 
 #[cfg(test)]

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1398,7 +1398,7 @@ impl Grid {
                     Some(mut last_line_above) => {
                         self.kitty_grid
                             .merge_rows_into_line_start(self.lines_above.len(), 1);
-                        last_line_above.append(&mut line_to_push_up.columns);
+                        last_line_above.append(&mut line_to_push_up);
                         last_line_above
                     },
                     None => {
@@ -1492,7 +1492,7 @@ impl Grid {
                     && !self.lines_above.is_empty()
                 {
                     let mut first_line_above = self.lines_above.pop_back().unwrap();
-                    first_line_above.append(&mut row.columns);
+                    first_line_above.append(&mut row);
                     viewport_canonical_lines.push(first_line_above);
                     cursor_canonical_line_index += 1;
                 } else if row.is_canonical {
@@ -1500,7 +1500,7 @@ impl Grid {
                 } else {
                     match viewport_canonical_lines.last_mut() {
                         Some(last_line) => {
-                            last_line.append(&mut row.columns);
+                            last_line.append(&mut row);
                         },
                         None => {
                             // the state is corrupted somehow
@@ -2320,7 +2320,7 @@ impl Grid {
     }
     pub fn clear_cursor_line(&mut self) {
         if let Some(viewport_line) = self.viewport.get_mut(self.cursor.y) {
-            viewport_line.truncate(0);
+            viewport_line.replace_columns(VecDeque::new());
             self.output_buffer.update_line(self.cursor.y);
         }
     }
@@ -2964,18 +2964,17 @@ impl Grid {
             self.mark_for_rerender();
             return;
         } else if self.click.is_triple_click() {
-            let Some((start_position, end_position)) = self.canonical_line_around_position(&start)
+            let Some((start_position, end_position)) = self
+                .osc133_command_around_position(start)
+                .or_else(|| self.canonical_line_around_position(start))
             else {
                 // no-op
                 return;
             };
             self.selection
                 .set_start_and_end_positions(start_position, end_position);
-            for i in std::cmp::min(start_position.line.0, end_position.line.0)
-                ..=std::cmp::max(start_position.line.0, end_position.line.0)
-            {
-                self.output_buffer.update_line(i as usize);
-            }
+            let current_selection = self.selection;
+            self.update_selected_lines(&old_selection, &current_selection);
             self.mark_for_rerender();
             return;
         }
@@ -3067,7 +3066,7 @@ impl Grid {
                 Row::from_columns(VecDeque::from(vec![EMPTY_TERMINAL_CHARACTER; self.width]));
 
             // get the row from lines_above, viewport, or lines below depending on index
-            let row = if l < 0 && self.lines_above.len() > l.abs() as usize {
+            let row = if l < 0 && self.lines_above.len() >= l.abs() as usize {
                 let offset_from_end = l.abs();
                 &self.lines_above[self
                     .lines_above
@@ -3206,6 +3205,88 @@ impl Grid {
             }
         }
         Some((position_start, position_end))
+    }
+
+    fn osc133_command_around_position(&self, position: &Position) -> Option<(Position, Position)> {
+        let lines_above = self.lines_above.len() as isize;
+        let markers: Vec<(Position, Osc133MarkerKind)> = self
+            .lines_above
+            .iter()
+            .chain(self.viewport.iter())
+            .chain(self.lines_below.iter())
+            .enumerate()
+            .flat_map(|(line, row)| {
+                row.osc133_markers.iter().map(move |marker| {
+                    (
+                        Position::new(
+                            line as i32 - lines_above as i32,
+                            marker.column.min(u16::MAX as usize) as u16,
+                        ),
+                        marker.kind,
+                    )
+                })
+            })
+            .collect();
+        let clicked = (position.line.0, position.column.0 as usize);
+        let mut input_start = None;
+        let mut active_output = None;
+
+        for (marker_position, kind) in &markers {
+            if (marker_position.line.0, marker_position.column.0 as usize) > clicked {
+                break;
+            }
+            match kind {
+                Osc133MarkerKind::Prompt => {
+                    input_start = None;
+                    active_output = None;
+                },
+                Osc133MarkerKind::Input => {
+                    input_start = Some(*marker_position);
+                    active_output = None;
+                },
+                Osc133MarkerKind::Output => {
+                    active_output =
+                        Some((input_start.unwrap_or(*marker_position), *marker_position));
+                },
+                Osc133MarkerKind::End => {
+                    input_start = None;
+                    active_output = None;
+                },
+            }
+        }
+
+        let (selection_start, _) = active_output?;
+        let selection_end = markers
+            .iter()
+            .find_map(|(marker_position, kind)| {
+                ((marker_position.line.0, marker_position.column.0 as usize) > clicked
+                    && matches!(
+                        kind,
+                        Osc133MarkerKind::Prompt
+                            | Osc133MarkerKind::Input
+                            | Osc133MarkerKind::Output
+                            | Osc133MarkerKind::End
+                    ))
+                .then_some(*marker_position)
+            })
+            .or_else(|| {
+                self.lines_above
+                    .iter()
+                    .chain(self.viewport.iter())
+                    .chain(self.lines_below.iter())
+                    .last()
+                    .map(|row| {
+                        Position::new(
+                            (self.lines_above.len() + self.viewport.len() + self.lines_below.len())
+                                as i32
+                                - lines_above as i32
+                                - 1,
+                            row.width().min(u16::MAX as usize) as u16,
+                        )
+                    })
+            })?;
+
+        Some((selection_start, selection_end))
     }
 
     fn update_selected_lines(&mut self, old_selection: &Selection, new_selection: &Selection) {
@@ -4225,6 +4306,19 @@ impl Perform for Grid {
                 // get/set cursor color currently unimplemented
             },
 
+            b"133" => {
+                let marker = params.get(1).and_then(|subcommand| match *subcommand {
+                    b"A" | b"P" => Some(Osc133MarkerKind::Prompt),
+                    b"B" | b"I" => Some(Osc133MarkerKind::Input),
+                    b"C" => Some(Osc133MarkerKind::Output),
+                    b"D" => Some(Osc133MarkerKind::End),
+                    _ => None,
+                });
+                if let (Some(marker), Some(row)) = (marker, self.viewport.get_mut(self.cursor.y)) {
+                    row.add_osc133_marker(self.cursor.x, marker);
+                }
+            },
+
             // Set cursor style.
             b"50" => {
                 if params.len() >= 2
@@ -5145,6 +5239,21 @@ pub struct Row {
     pub is_canonical: bool,
     width: Option<usize>,
     pub bg_color: Option<AnsiCode>,
+    osc133_markers: Vec<Osc133Marker>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Osc133MarkerKind {
+    Prompt,
+    Input,
+    Output,
+    End,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Osc133Marker {
+    column: usize,
+    kind: Osc133MarkerKind,
 }
 
 impl Debug for Row {
@@ -5163,6 +5272,7 @@ impl Row {
             is_canonical: false,
             width: None,
             bg_color: None,
+            osc133_markers: vec![],
         }
     }
     pub fn from_columns(columns: VecDeque<TerminalCharacter>) -> Self {
@@ -5171,6 +5281,7 @@ impl Row {
             is_canonical: false,
             width: None,
             bg_color: None,
+            osc133_markers: vec![],
         }
     }
     pub fn from_rows(mut rows: Vec<Row>) -> Self {
@@ -5179,7 +5290,7 @@ impl Row {
         } else {
             let mut first_row = rows.remove(0);
             for row in &mut rows {
-                first_row.append(&mut row.columns);
+                first_row.append(row);
             }
             first_row
         }
@@ -5293,6 +5404,15 @@ impl Row {
                 let (absolute_x_index, position_inside_character) =
                     self.absolute_character_index_and_position_in_char(x);
                 let character_width = terminal_character.width();
+                let overwrite_start = x.saturating_sub(position_inside_character);
+                let overwrite_end =
+                    overwrite_start + character_width.max(self.columns[absolute_x_index].width());
+                let replacing_blank = self.columns[absolute_x_index].character == ' ';
+                self.osc133_markers.retain(|marker| {
+                    marker.column < overwrite_start
+                        || marker.column >= overwrite_end
+                        || (replacing_blank && marker.column == overwrite_start)
+                });
                 let replaced_character =
                     std::mem::replace(&mut self.columns[absolute_x_index], terminal_character);
                 match character_width.cmp(&replaced_character.width()) {
@@ -5331,6 +5451,12 @@ impl Row {
         }
     }
     pub fn insert_character_at(&mut self, terminal_character: TerminalCharacter, x: usize) {
+        let character_width = terminal_character.width();
+        for marker in &mut self.osc133_markers {
+            if marker.column > x {
+                marker.column += character_width;
+            }
+        }
         let insert_position = self.absolute_character_index(x);
         match self.columns.len().cmp(&insert_position) {
             Ordering::Equal => self.columns.push_back(terminal_character),
@@ -5349,6 +5475,9 @@ impl Row {
         let absolute_x_index = self.absolute_character_index(x);
         if let Some(character) = self.columns.get_mut(absolute_x_index) {
             let terminal_character_width = terminal_character.width();
+            let overwrite_end = x + character.width().max(terminal_character_width);
+            self.osc133_markers
+                .retain(|marker| marker.column < x || marker.column >= overwrite_end);
             let character = std::mem::replace(character, terminal_character);
             let excess_width = character.width().saturating_sub(terminal_character_width);
             for _ in 0..excess_width {
@@ -5360,6 +5489,7 @@ impl Row {
     }
     pub fn replace_columns(&mut self, columns: VecDeque<TerminalCharacter>) {
         self.columns = columns;
+        self.osc133_markers.clear();
         self.width = None;
     }
     pub fn push(&mut self, terminal_character: TerminalCharacter) {
@@ -5372,6 +5502,7 @@ impl Row {
         if truncate_position < self.columns.len() {
             self.columns.truncate(truncate_position);
         }
+        self.osc133_markers.retain(|marker| marker.column <= x);
         self.width = None;
     }
     pub fn position_accounting_for_widechars(&self, x: usize) -> usize {
@@ -5392,6 +5523,7 @@ impl Row {
         to: usize,
         terminal_character: TerminalCharacter,
     ) {
+        self.osc133_markers.retain(|marker| marker.column <= from);
         let from_position_accounting_for_widechars = self.position_accounting_for_widechars(from);
         let to_position_accounting_for_widechars = self.position_accounting_for_widechars(to);
         let replacement_length = to_position_accounting_for_widechars
@@ -5402,8 +5534,14 @@ impl Row {
         self.columns.append(&mut replace_with);
         self.width = None;
     }
-    pub fn append(&mut self, to_append: &mut VecDeque<TerminalCharacter>) {
-        self.columns.append(to_append);
+    pub fn append(&mut self, to_append: &mut Row) {
+        let column_offset = self.width();
+        self.columns.append(&mut to_append.columns);
+        self.osc133_markers
+            .extend(to_append.osc133_markers.drain(..).map(|mut marker| {
+                marker.column += column_offset;
+                marker
+            }));
         self.width = None;
     }
     pub fn drain_until(&mut self, x: usize) -> VecDeque<TerminalCharacter> {
@@ -5431,6 +5569,9 @@ impl Row {
             .get(to_position_accounting_for_widechars)
             .map(|character| character.width())
             .unwrap_or(1);
+        let replaced_end = to + width_of_current_character;
+        self.osc133_markers
+            .retain(|marker| marker.column >= replaced_end);
         let mut replace_with =
             VecDeque::from(vec![terminal_character; to + width_of_current_character]);
         if to_position_accounting_for_widechars > self.columns.len() {
@@ -5454,12 +5595,27 @@ impl Row {
         let erase_position = self.absolute_character_index(x);
         if erase_position < self.columns.len() {
             self.width = None;
-            self.columns.remove(erase_position)
+            let deleted = self.columns.remove(erase_position);
+            if let Some(deleted) = &deleted {
+                let end = x + deleted.width();
+                self.osc133_markers.retain_mut(|marker| {
+                    if (x..end).contains(&marker.column) {
+                        false
+                    } else {
+                        if marker.column >= end {
+                            marker.column -= deleted.width();
+                        }
+                        true
+                    }
+                });
+            }
+            deleted
         } else {
             None
         }
     }
     pub fn split_to_rows_of_length(&mut self, max_row_length: usize) -> Vec<Row> {
+        let markers = std::mem::take(&mut self.osc133_markers);
         let mut parts: Vec<Row> = vec![];
         let mut current_part: VecDeque<TerminalCharacter> = VecDeque::new();
         let mut current_part_len = 0;
@@ -5483,8 +5639,24 @@ impl Row {
         if parts.is_empty() {
             parts.push(self.clone());
         }
+        for mut marker in markers {
+            let mut column_offset = 0;
+            for part_index in 0..parts.len() {
+                let part_width = parts[part_index].width();
+                if marker.column <= column_offset + part_width || part_index + 1 == parts.len() {
+                    marker.column = marker.column.saturating_sub(column_offset).min(part_width);
+                    parts[part_index].osc133_markers.push(marker);
+                    break;
+                }
+                column_offset += part_width;
+            }
+        }
         self.width = None;
         parts
+    }
+    fn add_osc133_marker(&mut self, column: usize, kind: Osc133MarkerKind) {
+        self.osc133_markers.push(Osc133Marker { column, kind });
+        self.osc133_markers.sort_by_key(|marker| marker.column);
     }
     pub fn last_index_in_line(&self) -> usize {
         self.columns.len()

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -753,6 +753,7 @@ pub struct Grid {
     // key: plugin_id (u32), inner vec: (pattern, compiled) pairs
     pub hover_position: Option<Position>, // pane-relative cursor cell; None when outside pane
     pub cached_hover_tooltip: Option<String>,
+    osc133_markers_seen: bool,
 }
 
 impl Grid {
@@ -1096,6 +1097,7 @@ impl Grid {
             plugin_highlights: HashMap::new(),
             hover_position: None,
             cached_hover_tooltip: None,
+            osc133_markers_seen: false,
         }
     }
     pub fn render_full_viewport(&mut self) {
@@ -2612,6 +2614,7 @@ impl Grid {
         self.set_scroll_region_to_viewport_size();
         self.pane_default_fg = None;
         self.pane_default_bg = None;
+        self.osc133_markers_seen = false;
         if let Some(images_to_reap) = self.sixel_grid.clear() {
             self.sixel_grid.reap_images(images_to_reap);
         }
@@ -3207,84 +3210,81 @@ impl Grid {
         Some((position_start, position_end))
     }
 
-    fn osc133_command_around_position(&self, position: &Position) -> Option<(Position, Position)> {
-        let lines_above = self.lines_above.len() as isize;
-        let markers: Vec<(Position, Osc133MarkerKind)> = self
-            .lines_above
-            .iter()
-            .chain(self.viewport.iter())
-            .chain(self.lines_below.iter())
-            .enumerate()
-            .flat_map(|(line, row)| {
-                row.osc133_markers.iter().map(move |marker| {
-                    (
-                        Position::new(
-                            line as i32 - lines_above as i32,
-                            marker.column.min(u16::MAX as usize) as u16,
-                        ),
-                        marker.kind,
-                    )
-                })
-            })
-            .collect();
-        let clicked = (position.line.0, position.column.0 as usize);
-        let mut input_start = None;
-        let mut active_output = None;
-
-        for (marker_position, kind) in &markers {
-            if (marker_position.line.0, marker_position.column.0 as usize) > clicked {
-                break;
+    fn row_at(&self, line: isize) -> Option<&Row> {
+        if line < 0 {
+            let offset_from_end = line.unsigned_abs();
+            if self.lines_above.len() >= offset_from_end {
+                self.lines_above
+                    .get(self.lines_above.len() - offset_from_end)
+            } else {
+                None
             }
-            match kind {
-                Osc133MarkerKind::Prompt => {
-                    input_start = None;
-                    active_output = None;
-                },
-                Osc133MarkerKind::Input => {
-                    input_start = Some(*marker_position);
-                    active_output = None;
-                },
-                Osc133MarkerKind::Output => {
-                    active_output =
-                        Some((input_start.unwrap_or(*marker_position), *marker_position));
-                },
-                Osc133MarkerKind::End => {
-                    input_start = None;
-                    active_output = None;
-                },
+        } else if (line as usize) < self.viewport.len() {
+            self.viewport.get(line as usize)
+        } else {
+            self.lines_below.get((line as usize) - self.viewport.len())
+        }
+    }
+
+    fn osc133_command_around_position(&self, position: &Position) -> Option<(Position, Position)> {
+        if !self.osc133_markers_seen {
+            return None;
+        }
+        let first_line = -(self.lines_above.len() as isize);
+        let last_line = (self.viewport.len() + self.lines_below.len()) as isize - 1;
+        let clicked_line = position.line.0 as isize;
+        let clicked_column = position.column.0 as usize;
+        let marker_position = |line: isize, column: usize| {
+            Position::new(line as i32, column.min(u16::MAX as usize) as u16)
+        };
+
+        let mut latest_output = None;
+        let mut selection_start = None;
+        'backward: for line in (first_line..=clicked_line.min(last_line)).rev() {
+            let Some(row) = self.row_at(line) else {
+                continue;
+            };
+            for marker in row.osc133_markers.iter().rev() {
+                if line == clicked_line && marker.column > clicked_column {
+                    continue;
+                }
+                match marker.kind {
+                    Osc133MarkerKind::Output => {
+                        if latest_output.is_none() {
+                            latest_output = Some(marker_position(line, marker.column));
+                        }
+                    },
+                    Osc133MarkerKind::Input => {
+                        latest_output?;
+                        selection_start = Some(marker_position(line, marker.column));
+                        break 'backward;
+                    },
+                    Osc133MarkerKind::Prompt | Osc133MarkerKind::End => {
+                        latest_output?;
+                        break 'backward;
+                    },
+                }
             }
         }
+        let selection_start = selection_start.or(latest_output)?;
 
-        let (selection_start, _) = active_output?;
-        let selection_end = markers
-            .iter()
-            .find_map(|(marker_position, kind)| {
-                ((marker_position.line.0, marker_position.column.0 as usize) > clicked
-                    && matches!(
-                        kind,
-                        Osc133MarkerKind::Prompt
-                            | Osc133MarkerKind::Input
-                            | Osc133MarkerKind::Output
-                            | Osc133MarkerKind::End
-                    ))
-                .then_some(*marker_position)
-            })
-            .or_else(|| {
-                self.lines_above
-                    .iter()
-                    .chain(self.viewport.iter())
-                    .chain(self.lines_below.iter())
-                    .last()
-                    .map(|row| {
-                        Position::new(
-                            (self.lines_above.len() + self.viewport.len() + self.lines_below.len())
-                                as i32
-                                - lines_above as i32
-                                - 1,
-                            row.width().min(u16::MAX as usize) as u16,
-                        )
-                    })
-            })?;
+        let mut selection_end = None;
+        'forward: for line in clicked_line.max(first_line)..=last_line {
+            let Some(row) = self.row_at(line) else {
+                continue;
+            };
+            for marker in row.osc133_markers.iter() {
+                if line == clicked_line && marker.column <= clicked_column {
+                    continue;
+                }
+                selection_end = Some(marker_position(line, marker.column));
+                break 'forward;
+            }
+        }
+        let selection_end = selection_end.or_else(|| {
+            self.row_at(last_line)
+                .map(|row| marker_position(last_line, row.width()))
+        })?;
 
         Some((selection_start, selection_end))
     }
@@ -4316,6 +4316,7 @@ impl Perform for Grid {
                 });
                 if let (Some(marker), Some(row)) = (marker, self.viewport.get_mut(self.cursor.y)) {
                     row.add_osc133_marker(self.cursor.x, marker);
+                    self.osc133_markers_seen = true;
                 }
             },
 

--- a/zellij-server/src/panes/plugin_pane.rs
+++ b/zellij-server/src/panes/plugin_pane.rs
@@ -633,6 +633,11 @@ impl Pane for PluginPane {
     fn clear_scroll(&mut self) {
         // noop
     }
+    fn set_selection_options(&mut self, osc133_command_selection: bool, word_separators: &str) {
+        for grid in self.grids.values_mut() {
+            grid.set_selection_options(osc133_command_selection, word_separators);
+        }
+    }
     fn start_selection(&mut self, start: &Position, client_id: ClientId) {
         if self.supports_mouse_selection {
             if let Some(grid) = self.grids.get_mut(&client_id) {

--- a/zellij-server/src/panes/terminal_pane.rs
+++ b/zellij-server/src/panes/terminal_pane.rs
@@ -883,6 +883,11 @@ impl Pane for TerminalPane {
         self.grid.pending_osc7_cwd.take()
     }
 
+    fn set_selection_options(&mut self, osc133_command_selection: bool, word_separators: &str) {
+        self.grid
+            .set_selection_options(osc133_command_selection, word_separators);
+    }
+
     fn start_selection(&mut self, start: &Position, _client_id: ClientId) {
         self.grid.start_selection(start);
         self.set_should_render(true);

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -4342,6 +4342,43 @@ fn osc133_unknown_subcommand_is_ignored() {
 }
 
 #[test]
+fn osc133_repeated_output_markers_without_input_start_at_latest_output() {
+    let mut grid = create_grid_with_content(
+        "\x1b]133;A\x07$ first\x1b]133;C\x07skip\x1b]133;C\x07keep\x1b]133;D\x07",
+    );
+
+    let position = viewport_position_of(&grid, "keep");
+    assert_eq!(select_with_click_count(&mut grid, position, 3), "keep");
+}
+
+#[test]
+fn osc133_click_exactly_on_output_marker_column_selects_command_and_output() {
+    let mut grid = create_grid_with_content(
+        "\x1b]133;A\x07$ \x1b]133;B\x07cmd\x1b]133;C\x07OUT\x1b]133;D\x07",
+    );
+
+    let position = viewport_position_of(&grid, "OUT");
+    assert_eq!(select_with_click_count(&mut grid, position, 3), "cmdOUT");
+}
+
+#[test]
+fn osc133_backward_scan_finds_command_start_in_deep_scrollback() {
+    let mut content = b"\x1b]133;A\x07$ \x1b]133;B\x07cmd\x1b]133;C\x07\r\nline00".to_vec();
+    for i in 1..40 {
+        content.extend_from_slice(format!("\r\nline{:02}", i).as_bytes());
+    }
+    content.extend_from_slice(b"\x1b]133;D\x07");
+    let mut grid = create_grid_with_size_and_raw(10, 20, &content);
+
+    let position = viewport_position_of(&grid, "line39");
+    let expected = std::iter::once("cmd".to_string())
+        .chain((0..40).map(|i| format!("line{:02}", i)))
+        .collect::<Vec<String>>()
+        .join("\n");
+    assert_eq!(select_with_click_count(&mut grid, position, 3), expected);
+}
+
+#[test]
 fn cursor_forward_over_unwritten_line_positions_character() {
     use crate::panes::terminal_character::AnsiCode;
 

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -10,6 +10,7 @@ use vte;
 use zellij_utils::consts::SCROLL_BUFFER_SIZE;
 use zellij_utils::{
     data::{Palette, Style},
+    input::options::DEFAULT_WORD_SEPARATORS,
     pane_size::SizeInPixels,
     position::Position,
 };
@@ -4214,11 +4215,23 @@ fn osc133_wrapped_command_and_output_are_selected_together() {
 }
 
 #[test]
-fn osc133_incomplete_command_selects_available_output() {
+fn osc133_running_command_without_end_boundary_falls_back_to_logical_line_selection() {
     let mut grid =
         create_grid_with_content("\x1b]133;A\x07$ \x1b]133;B\x07sleep\x1b]133;C\x07\r\npartial");
 
     let position = viewport_position_of(&grid, "partial");
+    assert_eq!(select_with_click_count(&mut grid, position, 3), "partial");
+}
+
+#[test]
+fn osc133_command_becomes_selectable_once_its_end_boundary_arrives() {
+    let mut grid =
+        create_grid_with_content("\x1b]133;A\x07$ \x1b]133;B\x07sleep\x1b]133;C\x07\r\npartial");
+    let position = viewport_position_of(&grid, "partial");
+
+    let mut vte_parser = vte::Parser::new();
+    vte_parser.advance(&mut grid, b"\x1b]133;D;0\x07");
+
     assert_eq!(
         select_with_click_count(&mut grid, position, 3),
         "sleep\npartial"
@@ -4339,6 +4352,69 @@ fn osc133_unknown_subcommand_is_ignored() {
         select_with_click_count(&mut grid, Position::new(0, 7), 3),
         "plain text"
     );
+}
+
+#[test]
+fn osc133_command_selection_disabled_falls_back_to_logical_line_selection() {
+    let mut grid = create_grid_with_content(
+        "\x1b]133;A\x07$ \x1b]133;B\x07echo hi\x1b]133;C\x07\r\nhi\x1b]133;D;0\x07",
+    );
+    grid.set_selection_options(false, DEFAULT_WORD_SEPARATORS);
+
+    assert_eq!(
+        select_with_click_count(&mut grid, Position::new(1, 0), 3),
+        "hi"
+    );
+}
+
+#[test]
+fn osc133_command_selection_can_be_re_enabled_for_existing_markers() {
+    let mut grid = create_grid_with_content(
+        "\x1b]133;A\x07$ \x1b]133;B\x07echo hi\x1b]133;C\x07\r\nhi\x1b]133;D;0\x07",
+    );
+    grid.set_selection_options(false, DEFAULT_WORD_SEPARATORS);
+    grid.set_selection_options(true, DEFAULT_WORD_SEPARATORS);
+
+    assert_eq!(
+        select_with_click_count(&mut grid, Position::new(1, 0), 3),
+        "echo hi\nhi"
+    );
+}
+
+#[test]
+fn configured_word_separators_split_double_click_selection() {
+    let mut grid = create_grid_with_content("foo:bar baz");
+    grid.set_selection_options(true, ":");
+
+    let position = viewport_position_of(&grid, "bar");
+    assert_eq!(select_with_click_count(&mut grid, position, 2), "bar");
+}
+
+#[test]
+fn characters_absent_from_word_separators_do_not_split_double_click_selection() {
+    let mut grid = create_grid_with_content("foo:bar baz");
+    grid.set_selection_options(true, DEFAULT_WORD_SEPARATORS);
+
+    let position = viewport_position_of(&grid, "bar");
+    assert_eq!(select_with_click_count(&mut grid, position, 2), "foo:bar");
+}
+
+#[test]
+fn word_separators_not_configured_as_separators_are_part_of_the_word() {
+    let mut grid = create_grid_with_content("foo(bar) baz");
+    grid.set_selection_options(true, "");
+
+    let position = viewport_position_of(&grid, "bar");
+    assert_eq!(select_with_click_count(&mut grid, position, 2), "foo(bar)");
+}
+
+#[test]
+fn default_word_separators_keep_bracket_boundaries() {
+    let mut grid = create_grid_with_content("foo(bar) baz");
+    grid.set_selection_options(true, DEFAULT_WORD_SEPARATORS);
+
+    let position = viewport_position_of(&grid, "bar");
+    assert_eq!(select_with_click_count(&mut grid, position, 2), "bar");
 }
 
 #[test]

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -4122,6 +4122,225 @@ fn create_grid_with_content(content: &str) -> Grid {
     grid
 }
 
+fn select_with_click_count(grid: &mut Grid, position: Position, click_count: usize) -> String {
+    for _ in 0..click_count {
+        grid.start_selection(&position);
+    }
+    grid.end_selection(&position);
+    grid.get_selected_text().unwrap()
+}
+
+fn viewport_position_of(grid: &Grid, needle: &str) -> Position {
+    grid.viewport
+        .iter()
+        .enumerate()
+        .find_map(|(line, row)| {
+            let text: String = row.columns.iter().map(|c| c.character).collect();
+            text.find(needle)
+                .map(|column| Position::new(line as i32, column as u16))
+        })
+        .unwrap_or_else(|| panic!("{needle:?} not found in viewport"))
+}
+
+#[test]
+fn osc133_a_b_c_d_selects_command_and_output_without_prompt() {
+    let mut grid = create_grid_with_content(
+        "\x1b]133;A\x07$ \x1b]133;B\x07echo hi\x1b]133;C\x07\r\nhi\x1b]133;D;0\x07 suffix",
+    );
+
+    assert_eq!(
+        select_with_click_count(&mut grid, Position::new(1, 0), 3),
+        "echo hi\nhi"
+    );
+}
+
+#[test]
+fn osc133_p_i_aliases_select_command_and_output_without_prompt() {
+    let mut grid = create_grid_with_content(
+        "\x1b]133;P\x07> \x1b]133;I\x07pwd\x1b]133;C\x07\r\n/tmp\x1b]133;D\x07",
+    );
+
+    let position = viewport_position_of(&grid, "/tmp");
+    assert_eq!(select_with_click_count(&mut grid, position, 3), "pwd\n/tmp");
+}
+
+#[test]
+fn osc133_input_marker_survives_ghostty_prompt_clear() {
+    let mut grid = create_grid_with_content(
+        "\x1b]133;A;cl=line\x07$ \x1b]133;B\x07\x1b[Kecho hi\r\n\x1b]133;C\x07hi\r\n\x1b]133;D;0\x07\r\x1b[J\x1b]133;A;cl=line\x07$ \x1b]133;B\x07\x1b[Knext",
+    );
+
+    assert_eq!(
+        select_with_click_count(&mut grid, Position::new(1, 0), 3),
+        "echo hi\nhi"
+    );
+}
+
+#[test]
+fn osc133_triple_click_outside_output_keeps_logical_line_selection() {
+    let mut grid = create_grid_with_content(
+        "\x1b]133;A\x07$ \x1b]133;B\x07echo hi\x1b]133;C\x07 output\x1b]133;D\x07",
+    );
+
+    assert_eq!(
+        select_with_click_count(&mut grid, Position::new(0, 0), 3),
+        "$ echo hi output"
+    );
+}
+
+#[test]
+fn osc133_double_click_keeps_word_selection() {
+    let mut grid = create_grid_with_content(
+        "\x1b]133;A\x07$ \x1b]133;B\x07echo\x1b]133;C\x07 result word\x1b]133;D\x07",
+    );
+
+    let position = viewport_position_of(&grid, "word");
+    assert_eq!(select_with_click_count(&mut grid, position, 2), "word");
+}
+
+#[test]
+fn osc133_wrapped_command_and_output_are_selected_together() {
+    let mut grid = create_grid_with_size_and_raw(
+        4,
+        8,
+        b"\x1b]133;A\x07$ \x1b]133;B\x07longcmd\x1b]133;C\x07-output\x1b]133;D\x07",
+    );
+
+    let position = viewport_position_of(&grid, "output");
+    assert_eq!(
+        select_with_click_count(&mut grid, position, 3),
+        "longcmd-output"
+    );
+}
+
+#[test]
+fn osc133_incomplete_command_selects_available_output() {
+    let mut grid =
+        create_grid_with_content("\x1b]133;A\x07$ \x1b]133;B\x07sleep\x1b]133;C\x07\r\npartial");
+
+    let position = viewport_position_of(&grid, "partial");
+    assert_eq!(
+        select_with_click_count(&mut grid, position, 3),
+        "sleep\npartial"
+    );
+}
+
+#[test]
+fn osc133_missing_input_starts_selection_at_output_boundary() {
+    let mut grid =
+        create_grid_with_content("\x1b]133;A\x07$ hidden\x1b]133;C\x07visible\x1b]133;D\x07");
+
+    let position = viewport_position_of(&grid, "visible");
+    assert_eq!(select_with_click_count(&mut grid, position, 3), "visible");
+}
+
+#[test]
+fn osc133_missing_end_stops_at_later_prompt() {
+    let mut grid = create_grid_with_content(
+        "\x1b]133;A\x07$ \x1b]133;B\x07one\x1b]133;C\x07:1\x1b]133;A\x07$ \x1b]133;B\x07two\x1b]133;C\x07:2",
+    );
+
+    assert_eq!(
+        select_with_click_count(&mut grid, Position::new(0, 5), 3),
+        "one:1"
+    );
+}
+
+#[test]
+fn osc133_multiple_commands_on_one_row_remain_distinct() {
+    let content = "\x1b]133;A\x07$ \x1b]133;B\x07one\x1b]133;C\x07:1\x1b]133;D\x07\x1b]133;P\x07$ \x1b]133;I\x07two\x1b]133;C\x07:2\x1b]133;D\x07";
+    let mut first = create_grid_with_content(content);
+    let mut second = create_grid_with_content(content);
+
+    assert_eq!(
+        select_with_click_count(&mut first, Position::new(0, 5), 3),
+        "one:1"
+    );
+    assert_eq!(
+        select_with_click_count(&mut second, Position::new(0, 12), 3),
+        "two:2"
+    );
+}
+
+#[test]
+fn osc133_markers_survive_scrollback() {
+    let mut grid = create_grid_with_size_and_raw(
+        3,
+        20,
+        b"\x1b]133;A\x07$ \x1b]133;B\x07cmd\x1b]133;C\x07\r\nRESULT\x1b]133;D\x07\r\ntail1\r\ntail2\r\ntail3\r\ntail4",
+    );
+    for _ in 0..3 {
+        grid.scroll_up_one_line();
+    }
+
+    let position = viewport_position_of(&grid, "RESULT");
+    assert_eq!(
+        select_with_click_count(&mut grid, position, 3),
+        "cmd\nRESULT"
+    );
+}
+
+#[test]
+fn osc133_markers_survive_resize_reflow() {
+    let mut grid = create_grid_with_size_and_raw(
+        5,
+        20,
+        b"\x1b]133;A\x07$ \x1b]133;B\x07echo hi\x1b]133;C\x07RESULT\x1b]133;D\x07",
+    );
+    grid.change_size(5, 6);
+
+    let position = viewport_position_of(&grid, "RES");
+    assert_eq!(
+        select_with_click_count(&mut grid, position, 3),
+        "echo hiRESULT"
+    );
+}
+
+#[test]
+fn osc133_cleared_markers_fall_back_to_logical_line_selection() {
+    let mut grid = create_grid_with_content(
+        "\x1b]133;A\x07$ \x1b]133;B\x07cmd\x1b]133;C\x07old\r\x1b[2Kunmarked",
+    );
+
+    assert_eq!(
+        select_with_click_count(&mut grid, Position::new(0, 6), 3),
+        "unmarked"
+    );
+}
+
+#[test]
+fn osc133_truncated_markers_fall_back_to_logical_line_selection() {
+    let mut grid = create_grid_with_content(
+        "\x1b]133;A\x07$ \x1b]133;B\x07cmd\x1b]133;C\x07old\r\x1b[2C\x1b[Jplain",
+    );
+
+    assert_eq!(
+        select_with_click_count(&mut grid, Position::new(0, 3), 3),
+        "$ plain"
+    );
+}
+
+#[test]
+fn osc133_overwritten_markers_fall_back_to_logical_line_selection() {
+    let mut grid =
+        create_grid_with_content("\x1b]133;A\x07$ \x1b]133;B\x07cmd\x1b]133;C\x07old\runmarked");
+
+    assert_eq!(
+        select_with_click_count(&mut grid, Position::new(0, 6), 3),
+        "unmarked"
+    );
+}
+
+#[test]
+fn osc133_unknown_subcommand_is_ignored() {
+    let mut grid = create_grid_with_content("plain\x1b]133;Z\x07 text");
+
+    assert_eq!(
+        select_with_click_count(&mut grid, Position::new(0, 7), 3),
+        "plain text"
+    );
+}
+
 #[test]
 fn cursor_forward_over_unwritten_line_positions_character() {
     use crate::panes::terminal_character::AnsiCode;

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -52,7 +52,9 @@ use zellij_utils::input::command::RunCommand;
 use zellij_utils::input::config::Config;
 use zellij_utils::input::keybinds::{shortcut_for_action, Keybinds};
 use zellij_utils::input::mouse::{MouseEvent, MouseEventType};
-use zellij_utils::input::options::{Clipboard, NestedSessionHandling, PaneFrameStyle};
+use zellij_utils::input::options::{
+    Clipboard, NestedSessionHandling, PaneFrameStyle, DEFAULT_WORD_SEPARATORS,
+};
 use zellij_utils::ipc::{
     ExitReason, MobileActivePanePayload, MobilePanePayload, MobileSessionPayload,
     MobileSizePayload, MobileStatePayload, MobileTabPayload, ServerToClientMsg,
@@ -785,6 +787,8 @@ pub enum ScreenInstruction {
         visual_bell: bool,
         focus_follows_mouse: bool,
         mouse_click_through: bool,
+        osc133_command_selection: bool,
+        word_separators: String,
         nested_session_handling: NestedSessionHandling,
     },
     RerunCommandPane(u32, Option<NotificationEnd>), // u32 - terminal pane id
@@ -1516,6 +1520,8 @@ pub(crate) struct Screen {
     web_sharing: WebSharing,
     current_pane_group: Rc<RefCell<PaneGroups>>,
     advanced_mouse_actions: bool,
+    osc133_command_selection: bool,
+    word_separators: String,
     mouse_scroll_resize: bool,
     mouse_hover_effects: bool,
     visual_bell: bool,
@@ -1633,6 +1639,8 @@ impl Screen {
         web_clients_allowed: bool,
         web_sharing: WebSharing,
         advanced_mouse_actions: bool,
+        osc133_command_selection: bool,
+        word_separators: String,
         mouse_scroll_resize: bool,
         mouse_hover_effects: bool,
         visual_bell: bool,
@@ -1699,6 +1707,8 @@ impl Screen {
             current_pane_group: Rc::new(RefCell::new(current_pane_group)),
             currently_marking_pane_group: Rc::new(RefCell::new(HashMap::new())),
             advanced_mouse_actions,
+            osc133_command_selection,
+            word_separators,
             mouse_scroll_resize,
             mouse_hover_effects,
             visual_bell,
@@ -4421,6 +4431,7 @@ impl Screen {
         if let Some(aggregate) = self.sixel_host_support_aggregate() {
             tab.update_sixel_host_support(aggregate);
         }
+        tab.update_selection_options(self.osc133_command_selection, self.word_separators.clone());
         self.tabs.insert(tab_id, tab);
         Ok(())
     }
@@ -6360,6 +6371,8 @@ impl Screen {
         visual_bell: bool,
         focus_follows_mouse: bool,
         mouse_click_through: bool,
+        osc133_command_selection: bool,
+        word_separators: String,
         nested_session_handling: NestedSessionHandling,
         client_id: ClientId,
     ) -> Result<()> {
@@ -6387,6 +6400,8 @@ impl Screen {
         self.visual_bell = visual_bell;
         self.focus_follows_mouse = focus_follows_mouse;
         self.mouse_click_through = mouse_click_through;
+        self.osc133_command_selection = osc133_command_selection;
+        self.word_separators = word_separators;
         self.nested_session_handling = nested_session_handling;
         self.default_mode_info
             .update_arrow_fonts(should_support_arrow_fonts);
@@ -6415,6 +6430,7 @@ impl Screen {
             tab.update_mouse_hover_effects(mouse_hover_effects);
             tab.update_focus_follows_mouse(focus_follows_mouse);
             tab.update_mouse_click_through(mouse_click_through);
+            tab.update_selection_options(osc133_command_selection, self.word_separators.clone());
             tab.sync_stacked_pane_list_mode();
         }
 
@@ -7553,6 +7569,11 @@ pub(crate) fn screen_thread_main(
         .unwrap_or(false);
     let web_sharing = config_options.web_sharing.unwrap_or_else(Default::default);
     let advanced_mouse_actions = config_options.advanced_mouse_actions.unwrap_or(true);
+    let osc133_command_selection = config_options.osc133_command_selection.unwrap_or(true);
+    let word_separators = config_options
+        .word_separators
+        .clone()
+        .unwrap_or_else(|| DEFAULT_WORD_SEPARATORS.to_owned());
     let mouse_scroll_resize = config_options.mouse_scroll_resize.unwrap_or(true);
     let mouse_hover_effects = config_options.mouse_hover_effects.unwrap_or(true);
     let visual_bell = config_options.visual_bell.unwrap_or(true);
@@ -7598,6 +7619,8 @@ pub(crate) fn screen_thread_main(
         web_clients_allowed,
         web_sharing,
         advanced_mouse_actions,
+        osc133_command_selection,
+        word_separators,
         mouse_scroll_resize,
         mouse_hover_effects,
         visual_bell,
@@ -10863,6 +10886,8 @@ pub(crate) fn screen_thread_main(
                 visual_bell,
                 focus_follows_mouse,
                 mouse_click_through,
+                osc133_command_selection,
+                word_separators,
                 nested_session_handling,
             } => {
                 screen.host_theme_dark_styling = host_theme_dark;
@@ -10890,6 +10915,8 @@ pub(crate) fn screen_thread_main(
                         visual_bell,
                         focus_follows_mouse,
                         mouse_click_through,
+                        osc133_command_selection,
+                        word_separators,
                         nested_session_handling,
                         client_id,
                     )

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -23,6 +23,7 @@ use zellij_utils::data::{
 use zellij_utils::errors::prelude::*;
 use zellij_utils::input::command::RunCommand;
 use zellij_utils::input::mouse::MouseEvent;
+use zellij_utils::input::options::DEFAULT_WORD_SEPARATORS;
 use zellij_utils::position::Position;
 use zellij_utils::position::{Column, Line};
 use zellij_utils::shared::clean_string_from_control_and_linebreak;
@@ -261,6 +262,8 @@ pub(crate) struct Tab {
     mouse_hover_effects: bool,
     focus_follows_mouse: bool,
     mouse_click_through: bool,
+    osc133_command_selection: bool,
+    word_separators: String,
     currently_marking_pane_group: Rc<RefCell<HashMap<ClientId, bool>>>,
     connected_clients_in_app: Rc<RefCell<HashMap<ClientId, bool>>>, // bool -> is_web_client
     // the below are the configured values - the ones that will be set if and when the web server
@@ -734,6 +737,7 @@ pub trait Pane {
         None
     } // only relevant to terminal panes
     fn update_theme(&mut self, _theme: Styling) {}
+    fn set_selection_options(&mut self, _osc133_command_selection: bool, _word_separators: &str) {}
     fn update_arrow_fonts(&mut self, _should_support_arrow_fonts: bool) {}
     fn update_kitty_host_support(&mut self, _supported: KittyHostSupport) {}
     fn update_sixel_host_support(&mut self, _supported: bool) {}
@@ -1011,6 +1015,8 @@ impl Tab {
             mouse_hover_effects,
             focus_follows_mouse,
             mouse_click_through,
+            osc133_command_selection: true,
+            word_separators: DEFAULT_WORD_SEPARATORS.to_owned(),
             connected_clients_in_app,
             web_server_ip,
             web_server_port,
@@ -7478,6 +7484,14 @@ impl Tab {
     }
     pub fn update_mouse_click_through(&mut self, mouse_click_through: bool) {
         self.mouse_click_through = mouse_click_through;
+    }
+    pub fn update_selection_options(
+        &mut self,
+        osc133_command_selection: bool,
+        word_separators: String,
+    ) {
+        self.osc133_command_selection = osc133_command_selection;
+        self.word_separators = word_separators;
     }
     pub fn clear_mouse_hover_state(&mut self) {
         self.mouse_hover_pane_id.clear();

--- a/zellij-server/src/tab/mouse_handler.rs
+++ b/zellij-server/src/tab/mouse_handler.rs
@@ -791,7 +791,7 @@ impl MouseHandler {
                     tab.selecting_with_mouse_in_pane = Some(pane_id);
                 }
                 if leave_clipboard_message {
-                    Ok(MouseEffect::leave_clipboard_message())
+                    Ok(MouseEffect::state_changed_and_leave_clipboard_message())
                 } else {
                     Ok(MouseEffect::default())
                 }

--- a/zellij-server/src/tab/mouse_handler.rs
+++ b/zellij-server/src/tab/mouse_handler.rs
@@ -777,12 +777,15 @@ impl MouseHandler {
                 Ok(MouseEffect::state_changed())
             },
             MouseAction::StartSelection { pane_id, position } => {
+                let osc133_command_selection = tab.osc133_command_selection;
+                let word_separators = tab.word_separators.clone();
                 let pane = tab
                     .get_pane_with_id_mut(pane_id)
                     .ok_or_else(|| anyhow!("Failed to find pane {pane_id:?}"))?;
                 let relative_position = pane.relative_position(&position);
 
                 let mut leave_clipboard_message = false;
+                pane.set_selection_options(osc133_command_selection, &word_separators);
                 pane.start_selection(&relative_position, client_id);
                 if pane.get_selected_text(client_id).is_some() {
                     leave_clipboard_message = true;
@@ -911,8 +914,11 @@ impl MouseHandler {
 
         Self::focus_pane_at(tab, &position, client_id).with_context(err_context)?;
 
+        let osc133_command_selection = tab.osc133_command_selection;
+        let word_separators = tab.word_separators.clone();
         if let Some(pane_at_position) = Self::unselectable_pane_at_position(tab, &position) {
             let relative_position = pane_at_position.relative_position(&position);
+            pane_at_position.set_selection_options(osc133_command_selection, &word_separators);
             pane_at_position.start_selection(&relative_position, client_id);
         }
 
@@ -952,8 +958,11 @@ impl MouseHandler {
         clear_hover_for_client(tab, client_id);
         Self::focus_pane_at(tab, &position, client_id).with_context(err_context)?;
 
+        let osc133_command_selection = tab.osc133_command_selection;
+        let word_separators = tab.word_separators.clone();
         if let Some(pane_at_position) = Self::unselectable_pane_at_position(tab, &position) {
             let relative_position = pane_at_position.relative_position(&position);
+            pane_at_position.set_selection_options(osc133_command_selection, &word_separators);
             pane_at_position.start_selection(&relative_position, client_id);
             return Ok(MouseEffect::state_changed());
         }
@@ -983,6 +992,7 @@ impl MouseHandler {
         } else {
             if let Some(pane) = tab.get_pane_with_id_mut(active_pane_id) {
                 let relative_position = pane.relative_position(&position);
+                pane.set_selection_options(osc133_command_selection, &word_separators);
                 pane.start_selection(&relative_position, client_id);
                 if pane.supports_mouse_selection() {
                     tab.selecting_with_mouse_in_pane = Some(active_pane_id);

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -10932,6 +10932,33 @@ fn test_left_release_after_selection_copies_to_clipboard() {
 }
 
 #[test]
+fn triple_click_without_motion_requests_render() {
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let client_id = 1;
+    let mut tab = create_new_tab(size, ModeInfo::default());
+    let position = Position::new(1, 5);
+
+    tab.handle_pty_bytes(1, Vec::from("Selectable text content here".as_bytes()))
+        .unwrap();
+
+    for _ in 0..2 {
+        tab.handle_mouse_event(&MouseEvent::new_left_press_event(position), client_id)
+            .unwrap();
+        tab.handle_mouse_event(&MouseEvent::new_left_release_event(position), client_id)
+            .unwrap();
+    }
+
+    let effect = tab
+        .handle_mouse_event(&MouseEvent::new_left_press_event(position), client_id)
+        .unwrap();
+
+    assert!(effect.state_changed);
+}
+
+#[test]
 fn test_ctrl_click_on_tiled_pane_edge_starts_resize() {
     let size = Size {
         cols: 121,

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -10959,6 +10959,36 @@ fn triple_click_without_motion_requests_render() {
 }
 
 #[test]
+fn configured_word_separators_reach_the_pane_on_double_click() {
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let client_id = 1;
+    let mut tab = create_new_tab(size, ModeInfo::default());
+    let position = Position::new(1, 6);
+
+    tab.update_selection_options(true, ":".to_owned());
+    tab.handle_pty_bytes(1, Vec::from("foo:bar baz".as_bytes()))
+        .unwrap();
+
+    tab.handle_mouse_event(&MouseEvent::new_left_press_event(position), client_id)
+        .unwrap();
+    tab.handle_mouse_event(&MouseEvent::new_left_release_event(position), client_id)
+        .unwrap();
+    tab.handle_mouse_event(&MouseEvent::new_left_press_event(position), client_id)
+        .unwrap();
+    tab.handle_mouse_event(&MouseEvent::new_left_release_event(position), client_id)
+        .unwrap();
+
+    let selected_text = tab
+        .get_active_pane(client_id)
+        .unwrap()
+        .get_selected_text(client_id);
+    assert_eq!(selected_text, Some("bar".to_owned()));
+}
+
+#[test]
 fn test_ctrl_click_on_tiled_pane_edge_starts_resize() {
     let size = Size {
         cols: 121,

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -19,7 +19,9 @@ use zellij_utils::input::layout::{
     RunPlugin, RunPluginLocation, RunPluginOrAlias, SplitDirection, TiledPaneLayout,
 };
 use zellij_utils::input::mouse::MouseEvent;
-use zellij_utils::input::options::{NestedSessionHandling, Options, PaneFrameStyle};
+use zellij_utils::input::options::{
+    NestedSessionHandling, Options, PaneFrameStyle, DEFAULT_WORD_SEPARATORS,
+};
 use zellij_utils::ipc::IpcReceiverWithContext;
 use zellij_utils::pane_size::{Size, SizeInPixels};
 use zellij_utils::position::Position;
@@ -348,6 +350,8 @@ fn create_new_screen_with_kitty_graphics(
         false,
         web_sharing,
         advanced_mouse_actions,
+        true,
+        DEFAULT_WORD_SEPARATORS.to_owned(),
         mouse_scroll_resize,
         mouse_hover_effects,
         visual_bell,
@@ -5684,6 +5688,8 @@ fn create_new_screen_with_message_capture(
         web_sharing,
         true,
         true,
+        DEFAULT_WORD_SEPARATORS.to_owned(),
+        true,
         true,
         visual_bell,
         false, // focus_follows_mouse
@@ -8782,6 +8788,8 @@ fn create_new_screen_with_forward_capture(size: Size) -> (Screen, ForwardCapture
         web_sharing,
         true,
         true,
+        DEFAULT_WORD_SEPARATORS.to_owned(),
+        true,
         true,
         visual_bell,
         false, // focus_follows_mouse
@@ -9458,6 +9466,8 @@ fn create_new_screen_with_theme_capture(size: Size) -> (Screen, ThemeCapture) {
         web_sharing,
         true,
         true,
+        DEFAULT_WORD_SEPARATORS.to_owned(),
+        true,
         true,
         true,
         false,
@@ -9986,7 +9996,9 @@ fn create_non_mirrored_screen(size: Size) -> Screen {
         None,
         false,
         WebSharing::Off,
-        true,  // advanced_mouse_actions
+        true, // advanced_mouse_actions
+        true,
+        DEFAULT_WORD_SEPARATORS.to_owned(),
         true,  // mouse_scroll_resize
         true,  // mouse_hover_effects
         true,  // visual_bell

--- a/zellij-utils/assets/config/default.kdl
+++ b/zellij-utils/assets/config/default.kdl
@@ -548,6 +548,18 @@ load_plugins {
 //
 // mouse_hover_effects false
 
+// Whether triple-clicking inside command output marked by the shell (OSC 133) selects
+// the command and its output instead of the logical line
+// Default: true
+//
+// osc133_command_selection false
+
+// Characters that terminate a word when double-clicking to select it
+// whitespace is always a separator and need not be listed here
+// Default: "[]{}<>()"
+//
+// word_separators "[]{}<>()"
+
 // Whether to output OSC8 hyperlink sequences
 // Default: true
 //

--- a/zellij-utils/assets/prost_ipc/client_server_contract.rs
+++ b/zellij-utils/assets/prost_ipc/client_server_contract.rs
@@ -2026,6 +2026,10 @@ pub struct Options {
     pub mouse_scroll_resize: ::core::option::Option<bool>,
     #[prost(bool, optional, tag="55")]
     pub support_kitty_graphics_protocol: ::core::option::Option<bool>,
+    #[prost(bool, optional, tag="56")]
+    pub osc133_command_selection: ::core::option::Option<bool>,
+    #[prost(string, optional, tag="57")]
+    pub word_separators: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// Pane-targeting action messages
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/zellij-utils/src/client_server_contract/common_types.proto
+++ b/zellij-utils/src/client_server_contract/common_types.proto
@@ -1209,6 +1209,8 @@ message Options {
   optional NestedSessionHandling nested_session_handling = 53;
   optional bool mouse_scroll_resize = 54;
   optional bool support_kitty_graphics_protocol = 55;
+  optional bool osc133_command_selection = 56;
+  optional string word_separators = 57;
 }
 
 enum OnForceClose {

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -8,6 +8,8 @@ use std::str::FromStr;
 
 use std::net::IpAddr;
 
+pub const DEFAULT_WORD_SEPARATORS: &str = "[]{}<>()";
+
 #[derive(Copy, Clone, Debug, PartialEq, Deserialize, Serialize, ValueEnum)]
 pub enum OnForceClose {
     #[serde(alias = "quit")]
@@ -359,6 +361,20 @@ pub struct Options {
     #[serde(default)]
     pub mouse_click_through: Option<bool>,
 
+    /// Whether triple-clicking inside shell-marked (OSC 133) command output selects the command
+    /// and its output rather than the logical line
+    /// default is true
+    #[clap(long, value_parser)]
+    #[serde(default)]
+    pub osc133_command_selection: Option<bool>,
+
+    /// Characters that terminate a word when double-clicking to select it, in addition to
+    /// whitespace (which is always a separator)
+    /// default is "[]{}<>()"
+    #[clap(long, value_parser)]
+    #[serde(default)]
+    pub word_separators: Option<String>,
+
     // these are intentionally excluded from the CLI options as they must be specified in the
     // configuration file
     pub web_server_ip: Option<IpAddr>,
@@ -481,6 +497,12 @@ impl Options {
         let visual_bell = other.visual_bell.or(self.visual_bell);
         let focus_follows_mouse = other.focus_follows_mouse.or(self.focus_follows_mouse);
         let mouse_click_through = other.mouse_click_through.or(self.mouse_click_through);
+        let osc133_command_selection = other
+            .osc133_command_selection
+            .or(self.osc133_command_selection);
+        let word_separators = other
+            .word_separators
+            .or_else(|| self.word_separators.clone());
         let web_server_ip = other.web_server_ip.or(self.web_server_ip);
         let web_server_port = other.web_server_port.or(self.web_server_port);
         let web_server_cert = other
@@ -545,6 +567,8 @@ impl Options {
             visual_bell,
             focus_follows_mouse,
             mouse_click_through,
+            osc133_command_selection,
+            word_separators,
             web_server_ip,
             web_server_port,
             web_server_cert,
@@ -630,6 +654,12 @@ impl Options {
         let visual_bell = other.visual_bell.or(self.visual_bell);
         let focus_follows_mouse = merge_bool(other.focus_follows_mouse, self.focus_follows_mouse);
         let mouse_click_through = merge_bool(other.mouse_click_through, self.mouse_click_through);
+        let osc133_command_selection = other
+            .osc133_command_selection
+            .or(self.osc133_command_selection);
+        let word_separators = other
+            .word_separators
+            .or_else(|| self.word_separators.clone());
         let web_server_ip = other.web_server_ip.or(self.web_server_ip);
         let web_server_port = other.web_server_port.or(self.web_server_port);
         let web_server_cert = other
@@ -694,6 +724,8 @@ impl Options {
             visual_bell,
             focus_follows_mouse,
             mouse_click_through,
+            osc133_command_selection,
+            word_separators,
             web_server_ip,
             web_server_port,
             web_server_cert,

--- a/zellij-utils/src/ipc/protobuf_conversion.rs
+++ b/zellij-utils/src/ipc/protobuf_conversion.rs
@@ -940,6 +940,8 @@ impl From<crate::input::options::Options>
             visual_bell: options.visual_bell,
             focus_follows_mouse: options.focus_follows_mouse,
             mouse_click_through: options.mouse_click_through,
+            osc133_command_selection: options.osc133_command_selection,
+            word_separators: options.word_separators,
             pane_frame_style: options.pane_frame_style.map(|s| match s {
                 crate::input::options::PaneFrameStyle::Full => "full".to_owned(),
                 crate::input::options::PaneFrameStyle::Titles => "titles".to_owned(),
@@ -1063,6 +1065,8 @@ impl TryFrom<crate::client_server_contract::client_server_contract::Options>
             visual_bell: options.visual_bell,
             focus_follows_mouse: options.focus_follows_mouse,
             mouse_click_through: options.mouse_click_through,
+            osc133_command_selection: options.osc133_command_selection,
+            word_separators: options.word_separators,
             nested_session_handling: options
                 .nested_session_handling
                 .map(|n| match ProtoNestedSessionHandling::from_i32(n) {

--- a/zellij-utils/src/ipc/tests/roundtrip_tests.rs
+++ b/zellij-utils/src/ipc/tests/roundtrip_tests.rs
@@ -496,6 +496,8 @@ fn test_client_messages() {
                 visual_bell: Some(true),
                 focus_follows_mouse: Some(false),
                 mouse_click_through: Some(false),
+                osc133_command_selection: Some(false),
+                word_separators: Some("[]{}<>():".to_owned()),
                 nested_session_handling: Some(NestedSessionHandling::Fullscreen),
             }),
             layout: None,

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -12,7 +12,9 @@ use crate::input::keybinds::Keybinds;
 use crate::input::layout::{
     Layout, PercentOrFixed, PluginUserConfiguration, RunPlugin, RunPluginOrAlias, TabLayoutInfo,
 };
-use crate::input::options::{Clipboard, OnForceClose, Options, PaneFrameStyle};
+use crate::input::options::{
+    Clipboard, OnForceClose, Options, PaneFrameStyle, DEFAULT_WORD_SEPARATORS,
+};
 use crate::input::permission::{GrantedPermission, PermissionCache};
 use crate::input::plugins::PluginAliases;
 use crate::input::theme::{FrameConfig, Theme, Themes, UiConfig};
@@ -2913,6 +2915,12 @@ impl Options {
         let mouse_click_through =
             kdl_property_first_arg_as_bool_or_error!(kdl_options, "mouse_click_through")
                 .map(|(v, _)| v);
+        let osc133_command_selection =
+            kdl_property_first_arg_as_bool_or_error!(kdl_options, "osc133_command_selection")
+                .map(|(v, _)| v);
+        let word_separators =
+            kdl_property_first_arg_as_string_or_error!(kdl_options, "word_separators")
+                .map(|(separators, _entry)| separators.to_string());
         let nested_session_handling = match kdl_property_first_arg_as_string_or_error!(
             kdl_options,
             "nested_session_handling"
@@ -2972,6 +2980,8 @@ impl Options {
             visual_bell,
             focus_follows_mouse,
             mouse_click_through,
+            osc133_command_selection,
+            word_separators,
             web_server_ip,
             web_server_port,
             web_server_cert,
@@ -4358,6 +4368,62 @@ impl Options {
             None
         }
     }
+    fn osc133_command_selection_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
+        let comment_text = format!(
+            "{}\n{}\n{}\n{}",
+            " ",
+            "// Whether triple-clicking inside command output marked by the shell (OSC 133) selects",
+            "// the command and its output instead of the logical line",
+            "// default is true",
+        );
+
+        let create_node = |node_value: bool| -> KdlNode {
+            let mut node = KdlNode::new("osc133_command_selection");
+            node.push(KdlValue::Bool(node_value));
+            node
+        };
+        if let Some(osc133_command_selection) = self.osc133_command_selection {
+            let mut node = create_node(osc133_command_selection);
+            if add_comments {
+                node.set_leading(format!("{}\n", comment_text));
+            }
+            Some(node)
+        } else if add_comments {
+            let mut node = create_node(false);
+            node.set_leading(format!("{}\n// ", comment_text));
+            Some(node)
+        } else {
+            None
+        }
+    }
+    fn word_separators_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
+        let comment_text = format!(
+            "{}\n{}\n{}\n{}",
+            " ",
+            "// Characters that terminate a word when double-clicking to select it",
+            "// whitespace is always a separator and need not be listed here",
+            "// default is \"[]{}<>()\"",
+        );
+
+        let create_node = |node_value: &str| -> KdlNode {
+            let mut node = KdlNode::new("word_separators");
+            node.push(node_value.to_owned());
+            node
+        };
+        if let Some(word_separators) = &self.word_separators {
+            let mut node = create_node(word_separators);
+            if add_comments {
+                node.set_leading(format!("{}\n", comment_text));
+            }
+            Some(node)
+        } else if add_comments {
+            let mut node = create_node(DEFAULT_WORD_SEPARATORS);
+            node.set_leading(format!("{}\n// ", comment_text));
+            Some(node)
+        } else {
+            None
+        }
+    }
     fn web_server_ip_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
         let comment_text = format!(
             "{}\n{}\n{}\n{}",
@@ -4658,6 +4724,12 @@ impl Options {
         }
         if let Some(mouse_click_through) = self.mouse_click_through_to_kdl(add_comments) {
             nodes.push(mouse_click_through);
+        }
+        if let Some(osc133_command_selection) = self.osc133_command_selection_to_kdl(add_comments) {
+            nodes.push(osc133_command_selection);
+        }
+        if let Some(word_separators) = self.word_separators_to_kdl(add_comments) {
+            nodes.push(word_separators);
         }
         if let Some(web_server_ip) = self.web_server_ip_to_kdl(add_comments) {
             nodes.push(web_server_ip);
@@ -7410,6 +7482,30 @@ fn env_vars_to_string_with_no_env_vars() {
     let document: KdlDocument = fake_config.parse().unwrap();
     let deserialized = EnvironmentVariables::from_kdl(document.get("env").unwrap()).unwrap();
     assert_eq!(EnvironmentVariables::to_kdl(&deserialized), None);
+}
+
+#[test]
+fn selection_options_from_kdl() {
+    let fake_config = r##"
+        osc133_command_selection false
+        word_separators "[]{}<>():,"
+    "##;
+    let document: KdlDocument = fake_config.parse().unwrap();
+    let deserialized = Options::from_kdl(&document).unwrap();
+    assert_eq!(deserialized.osc133_command_selection, Some(false));
+    assert_eq!(
+        deserialized.word_separators,
+        Some("[]{}<>():,".to_owned()),
+        "word separators are parsed verbatim"
+    );
+}
+
+#[test]
+fn selection_options_default_to_none_when_unspecified() {
+    let document: KdlDocument = "".parse().unwrap();
+    let deserialized = Options::from_kdl(&document).unwrap();
+    assert_eq!(deserialized.osc133_command_selection, None);
+    assert_eq!(deserialized.word_separators, None);
 }
 
 #[test]

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__bare_config_from_default_assets_to_string_with_comments.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__bare_config_from_default_assets_to_string_with_comments.snap
@@ -585,6 +585,16 @@ web_client {
 // default is false
 // mouse_click_through false
  
+// Whether triple-clicking inside command output marked by the shell (OSC 133) selects
+// the command and its output instead of the logical line
+// default is true
+// osc133_command_selection false
+ 
+// Characters that terminate a word when double-clicking to select it
+// whitespace is always a separator and need not be listed here
+// default is "[]{}<>()"
+// word_separators "[]{}<>()"
+ 
 // The ip address the web server should listen on when it starts
 // Default: "127.0.0.1"
 // (Requires restart)

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__config_options_to_string_with_comments.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__config_options_to_string_with_comments.snap
@@ -300,6 +300,16 @@ web_sharing "disabled"
 // default is false
 // mouse_click_through false
  
+// Whether triple-clicking inside command output marked by the shell (OSC 133) selects
+// the command and its output instead of the logical line
+// default is true
+// osc133_command_selection false
+ 
+// Characters that terminate a word when double-clicking to select it
+// whitespace is always a separator and need not be listed here
+// default is "[]{}<>()"
+// word_separators "[]{}<>()"
+ 
 // The ip address the web server should listen on when it starts
 // Default: "127.0.0.1"
 // (Requires restart)

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
@@ -49,6 +49,8 @@ Options {
     visual_bell: None,
     focus_follows_mouse: None,
     mouse_click_through: None,
+    osc133_command_selection: None,
+    word_separators: None,
     web_server_ip: None,
     web_server_port: None,
     web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
@@ -49,6 +49,8 @@ Options {
     visual_bell: None,
     focus_follows_mouse: None,
     mouse_click_through: None,
+    osc133_command_selection: None,
+    word_separators: None,
     web_server_ip: None,
     web_server_port: None,
     web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
@@ -47,6 +47,8 @@ Options {
     visual_bell: None,
     focus_follows_mouse: None,
     mouse_click_through: None,
+    osc133_command_selection: None,
+    word_separators: None,
     web_server_ip: None,
     web_server_port: None,
     web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
@@ -6072,6 +6072,8 @@ Config {
         visual_bell: None,
         focus_follows_mouse: None,
         mouse_click_through: None,
+        osc133_command_selection: None,
+        word_separators: None,
         web_server_ip: None,
         web_server_port: None,
         web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
@@ -6072,6 +6072,8 @@ Config {
         visual_bell: None,
         focus_follows_mouse: None,
         mouse_click_through: None,
+        osc133_command_selection: None,
+        word_separators: None,
         web_server_ip: None,
         web_server_port: None,
         web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
@@ -134,6 +134,8 @@ Config {
         visual_bell: None,
         focus_follows_mouse: None,
         mouse_click_through: None,
+        osc133_command_selection: None,
+        word_separators: None,
         web_server_ip: None,
         web_server_port: None,
         web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
@@ -49,6 +49,8 @@ Options {
     visual_bell: None,
     focus_follows_mouse: None,
     mouse_click_through: None,
+    osc133_command_selection: None,
+    word_separators: None,
     web_server_ip: None,
     web_server_port: None,
     web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
@@ -6072,6 +6072,8 @@ Config {
         visual_bell: None,
         focus_follows_mouse: None,
         mouse_click_through: None,
+        osc133_command_selection: None,
+        word_separators: None,
         web_server_ip: None,
         web_server_port: None,
         web_server_cert: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
@@ -6072,6 +6072,8 @@ Config {
         visual_bell: None,
         focus_follows_mouse: None,
         mouse_click_through: None,
+        osc133_command_selection: None,
+        word_separators: None,
         web_server_ip: None,
         web_server_port: None,
         web_server_cert: None,


### PR DESCRIPTION
Disclaimer: I am not a Rust developer, this was analyzed and implemented by LLMs for my own usage (Fable and Sol)

## Summary

- parse OSC 133 `A`/`P`, `B`/`I`, `C`, and `D` into row-local semantic boundaries
- make triple-click on marked output select the command and output while excluding the prompt, with the existing logical-line fallback elsewhere
- preserve boundaries through scrollback, wrapping, reflow, clearing, truncation, and overwriting, and render click selections without mouse movement

Related to #899.

## Testing

- `cargo fmt --all -- --check`
- `cargo test --no-default-features -p zellij-server --lib` (1423 passed, 150 ignored)
- `cargo test` (10 passed, 5 ignored)
- `cargo xtask build`
- manual Ghostty and Powerlevel10k verification for command/output selection, prompt exclusion, and stationary triple-click highlighting