### PR TITLE
fix(plugins): avoid full updates for title-only changes

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -4044,8 +4044,13 @@ impl Screen {
             }
 
             let single_pane_names_changed = self.update_single_pane_tab_names();
-            if bell_state_changed || single_pane_names_changed {
+            if bell_state_changed {
                 self.log_and_report_session_state()?;
+            } else if single_pane_names_changed {
+                // Terminal titles can animate many times per second. The derived tab name is the
+                // only session state that changed, so avoid broadcasting full pane and session
+                // manifests for every animation frame.
+                self.generate_and_report_tab_state()?;
             }
         } else {
             // No regular clients, output is not dirty

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -7765,6 +7765,102 @@ fn subscriber_ansi_and_plain_receive_different_content() {
 }
 
 #[test]
+pub fn repeated_single_pane_title_changes_only_report_tab_state() {
+    let size = Size { cols: 80, rows: 10 };
+    let mut mock_screen = MockScreen::new(size);
+    mock_screen.config.options.pane_frame_style = Some(PaneFrameStyle::Titles);
+    mock_screen.drop_all_pty_messages();
+    let screen_thread = mock_screen.run(None, vec![]);
+
+    let mut subscriptions = HashSet::new();
+    subscriptions.insert(EventType::TabUpdate);
+    subscriptions.insert(EventType::PaneUpdate);
+    subscriptions.insert(EventType::SessionUpdate);
+    let _ = mock_screen
+        .to_screen
+        .send(ScreenInstruction::UpdateBackgroundPluginSubscriptions(
+            99,
+            mock_screen.main_client_id,
+            subscriptions,
+        ));
+
+    let received_plugin_instructions = Arc::new(Mutex::new(vec![]));
+    let plugin_receiver = mock_screen.plugin_receiver.take().unwrap();
+    let plugin_thread = log_actions_in_thread!(
+        received_plugin_instructions,
+        PluginInstruction::Exit,
+        plugin_receiver
+    );
+
+    let _ = mock_screen.to_screen.send(ScreenInstruction::PtyBytes(
+        0,
+        b"\x1b]0;spinner-0\x07".to_vec(),
+    ));
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    received_plugin_instructions.lock().unwrap().clear();
+    mock_screen.received_background_jobs.lock().unwrap().clear();
+
+    for frame in 1..=3 {
+        let title = format!("\x1b]0;spinner-{frame}\x07");
+        let _ = mock_screen
+            .to_screen
+            .send(ScreenInstruction::PtyBytes(0, title.into_bytes()));
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    mock_screen.teardown(vec![plugin_thread, screen_thread]);
+
+    let instructions = received_plugin_instructions.lock().unwrap();
+    let mut tab_updates = vec![];
+    let mut pane_update_count = 0;
+    let mut session_update_count = 0;
+    for instruction in instructions.iter() {
+        if let PluginInstruction::Update(updates) = instruction {
+            for (plugin_id, _client_id, event) in updates {
+                if *plugin_id != Some(99) {
+                    continue;
+                }
+                match event {
+                    Event::TabUpdate(tabs) => tab_updates.push(tabs.clone()),
+                    Event::PaneUpdate(_) => pane_update_count += 1,
+                    Event::SessionUpdate(_, _) => session_update_count += 1,
+                    _ => {},
+                }
+            }
+        }
+    }
+
+    assert!(
+        tab_updates
+            .iter()
+            .any(|tabs| { tabs.iter().any(|tab| tab.name == "spinner-3" && tab.active) }),
+        "the final animated title should still reach TabUpdate subscribers: {tab_updates:?}"
+    );
+    assert_eq!(
+        pane_update_count, 0,
+        "cosmetic title frames must not broadcast full pane manifests"
+    );
+    assert_eq!(
+        session_update_count, 0,
+        "cosmetic title frames must not broadcast full session manifests"
+    );
+
+    let background_jobs = mock_screen.received_background_jobs.lock().unwrap();
+    assert!(
+        !background_jobs
+            .iter()
+            .any(|job| matches!(job, BackgroundJob::ReportSessionInfo(..))),
+        "cosmetic title frames must not report full session info: {background_jobs:?}"
+    );
+    assert!(
+        !background_jobs
+            .iter()
+            .any(|job| matches!(job, BackgroundJob::QueryZellijWebServerStatus)),
+        "cosmetic title frames must not query web-server status: {background_jobs:?}"
+    );
+}
+
+#[test]
 fn integration_subscribe_with_ansi_flag() {
     let size = Size { cols: 80, rows: 20 };
     let mut mock_screen = MockScreen::new(size);


### PR DESCRIPTION
## Problem

A single-pane tab derives its name from its terminal title. Some terminals animate
that title through OSC sequences many times per second.

Each derived title change currently reports full session state, broadcasting
`PaneUpdate` and `SessionUpdate` events and scheduling unrelated session-info
and web-server-status work, although only the tab name changed.

## Fix

Use the tab-state-only reporting path when the derived single-pane tab name
changes without a bell-state change. Bell updates retain the existing full
session-state path.

## Coverage

Adds a regression test that sends repeated OSC title changes and verifies that
subscribers receive the final `TabUpdate`, but no `PaneUpdate`,
`SessionUpdate`, session-info report, or web-server-status query.

Related to #4203.

## Validation

- `cargo fmt --check`
- `cargo test -p zellij-server repeated_single_pane_title_changes_only_report_tab_state -- --nocapture`
