### PR TITLE
Fix typos in comments, docs and error messages

### DIFF
--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -530,13 +530,13 @@ match pty
     },
     Err(err) => match err.downcast_ref::<ZellijError>() {
         Some(ZellijError::CommandNotFound { terminal_id, .. }) => {
-            // Do something now that this error occured.
+            // Do something now that this error occurred.
             // We can even access the values stored inside it, "terminal_id" in
             // this case
         },
         // You can check for other error variants here
         _ => {
-            // Some other error, which we haven't checked for, occured here.
+            // Some other error, which we haven't checked for, occurred here.
             // Now we can, for example, log it!
             Err::<(), _>(err).non_fatal(),
         },

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -223,7 +223,7 @@ impl ClientSender {
         // client. If it fills up, the client is disconnected with a "Buffer full" sort of error
         // message. It was previously found to be too small (with depth 50), so it was increased to
         // 5000 instead. This decision was made because it was found that a queue of depth 5000
-        // doesn't cause noticable increase in RAM usage, but there's no reason beyond that. If in
+        // doesn't cause noticeable increase in RAM usage, but there's no reason beyond that. If in
         // the future this is found to fill up too quickly again, it may be worthwhile to increase
         // the size even further (or better yet, implement a redraw-on-backpressure mechanism).
         // We, the zellij maintainers, have decided against an unbounded

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1993,7 +1993,7 @@ impl Grid {
         self.reset_terminal_state();
         self.mark_for_rerender();
     }
-    /// Dumps all lines above terminal vieport and the viewport itself to a string
+    /// Dumps all lines above terminal viewport and the viewport itself to a string
     pub fn dump_screen(&self, full: bool) -> String {
         let viewport: String = dump_screen!(self.viewport);
         if !full {

--- a/zellij-tile/src/lib.rs
+++ b/zellij-tile/src/lib.rs
@@ -70,7 +70,7 @@ pub trait ZellijWorker<'de>: Default + Serialize + Deserialize<'de> {
 }
 
 pub const PLUGIN_MISMATCH: &str =
-    "An error occured in a plugin while receiving an Event from zellij. This means
+    "An error occurred in a plugin while receiving an Event from zellij. This means
 that the plugins aren't compatible with the current zellij version.
 
 The most likely explanation for this is that you're running either a

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -2271,9 +2271,9 @@ pub struct TabInfo {
     pub active_swap_layout_name: Option<String>,
     /// Whether the user manually changed the layout, moving out of the swap layout scheme
     pub is_swap_layout_dirty: bool,
-    /// Row count in the viewport (including all non-ui panes, eg. will excluse the status bar)
+    /// Row count in the viewport (including all non-ui panes, eg. will exclude the status bar)
     pub viewport_rows: usize,
-    /// Column count in the viewport (including all non-ui panes, eg. will excluse the status bar)
+    /// Column count in the viewport (including all non-ui panes, eg. will exclude the status bar)
     pub viewport_columns: usize,
     /// Row count in the display area (including all panes, will typically be larger than the
     /// viewport)

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -148,7 +148,7 @@ fn discard_result<T>(_arg: anyhow::Result<T>) {}
 impl<T> FatalError<T> for anyhow::Result<T> {
     fn non_fatal(self) {
         if self.is_err() {
-            discard_result(self.context("a non-fatal error occured").to_log());
+            discard_result(self.context("a non-fatal error occurred").to_log());
         }
     }
 
@@ -156,7 +156,7 @@ impl<T> FatalError<T> for anyhow::Result<T> {
         if let Ok(val) = self {
             val
         } else {
-            self.context("a fatal error occured")
+            self.context("a fatal error occurred")
                 .expect("Program terminates")
         }
     }
@@ -736,7 +736,7 @@ open an issue on GitHub:
     #[error("Pane size remains unchanged")]
     PaneSizeUnchanged,
 
-    #[error("an error occured")]
+    #[error("an error occurred")]
     GenericError { source: anyhow::Error },
 
     #[error("Client {client_id} is too slow to handle incoming messages")]
@@ -843,7 +843,7 @@ mod not_wasm {
         error!(
             "{}",
             format!(
-                "Panic occured:
+                "Panic occurred:
              thread: {}
              location: {}
              message: {}",

--- a/zellij-utils/src/setup.rs
+++ b/zellij-utils/src/setup.rs
@@ -287,8 +287,8 @@ pub struct Setup {
 impl Setup {
     /// Entrypoint from main
     /// Merges options from the config file and the command line options
-    /// into `[Options]`, the command line options superceeding the layout
-    /// file options, superceeding the config file options:
+    /// into `[Options]`, the command line options superseding the layout
+    /// file options, superseding the config file options:
     /// 1. command line options (`zellij options`)
     /// 2. layout options
     ///    (`layout.kdl` / `zellij --layout`)


### PR DESCRIPTION
Small spelling fixes I noticed while reading through the codebase:

- `occured` -> `occurred` (`zellij-utils/src/errors.rs`, `zellij-tile/src/lib.rs`, `docs/ERROR_HANDLING.md`)
- `superceeding` -> `superseding` (`zellij-utils/src/setup.rs`)
- `noticable` -> `noticeable` (`zellij-server/src/os_input_output.rs`)
- `vieport` -> `viewport` (`zellij-server/src/panes/grid.rs`)
- `excluse` -> `exclude` (`zellij-utils/src/data.rs`)

Comments, doc comments and a few user-visible error strings only. No behaviour changes, and I checked that nothing asserts on the changed strings.