### PR TITLE
fix(server): non-zero exit status when a tab-by-id action targets a nonexistent tab

### DIFF
--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -10976,7 +10976,7 @@ pub(crate) fn screen_thread_main(
                 }
                 screen.log_and_report_session_state()?;
             },
-            ScreenInstruction::GoToTabWithId(tab_id, client_id, _completion_tx) => {
+            ScreenInstruction::GoToTabWithId(tab_id, client_id, mut _completion_tx) => {
                 let client_id_to_switch = client_id
                     .and_then(|cid| {
                         if screen.active_tab_ids.contains_key(&cid) {
@@ -11001,23 +11001,35 @@ pub(crate) fn screen_thread_main(
                             .push(tab_id);
                     } else {
                         log::error!("Tab with ID {} not found", tab_id);
+                        if let Some(ref mut c) = _completion_tx {
+                            c.set_exit_status(1);
+                            c.set_error_message(format!("Tab with id {} not found", tab_id));
+                        }
                     }
                 }
             },
-            ScreenInstruction::RenameTabWithId(tab_id, new_name, _completion_tx) => {
+            ScreenInstruction::RenameTabWithId(tab_id, new_name, mut _completion_tx) => {
                 // Use get_tab_by_id_mut() helper method
                 if let Some(tab) = screen.get_tab_by_id_mut(tab_id) {
                     tab.name = String::from_utf8_lossy(&new_name).to_string();
                     screen.log_and_report_session_state()?;
                 } else {
                     log::error!("Failed to find tab with ID: {}", tab_id);
+                    if let Some(ref mut c) = _completion_tx {
+                        c.set_exit_status(1);
+                        c.set_error_message(format!("Tab with id {} not found", tab_id));
+                    }
                 }
             },
-            ScreenInstruction::CloseTabWithId(tab_id, _completion_tx) => {
+            ScreenInstruction::CloseTabWithId(tab_id, mut _completion_tx) => {
                 if screen.get_tab_by_id(tab_id).is_some() {
                     screen.close_tab_by_id(tab_id).non_fatal();
                 } else {
                     log::error!("Failed to find tab with ID: {}", tab_id);
+                    if let Some(ref mut c) = _completion_tx {
+                        c.set_exit_status(1);
+                        c.set_error_message(format!("Tab with id {} not found", tab_id));
+                    }
                 }
             },
             ScreenInstruction::BreakPanesToTabWithId {


### PR DESCRIPTION
Fixes #5494.

`GoToTabWithId`, `RenameTabWithId` and `CloseTabWithId` log an error when the requested tab id is absent, but drop their `_completion_tx` without touching it — so the CLI reports success for an action that did nothing.

## Before

```console
$ zellij action rename-tab --tab-id 9999 -- ghost ; echo $?
0
$ zellij action go-to-tab-by-id 9999              ; echo $?
0
$ zellij action close-tab-by-id 9999              ; echo $?
0
```

Sibling handlers on the same code path already behave correctly, and are the pattern this PR follows:

```console
$ zellij action undo-rename-tab --tab-id 9999
Tab with id 9999 not found
$ echo $?
2
```

## The change

Two lines added to each of the three arms, matching `UndoRenameTabWithTabId` / `ToggleActiveSyncTabWithTabId` exactly — including keeping the `mut _completion_tx` binding style used by the surrounding code:

```rust
} else {
    log::error!("Failed to find tab with ID: {}", tab_id);
    if let Some(ref mut c) = _completion_tx {
        c.set_exit_status(1);
        c.set_error_message(format!("Tab with id {} not found", tab_id));
    }
}
```

Existing `log::error!` lines are left untouched to keep the diff minimal. Nothing on the success path changes.

## Why these three

Not a judgement call — I scanned every `screen_thread_main` arm that takes a `completion_tx` **and** logs an error on a missing target. There are 38. **34 already call `set_exit_status`**; these 3 were the exceptions. So this brings them in line with an existing convention rather than introducing one.

(My scan initially flagged a 4th, `RenameActivePane`. Reading it by hand showed the `log::error!` belonged to a neighbouring arm and it has no not-found branch — false positive, not included.)

## Verification

- `cargo check -p zellij-server` — clean, no new warnings.
- Negative control on that check: introducing a deliberate typo in the added lines produces `error[E0599]` and a non-zero exit, so the check demonstrably can fail rather than passing vacuously.
- `cargo test -p zellij-server --lib` — **1499 passed, 1 failed**. The one failure is `panes::kitty_graphics::parser::parser_tests::temp_file_medium_outside_temp_dir_is_not_deleted`, which is **pre-existing and unrelated**: I re-ran that single test with `screen.rs` reverted to the parent commit and it fails identically, then restored and confirmed the tree was clean. Happy to drop that detail if it is already known.
- Behaviour measured on 0.44.1; code confirmed unchanged on `main` @ b961fac.

I have not added a regression test — the CLI exit-status path here does not appear to have existing unit coverage that I could extend, and I did not want to invent a harness shape in a first PR. Glad to add one if you would like it and can point me at the right place.

## Why it matters

Any tool driving zellij by tab id cannot distinguish "done" from "no such tab". Tab ids are stable but recyclable, so a cached id can start pointing at nothing after a tab closes, and the command that would reveal it returns success. `log::error!` goes to the server log, which a scripting caller is not reading; exit status is the only channel it has.

Noting per CONTRIBUTING that minor fixes may take a while to get to — no rush expected, and the issue stands on its own if this sits.
