### PR TITLE
fix(mouse): always clear selection state when a mouse selection ends

### DIFF
--- a/zellij-server/src/tab/mouse_handler.rs
+++ b/zellij-server/src/tab/mouse_handler.rs
@@ -1012,8 +1012,12 @@ impl MouseHandler {
         let mut leave_clipboard_message = false;
         let copy_on_release = tab.copy_on_select;
 
+        // a release must always clear this state, even if the selecting pane was closed
+        // or its terminal enabled mouse tracking mid-drag, otherwise future left-motions
+        // would keep updating the stale selection
         if let Some(pane_with_selection) = tab
             .selecting_with_mouse_in_pane
+            .take()
             .and_then(|p_id| tab.get_pane_with_id_mut(p_id))
         {
             let mut relative_position = pane_with_selection.relative_position(&position);
@@ -1048,7 +1052,6 @@ impl MouseHandler {
                         }
                     }
                 }
-                tab.selecting_with_mouse_in_pane = None;
             }
         }
 

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -15841,3 +15841,74 @@ fn host_focus_events_only_reach_panes_that_asked_for_them() {
         .map(|bytes| String::from_utf8_lossy(bytes).to_string());
     assert_eq!(written, Some("\u{1b}[O\u{1b}[I".to_owned()));
 }
+
+#[test]
+fn selection_stops_on_release_when_terminal_enabled_mouse_tracking_mid_drag() {
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let client_id = 1;
+    let mut tab = create_new_tab(size, ModeInfo::default());
+
+    tab.handle_mouse_event(
+        &MouseEvent::new_left_press_event(Position::new(2, 5)),
+        client_id,
+    )
+    .unwrap();
+    assert!(
+        tab.selecting_with_mouse_in_pane.is_some(),
+        "started selecting with mouse on click"
+    );
+    tab.handle_mouse_event(
+        &MouseEvent::new_left_motion_event(Position::new(2, 10)),
+        client_id,
+    )
+    .unwrap();
+    // the application inside the pane enables mouse tracking while the user is
+    // still dragging (eg. a TUI app that was starting up when the drag began)
+    tab.handle_pty_bytes(1, Vec::from("\u{1b}[?1000h".as_bytes()))
+        .unwrap();
+    tab.handle_mouse_event(
+        &MouseEvent::new_left_release_event(Position::new(2, 10)),
+        client_id,
+    )
+    .unwrap();
+    assert!(
+        tab.selecting_with_mouse_in_pane.is_none(),
+        "stopped selecting with mouse on release even though the terminal now wants mouse events"
+    );
+}
+
+#[test]
+fn selection_state_cleared_on_release_when_pane_closed_mid_selection() {
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let client_id = 1;
+    let mut tab = create_new_tab(size, ModeInfo::default());
+    let new_pane_id = PaneId::Terminal(2);
+    tab.vertical_split(new_pane_id, None, client_id, None, None)
+        .unwrap();
+    tab.handle_mouse_event(
+        &MouseEvent::new_left_press_event(Position::new(2, 90)),
+        client_id,
+    )
+    .unwrap();
+    assert_eq!(
+        tab.selecting_with_mouse_in_pane,
+        Some(new_pane_id),
+        "started selecting with mouse in the new pane"
+    );
+    tab.close_pane(new_pane_id, false, None);
+    tab.handle_mouse_event(
+        &MouseEvent::new_left_release_event(Position::new(2, 90)),
+        client_id,
+    )
+    .unwrap();
+    assert!(
+        tab.selecting_with_mouse_in_pane.is_none(),
+        "selection state cleared on release even though the selecting pane was closed mid-drag"
+    );
+}


### PR DESCRIPTION
## Problem

A mouse selection can get stuck, leaving the tab's mouse handling broken. clicks no longer focus panes, new selections cannot be started (drags extend the stale selection from its original anchor instead) and hover and wheel scroll are inert. Keyboard input is unaffected.

Reproduce (default config, deterministic):
1. Open two panes.
2. Press and hold the left button on the focused pane and drag a little. Keep holding.
3. While still holding the button, close the focused pane with the keyboard (Ctrl+p, x).
4. Release the button.

The mouse is now permanently broken in that tab. This also happens without keyboard involvement when the pane's command exits on its own mid-drag, and in a transient form when a TUI app in the pane enables mouse tracking between press and release.

## Cause

`execute_end_selection` only cleared `tab.selecting_with_mouse_in_pane` when the release event took the plain selection path. Two paths leaked the state: the release being forwarded to the terminal via `mouse_left_click_release` (mouse tracking enabled mid-drag), and the pane lookup failing (pane closed mid-drag). With the state leaked, `determine_mouse_action` keeps routing every event through the selection branch: presses are swallowed and left-motions keep updating the stale selection.

## Fix

`take()` the state unconditionally when handling the end of a selection, so it is cleared regardless of which branch handles the release or whether the pane still exists.

## Tests

Two regression tests, one per leak path. Both fail without the fix and pass with it.