### PR TITLE
fix: don't log error when resizing unspawned or cleared terminal

### DIFF
--- a/zellij-server/src/os_input_output_unix.rs
+++ b/zellij-server/src/os_input_output_unix.rs
@@ -374,9 +374,10 @@ impl UnixPtyBackend {
                 }
             },
             _ => {
-                Err::<(), _>(anyhow!("failed to find terminal fd for id {terminal_id}"))
-                    .with_context(err_context)
-                    .non_fatal();
+                log::debug!(
+                    "tried to resize terminal id {} which is not yet spawned or already closed",
+                    terminal_id
+                );
             },
         }
         Ok(())
@@ -470,6 +471,7 @@ mod tests {
     use nix::fcntl::{fcntl, FcntlArg, OFlag};
     use nix::sys::termios;
     use std::io::Read;
+    use std::sync::OnceLock;
 
     /// Verify that `try_write_to_fd` writes as many bytes as the kernel will
     /// accept in one pass and returns a partial count (not an error) when the
@@ -578,5 +580,98 @@ mod tests {
             libc::close(master_fd);
             libc::close(slave_fd);
         }
+    }
+
+    /// Test-only logger that records (level, message) pairs for assertions.
+    static LOG_CAPTURE: OnceLock<Arc<Mutex<Vec<(log::Level, String)>>>> = OnceLock::new();
+
+    struct CapturingLogger {
+        records: Arc<Mutex<Vec<(log::Level, String)>>>,
+    }
+
+    impl log::Log for CapturingLogger {
+        fn enabled(&self, _metadata: &log::Metadata) -> bool {
+            true
+        }
+        fn log(&self, record: &log::Record) {
+            self.records
+                .lock()
+                .unwrap()
+                .push((record.level(), record.args().to_string()));
+        }
+        fn flush(&self) {}
+    }
+
+    /// Install the capturing logger once per process and return the record
+    /// store. If another test already installed a logger, `set_boxed_logger`
+    /// fails and the caller's probe assertion will detect it.
+    fn init_log_capture() -> Arc<Mutex<Vec<(log::Level, String)>>> {
+        let records = LOG_CAPTURE.get_or_init(|| {
+            let records = Arc::new(Mutex::new(Vec::new()));
+            let logger = CapturingLogger {
+                records: records.clone(),
+            };
+            let _ = log::set_boxed_logger(Box::new(logger));
+            log::set_max_level(log::LevelFilter::Trace);
+            records
+        });
+        records.clone()
+    }
+
+    /// A `ResizePty` for a terminal that was reserved but not yet spawned
+    /// (`Some(None)` in `terminal_id_to_raw_fd`) — or whose id was already
+    /// cleared (pane closed) — is a normal transient/stale state, not an
+    /// error. The resize is re-sent after spawn for live panes, and resizing
+    /// a closed terminal is a no-op. Resizing such a terminal must not log an
+    /// ERROR.
+    #[test]
+    fn resize_for_unspawned_or_cleared_terminal_is_not_an_error() {
+        let records = init_log_capture();
+        records.lock().unwrap().clear();
+
+        // Probe: prove the capturing logger is active. If another logger won
+        // the global slot, we cannot assert on log output and must fail.
+        log::error!("log-capture-probe");
+        assert!(
+            records
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|(_, msg)| msg.contains("log-capture-probe")),
+            "test log capture is not active; cannot assert on log output",
+        );
+
+        let backend = UnixPtyBackend::new().expect("backend init failed");
+        let terminal_id = 5;
+
+        // Case 1: reserved but not yet spawned.
+        backend.reserve_terminal_id(terminal_id);
+        backend
+            .set_terminal_size(terminal_id, 80, 24, None, None)
+            .expect("set_terminal_size should succeed for a reserved terminal");
+        assert!(
+            !records
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|(level, msg)| *level == log::Level::Error
+                    && msg.contains("failed to find terminal fd for id 5")),
+            "resize for a reserved-but-unspawned terminal must not log an error",
+        );
+
+        // Case 2: id already cleared (pane closed).
+        backend.clear_terminal_id(terminal_id);
+        backend
+            .set_terminal_size(terminal_id, 80, 24, None, None)
+            .expect("set_terminal_size should succeed for a cleared terminal");
+        assert!(
+            !records
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|(level, msg)| *level == log::Level::Error
+                    && msg.contains("failed to find terminal fd for id 5")),
+            "resize for a cleared terminal must not log an error",
+        );
     }
 }


### PR DESCRIPTION
## The error

Users see recurring ERROR lines in the zellij log, sometimes dozens per day, from `pty_writer`:

```
ERROR [pty_writer] zellij-server/src/os_input_output_unix.rs:377: a non-fatal error occured
Caused by: failed to set terminal id 0 to size (49, 171)
Caused by: failed to find terminal fd for id 0
```

The terminal id varies (0, 1, 2...), and the size alternates between a full-size and a 1-row state in ~700ms bursts.

## The reason

`set_terminal_size` looks up the terminal id in `terminal_id_to_raw_fd` (a map of terminal id → optional raw fd). The lookup has three states:

- `Some(Some(fd))` — live terminal, resize proceeds
- `Some(None)` — id **reserved but not yet spawned** (`reserve_terminal_id` inserts this placeholder before the pty spawn completes)
- entry missing — terminal **already cleared** (`clear_terminal_id` removes it when its pane closes)

`ResizePty` instructions can legitimately arrive for both non-live states:

1. During the reserve→spawn window (a resize fired between `reserve_terminal_id` and `spawn_terminal` — pane creation paths re-fire the resize after spawn, so the intermediate one is redundant).
2. After a terminal is cleared: a stale pane/layout pass re-fires `resize_pty!` for the dead id (also reachable through `apply_cached_resizes`, which drains cached resizes for terminals that may have been cleared in the meantime).

Both are normal transient/stale conditions, not failures. The old `_` arm turned them into an `anyhow!` error logged at **ERROR** level via `.non_fatal()`, producing pure log noise with no behavioral effect (the error was already swallowed by `non_fatal` and callers never observed it).

## The fix

Treat a missing/unspawned terminal id as a benign skip: log at **debug** level and return `Ok(())`:

```rust
_ => {
    log::debug!("tried to resize terminal id {} which is not yet spawned or already closed", terminal_id);
}
```

`write_to_tty_stdin` and `tcdrain` keep their `_ => Err(...)` behavior — writing to a genuinely dead fd is still a real failure that the pty_writer handles.

## Test

Added `resize_for_unspawned_or_cleared_terminal_is_not_an_error` in `os_input_output_unix.rs`: with a real `UnixPtyBackend`, reserves a terminal id, resizes it before spawn, then clears it and resizes again — asserting no ERROR-level "failed to find terminal fd" record is logged (via a test-scoped `log` capture). Fails on main, passes with the fix. Full `zellij-server` suite: 1407 passed, 0 failed.