### PR TITLE
fix(client): hold fragmented host replies across the idle drain (backport of main's fix for #5174)

### DIFF
--- a/zellij-client/src/stdin_ansi_parser.rs
+++ b/zellij-client/src/stdin_ansi_parser.rs
@@ -222,6 +222,14 @@ enum SeqStatus {
 }
 
 /// Continuous host-reply parser. Lives for the whole client session.
+/// See `StdinAnsiParser::pending_partial`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PendingPartial {
+    None,
+    LoneEsc,
+    ReplyInProgress,
+}
+
 pub struct StdinAnsiParser {
     inner: InputParser,
     /// Active forwarding slot: `Some` while a forwarded query is in
@@ -398,13 +406,40 @@ impl StdinAnsiParser {
         out
     }
 
-    /// Drain any speculatively-buffered partial OSC/CSI bytes back into
-    /// keyboard residue. Called from the stdin handler's idle-timeout
-    /// path so a lone trailing ESC (or any unterminated host-reply
-    /// prefix that never received a follow-up byte) reaches the
-    /// keyboard parser instead of being stuck forever waiting for a
-    /// disambiguating byte that is never coming.
-    pub fn finalize(&mut self) -> Vec<u8> {
+    /// What kind of partial the parser is currently holding. The idle
+    /// drain in the stdin handler keys off this: a lone ESC is almost
+    /// certainly a real Esc keypress and must be released after one
+    /// tick, but a partial that already carries payload bytes is a
+    /// host reply split across reads — releasing it types the reply
+    /// into the focused pane (the 0.44.2 palette-leak regression).
+    pub fn pending_partial(&self) -> PendingPartial {
+        if self.partial_csi.is_empty() && self.partial_osc.is_empty() {
+            PendingPartial::None
+        } else if self.partial_csi.is_empty() && self.partial_osc == [0x1b] {
+            PendingPartial::LoneEsc
+        } else {
+            PendingPartial::ReplyInProgress
+        }
+    }
+
+    /// Drain the buffered partial back into keyboard residue, but only
+    /// when it is a lone ESC waiting for a disambiguating byte that is
+    /// never coming — a real Esc keypress. Anything longer is a reply
+    /// in flight and stays buffered; `finalize_force` is the escape
+    /// hatch for the pathological case where the rest never arrives.
+    pub fn finalize_lone_esc(&mut self) -> Vec<u8> {
+        if self.partial_csi.is_empty() && self.partial_osc == [0x1b] {
+            std::mem::take(&mut self.partial_osc)
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Unconditionally drain whatever partial is buffered. Reached only
+    /// after the stdin handler's long guard elapses with no follow-up
+    /// bytes: at that point the "reply" is genuinely truncated and
+    /// holding its bytes forever would swallow real input.
+    pub fn finalize_force(&mut self) -> Vec<u8> {
         let mut out = Vec::with_capacity(self.partial_osc.len() + self.partial_csi.len());
         out.append(&mut self.partial_osc);
         out.append(&mut self.partial_csi);

--- a/zellij-client/src/stdin_ansi_parser_tests.rs
+++ b/zellij-client/src/stdin_ansi_parser_tests.rs
@@ -1,6 +1,6 @@
 //! Unit tests for the continuous host-reply parser.
 
-use super::{schedule_forward_timeout, HostReply, StdinAnsiParser};
+use super::{schedule_forward_timeout, HostReply, PendingPartial, StdinAnsiParser};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -295,8 +295,8 @@ fn lone_trailing_esc_is_buffered_then_finalized_as_residue() {
     // OSC or CSI host-reply that's been fragmented at the ESC
     // boundary, so `feed` parks it under partial state instead of
     // leaking it as a keyboard residue. But the byte must not stay
-    // parked forever — `finalize()` is the idle drain that releases
-    // it back to the keyboard parser when no follow-up arrives.
+    // parked forever — `finalize_lone_esc()` is the idle drain that
+    // releases it back to the keyboard parser when no follow-up arrives.
     let mut p = StdinAnsiParser::new();
     let out = p.feed(b"\x1b");
     assert!(
@@ -308,14 +308,16 @@ fn lone_trailing_esc_is_buffered_then_finalized_as_residue() {
         out.has_partial_state,
         "lone ESC must mark has_partial_state so the caller schedules a finalize tick"
     );
-    let drained = p.finalize();
+    assert_eq!(p.pending_partial(), PendingPartial::LoneEsc);
+    let drained = p.finalize_lone_esc();
     assert_eq!(
         drained,
         vec![0x1b],
         "finalize must release the parked ESC as keyboard residue"
     );
     // Subsequent finalize is a no-op once the parker is empty.
-    assert!(p.finalize().is_empty());
+    assert!(p.finalize_lone_esc().is_empty());
+    assert_eq!(p.pending_partial(), PendingPartial::None);
 }
 
 #[test]
@@ -333,7 +335,99 @@ fn fragmented_osc_does_not_finalize_partial() {
     let r2 = p.feed(&full[1..]);
     assert!(r2.residue.is_empty(), "tail must complete the OSC");
     assert_eq!(r1.replies.len() + r2.replies.len(), 1);
-    assert!(p.finalize().is_empty(), "no partial left after completion");
+    assert!(
+        p.finalize_force().is_empty(),
+        "no partial left after completion"
+    );
+}
+
+/// Helper: a payload-bearing partial must survive the short idle drain.
+fn assert_held_across_idle(parser: &mut StdinAnsiParser) {
+    assert_eq!(
+        parser.pending_partial(),
+        PendingPartial::ReplyInProgress,
+        "a payload-bearing partial must report ReplyInProgress while held"
+    );
+    assert!(
+        parser.finalize_lone_esc().is_empty(),
+        "the short idle finalize must NOT drain a reply-in-progress partial"
+    );
+    assert_eq!(
+        parser.pending_partial(),
+        PendingPartial::ReplyInProgress,
+        "the partial must still be held after a lone-esc finalize"
+    );
+}
+
+#[test]
+fn fragmented_osc4_reply_is_retained_not_leaked() {
+    let mut p = StdinAnsiParser::new();
+    let r1 = p.feed(b"\x1b]4;1;rgb:1111");
+    assert!(
+        r1.residue.is_empty(),
+        "incomplete OSC 4 must not leak: {:?}",
+        r1.residue
+    );
+    assert!(r1.replies.is_empty());
+    assert_held_across_idle(&mut p);
+
+    let r2 = p.feed(b"/2222/3333\x1b\\");
+    assert!(
+        r2.residue.is_empty(),
+        "completion must not leak: {:?}",
+        r2.residue
+    );
+    assert_eq!(r2.replies.len(), 1, "the rejoined OSC 4 classifies once");
+    match &r2.replies[0] {
+        HostReply::ColorRegisters(regs) => {
+            assert_eq!(regs[0].0, 1);
+            assert_eq!(regs[0].1, "rgb:1111/2222/3333");
+        },
+        other => panic!("expected ColorRegisters, got {:?}", other),
+    }
+    assert_eq!(p.pending_partial(), PendingPartial::None);
+}
+
+#[test]
+fn fragmented_osc11_reply_is_retained_across_idle() {
+    let mut p = StdinAnsiParser::new();
+    let r1 = p.feed(b"\x1b]11;rgb:0000/00");
+    assert!(r1.residue.is_empty());
+    assert_held_across_idle(&mut p);
+
+    let r2 = p.feed(b"00/0000\x1b\\");
+    assert!(r2.residue.is_empty());
+    assert_eq!(r2.replies.len(), 1);
+    matches!(r2.replies[0], HostReply::BackgroundColor(_));
+}
+
+#[test]
+fn last_resort_force_drain_recovers_a_never_terminated_partial() {
+    let mut p = StdinAnsiParser::new();
+    let r1 = p.feed(b"\x1b]4;1;rgb:incomplete");
+    assert!(r1.residue.is_empty());
+    assert_eq!(p.pending_partial(), PendingPartial::ReplyInProgress);
+
+    let r2 = p.feed(b"and-more");
+    assert!(r2.residue.is_empty());
+    assert_eq!(p.pending_partial(), PendingPartial::ReplyInProgress);
+
+    let drained = p.finalize_force();
+    assert!(
+        drained.windows(14).any(|w| w == b"rgb:incomplete"),
+        "force-drain must recover the buffered partial: {:?}",
+        drained
+    );
+    assert!(
+        drained.windows(8).any(|w| w == b"and-more"),
+        "force-drain must recover bytes appended before the guard: {:?}",
+        drained
+    );
+    assert_eq!(
+        p.pending_partial(),
+        PendingPartial::None,
+        "the buffer is empty after a force-drain"
+    );
 }
 
 #[test]

--- a/zellij-client/src/stdin_handler.rs
+++ b/zellij-client/src/stdin_handler.rs
@@ -1,11 +1,22 @@
 use crate::keyboard_parser::{KittyKeyboardParser, KittyParseOutcome};
 use crate::os_input_output::ClientOsApi;
-use crate::stdin_ansi_parser::StdinAnsiParser;
+use crate::stdin_ansi_parser::{PendingPartial, StdinAnsiParser};
 #[cfg(windows)]
 use crate::stdin_handler_windows::enable_vt_input;
 use crate::InputInstruction;
 use std::sync::{mpsc, Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
+
+/// How long stdin must stay quiet before a parked lone ESC is released
+/// to the keyboard parser as a real Esc keypress.
+const LONE_ESC_FLUSH_INTERVAL: Duration = Duration::from_millis(50);
+/// How long a payload-bearing partial host reply may sit unfinished
+/// before being force-drained. A fragmented reply normally completes
+/// within a read or two; 50ms of quiet is routine on a slow or remote
+/// host and must NOT release half an OSC 4 into the pane — that is the
+/// 0.44.2 palette-leak regression. One full second of silence means the
+/// reply is genuinely truncated.
+const PARTIAL_REPLY_FLUSH_GUARD: Duration = Duration::from_millis(1000);
 use zellij_utils::{
     channels::SenderWithContext,
     vendored::termwiz::input::{InputEvent, InputParser},
@@ -99,9 +110,10 @@ pub(crate) fn stdin_loop(
             }
         });
     let mut needs_finalization = false;
+    let mut reply_in_progress_since: Option<Instant> = None;
     loop {
         match if needs_finalization {
-            stdin_rx.recv_timeout(Duration::from_millis(50))
+            stdin_rx.recv_timeout(LONE_ESC_FLUSH_INTERVAL)
         } else {
             stdin_rx
                 .recv()
@@ -146,7 +158,12 @@ pub(crate) fn stdin_loop(
                             // so the idle drain releases it as keyboard
                             // residue when no follow-up arrives.
                             if has_partial {
-                                needs_finalization = true;
+                                schedule_finalization(
+                                    &stdin_ansi_parser,
+                                    false,
+                                    &mut needs_finalization,
+                                    &mut reply_in_progress_since,
+                                );
                             }
                             continue;
                         }
@@ -168,6 +185,12 @@ pub(crate) fn stdin_loop(
                                             true,
                                         ))
                                         .unwrap();
+                                    schedule_finalization(
+                                        &stdin_ansi_parser,
+                                        false,
+                                        &mut needs_finalization,
+                                        &mut reply_in_progress_since,
+                                    );
                                     continue;
                                 },
                                 KittyParseOutcome::Incomplete | KittyParseOutcome::NoMatch => {},
@@ -201,7 +224,12 @@ pub(crate) fn stdin_loop(
                                 .unwrap();
                         }
 
-                        needs_finalization = true;
+                        schedule_finalization(
+                            &stdin_ansi_parser,
+                            true,
+                            &mut needs_finalization,
+                            &mut reply_in_progress_since,
+                        );
                     },
                     Err(e) => {
                         if e == "Session ended" {
@@ -215,13 +243,42 @@ pub(crate) fn stdin_loop(
                 }
             },
             Err(mpsc::RecvTimeoutError::Timeout) => {
-                finalize_events(
-                    &mut input_parser,
-                    &mut current_buffer,
-                    send_input_instructions.clone(),
-                    &stdin_ansi_parser,
-                );
-                needs_finalization = false;
+                // What gets drained on idle depends on what is parked.
+                // A lone ESC is a real keypress and is released now; a
+                // payload-bearing partial is a host reply in flight and
+                // is held until the long guard says it is truncated.
+                let pending = stdin_ansi_parser.lock().unwrap().pending_partial();
+                match pending {
+                    PendingPartial::ReplyInProgress => {
+                        let elapsed = reply_in_progress_since
+                            .map(|since| since.elapsed())
+                            .unwrap_or_default();
+                        if elapsed >= PARTIAL_REPLY_FLUSH_GUARD {
+                            let drained = stdin_ansi_parser.lock().unwrap().finalize_force();
+                            drain_partial_to_keyboard(
+                                &mut input_parser,
+                                &mut current_buffer,
+                                send_input_instructions.clone(),
+                                drained,
+                            );
+                            needs_finalization = false;
+                            reply_in_progress_since = None;
+                        } else {
+                            needs_finalization = true;
+                        }
+                    },
+                    _ => {
+                        let drained = stdin_ansi_parser.lock().unwrap().finalize_lone_esc();
+                        drain_partial_to_keyboard(
+                            &mut input_parser,
+                            &mut current_buffer,
+                            send_input_instructions.clone(),
+                            drained,
+                        );
+                        needs_finalization = false;
+                        reply_in_progress_since = None;
+                    },
+                }
             },
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 log::debug!("STDIN pump disconnected");
@@ -232,18 +289,34 @@ pub(crate) fn stdin_loop(
     }
 }
 
-fn finalize_events(
+fn schedule_finalization(
+    stdin_ansi_parser: &Arc<Mutex<StdinAnsiParser>>,
+    fed_termwiz: bool,
+    needs_finalization: &mut bool,
+    reply_in_progress_since: &mut Option<Instant>,
+) {
+    let pending = stdin_ansi_parser.lock().unwrap().pending_partial();
+    if fed_termwiz || pending != PendingPartial::None {
+        *needs_finalization = true;
+    }
+    // The guard clock starts when a reply first goes partial and is NOT
+    // restarted by later empty ticks — restarting it would let a reply
+    // that trickles one byte per tick hold the buffer forever.
+    if pending == PendingPartial::ReplyInProgress {
+        if reply_in_progress_since.is_none() {
+            *reply_in_progress_since = Some(Instant::now());
+        }
+    } else {
+        *reply_in_progress_since = None;
+    }
+}
+
+fn drain_partial_to_keyboard(
     input_parser: &mut InputParser,
     current_buffer: &mut Vec<u8>,
     send_input_instructions: SenderWithContext<InputInstruction>,
-    stdin_ansi_parser: &Arc<Mutex<StdinAnsiParser>>,
+    drained: Vec<u8>,
 ) {
-    // Drain any speculatively-buffered partial host-reply bytes (a
-    // lone trailing ESC, or an unterminated OSC/CSI prefix whose
-    // follow-up never arrived). They become keyboard residue — same
-    // path real keypress bytes take. Without this drain, a real Esc
-    // press whose byte was parked under partial_osc would be lost.
-    let drained = stdin_ansi_parser.lock().unwrap().finalize();
     if !drained.is_empty() {
         current_buffer.extend_from_slice(&drained);
     }


### PR DESCRIPTION
Backports main's fragmented-reply guard to `release-0.44`, fixing #5174.

## What happens on 0.44.2/0.44.3

`stdin_handler`'s idle tick (50 ms of stdin silence) calls `StdinAnsiParser::finalize()`, which drains **any** buffered partial — including an OSC reply that was split across reads and whose tail is still in flight. The drained half-reply becomes keyboard residue and is written into the focused pane, which is why reattaching over SSH (or any slow host path) types fragments like `11;rgb:2b2b/3030/...` into the shell. The startup/reattach burst of 258 palette queries is exactly when a chunk boundary lands mid-reply.

0.44.1 was immune because startup queries lived behind a 500 ms parse window that dropped unrecognized bytes; the 0.44.2 stdin rewrite removed the window (a good change) but made the idle drain indiscriminate.

## The fix (already on main, never released)

main resolves this with `PendingPartial` / `finalize_lone_esc()` / `finalize_force()`: the 50 ms tick only releases a parked **lone ESC** (a real Esc keypress), while a payload-bearing partial is held as a reply in progress, with a 1 s last-resort force-drain so a genuinely truncated reply cannot wedge the buffer. This PR is that mechanism, trimmed to what exists on 0.44.x — main's surrounding features (bracketed-paste partials, APC/kitty-graphics probe, nested-frame extraction) are not part of the backport, which is why it is a small diff rather than a cherry-pick.

Also ports main's regression tests: `fragmented_osc4_reply_is_retained_not_leaked`, `fragmented_osc11_reply_is_retained_across_idle`, `last_resort_force_drain_recovers_a_never_terminated_partial`, and the updated lone-ESC test.

`cargo test -p zellij-client`: 70 passed, 0 failed.

We are running this build day-to-day (as `0.44.3+red.1`) on a WSL2/Windows Terminal machine that hit #5174 on 0.44.2 and 0.44.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
