### PR TITLE
fix(cli): add recv timeout in assert_socket so zellij ls doesn't hang on a wedged server

### DIFF
--- a/zellij-utils/src/sessions.rs
+++ b/zellij-utils/src/sessions.rs
@@ -150,6 +150,12 @@ fn assert_socket(name: &str) -> bool {
     let path = &*ZELLIJ_SOCK_DIR.join(name);
     match ipc_connect(path) {
         Ok(stream) => {
+            // a wedged server accepts connections but never replies; without a
+            // read timeout `zellij ls` would block forever on recv below
+            {
+                use interprocess::local_socket::prelude::*;
+                let _ = stream.set_recv_timeout(Some(std::time::Duration::from_secs(5)));
+            }
             let mut sender: IpcSenderWithContext<ClientToServerMsg> =
                 IpcSenderWithContext::new(stream);
             let _ = sender.send_client_msg(ClientToServerMsg::ConnStatus);


### PR DESCRIPTION
## Problem
`zellij ls` hangs forever if a session's server process is alive enough to accept the socket connection but its main loop is wedged (e.g. stuck mid-shutdown after its wasm thread exited). `assert_socket` sends `ConnStatus` and then blocks on `recv_server_msg()` with no timeout, so one dead-but-listening server makes `zellij ls` unusable for all sessions.

Observed in practice: server stuck after a partial shutdown (router threads blocked on the `to_server` channel, main loop not draining it) - the socket accepted connections, `Connected` was never sent, and `zellij ls` blocked indefinitely.

## Fix
Set a 5s receive timeout on the probe stream via `set_recv_timeout` before waiting for the reply. On timeout `recv_server_msg()` returns `None` and the session is treated as not alive, so `zellij ls` still lists the remaining sessions.