### PR TITLE
fix(layout): compose the containing node's cwd into floating panes

### DIFF
--- a/zellij-utils/src/kdl/kdl_layout_parser.rs
+++ b/zellij-utils/src/kdl/kdl_layout_parser.rs
@@ -2099,6 +2099,11 @@ impl<'a> KdlLayoutParser<'a> {
         let mut floating_panes = vec![];
         self.assert_valid_tab_properties(layout_node)?;
         self.populate_floating_pane_children(layout_node, &mut floating_panes)?;
+        if let Some(cwd_prefix) = self.cwd_prefix(None)? {
+            for floating_pane in floating_panes.iter_mut() {
+                floating_pane.add_cwd_to_layout(&cwd_prefix);
+            }
+        }
         Ok(floating_panes)
     }
     fn populate_one_swap_floating_layout_with_template(
@@ -2364,10 +2369,7 @@ impl<'a> KdlLayoutParser<'a> {
         if let Some(children) = kdl_children_nodes!(child) {
             for child in children {
                 if kdl_name!(child) == "pane" {
-                    let mut pane_node = self.parse_floating_pane_node(child)?;
-                    if let Some(global_cwd) = &self.global_cwd {
-                        pane_node.add_cwd_to_layout(&global_cwd);
-                    }
+                    let pane_node = self.parse_floating_pane_node(child)?;
                     child_floating_panes.push(pane_node);
                 } else if let Some((pane_template, pane_template_kdl_node)) =
                     self.pane_templates.get(kdl_name!(child)).cloned()


### PR DESCRIPTION
## Problem

Fixes #2660.

A `tab`'s `cwd` is not applied to its floating panes when the layout also sets a global `cwd`. Tiled panes in the same tab are unaffected, so the two pane kinds disagree about which directory they belong to.

```kdl
layout {
    cwd "/global"
    tab cwd="/tabdir" {
        pane                 // starts in /tabdir
        floating_panes {
            pane             // starts in /global     <-- wrong
            pane cwd="sub"   // starts in /global/sub <-- wrong
        }
    }
}
```

This contradicts the documented rule that a relative `cwd` is appended to its container node's `cwd`, and it silently sends commands to the wrong directory.

`populate_floating_pane_children()` applied `self.global_cwd` to every floating pane as it parsed them. That made each pane's cwd absolute.

Callers then apply the correct prefix via `Run::add_cwd()`, which joins with `cwd.join(&run_cwd)`; the correct prefix is composed by `cwd_prefix()` from the global cwd and the containing node's cwd. `PathBuf::join` discards its base when the argument is absolute, so the already-absolute pane cwd swallowed the tab cwd.

Tiled panes never had this problem beacause `parse_child_pane_nodes_for_tab()` returns panes carrying only their own cwd, and the prefix is applied exactly once by the caller.

## Change

Two hunks in `zellij-utils/src/kdl/kdl_layout_parser.rs`:
1. `populate_floating_pane_children()` no longer applies the global cwd, making it symmetric with `parse_child_pane_nodes_for_tab()`, i.e. the returned panes carry only their own cwd, and composing them with the containing node's cwd is the caller's responsibility.
2. `populate_one_swap_floating_layout()` applies `cwd_prefix(None)` itself. It is the only caller with no containing tab to compose a prefix for it, so it now takes on the responsibility the shared helper gave up. This keeps `swap_floating_layout` behaviour unchanged.

## Effect

Floating pane cwd across the layout forms that reach this code path:

| Layout | Before | After |
| --- | --- | --- |
| global cwd + absolute tab cwd | `/global`, `/global/sub` | `/tabdir`, `/tabdir/sub` |
| global cwd + relative tab cwd `rel` | `/global`, `/global/sub` | `/global/rel`, `/global/rel/sub` |
| floating panes in a `default_tab_template` + tab cwd | `/global/tmpl` | `/tabdir/tmpl` |
| tab cwd only | `/tabdir`, `/tabdir/sub` | unchanged |
| global cwd only | `/global`, `/global/sub` | unchanged |
| top-level `floating_panes` | `/global`, `/global/sub` | unchanged |
| floating `pane_template` + tab cwd | `/tabdir/sub` | unchanged |
| `swap_floating_layout` | `/global`, `/global/sub` | unchanged |