### PR TITLE
fix(grid): attach combining marks instead of dropping them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
-* fix: combining marks (Thai and Lao vowels and tone marks, Devanagari matras, Hebrew points, Arabic harakat, decomposed Latin accents, emoji variation selectors) were dropped instead of being attached to the character they modify
+* fix: combining marks (Thai and Lao vowels and tone marks, Devanagari matras, Hebrew points, Arabic harakat, decomposed Latin accents, emoji variation selectors) were dropped instead of being attached to the character they modify (https://github.com/zellij-org/zellij/pull/5500)
 
 ## [0.45.0] - 2026-08-20
 * feat: allow tabs to have different sizes if clients aren't focused on the same one (https://github.com/zellij-org/zellij/pull/5133)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+* fix: combining marks (Thai and Lao vowels and tone marks, Devanagari matras, Hebrew points, Arabic harakat, decomposed Latin accents, emoji variation selectors) were dropped instead of being attached to the character they modify
 
 ## [0.45.0] - 2026-08-20
 * feat: allow tabs to have different sizes if clients aren't focused on the same one (https://github.com/zellij-org/zellij/pull/5133)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
-* fix: combining marks (Thai and Lao vowels and tone marks, Devanagari matras, Hebrew points, Arabic harakat, decomposed Latin accents, emoji variation selectors) were dropped instead of being attached to the character they modify (https://github.com/zellij-org/zellij/pull/5500)
+* fix: combining marks (Thai and Lao vowels and tone marks, Devanagari matras, Hebrew points, Arabic harakat, decomposed Latin accents, emoji variation selectors) and the conjoining jamo of decomposed Hangul syllables were dropped instead of being attached to the character they modify (https://github.com/zellij-org/zellij/pull/5500)
 
 ## [0.45.0] - 2026-08-20
 * feat: allow tabs to have different sizes if clients aren't focused on the same one (https://github.com/zellij-org/zellij/pull/5133)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
-* fix: combining marks (Thai and Lao vowels and tone marks, Devanagari matras, Hebrew points, Arabic harakat, decomposed Latin accents, emoji variation selectors) and the conjoining jamo of decomposed Hangul syllables were dropped instead of being attached to the character they modify (https://github.com/zellij-org/zellij/pull/5500)
+* fix: combining marks (Thai and Lao vowels and tone marks, Devanagari matras, Hebrew points, Arabic harakat, decomposed Latin accents, emoji variation selectors) and the conjoining jamo of decomposed Hangul syllables were dropped instead of being attached to the character they modify, and were lost again when a screen was dumped, a session serialized or a selection copied (https://github.com/zellij-org/zellij/pull/5500)
 
 ## [0.45.0] - 2026-08-20
 * feat: allow tabs to have different sizes if clients aren't focused on the same one (https://github.com/zellij-org/zellij/pull/5133)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4057,6 +4057,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5114,6 +5120,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "tokio",
+ "unicode-properties",
  "unicode-width 0.2.2",
  "url",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ tokio = { version = "1.40", default-features = false, features = ["fs", "rt-mult
 thiserror = { version = "2.0.18", default-features = false, features = ["std"] }
 tokio-util = { version = "0.7.15" }
 unicode-width = { version = "0.2.2", default-features = false }
+unicode-properties = { version = "0.1.3", default-features = false, features = ["general-category"] }
 url = { version = "2.2.2", default-features = false, features = ["serde"] }
 uuid = { version = "1.4.1", default-features = false, features = ["serde", "v4", "std"] }
 vte = { version = "0.15", default-features = false, features = ["std"] }

--- a/zellij-server/Cargo.toml
+++ b/zellij-server/Cargo.toml
@@ -38,6 +38,7 @@ sysinfo = { version = "0.39.5", default-features = false, features = ["system"] 
 tempfile = { workspace = true }
 tokio = { workspace = true }
 unicode-width = { workspace = true }
+unicode-properties = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
 vte = { workspace = true }

--- a/zellij-server/src/output/mod.rs
+++ b/zellij-server/src/output/mod.rs
@@ -191,6 +191,9 @@ fn serialize_chunks_with_newlines(
             .with_context(err_context)?;
             chunk_width += t_character.width();
             vte_output.push(t_character.character);
+            for mark in t_character.combining_marks() {
+                vte_output.push(mark);
+            }
         }
     }
     Ok(vte_output)
@@ -257,6 +260,9 @@ fn serialize_chunks(
             .with_context(err_context)?;
             chunk_width += t_character.width();
             vte_output.push(t_character.character);
+            for mark in t_character.combining_marks() {
+                vte_output.push(mark);
+            }
         }
     }
     if let Some(sixel_image_store) = sixel_image_store {

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -12,6 +12,7 @@ use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::rc::Rc;
+use unicode_properties::{GeneralCategoryGroup, UnicodeGeneralCategory};
 use unicode_width::UnicodeWidthChar;
 use zellij_utils::data::{
     HighlightLayer, HighlightStyle, HostTerminalThemeMode, RegexHighlight, Style,
@@ -780,6 +781,18 @@ pub struct Grid {
     osc133_command_selection: bool,
     command_output_flash: Option<Selection>,
     word_separators: String,
+}
+
+/// True for Unicode general category Mark (Mn, Mc, Me): the nonspacing and combining marks
+/// that modify the character they follow. Thai and Lao vowels and tone marks, Devanagari
+/// matras, Hebrew points, Arabic harakat and the emoji variation selectors are all marks.
+/// The zero width joiner is deliberately not one: joining emoji into a single cluster also
+/// requires recomputing the width of that cluster, which is a separate concern.
+fn is_combining_mark(character: char) -> bool {
+    matches!(
+        character.general_category_group(),
+        GeneralCategoryGroup::Mark
+    )
 }
 
 impl Grid {
@@ -2343,13 +2356,42 @@ impl Grid {
             },
         }
     }
+    /// Attach a zero width codepoint to the character preceding the cursor. Marks arriving
+    /// with no character to modify (at the start of a line, or before anything has been
+    /// printed) have nothing to attach to and are dropped, which is what every other terminal
+    /// does with them.
+    fn attach_combining_mark(&mut self, mark: char) {
+        if self.cursor.x == 0 {
+            return;
+        }
+        let y = self.cursor.y;
+        let x = self.cursor.x - 1;
+        let Some(row) = self.viewport.get_mut(y) else {
+            return;
+        };
+        // absolute_character_index maps a display column back to the character occupying it,
+        // so a mark following a wide character lands on that character rather than its
+        // second, empty column.
+        let index = row.absolute_character_index(x);
+        let Some(character) = row.columns.get_mut(index) else {
+            return;
+        };
+        character.add_combining_mark(mark);
+        self.output_buffer.update_line(y);
+    }
+
     pub fn add_character(&mut self, terminal_character: TerminalCharacter) {
         let character_width = terminal_character.width();
-        // Drop zero-width Unicode/UTF-8 codepoints, like for example Variation Selectors.
-        // This breaks unicode grapheme segmentation, and is the reason why some characters
-        // aren't displayed correctly. Refer to this issue for more information:
-        //     https://github.com/zellij-org/zellij/issues/1538
+        // Zero width codepoints never get a cell of their own. Combining marks are attached to
+        // the character they modify so that the two render as a single grapheme cluster, which
+        // keeps the column count and the cursor position identical to the precomposed form of
+        // the same text. Everything else that happens to be zero width (controls, format
+        // characters such as the soft hyphen and the zero width joiner, fillers) has nothing
+        // to combine with and is dropped as before.
         if character_width == 0 {
+            if is_combining_mark(terminal_character.character) {
+                self.attach_combining_mark(terminal_character.character);
+            }
             return;
         }
         if self.cursor.x + character_width > self.width {

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -469,7 +469,7 @@ macro_rules! dump_screen {
             if line.is_canonical && !is_first {
                 buf.push_str("\n");
             }
-            let s: String = (&line.columns).into_iter().map(|x| x.character).collect();
+            let s: String = line.to_text();
             // Replace the spaces at the end of the line. Sometimes, the lines are
             // collected with spaces until the end of the panel.
             buf.push_str(&s.trim_end_matches(' '));
@@ -496,7 +496,7 @@ macro_rules! dump_screen_with_ansi {
                 .columns
                 .iter()
                 .rposition(|tc| {
-                    let space = tc.character == ' ';
+                    let space = tc.character == ' ' && !tc.has_combining_marks();
                     let styled = !matches!(tc.styles.background, Some(AnsiCode::Reset) | None);
                     !space || styled // it's, something drawable
                 })
@@ -509,7 +509,7 @@ macro_rules! dump_screen_with_ansi {
                     write!(buf, "{}", tc.styles).unwrap();
                     last_styles = Some(tc.styles.clone());
                 }
-                buf.push(tc.character);
+                tc.push_cluster_to(&mut buf);
             }
             is_first = false;
         }
@@ -3242,7 +3242,7 @@ impl Grid {
             let mut terminal_col = 0;
             for terminal_character in &row.columns {
                 if (start_column..end_column).contains(&terminal_col) {
-                    line_selection.push(terminal_character.character);
+                    terminal_character.push_cluster_to(&mut line_selection);
                 }
 
                 terminal_col += terminal_character.width();
@@ -4276,13 +4276,13 @@ impl Grid {
     ) -> PaneContents {
         let mut viewport: Vec<String> = Vec::with_capacity(self.viewport.len());
         for row in &self.viewport {
-            let s: String = (&row.columns).into_iter().map(|x| x.character).collect();
+            let s: String = row.to_text();
             viewport.push(s);
         }
         let mut contents = if get_full_scrollback {
             let mut lines_above_viewport: Vec<String> = Vec::with_capacity(self.lines_above.len());
             for row in &self.lines_above {
-                let s: String = (&row.columns).into_iter().map(|x| x.character).collect();
+                let s: String = row.to_text();
                 lines_above_viewport.push(s);
             }
             // Truncate to last N lines if max specified (Some(0) means "all" — no truncation)
@@ -4294,7 +4294,7 @@ impl Grid {
             }
             let mut lines_below_viewport: Vec<String> = Vec::with_capacity(self.lines_below.len());
             for row in &self.lines_below {
-                let s: String = (&row.columns).into_iter().map(|x| x.character).collect();
+                let s: String = row.to_text();
                 lines_below_viewport.push(s);
             }
             PaneContents::new_with_scrollback(
@@ -4325,7 +4325,7 @@ impl Grid {
                 .columns
                 .iter()
                 .rposition(|tc| {
-                    let space = tc.character == ' ';
+                    let space = tc.character == ' ' && !tc.has_combining_marks();
                     let styled = !matches!(tc.styles.background, Some(AnsiCode::Reset) | None);
                     !space || styled
                 })
@@ -4337,7 +4337,7 @@ impl Grid {
                     write!(buf, "{}", tc.styles).unwrap();
                     last_styles = Some(tc.styles.clone());
                 }
-                buf.push(tc.character);
+                tc.push_cluster_to(&mut buf);
             }
             if last_styles.is_some() {
                 buf.push_str("\u{1b}[m");
@@ -5683,6 +5683,15 @@ impl Row {
             bg_color: None,
             osc133_markers: vec![],
         }
+    }
+    /// The text of this row, each cell rendered as its full cluster: the character together with
+    /// any combining marks attached to it.
+    pub fn to_text(&self) -> String {
+        let mut buf = String::with_capacity(self.columns.len());
+        for terminal_character in &self.columns {
+            terminal_character.push_cluster_to(&mut buf);
+        }
+        buf
     }
     pub fn from_columns(columns: VecDeque<TerminalCharacter>) -> Self {
         Row {

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -786,12 +786,26 @@ pub struct Grid {
 /// True for Unicode general category Mark (Mn, Mc, Me): the nonspacing and combining marks
 /// that modify the character they follow. Thai and Lao vowels and tone marks, Devanagari
 /// matras, Hebrew points, Arabic harakat and the emoji variation selectors are all marks.
+/// Also true for the medial vowels and final consonants of Hangul Jamo, which are letters
+/// rather than marks but conjoin with the leading consonant before them just the same.
 /// The zero width joiner is deliberately not one: joining emoji into a single cluster also
 /// requires recomputing the width of that cluster, which is a separate concern.
 fn is_combining_mark(character: char) -> bool {
     matches!(
         character.general_category_group(),
         GeneralCategoryGroup::Mark
+    ) || is_hangul_conjoining_jamo_vowel_or_final(character)
+}
+
+/// The medial vowels (jungseong) and final consonants (jongseong) of the Hangul Jamo block
+/// and its Extended-B block. Unicode classifies them as letters, but they have zero width
+/// because they never stand alone: a decomposed syllable is one leading consonant followed
+/// by them, and the three render as one wide grapheme cluster. Dropping them turned Korean
+/// into a row of leading consonants, which is the form macOS hands a terminal for file names.
+fn is_hangul_conjoining_jamo_vowel_or_final(character: char) -> bool {
+    matches!(
+        character,
+        '\u{1160}'..='\u{11FF}' | '\u{D7B0}'..='\u{D7C6}' | '\u{D7CB}'..='\u{D7FB}'
     )
 }
 

--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::convert::From;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::ops::{Index, IndexMut};
@@ -15,6 +17,7 @@ use crate::panes::alacritty_functions::parse_sgr_color;
 pub const EMPTY_TERMINAL_CHARACTER: TerminalCharacter = TerminalCharacter {
     character: ' ',
     width: 1,
+    combining_marks: NO_COMBINING_MARKS,
     styles: RcCharacterStyles::Reset,
 };
 
@@ -917,16 +920,75 @@ impl Cursor {
     }
 }
 
+// Combining marks (Unicode nonspacing marks, variation selectors and zero width joiners) have
+// no width of their own, so they cannot occupy a cell. Rather than grow every cell to carry
+// them, each distinct cluster of marks is interned once and referred to by a 24 bit id that
+// fits in padding TerminalCharacter already had. Clusters are keyed by content, so repeated
+// text reuses ids and the table stays small: a session displaying Thai reuses a handful of
+// entries no matter how much text scrolls by.
+//
+// The interner is thread local, which is sound because TerminalCharacter holds an Rc and is
+// therefore !Send, so a cell can never be read from a thread other than the one that built it.
+const NO_COMBINING_MARKS: [u8; 3] = [0, 0, 0];
+// ponytail: the table is never evicted. Both ceilings below exist to bound it against
+// pathological input (Zalgo text, a fuzzer); a real session stays in the low hundreds. If
+// either is ever hit in practice, the fix is refcounting cluster ids against live cells.
+const MAX_COMBINING_MARK_CLUSTERS: usize = (1 << 24) - 1;
+const MAX_COMBINING_MARKS_PER_CHARACTER: usize = 8;
+
+thread_local! {
+    static COMBINING_MARK_CLUSTERS: RefCell<CombiningMarkInterner> =
+        RefCell::new(CombiningMarkInterner::default());
+}
+
+#[derive(Default)]
+struct CombiningMarkInterner {
+    ids: HashMap<Vec<char>, u32>,
+    clusters: Vec<Vec<char>>,
+}
+
+impl CombiningMarkInterner {
+    fn intern(&mut self, cluster: &[char]) -> Option<u32> {
+        if let Some(id) = self.ids.get(cluster) {
+            return Some(*id);
+        }
+        if self.clusters.len() >= MAX_COMBINING_MARK_CLUSTERS {
+            return None;
+        }
+        // ids are 1 based so that 0 can mean "this character has no combining marks"
+        let id = self.clusters.len() as u32 + 1;
+        self.clusters.push(cluster.to_vec());
+        self.ids.insert(cluster.to_vec(), id);
+        Some(id)
+    }
+    fn get(&self, id: u32) -> Option<&Vec<char>> {
+        self.clusters.get(id.checked_sub(1)? as usize)
+    }
+}
+
+fn combining_mark_id_to_bytes(id: u32) -> [u8; 3] {
+    [(id >> 16) as u8, (id >> 8) as u8, id as u8]
+}
+
+fn combining_mark_id_from_bytes(bytes: [u8; 3]) -> u32 {
+    ((bytes[0] as u32) << 16) | ((bytes[1] as u32) << 8) | bytes[2] as u32
+}
+
 #[derive(Clone, PartialEq)]
 pub struct TerminalCharacter {
     pub character: char,
-    pub styles: RcCharacterStyles,
     width: u8,
+    // A 24 bit id into the thread local interner of combining mark clusters, or
+    // NO_COMBINING_MARKS for the overwhelmingly common case of a character that has none.
+    // This deliberately occupies the three padding bytes that already sat between `width`
+    // and `styles`, so carrying combining marks costs no extra memory per cell.
+    combining_marks: [u8; 3],
+    pub styles: RcCharacterStyles,
 }
 
 // This size has significant memory and CPU implications for long lines,
 // be careful about allowing it to grow
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 const _: [(); 16] = [(); std::mem::size_of::<TerminalCharacter>()];
 
 impl TerminalCharacter {
@@ -941,6 +1003,7 @@ impl TerminalCharacter {
             character,
             styles,
             width: character.width().unwrap_or(0) as u8,
+            combining_marks: NO_COMBINING_MARKS,
         }
     }
 
@@ -955,17 +1018,53 @@ impl TerminalCharacter {
             character,
             styles,
             width: 1,
+            combining_marks: NO_COMBINING_MARKS,
         }
     }
 
     pub fn width(&self) -> usize {
         self.width as usize
     }
+
+    #[inline]
+    pub fn has_combining_marks(&self) -> bool {
+        self.combining_marks != NO_COMBINING_MARKS
+    }
+
+    /// The combining marks attached to this character, in the order they arrived.
+    pub fn combining_marks(&self) -> Vec<char> {
+        if !self.has_combining_marks() {
+            return Vec::new();
+        }
+        let id = combining_mark_id_from_bytes(self.combining_marks);
+        COMBINING_MARK_CLUSTERS
+            .with(|clusters| clusters.borrow().get(id).cloned())
+            .unwrap_or_default()
+    }
+
+    /// Attach a zero width combining mark to this character, so that it is rendered as one
+    /// grapheme cluster without consuming a column of its own.
+    pub fn add_combining_mark(&mut self, mark: char) {
+        let mut cluster = self.combining_marks();
+        if cluster.len() >= MAX_COMBINING_MARKS_PER_CHARACTER {
+            return;
+        }
+        cluster.push(mark);
+        if let Some(id) =
+            COMBINING_MARK_CLUSTERS.with(|clusters| clusters.borrow_mut().intern(&cluster))
+        {
+            self.combining_marks = combining_mark_id_to_bytes(id);
+        }
+    }
 }
 
 impl ::std::fmt::Debug for TerminalCharacter {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.character)
+        write!(f, "{}", self.character)?;
+        for mark in self.combining_marks() {
+            write!(f, "{}", mark)?;
+        }
+        Ok(())
     }
 }
 

--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -1042,6 +1042,17 @@ impl TerminalCharacter {
             .unwrap_or_default()
     }
 
+    /// Append this cell as the cluster the screen renders it as: the character followed by any
+    /// combining marks attached to it. Every path that reads text back out of the grid -- dumping
+    /// a screen, serializing a session, copying a selection -- has to go through this, or it hands
+    /// back the base characters alone and silently strips the marks the grid took care to keep.
+    pub fn push_cluster_to(&self, buf: &mut String) {
+        buf.push(self.character);
+        if self.has_combining_marks() {
+            buf.extend(self.combining_marks());
+        }
+    }
+
     /// Attach a zero width combining mark to this character, so that it is rendered as one
     /// grapheme cluster without consuming a column of its own.
     pub fn add_combining_mark(&mut self, mark: char) {
@@ -1060,11 +1071,9 @@ impl TerminalCharacter {
 
 impl ::std::fmt::Debug for TerminalCharacter {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.character)?;
-        for mark in self.combining_marks() {
-            write!(f, "{}", mark)?;
-        }
-        Ok(())
+        let mut cluster = String::new();
+        self.push_cluster_to(&mut cluster);
+        write!(f, "{}", cluster)
     }
 }
 

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -8918,7 +8918,10 @@ fn rendered_row(grid: &Grid, row_index: usize) -> String {
     grid.viewport[row_index]
         .columns
         .iter()
-        .map(|terminal_character| terminal_character.character)
+        .flat_map(|terminal_character| {
+            std::iter::once(terminal_character.character)
+                .chain(terminal_character.combining_marks())
+        })
         .collect()
 }
 
@@ -8982,17 +8985,48 @@ fn skin_tone_modifier_occupies_its_own_two_columns() {
 fn variation_selector_and_zero_width_joiner_do_not_advance_the_cursor() {
     let grid = create_grid_with_content("\u{26a0}\u{fe0f}\u{200d}\u{200b}");
 
-    assert_eq!(rendered_row(&grid, 0), "\u{26a0}");
+    // The variation selector is a combining mark and is kept, so the sign retains its emoji
+    // presentation rather than degrading to the text one. The zero width joiner and the zero
+    // width space are format characters with nothing to combine with, and are dropped.
+    assert_eq!(rendered_row(&grid, 0), "\u{26a0}\u{fe0f}");
     assert_eq!(grid.viewport[0].width(), 1);
     assert_eq!(cursor_position(&grid), Some((1, 0)));
 }
 
 #[test]
-fn combining_marks_are_dropped_and_do_not_advance_the_cursor() {
+fn combining_marks_attach_to_the_preceding_character_and_do_not_advance_the_cursor() {
     let grid = create_grid_with_content("e\u{301}a\u{300}\u{308}o\u{331}");
 
-    assert_eq!(rendered_row(&grid, 0), "eao");
+    assert_eq!(rendered_row(&grid, 0), "e\u{301}a\u{300}\u{308}o\u{331}");
     assert_eq!(grid.viewport[0].width(), 3);
+    assert_eq!(cursor_position(&grid), Some((3, 0)));
+}
+
+#[test]
+fn thai_vowels_and_tone_marks_are_preserved() {
+    // Thai writes its vowels and tone marks as zero width combining marks. Dropping them
+    // turns words into different words: ผู้ใหญ่ (adult) becomes ผใหญ, which is not a word.
+    let grid = create_grid_with_content("สวัสดีครับ");
+
+    assert_eq!(rendered_row(&grid, 0), "สวัสดีครับ");
+    // ten codepoints, three of which are marks, so seven columns
+    assert_eq!(grid.viewport[0].width(), 7);
+    assert_eq!(cursor_position(&grid), Some((7, 0)));
+}
+
+#[test]
+fn combining_marks_with_no_preceding_character_are_dropped() {
+    let grid = create_grid_with_content("\u{301}\u{300}a");
+
+    assert_eq!(rendered_row(&grid, 0), "a");
+    assert_eq!(cursor_position(&grid), Some((1, 0)));
+}
+
+#[test]
+fn a_combining_mark_attaches_to_a_wide_character_rather_than_its_second_column() {
+    let grid = create_grid_with_content("世\u{301}a");
+
+    assert_eq!(rendered_row(&grid, 0), "世\u{301}a");
     assert_eq!(cursor_position(&grid), Some((3, 0)));
 }
 

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -9044,6 +9044,54 @@ fn hangul_conjoining_jamo_attach_to_the_leading_consonant() {
 }
 
 #[test]
+fn dumping_the_screen_keeps_the_combining_marks_it_shows() {
+    // The grid attaches marks to the character they modify, so every path that reads the text
+    // back out has to emit the whole cluster. `zellij action dump-screen` handing back the base
+    // characters alone would turn สวัสดี back into สวสด, which is not the word on the screen.
+    let grid = create_grid_with_content("\u{e2a}\u{e27}\u{e31}\u{e2a}\u{e14}\u{e35}");
+
+    assert_eq!(
+        grid.dump_screen(false).trim_end(),
+        "\u{e2a}\u{e27}\u{e31}\u{e2a}\u{e14}\u{e35}"
+    );
+}
+
+#[test]
+fn copying_a_selection_keeps_the_combining_marks_it_covers() {
+    let mut grid = create_grid_with_content("\u{e2a}\u{e27}\u{e31}\u{e2a}\u{e14}\u{e35}");
+
+    // The six code points occupy four columns: the two marks ride along with the character
+    // before them rather than taking a column of their own. Selecting the first two columns
+    // takes ส and ว, and ว keeps its ั.
+    grid.start_selection(&Position::new(0, 0));
+    grid.end_selection(&Position::new(0, 2));
+
+    assert_eq!(grid.get_selected_text().unwrap(), "\u{e2a}\u{e27}\u{e31}");
+}
+
+#[test]
+fn serializing_pane_contents_keeps_the_combining_marks() {
+    // A session that is serialized and resurrected has to come back with the text it had.
+    let grid = create_grid_with_content("\u{e2a}\u{e27}\u{e31}\u{e2a}\u{e14}\u{e35}");
+
+    let contents = grid.pane_contents(false, None);
+
+    assert_eq!(
+        contents.viewport[0].trim_end(),
+        "\u{e2a}\u{e27}\u{e31}\u{e2a}\u{e14}\u{e35}"
+    );
+}
+
+#[test]
+fn a_blank_carrying_a_combining_mark_is_not_trailing_whitespace() {
+    // Trailing blanks are trimmed off a dumped line. A space that a mark attached to is not one:
+    // dropping it would drop the mark with it.
+    let grid = create_grid_with_content("a \u{308}");
+
+    assert_eq!(grid.dump_screen(false).trim_end_matches('\n'), "a \u{308}");
+}
+
+#[test]
 fn precomposed_and_decomposed_forms_occupy_the_same_number_of_columns() {
     let precomposed = create_grid_with_content("\u{e9}cole");
     let decomposed = create_grid_with_content("e\u{301}cole");

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -9031,6 +9031,19 @@ fn a_combining_mark_attaches_to_a_wide_character_rather_than_its_second_column()
 }
 
 #[test]
+fn hangul_conjoining_jamo_attach_to_the_leading_consonant() {
+    // A decomposed syllable is a leading consonant followed by a medial vowel and a final
+    // consonant. All three are letters rather than marks, and the vowel and the final are
+    // zero width because they conjoin with the consonant before them, so they attach as
+    // marks do: 한 as U+1112 U+1161 U+11AB is one wide cell, not one cell and two dropped
+    // code points. This is the shape macOS hands a terminal for every file name.
+    let grid = create_grid_with_content("\u{1112}\u{1161}\u{11ab}a");
+
+    assert_eq!(rendered_row(&grid, 0), "\u{1112}\u{1161}\u{11ab}a");
+    assert_eq!(cursor_position(&grid), Some((3, 0)));
+}
+
+#[test]
 fn precomposed_and_decomposed_forms_occupy_the_same_number_of_columns() {
     let precomposed = create_grid_with_content("\u{e9}cole");
     let decomposed = create_grid_with_content("e\u{301}cole");


### PR DESCRIPTION
Fixes #1538
Fixes #3667

## The problem

`Grid::add_character` dropped every zero width codepoint outright. The comment above it acknowledged that this breaks grapheme segmentation and pointed at #1538.

For scripts that write their vowels and tone marks as combining marks, this is not lost decoration, it is lost text. Thai:

```
$ printf 'สวัสดีครับ ที่ไหน ผู้ใหญ่\n'
```

| | |
|---|---|
| outside zellij | `สวัสดีครับ ที่ไหน ผู้ใหญ่` |
| inside zellij | `สวสดครบ ทไหน ผใหญ` |

`ผู้ใหญ่` means "adult". `ผใหญ` is not a word. The same applies to Lao, Khmer, Myanmar, Devanagari, Hebrew points and Arabic harakat, and to decomposed Latin, where `e` + U+0301 lost its acute (#3667).

## The change

Combining marks (general category Mn, Mc, Me) are attached to the character they follow and rendered as part of it. Zero width codepoints that are *not* marks — controls, format characters such as the soft hyphen and the zero width joiner, fillers — have nothing to combine with and are still dropped, exactly as before.

Column count and cursor position are unchanged. The existing `precomposed_and_decomposed_forms_occupy_the_same_number_of_columns` test already pinned that invariant and still passes untouched.

Variation selectors are marks, so they survive too: U+26A0 U+FE0F now keeps its emoji presentation (⚠️) instead of degrading to the text one (⚠). That is the case #1538 was originally filed about.

## Memory

I assumed this was deliberate and load bearing:

```rust
// This size has significant memory and CPU implications for long lines,
// be careful about allowing it to grow
const _: [(); 16] = [(); std::mem::size_of::<TerminalCharacter>()];
```

So marks are not stored in the cell. They live in an interner keyed by cluster content, and the cell holds a 24 bit id into it. That id occupies the three padding bytes that already sat between `width` and `styles`:

```rust
pub struct TerminalCharacter {
    pub character: char,           // 4
    width: u8,                     // 1
    combining_marks: [u8; 3],      // 3, was padding
    pub styles: RcCharacterStyles, // 8
}
```

`size_of::<TerminalCharacter>()` is still 16. Carrying combining marks costs no additional memory per cell, and a cell without marks does no work at all beyond a three byte comparison. I extended the assertion to cover `aarch64` as well as `x86_64`, so it is actually checked on Apple Silicon.

The interner is thread local rather than shared, which is sound because `TerminalCharacter` holds an `Rc` and is therefore `!Send`: a cell can never be read from a thread other than the one that built it. No locking.

Keying by content means repeated text reuses ids, so a session rendering Thai holds a handful of entries no matter how much scrolls past.

## Things I would rather flag than hide

- **The interner is never evicted.** It is bounded by two caps: 8 marks per character, and 2^24 distinct clusters. Those exist to contain pathological input rather than because real sessions approach them. Doing this properly means refcounting cluster ids against live cells, which seemed like a lot of machinery for a table that holds a few hundred entries. Happy to add it if you disagree.
- **ZWJ emoji (#3453) is not fixed.** The zero width joiner is a format character, not a mark, and joining emoji into one cluster also requires recomputing the width of that cluster. That is a separate change and I did not want to smuggle it in here.
- **Search still matches on base characters only.** `search.rs` reads `.character`, so searching text with marks behaves as it did before this PR. Not a regression, but not fixed either.
- **New dependency: `unicode-properties`.** Needed to tell a mark from any other zero width codepoint. It is from unicode-rs, data only, no transitive dependencies, and `default-features = false` with just `general-category`. If you would rather not take it, the alternative is a hand maintained range table, which I did not think was a good trade.

## Testing

`cargo test -p zellij-server --lib`: 1534 passed, 0 failed. `cargo fmt --all --check` clean.

Existing tests updated, both because the behavior they pinned is the behavior being fixed:

- `combining_marks_are_dropped_and_do_not_advance_the_cursor` → `combining_marks_attach_to_the_preceding_character_and_do_not_advance_the_cursor`
- `variation_selector_and_zero_width_joiner_do_not_advance_the_cursor` now expects the variation selector to survive; the joiner and the zero width space are still dropped

Added:

- `thai_vowels_and_tone_marks_are_preserved` — `สวัสดีครับ`, ten codepoints, seven columns
- `combining_marks_with_no_preceding_character_are_dropped`
- `a_combining_mark_attaches_to_a_wide_character_rather_than_its_second_column`

Unchanged and still passing, which is the part that matters: the soft hyphen, hangul filler, halfwidth katakana sound mark, ZWJ emoji and vttest snapshot tests.

Also checked a release build by hand in a real session: Thai renders correctly, and the status bar, pane frames and tab names are unaffected.
