### PR TITLE
feat(packaging): build .deb and .rpm packages for Linux releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,6 +167,71 @@ jobs:
           asset_name: zellij-${{matrix.target}}.sha256sum
           asset_content_type: text/plain
 
+      # ===== Linux .deb / .rpm packages =====
+      - name: Install packaging tools
+        if: runner.os == 'Linux'
+        run: cargo install cargo-deb cargo-generate-rpm --locked
+
+      - name: Build .deb and .rpm packages
+        if: runner.os == 'Linux'
+        run: |
+          # The binary is already stripped by the release profile, and a host
+          # `strip` cannot process a cross-compiled binary anyway.
+          cargo deb --no-build --no-strip --target "${{ matrix.target }}" \
+            --output "zellij-${{ matrix.target }}.deb"
+          cargo generate-rpm --target "${{ matrix.target }}" \
+            --output "zellij-${{ matrix.target }}.rpm"
+
+      - name: Create package checksums
+        if: runner.os == 'Linux'
+        run: |
+          sha256sum "zellij-${{ matrix.target }}.deb" > "zellij-${{ matrix.target }}.deb.sha256sum"
+          sha256sum "zellij-${{ matrix.target }}.rpm" > "zellij-${{ matrix.target }}.rpm.sha256sum"
+
+      - name: Upload .deb package
+        if: runner.os == 'Linux'
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: zellij-${{ matrix.target }}.deb
+          asset_name: zellij-${{ matrix.target }}.deb
+          asset_content_type: application/vnd.debian.binary-package
+
+      - name: Upload .deb checksum
+        if: runner.os == 'Linux'
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: zellij-${{ matrix.target }}.deb.sha256sum
+          asset_name: zellij-${{ matrix.target }}.deb.sha256sum
+          asset_content_type: text/plain
+
+      - name: Upload .rpm package
+        if: runner.os == 'Linux'
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: zellij-${{ matrix.target }}.rpm
+          asset_name: zellij-${{ matrix.target }}.rpm
+          asset_content_type: application/x-rpm
+
+      - name: Upload .rpm checksum
+        if: runner.os == 'Linux'
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: zellij-${{ matrix.target }}.rpm.sha256sum
+          asset_name: zellij-${{ matrix.target }}.rpm.sha256sum
+          asset_content_type: text/plain
+
       # ===== Windows MSI installer =====
       - name: Install WiX v6
         if: runner.os == 'Windows'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * feat: support OSC133, triple-mouse-click to mark whole command, configurable double-click word boundaries (https://github.com/zellij-org/zellij/pull/5460)
 * fix(scroll): keep a pane's scroll position when leaving scroll mode, and re-enter scroll mode when focusing a scrolled pane (https://github.com/zellij-org/zellij/pull/5299)
 * feat: allow opting-in to reading paste buffer (default false) (https://github.com/zellij-org/zellij/pull/5472)
+* feat(packaging): build .deb and .rpm packages for Linux releases (https://github.com/zellij-org/zellij/pull/5477)
 
 ## [0.44.3] - 2026-05-13
 * fix(windows): bump windows-sys to 0.59 to align manifest with code, fixing source builds via `cargo install`/`cargo binstall` (https://github.com/zellij-org/zellij/pull/5139)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,13 +134,36 @@ lto = true
 strip = true
 codegen-units = 1
 
+# Release binaries are statically linked against musl, so there is nothing to
+# depend on. `$auto` would shell out to dpkg-shlibdeps, which cannot inspect a
+# foreign-architecture binary when we cross-compile for aarch64.
 [package.metadata.deb]
-depends = "$auto"
+depends = ""
+section = "utils"
+priority = "optional"
 license-file = ["LICENSE.md", "4"]
+extended-description = """\
+Zellij is a terminal workspace and multiplexer. It splits the terminal into \
+panes and tabs, keeps sessions alive across disconnects and is extensible \
+through WebAssembly plugins."""
 assets = [
   ["target/release/zellij", "usr/bin/zellij", "755"],
+  ["assets/zellij.desktop", "usr/share/applications/zellij.desktop", "644"],
+  ["assets/logo.svg", "usr/share/icons/hicolor/scalable/apps/zellij.svg", "644"],
   ["GOVERNANCE.md", "usr/share/doc/zellij/GOVERNANCE.md", "644"],
   ["README.md", "usr/share/doc/zellij/README.md", "644"],
+]
+
+[package.metadata.generate-rpm]
+# Same reasoning as `metadata.deb.depends` above.
+auto-req = "disabled"
+assets = [
+  { source = "target/release/zellij", dest = "/usr/bin/zellij", mode = "755" },
+  { source = "assets/zellij.desktop", dest = "/usr/share/applications/zellij.desktop", mode = "644" },
+  { source = "assets/logo.svg", dest = "/usr/share/icons/hicolor/scalable/apps/zellij.svg", mode = "644" },
+  { source = "LICENSE.md", dest = "/usr/share/doc/zellij/LICENSE.md", mode = "644", doc = true },
+  { source = "GOVERNANCE.md", dest = "/usr/share/doc/zellij/GOVERNANCE.md", mode = "644", doc = true },
+  { source = "README.md", dest = "/usr/share/doc/zellij/README.md", mode = "644", doc = true },
 ]
 
 [package.metadata.binstall]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ The easiest way to install Zellij is through a [package for your OS](./docs/THIR
 
 If one is not available for your OS, you could download a prebuilt binary from the [latest release](https://github.com/zellij-org/zellij/releases/latest) and place it in your `$PATH`. If you'd like, we could [automatically choose one for you](#try-zellij-without-installing).
 
+On Debian/Ubuntu and Fedora/RHEL/openSUSE, every release also ships `.deb` and `.rpm` packages that install `zellij` into `/usr/bin` along with a desktop entry and icon:
+
+```bash
+# Debian/Ubuntu (use aarch64-unknown-linux-musl on ARM)
+sudo dpkg -i zellij-x86_64-unknown-linux-musl.deb
+
+# Fedora/RHEL/openSUSE
+sudo rpm -i zellij-x86_64-unknown-linux-musl.rpm
+```
+
 You can also install (compile) with `cargo`:
 
 ```


### PR DESCRIPTION
## What

Linux releases currently ship only `.tar.gz` archives, so users who don't have a
third-party package for their distro have to unpack the binary and put it in
`$PATH` themselves. This adds `.deb` and `.rpm` packages to the release
artifacts.

`[package.metadata.deb]` already existed in `Cargo.toml` but was never invoked
by any workflow, and its asset paths pointed at `target/release/zellij`, which
doesn't exist for the cross-compiled release builds.

## How

- Extended `[package.metadata.deb]` and added `[package.metadata.generate-rpm]`
  with the same asset set: the binary in `/usr/bin/zellij`, plus
  `assets/zellij.desktop` and a hicolor icon so the entry shows up in desktop
  menus.
- Added a packaging step to the Linux legs of `build-release-normal` in
  `release.yml`, which builds both packages from the already cross-compiled
  binary and uploads them (with sha256sums) as
  `zellij-<target>.deb` / `zellij-<target>.rpm`.
- Documented the packages in the installation section of the README.

Two deliberate choices:

- **No dependency detection** (`depends = ""` / `auto-req = "disabled"`).
  Release binaries are statically linked against musl, and `dpkg-shlibdeps`
  can't inspect a foreign-architecture binary when cross-compiling for aarch64.
- **`cargo deb --no-strip`.** The release profile already strips, and a host
  `strip` can't process the aarch64 binary.

## Testing

Built both formats for both release targets locally and inspected the results:

| target | `.deb` | `.rpm` |
| --- | --- | --- |
| `x86_64-unknown-linux-musl` | `Architecture: amd64` | `zellij(x86-64)` |
| `aarch64-unknown-linux-musl` | `Architecture: arm64` | `aarch64` |

Both contain `/usr/bin/zellij` (755), `/usr/share/applications/zellij.desktop`,
`/usr/share/icons/hicolor/scalable/apps/zellij.svg` and the docs.
`dpkg-deb -R` / `dpkg-deb -b` round-trips the `.deb` without complaints.

No Rust code is touched, so `cargo fmt` / `cargo test` are unaffected.

## Not included

- **Shell completions.** `zellij setup --generate-completion` needs to run the
  binary, which isn't possible for the aarch64 artifact on an x86 runner.
  Generating them only for x86_64 would make the packages differ by
  architecture, so they're left out until there's a qemu step or a native
  aarch64 runner.
- **Packages for the `no-web` build**, which would collide on the `zellij`
  package name in apt/dnf. Happy to add a separate `zellij-no-web` package if
  that's wanted.

Happy to split this up or drop the README part if you'd prefer packaging to
stay with the distro maintainers listed in `docs/THIRD_PARTY_INSTALL.md`.
