### PR TITLE
fix(themes): skip invalid files while loading theme directories

### DIFF
--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -6,6 +6,7 @@ use crate::data::{
     DEFAULT_STYLES,
 };
 use crate::envs::EnvironmentVariables;
+use crate::errors::FatalError;
 use crate::home::{find_default_config_dir, get_layout_dir};
 use crate::input::config::{Config, ConfigError, KdlError};
 use crate::input::keybinds::Keybinds;
@@ -19,6 +20,7 @@ use crate::input::permission::{GrantedPermission, PermissionCache};
 use crate::input::plugins::PluginAliases;
 use crate::input::theme::{FrameConfig, Theme, Themes, UiConfig};
 use crate::input::web_client::WebClientConfig;
+use anyhow::Context;
 use kdl_layout_parser::KdlLayoutParser;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr};
@@ -5756,7 +5758,14 @@ impl Themes {
             let path = entry.path();
             if let Some(extension) = path.extension() {
                 if extension == "kdl" {
-                    themes = themes.merge(Themes::from_path(path)?);
+                    match Themes::from_path(path.clone()) {
+                        Ok(themes_from_file) => themes = themes.merge(themes_from_file),
+                        Err(error) => Err::<(), anyhow::Error>(anyhow::anyhow!("{error:?}"))
+                            .with_context(|| {
+                                format!("Failed to load theme file {}", path.display())
+                            })
+                            .non_fatal(),
+                    }
                 }
             }
         }
@@ -7208,6 +7217,42 @@ fn themes_to_string() {
         "Deserialized serialized config equals original config",
     );
     insta::assert_snapshot!(serialized.to_string());
+}
+
+#[test]
+fn invalid_theme_file_does_not_prevent_loading_valid_themes() {
+    let theme_dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        theme_dir.path().join("valid.kdl"),
+        r##"
+        themes {
+            valid {
+                fg "#D8DEE9"
+                bg "#2E3440"
+                black "#3B4252"
+                red "#BF616A"
+                green "#A3BE8C"
+                yellow "#EBCB8B"
+                blue "#81A1C1"
+                magenta "#B48EAD"
+                cyan "#88C0D0"
+                white "#E5E9F0"
+                orange "#D08770"
+            }
+        }
+        "##,
+    )
+    .unwrap();
+    std::fs::write(
+        theme_dir.path().join("invalid.kdl"),
+        "themes { invalid { fg }",
+    )
+    .unwrap();
+
+    let themes = Themes::from_dir(theme_dir.path().to_path_buf()).unwrap();
+
+    assert!(themes.get_theme("valid").is_some());
+    assert!(themes.get_theme("invalid").is_none());
 }
 
 #[test]


### PR DESCRIPTION
Fixes #2598.

An invalid file in the theme directory currently makes `Themes::from_dir` return immediately, so startup and config reload fail even when the malformed theme is not selected.

This restores the earlier per-file behavior: theme-file read and parse errors are logged as non-fatal, valid files continue to be merged, and errors opening or iterating the theme directory itself still propagate.

The regression test loads a directory containing one valid theme and one malformed theme, then verifies that the valid theme remains available.

Tests:

- `cargo test -p zellij-utils`
- `cargo xtask format --check`
