### PR TITLE
fix(server): clear disconnected client pane focus

### DIFF
--- a/zellij-server/src/panes/active_panes.rs
+++ b/zellij-server/src/panes/active_panes.rs
@@ -69,6 +69,22 @@ impl ActivePanes {
         }
         self.active_panes.remove(client_id)
     }
+    pub fn remove_client(
+        &mut self,
+        client_id: &ClientId,
+        panes: &mut BTreeMap<PaneId, Box<dyn Pane>>,
+    ) {
+        if let Some(pane_id) = self.active_panes.remove(client_id) {
+            let still_focused = self
+                .active_panes
+                .values()
+                .any(|active_pane_id| *active_pane_id == pane_id);
+            if !still_focused {
+                self.unfocus_pane(pane_id, panes);
+            }
+        }
+        self.last_panes.remove(client_id);
+    }
     pub fn unfocus_all_panes(&self, panes: &mut BTreeMap<PaneId, Box<dyn Pane>>) {
         for (_client_id, pane_id) in &self.active_panes {
             self.unfocus_pane(*pane_id, panes);

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -276,6 +276,9 @@ impl FloatingPanes {
     pub fn has_active_panes(&self) -> bool {
         !self.active_panes.is_empty()
     }
+    pub fn remove_client(&mut self, client_id: ClientId) {
+        self.active_panes.remove_client(&client_id, &mut self.panes);
+    }
     pub fn has_panes(&self) -> bool {
         !self.panes.is_empty()
     }

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -3018,6 +3018,9 @@ impl TiledPanes {
     pub fn active_panes(&self) -> ActivePanes {
         self.active_panes.clone()
     }
+    pub fn remove_client(&mut self, client_id: ClientId) {
+        self.active_panes.remove_client(&client_id, &mut self.panes);
+    }
     pub fn set_active_panes(&mut self, active_panes: ActivePanes) {
         self.active_panes = active_panes;
     }

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -2267,6 +2267,8 @@ impl Tab {
     }
     pub fn remove_client(&mut self, client_id: ClientId) {
         self.focus_pane_id = None;
+        self.tiled_panes.remove_client(client_id);
+        self.floating_panes.remove_client(client_id);
         self.mode_info
             .borrow_mut()
             .get_mut(&client_id)

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -5952,6 +5952,29 @@ fn subscriber_removed_on_remove_client() {
 }
 
 #[test]
+fn removing_client_clears_pane_focus() {
+    let size = Size { cols: 80, rows: 20 };
+    let mut screen = create_new_screen(size, true, true);
+    new_tab(&mut screen, 1, 0);
+
+    let pane_is_focused = |screen: &Screen| {
+        screen
+            .tabs
+            .get(&0)
+            .unwrap()
+            .pane_infos()
+            .iter()
+            .any(|pane_info| pane_info.id == 1 && pane_info.is_focused)
+    };
+
+    assert!(pane_is_focused(&screen));
+    screen.remove_client(1).expect("TEST");
+    assert!(!pane_is_focused(&screen));
+    screen.add_client(1, false).expect("TEST");
+    assert!(pane_is_focused(&screen));
+}
+
+#[test]
 fn subscriber_removed_when_all_panes_closed() {
     let size = Size { cols: 80, rows: 20 };
     let (mut screen, messages) = create_new_screen_with_message_capture(size);


### PR DESCRIPTION
## Summary

- Clear tiled and floating pane focus state when a client disconnects.
- Prevent `zellij action list-panes -a` from reporting stale `FOCUSED=true` values.
- Preserve the focused state when another connected client still focuses the same pane.

Fixes #5468

## Testing

- `cargo test -p zellij-server --lib`
- `cargo fmt --all`
