### PR TITLE
fix(panes): route focus events through the pty writer

### DIFF
--- a/zellij-integration-tests/src/fake_server_os_api.rs
+++ b/zellij-integration-tests/src/fake_server_os_api.rs
@@ -129,9 +129,6 @@ impl ServerOsApi for FakeServerOsApi {
             Err(anyhow!("no fake pty for terminal id {terminal_id}"))
         }
     }
-    fn tcdrain(&self, _terminal_id: u32) -> Result<()> {
-        Ok(())
-    }
     fn kill(&self, pid: u32) -> Result<()> {
         self.shared_ptys
             .exit_terminal(pid.saturating_sub(FAKE_PID_BASE), None);

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -321,8 +321,6 @@ pub trait ServerOsApi: Send + Sync {
     }
     /// Write bytes to the standard input of the virtual terminal referred to by `terminal_id`.
     fn write_to_tty_stdin(&self, terminal_id: u32, buf: &[u8]) -> Result<usize>;
-    /// Wait until all output written to the terminal has been transmitted.
-    fn tcdrain(&self, terminal_id: u32) -> Result<()>;
     /// Terminate the process with process ID `pid`. (SIGHUP)
     fn kill(&self, pid: u32) -> Result<()>;
     /// Terminate the process with process ID `pid`. (SIGKILL)
@@ -429,9 +427,6 @@ impl ServerOsApi for ServerOsInputOutput {
     }
     fn write_to_tty_stdin(&self, terminal_id: u32, buf: &[u8]) -> Result<usize> {
         self.pty_backend.write_to_tty_stdin(terminal_id, buf)
-    }
-    fn tcdrain(&self, terminal_id: u32) -> Result<()> {
-        self.pty_backend.tcdrain(terminal_id)
     }
     fn box_clone(&self) -> Box<dyn ServerOsApi> {
         Box::new((*self).clone())

--- a/zellij-server/src/os_input_output_unix.rs
+++ b/zellij-server/src/os_input_output_unix.rs
@@ -401,23 +401,6 @@ impl UnixPtyBackend {
         try_write_to_fd(fd, buf).with_context(err_context)
     }
 
-    pub fn tcdrain(&self, terminal_id: u32) -> Result<()> {
-        let err_context = || format!("failed to tcdrain to TTY ID {}", terminal_id);
-
-        match self
-            .terminal_id_to_raw_fd
-            .lock()
-            .to_anyhow()
-            .with_context(err_context)?
-            .get(&terminal_id)
-        {
-            Some(Some(fd)) => {
-                termios::tcdrain(unsafe { BorrowedFd::borrow_raw(*fd) }).with_context(err_context)
-            },
-            _ => Err(anyhow!("could not find raw file descriptor")).with_context(err_context),
-        }
-    }
-
     pub fn tcgetpgrp(&self, terminal_id: u32) -> Option<i32> {
         match self.terminal_id_to_raw_fd.lock().ok()?.get(&terminal_id) {
             Some(Some(fd)) => unistd::tcgetpgrp(unsafe { BorrowedFd::borrow_raw(*fd) })

--- a/zellij-server/src/os_input_output_windows.rs
+++ b/zellij-server/src/os_input_output_windows.rs
@@ -18,7 +18,7 @@ use tokio::net::windows::named_pipe::NamedPipeServer;
 
 use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE, S_OK};
 use windows_sys::Win32::Storage::FileSystem::{
-    CreateFileW, FlushFileBuffers, WriteFile, FILE_FLAG_OVERLAPPED, OPEN_EXISTING,
+    CreateFileW, WriteFile, FILE_FLAG_OVERLAPPED, OPEN_EXISTING,
 };
 use windows_sys::Win32::System::Console::{
     ClosePseudoConsole, CreatePseudoConsole, GenerateConsoleCtrlEvent, ResizePseudoConsole, COORD,
@@ -598,31 +598,6 @@ impl WindowsPtyBackend {
                 } else {
                     Ok(written as usize)
                 }
-            },
-            _ => Err(anyhow!("no ConPTY terminal found for id {}", terminal_id))
-                .with_context(err_context),
-        }
-    }
-
-    pub fn tcdrain(&self, terminal_id: u32) -> Result<()> {
-        let err_context = || format!("failed to drain terminal {}", terminal_id);
-
-        match self
-            .terminals
-            .lock()
-            .to_anyhow()
-            .with_context(err_context)?
-            .get(&terminal_id)
-        {
-            Some(Some(term)) => {
-                let ok = unsafe { FlushFileBuffers(term.input_write_handle) };
-                if ok == 0 {
-                    // FlushFileBuffers can legitimately fail on pipe handles
-                    // (ERROR_INVALID_FUNCTION) — treat as non-fatal.
-                    let e = io::Error::last_os_error();
-                    log::debug!("FlushFileBuffers on terminal {}: {}", terminal_id, e);
-                }
-                Ok(())
             },
             _ => Err(anyhow!("no ConPTY terminal found for id {}", terminal_id))
                 .with_context(err_context),

--- a/zellij-server/src/panes/active_panes.rs
+++ b/zellij-server/src/panes/active_panes.rs
@@ -1,13 +1,15 @@
 use crate::tab::Pane;
 
-use crate::{os_input_output::ServerOsApi, panes::PaneId, ClientId};
+use crate::pty_writer::PtyWriteInstruction;
+use crate::thread_bus::ThreadSenders;
+use crate::{panes::PaneId, ClientId};
 use std::collections::{BTreeMap, HashMap};
 
 #[derive(Clone)]
 pub struct ActivePanes {
     active_panes: HashMap<ClientId, PaneId>,
     last_panes: HashMap<ClientId, PaneId>,
-    os_api: Box<dyn ServerOsApi>,
+    senders: ThreadSenders,
 }
 
 impl std::fmt::Debug for ActivePanes {
@@ -17,12 +19,11 @@ impl std::fmt::Debug for ActivePanes {
 }
 
 impl ActivePanes {
-    pub fn new(os_api: &Box<dyn ServerOsApi>) -> Self {
-        let os_api = os_api.clone();
+    pub fn new(senders: ThreadSenders) -> Self {
         ActivePanes {
             active_panes: HashMap::new(),
             last_panes: HashMap::new(),
-            os_api,
+            senders,
         }
     }
     pub fn get(&self, client_id: &ClientId) -> Option<&PaneId> {
@@ -97,18 +98,22 @@ impl ActivePanes {
     fn unfocus_pane(&self, pane_id: PaneId, panes: &mut BTreeMap<PaneId, Box<dyn Pane>>) {
         if let PaneId::Terminal(terminal_id) = pane_id {
             if let Some(focus_event) = panes.get(&pane_id).and_then(|p| p.unfocus_event()) {
-                let _ = self
-                    .os_api
-                    .write_to_tty_stdin(terminal_id, focus_event.as_bytes());
+                let _ = self.senders.send_to_pty_writer(PtyWriteInstruction::Write(
+                    focus_event.into_bytes(),
+                    terminal_id,
+                    None,
+                ));
             }
         }
     }
     fn focus_pane(&self, pane_id: PaneId, panes: &mut BTreeMap<PaneId, Box<dyn Pane>>) {
         if let PaneId::Terminal(terminal_id) = pane_id {
             if let Some(focus_event) = panes.get(&pane_id).and_then(|p| p.focus_event()) {
-                let _ = self
-                    .os_api
-                    .write_to_tty_stdin(terminal_id, focus_event.as_bytes());
+                let _ = self.senders.send_to_pty_writer(PtyWriteInstruction::Write(
+                    focus_event.into_bytes(),
+                    terminal_id,
+                    None,
+                ));
             }
         }
     }

--- a/zellij-server/src/panes/floating_panes/mod.rs
+++ b/zellij-server/src/panes/floating_panes/mod.rs
@@ -77,7 +77,6 @@ impl FloatingPanes {
         session_is_mirrored: bool,
         default_mode_info: ModeInfo,
         style: Style,
-        os_input: Box<dyn ServerOsApi>,
         senders: ThreadSenders,
     ) -> Self {
         FloatingPanes {
@@ -94,7 +93,7 @@ impl FloatingPanes {
             desired_pane_positions: HashMap::new(),
             z_indices: vec![],
             show_panes: false,
-            active_panes: ActivePanes::new(&os_input),
+            active_panes: ActivePanes::new(senders.clone()),
             pane_being_moved_with_mouse: None,
             senders,
             window_title: None,

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -16,7 +16,6 @@ use crate::resize_pty;
 use tiled_pane_grid::{split, TiledPaneGrid, RESIZE_PERCENT};
 
 use crate::{
-    os_input_output::ServerOsApi,
     output::Output,
     panes::{ActivePanes, PaneId},
     plugins::PluginInstruction,
@@ -106,7 +105,6 @@ impl TiledPanes {
         pane_frame_style: PaneFrameStyle,
         default_mode_info: ModeInfo,
         style: Style,
-        os_api: Box<dyn ServerOsApi>,
         senders: ThreadSenders,
     ) -> Self {
         TiledPanes {
@@ -122,7 +120,7 @@ impl TiledPanes {
             default_mode_info,
             style,
             session_is_mirrored,
-            active_panes: ActivePanes::new(&os_api),
+            active_panes: ActivePanes::new(senders.clone()),
             pane_frame_style,
             panes_to_hide: HashSet::new(),
             fullscreen_is_active: None,

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -926,7 +926,6 @@ impl Tab {
             pane_frame_style,
             default_mode_info.clone(),
             style,
-            os_api.clone(),
             senders.clone(),
         );
         let floating_panes = FloatingPanes::new(
@@ -941,7 +940,6 @@ impl Tab {
             session_is_mirrored,
             default_mode_info.clone(),
             style,
-            os_api.clone(),
             senders.clone(),
         );
 
@@ -3789,9 +3787,11 @@ impl Tab {
             }
         });
         if let Some(focus_event) = focus_event {
-            let _ = self
-                .os_api
-                .write_to_tty_stdin(terminal_id, focus_event.as_bytes());
+            let _ = self.senders.send_to_pty_writer(PtyWriteInstruction::Write(
+                focus_event.into_bytes(),
+                terminal_id,
+                None,
+            ));
         }
     }
     pub fn check_and_handle_bell_notifications(

--- a/zellij-server/src/tab/unit/layout_applier_tests.rs
+++ b/zellij-server/src/tab/unit/layout_applier_tests.rs
@@ -55,10 +55,6 @@ impl ServerOsApi for FakeInputOutput {
         unimplemented!()
     }
 
-    fn tcdrain(&self, _id: u32) -> Result<()> {
-        unimplemented!()
-    }
-
     fn kill(&self, _pid: u32) -> Result<()> {
         unimplemented!()
     }
@@ -208,7 +204,6 @@ fn create_layout_applier_fixtures(
         draw_pane_frames,
         default_mode_info.clone(),
         style.clone(),
-        os_api.box_clone(),
         senders.clone(),
     );
 
@@ -225,7 +220,6 @@ fn create_layout_applier_fixtures(
         session_is_mirrored,
         default_mode_info,
         style.clone(),
-        os_api.box_clone(),
         senders.clone(),
     );
 
@@ -344,7 +338,6 @@ fn create_layout_applier_fixtures_with_receivers(
         draw_pane_frames,
         default_mode_info.clone(),
         style.clone(),
-        os_api.box_clone(),
         senders.clone(),
     );
 
@@ -361,7 +354,6 @@ fn create_layout_applier_fixtures_with_receivers(
         session_is_mirrored,
         default_mode_info,
         style.clone(),
-        os_api.box_clone(),
         senders.clone(),
     );
 

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -47,7 +47,6 @@ use zellij_utils::{
 #[derive(Clone, Default)]
 struct FakeInputOutput {
     file_dumps: Arc<Mutex<HashMap<String, String>>>,
-    pub tty_stdin_bytes: Arc<Mutex<BTreeMap<u32, Vec<u8>>>>,
 }
 
 impl ServerOsApi for FakeInputOutput {
@@ -70,17 +69,8 @@ impl ServerOsApi for FakeInputOutput {
     ) -> Result<(u32, Box<dyn AsyncReader>, Option<u32>)> {
         unimplemented!()
     }
-    fn write_to_tty_stdin(&self, id: u32, buf: &[u8]) -> Result<usize> {
-        self.tty_stdin_bytes
-            .lock()
-            .unwrap()
-            .entry(id)
-            .or_insert_with(|| vec![])
-            .extend_from_slice(buf);
+    fn write_to_tty_stdin(&self, _id: u32, buf: &[u8]) -> Result<usize> {
         Ok(buf.len())
-    }
-    fn tcdrain(&self, _id: u32) -> Result<()> {
-        unimplemented!()
     }
     fn kill(&self, _pid: u32) -> Result<()> {
         unimplemented!()
@@ -613,102 +603,6 @@ fn create_new_tab_with_swap_layouts(
     tab
 }
 
-fn create_new_tab_with_os_api(
-    size: Size,
-    default_mode: ModeInfo,
-    os_api: &Box<FakeInputOutput>,
-) -> Tab {
-    set_session_name("test".into());
-    let index = 0;
-    let position = 0;
-    let name = String::new();
-    let os_api = os_api.clone();
-    let senders = ThreadSenders::default().silently_fail_on_send();
-    let max_panes = None;
-    let mode_info = default_mode;
-    let style = Style::default();
-    let draw_pane_frames = PaneFrameStyle::Full;
-    let auto_layout = true;
-    let client_id = 1;
-    let session_is_mirrored = true;
-    let mut connected_clients = HashMap::new();
-    connected_clients.insert(client_id, false);
-    let connected_clients = Rc::new(RefCell::new(connected_clients));
-    let character_cell_info = Rc::new(RefCell::new(None));
-    let stacked_resize = Rc::new(RefCell::new(true));
-    let terminal_emulator_colors = Rc::new(RefCell::new(Palette::default()));
-    let copy_options = CopyOptions::default();
-    let terminal_emulator_color_codes = Rc::new(RefCell::new(HashMap::new()));
-    let sixel_image_store = Rc::new(RefCell::new(SixelImageStore::default()));
-    let current_group = Rc::new(RefCell::new(PaneGroups::new(ThreadSenders::default())));
-    let currently_marking_pane_group = Rc::new(RefCell::new(HashMap::new()));
-    let debug = false;
-    let arrow_fonts = true;
-    let styled_underlines = true;
-    let osc8_hyperlinks = true;
-    let explicitly_disable_kitty_keyboard_protocol = false;
-    let advanced_mouse_actions = true;
-    let mouse_scroll_resize = true;
-    let web_sharing = WebSharing::Off;
-    let web_server_ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-    let web_server_port = 8080;
-    let mut tab = Tab::new(
-        index,
-        position,
-        name,
-        size,
-        character_cell_info,
-        stacked_resize,
-        Rc::new(RefCell::new(false)),
-        sixel_image_store,
-        Rc::new(RefCell::new(KittyImageStore::default())),
-        os_api,
-        senders,
-        max_panes,
-        style,
-        mode_info,
-        draw_pane_frames,
-        auto_layout,
-        connected_clients,
-        session_is_mirrored,
-        Some(client_id),
-        copy_options,
-        terminal_emulator_colors,
-        terminal_emulator_color_codes,
-        (vec![], vec![]), // swap layouts
-        PathBuf::from("my_default_shell"),
-        debug,
-        arrow_fonts,
-        styled_underlines,
-        osc8_hyperlinks,
-        explicitly_disable_kitty_keyboard_protocol,
-        None,
-        false,
-        web_sharing,
-        current_group,
-        currently_marking_pane_group,
-        advanced_mouse_actions,
-        mouse_scroll_resize,
-        true, // mouse_hover_effects
-        true,
-        false, // focus_follows_mouse
-        false, // mouse_click_through
-        web_server_ip,
-        web_server_port,
-    );
-    tab.apply_layout(
-        TiledPaneLayout::default(),
-        vec![],
-        vec![(1, None)],
-        vec![],
-        HashMap::new(),
-        client_id,
-        None,
-    )
-    .unwrap();
-    tab
-}
-
 fn create_new_tab_with_layout(size: Size, default_mode: ModeInfo, layout: &str) -> Tab {
     set_session_name("test".into());
     let index = 0;
@@ -812,6 +706,21 @@ fn create_new_tab_with_layout(size: Size, default_mode: ModeInfo, layout: &str) 
     )
     .unwrap();
     tab
+}
+
+fn drain_tty_stdin_bytes(
+    pty_writer_receiver: &Receiver<(PtyWriteInstruction, ErrorContext)>,
+) -> BTreeMap<u32, Vec<u8>> {
+    let mut tty_stdin_bytes: BTreeMap<u32, Vec<u8>> = BTreeMap::new();
+    while let Ok((instruction, _)) = pty_writer_receiver.try_recv() {
+        if let PtyWriteInstruction::Write(bytes, terminal_id, _) = instruction {
+            tty_stdin_bytes
+                .entry(terminal_id)
+                .or_default()
+                .extend(bytes);
+        }
+    }
+    tty_stdin_bytes
 }
 
 fn create_new_tab_with_mock_pty_writer(
@@ -5162,12 +5071,10 @@ fn move_pane_focus_sends_tty_csi_event() {
         rows: 20,
     };
     let client_id = 1;
-    let tty_stdin_bytes = Arc::new(Mutex::new(BTreeMap::new()));
-    let os_api = Box::new(FakeInputOutput {
-        tty_stdin_bytes: tty_stdin_bytes.clone(),
-        ..Default::default()
-    });
-    let mut tab = create_new_tab_with_os_api(size, ModeInfo::default(), &os_api);
+    let (pty_writer_sender, pty_writer_receiver): ChannelWithContext<PtyWriteInstruction> =
+        channels::unbounded();
+    let pty_writer_sender = SenderWithContext::new(pty_writer_sender);
+    let mut tab = create_new_tab_with_mock_pty_writer(size, ModeInfo::default(), pty_writer_sender);
     let new_pane_id_1 = PaneId::Terminal(2);
     tab.new_pane(
         new_pane_id_1,
@@ -5193,7 +5100,8 @@ fn move_pane_focus_sends_tty_csi_event() {
     )
     .unwrap();
     tab.move_focus_left(client_id).unwrap();
-    assert_snapshot!(format!("{:?}", *tty_stdin_bytes.lock().unwrap()));
+    let tty_stdin_bytes = drain_tty_stdin_bytes(&pty_writer_receiver);
+    assert_snapshot!(format!("{:?}", tty_stdin_bytes));
 }
 
 #[test]
@@ -5203,12 +5111,10 @@ fn move_floating_pane_focus_sends_tty_csi_event() {
         rows: 20,
     };
     let client_id = 1;
-    let tty_stdin_bytes = Arc::new(Mutex::new(BTreeMap::new()));
-    let os_api = Box::new(FakeInputOutput {
-        tty_stdin_bytes: tty_stdin_bytes.clone(),
-        ..Default::default()
-    });
-    let mut tab = create_new_tab_with_os_api(size, ModeInfo::default(), &os_api);
+    let (pty_writer_sender, pty_writer_receiver): ChannelWithContext<PtyWriteInstruction> =
+        channels::unbounded();
+    let pty_writer_sender = SenderWithContext::new(pty_writer_sender);
+    let mut tab = create_new_tab_with_mock_pty_writer(size, ModeInfo::default(), pty_writer_sender);
     let new_pane_id_1 = PaneId::Terminal(2);
     let new_pane_id_2 = PaneId::Terminal(3);
 
@@ -5255,7 +5161,8 @@ fn move_floating_pane_focus_sends_tty_csi_event() {
     )
     .unwrap();
     tab.move_focus_left(client_id).unwrap();
-    assert_snapshot!(format!("{:?}", *tty_stdin_bytes.lock().unwrap()));
+    let tty_stdin_bytes = drain_tty_stdin_bytes(&pty_writer_receiver);
+    assert_snapshot!(format!("{:?}", tty_stdin_bytes));
 }
 
 #[test]
@@ -5265,12 +5172,10 @@ fn toggle_floating_panes_on_sends_tty_csi_event() {
         rows: 20,
     };
     let client_id = 1;
-    let tty_stdin_bytes = Arc::new(Mutex::new(BTreeMap::new()));
-    let os_api = Box::new(FakeInputOutput {
-        tty_stdin_bytes: tty_stdin_bytes.clone(),
-        ..Default::default()
-    });
-    let mut tab = create_new_tab_with_os_api(size, ModeInfo::default(), &os_api);
+    let (pty_writer_sender, pty_writer_receiver): ChannelWithContext<PtyWriteInstruction> =
+        channels::unbounded();
+    let pty_writer_sender = SenderWithContext::new(pty_writer_sender);
+    let mut tab = create_new_tab_with_mock_pty_writer(size, ModeInfo::default(), pty_writer_sender);
     let new_pane_id_1 = PaneId::Terminal(2);
     let new_pane_id_2 = PaneId::Terminal(3);
 
@@ -5320,7 +5225,8 @@ fn toggle_floating_panes_on_sends_tty_csi_event() {
     .unwrap();
     tab.toggle_floating_panes(Some(client_id), None, None)
         .unwrap();
-    assert_snapshot!(format!("{:?}", *tty_stdin_bytes.lock().unwrap()));
+    let tty_stdin_bytes = drain_tty_stdin_bytes(&pty_writer_receiver);
+    assert_snapshot!(format!("{:?}", tty_stdin_bytes));
 }
 
 #[test]
@@ -5330,12 +5236,10 @@ fn toggle_floating_panes_off_sends_tty_csi_event() {
         rows: 20,
     };
     let client_id = 1;
-    let tty_stdin_bytes = Arc::new(Mutex::new(BTreeMap::new()));
-    let os_api = Box::new(FakeInputOutput {
-        tty_stdin_bytes: tty_stdin_bytes.clone(),
-        ..Default::default()
-    });
-    let mut tab = create_new_tab_with_os_api(size, ModeInfo::default(), &os_api);
+    let (pty_writer_sender, pty_writer_receiver): ChannelWithContext<PtyWriteInstruction> =
+        channels::unbounded();
+    let pty_writer_sender = SenderWithContext::new(pty_writer_sender);
+    let mut tab = create_new_tab_with_mock_pty_writer(size, ModeInfo::default(), pty_writer_sender);
     let new_pane_id_1 = PaneId::Terminal(2);
     let new_pane_id_2 = PaneId::Terminal(3);
 
@@ -5383,7 +5287,8 @@ fn toggle_floating_panes_off_sends_tty_csi_event() {
     .unwrap();
     tab.toggle_floating_panes(Some(client_id), None, None)
         .unwrap();
-    assert_snapshot!(format!("{:?}", *tty_stdin_bytes.lock().unwrap()));
+    let tty_stdin_bytes = drain_tty_stdin_bytes(&pty_writer_receiver);
+    assert_snapshot!(format!("{:?}", tty_stdin_bytes));
 }
 
 #[test]
@@ -16171,17 +16076,15 @@ fn host_focus_events_only_reach_panes_that_asked_for_them() {
         cols: 121,
         rows: 20,
     };
-    let tty_stdin_bytes = Arc::new(Mutex::new(BTreeMap::new()));
-    let os_api = Box::new(FakeInputOutput {
-        tty_stdin_bytes: tty_stdin_bytes.clone(),
-        ..Default::default()
-    });
-    let mut tab = create_new_tab_with_os_api(size, ModeInfo::default(), &os_api);
+    let (pty_writer_sender, pty_writer_receiver): ChannelWithContext<PtyWriteInstruction> =
+        channels::unbounded();
+    let pty_writer_sender = SenderWithContext::new(pty_writer_sender);
+    let mut tab = create_new_tab_with_mock_pty_writer(size, ModeInfo::default(), pty_writer_sender);
     let pane_id = PaneId::Terminal(1);
 
     tab.send_host_focus_event_to_pane(pane_id, false);
     assert!(
-        tty_stdin_bytes.lock().unwrap().is_empty(),
+        drain_tty_stdin_bytes(&pty_writer_receiver).is_empty(),
         "a pane that did not subscribe to focus events receives nothing"
     );
 
@@ -16190,9 +16093,7 @@ fn host_focus_events_only_reach_panes_that_asked_for_them() {
     tab.send_host_focus_event_to_pane(pane_id, false);
     tab.send_host_focus_event_to_pane(pane_id, true);
 
-    let written = tty_stdin_bytes
-        .lock()
-        .unwrap()
+    let written = drain_tty_stdin_bytes(&pty_writer_receiver)
         .get(&1)
         .map(|bytes| String::from_utf8_lossy(bytes).to_string());
     assert_eq!(written, Some("\u{1b}[O\u{1b}[I".to_owned()));

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -53,9 +53,6 @@ impl ServerOsApi for FakeInputOutput {
     fn write_to_tty_stdin(&self, _id: u32, _buf: &[u8]) -> Result<usize> {
         unimplemented!()
     }
-    fn tcdrain(&self, _id: u32) -> Result<()> {
-        unimplemented!()
-    }
     fn kill(&self, _pid: u32) -> Result<()> {
         unimplemented!()
     }

--- a/zellij-server/src/unit/pty_tests.rs
+++ b/zellij-server/src/unit/pty_tests.rs
@@ -67,9 +67,6 @@ impl ServerOsApi for MockOsApi {
     fn write_to_tty_stdin(&self, _: u32, buf: &[u8]) -> anyhow::Result<usize> {
         Ok(buf.len())
     }
-    fn tcdrain(&self, _: u32) -> anyhow::Result<()> {
-        Ok(())
-    }
     fn kill(&self, _: u32) -> anyhow::Result<()> {
         Ok(())
     }

--- a/zellij-server/src/unit/pty_writer_tests.rs
+++ b/zellij-server/src/unit/pty_writer_tests.rs
@@ -111,9 +111,6 @@ impl ServerOsApi for MockServerOsApi {
             )),
         }
     }
-    fn tcdrain(&self, _id: u32) -> Result<()> {
-        Ok(())
-    }
     fn kill(&self, _pid: u32) -> Result<()> {
         Ok(())
     }

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -215,9 +215,6 @@ impl ServerOsApi for FakeInputOutput {
             .extend_from_slice(buf);
         Ok(buf.len())
     }
-    fn tcdrain(&self, _id: u32) -> Result<()> {
-        unimplemented!()
-    }
     fn kill(&self, _pid: u32) -> Result<()> {
         unimplemented!()
     }
@@ -309,8 +306,33 @@ fn create_new_screen_with_kitty_graphics(
     screen
 }
 
-type TtyStdinBytes = Arc<Mutex<BTreeMap<u32, Vec<u8>>>>;
 type ServerReceiver = Receiver<(ServerInstruction, ErrorContext)>;
+
+// Focus events are sent to the pty writer, not written to the tty directly, so
+// tests read them off that channel. Reads accumulate so callers can assert on
+// the running total the way they did with the old tty capture map.
+struct FocusCapture {
+    receiver: Receiver<(PtyWriteInstruction, ErrorContext)>,
+    accumulated: RefCell<BTreeMap<u32, Vec<u8>>>,
+}
+
+impl FocusCapture {
+    fn pump(&self) {
+        while let Ok((instruction, _)) = self.receiver.try_recv() {
+            if let PtyWriteInstruction::Write(bytes, terminal_id, _) = instruction {
+                self.accumulated
+                    .borrow_mut()
+                    .entry(terminal_id)
+                    .or_default()
+                    .extend(bytes);
+            }
+        }
+    }
+    fn clear(&self) {
+        self.pump();
+        self.accumulated.borrow_mut().clear();
+    }
+}
 
 fn create_new_screen_with_capture(
     size: Size,
@@ -318,13 +340,19 @@ fn create_new_screen_with_capture(
     mouse_hover_effects: bool,
     support_kitty_graphics_protocol: bool,
     session_is_mirrored: bool,
-) -> (Screen, TtyStdinBytes, ServerReceiver) {
+) -> (Screen, FocusCapture, ServerReceiver) {
     let mut bus: Bus<ScreenInstruction> = Bus::empty();
     let fake_os_input = FakeInputOutput::default();
-    let tty_stdin_bytes = fake_os_input.tty_stdin_bytes.clone();
     bus.os_input = Some(Box::new(fake_os_input));
     let (to_server, server_receiver): ChannelWithContext<ServerInstruction> = channels::unbounded();
     bus.senders.to_server = Some(SenderWithContext::new(to_server));
+    let (to_pty_writer, pty_writer_receiver): ChannelWithContext<PtyWriteInstruction> =
+        channels::unbounded();
+    bus.senders.to_pty_writer = Some(SenderWithContext::new(to_pty_writer));
+    let focus_capture = FocusCapture {
+        receiver: pty_writer_receiver,
+        accumulated: RefCell::new(BTreeMap::new()),
+    };
     let client_attributes = ClientAttributes {
         size,
         ..Default::default()
@@ -396,7 +424,7 @@ fn create_new_screen_with_capture(
     );
     (
         seed_first_client_size(screen, size),
-        tty_stdin_bytes,
+        focus_capture,
         server_receiver,
     )
 }
@@ -12659,10 +12687,11 @@ fn subscribe_pane_to_focus_events(screen: &mut Screen, client_id: ClientId, term
         .unwrap();
 }
 
-fn focus_events_written_to_pane(tty_stdin_bytes: &TtyStdinBytes, terminal_id: u32) -> String {
-    tty_stdin_bytes
-        .lock()
-        .unwrap()
+fn focus_events_written_to_pane(focus_capture: &FocusCapture, terminal_id: u32) -> String {
+    focus_capture.pump();
+    focus_capture
+        .accumulated
+        .borrow()
         .get(&terminal_id)
         .map(|bytes| String::from_utf8_lossy(bytes).to_string())
         .unwrap_or_default()
@@ -12679,7 +12708,7 @@ fn host_focus_changes_are_forwarded_to_the_active_pane() {
         create_new_screen_with_capture(size, true, true, true, true);
     new_tab(&mut screen, 1, 0);
     subscribe_pane_to_focus_events(&mut screen, client_id, 1);
-    tty_stdin_bytes.lock().unwrap().clear();
+    tty_stdin_bytes.clear();
 
     screen.host_terminal_focus_changed(client_id, false);
     assert_eq!(
@@ -12707,7 +12736,7 @@ fn repeated_host_focus_reports_are_not_forwarded_twice() {
         create_new_screen_with_capture(size, true, true, true, true);
     new_tab(&mut screen, 1, 0);
     subscribe_pane_to_focus_events(&mut screen, client_id, 1);
-    tty_stdin_bytes.lock().unwrap().clear();
+    tty_stdin_bytes.clear();
 
     screen.host_terminal_focus_changed(client_id, false);
     screen.host_terminal_focus_changed(client_id, false);
@@ -12731,7 +12760,7 @@ fn host_focus_is_not_forwarded_to_a_pane_that_did_not_subscribe() {
     let (mut screen, tty_stdin_bytes, _server_receiver) =
         create_new_screen_with_capture(size, true, true, true, true);
     new_tab(&mut screen, 1, 0);
-    tty_stdin_bytes.lock().unwrap().clear();
+    tty_stdin_bytes.clear();
 
     screen.host_terminal_focus_changed(client_id, false);
     screen.host_terminal_focus_changed(client_id, true);
@@ -12757,7 +12786,7 @@ fn host_focus_loss_is_withheld_while_another_client_is_still_focused() {
     screen.set_client_size(second_client_id, size);
     screen.add_client(second_client_id, false).unwrap();
     subscribe_pane_to_focus_events(&mut screen, first_client_id, 1);
-    tty_stdin_bytes.lock().unwrap().clear();
+    tty_stdin_bytes.clear();
 
     screen.host_terminal_focus_changed(first_client_id, false);
     assert_eq!(
@@ -12816,7 +12845,7 @@ fn host_focus_changes_of_clients_on_different_panes_are_independent() {
         .unwrap();
     subscribe_pane_to_focus_events(&mut screen, first_client_id, 1);
     subscribe_pane_to_focus_events(&mut screen, first_client_id, 2);
-    tty_stdin_bytes.lock().unwrap().clear();
+    tty_stdin_bytes.clear();
 
     screen.host_terminal_focus_changed(second_client_id, false);
 
@@ -13127,7 +13156,7 @@ fn a_client_whose_host_focus_was_never_reported_counts_as_focused() {
         create_new_screen_with_capture(size, true, true, true, true);
     new_tab(&mut screen, 1, 0);
     subscribe_pane_to_focus_events(&mut screen, 1, 1);
-    tty_stdin_bytes.lock().unwrap().clear();
+    tty_stdin_bytes.clear();
 
     screen.host_terminal_focus_changed(1, true);
 


### PR DESCRIPTION
Fixes #5496.

`ActivePanes::{focus,unfocus}_pane` and `Tab::send_host_focus_event_to_pane` wrote the focus in/out sequences to the pane's tty from the screen thread and ignored the result. Since #4818 `write_to_tty_stdin` is a single non-blocking pass, so on a full pane stdin buffer the event gets dropped, half-written (a stray `\x1b`/`\x1b[`), or wedged into the middle of a queued paste. This routes them through the pty writer like other pane writes, so they get its queue and EAGAIN retry and stay ordered with the pane's input (the path #1383 set up for exactly this).

Closing panes don't generate a write: the close path drops the pane from the map before `ActivePanes` reads it.

Fallout:

- `ActivePanes` no longer uses `ServerOsApi`, which leaves the `os_api` params on `TiledPanes::new`/`FloatingPanes::new` unused (`resize_pty!` ignores that arg), so removed.
- `tcdrain` has had no callers since #4818; removed from the `ServerOsApi` trait and both backends.

## Test plan

- the focus-event tests (tab + screen) read the events off the pty writer channel instead of the fake OS API; assertions unchanged
- `zellij-server` suite passes on macOS (arm64) and Linux (x86_64)
- `cargo fmt`
