### PR TITLE
Add sessions registry

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -776,7 +776,10 @@ pub(crate) fn start_client(opts: CliArgs) {
                             }
                             ClientInfo::Resurrect(
                                 session_name.clone(),
-                                session_layout_cache_file_name(session_name.as_ref()),
+                                session_layout_cache_file_name(
+                                    &zellij_utils::sessions::resolve_session_id(session_name)
+                                        .unwrap_or_else(|| session_name.to_string()),
+                                ),
                                 force_run_commands,
                                 new_session_cwd.clone(),
                             )

--- a/zellij-client/src/cli_client.rs
+++ b/zellij-client/src/cli_client.rs
@@ -22,11 +22,11 @@ pub fn start_cli_client(
     actions: Vec<Action>,
 ) -> i32 {
     let zellij_ipc_pipe: PathBuf = {
-        let mut sock_dir = zellij_utils::consts::ZELLIJ_SOCK_DIR.clone();
+        let sock_dir = zellij_utils::consts::ZELLIJ_SOCK_DIR.clone();
         fs::create_dir_all(&sock_dir).unwrap();
         zellij_utils::shared::set_permissions(&sock_dir, 0o700).unwrap();
-        sock_dir.push(session_name);
-        sock_dir
+        zellij_utils::sessions::resolve_session_socket_path(session_name)
+            .unwrap_or_else(|| sock_dir.join(session_name))
     };
     crate::check_ipc_pipe_length(&zellij_ipc_pipe);
     os_input.connect_to_server(&*zellij_ipc_pipe);
@@ -264,11 +264,11 @@ pub fn start_subscribe_client(
     subscribe_cli: SubscribeCli,
 ) {
     let zellij_ipc_pipe: PathBuf = {
-        let mut sock_dir = zellij_utils::consts::ZELLIJ_SOCK_DIR.clone();
+        let sock_dir = zellij_utils::consts::ZELLIJ_SOCK_DIR.clone();
         fs::create_dir_all(&sock_dir).unwrap();
         zellij_utils::shared::set_permissions(&sock_dir, 0o700).unwrap();
-        sock_dir.push(session_name);
-        sock_dir
+        zellij_utils::sessions::resolve_session_socket_path(session_name)
+            .unwrap_or_else(|| sock_dir.join(session_name))
     };
     crate::check_ipc_pipe_length(&zellij_ipc_pipe);
     os_input.connect_to_server(&*zellij_ipc_pipe);

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -417,8 +417,11 @@ fn spawn_server_error_message(e: io::Error) -> String {
     )
 }
 
-fn create_ipc_pipe(teardown: Option<TerminalTeardown>) -> PathBuf {
-    let mut sock_dir = ZELLIJ_SOCK_DIR.clone();
+/// Ensure the socket directory exists and is private (0700), and is short
+/// enough to hold a session id. On failure, tear down the terminal and exit
+/// with a helpful message.
+fn prepare_sock_dir(teardown: Option<TerminalTeardown>) {
+    let sock_dir = ZELLIJ_SOCK_DIR.clone();
     if let Err(e) = std::fs::create_dir_all(&sock_dir) {
         exit_after_startup_error(
             teardown,
@@ -449,9 +452,29 @@ fn create_ipc_pipe(teardown: Option<TerminalTeardown>) -> PathBuf {
             ),
         );
     }
-    sock_dir.push(envs::get_session_name().unwrap());
-    check_ipc_pipe_length(&sock_dir);
-    sock_dir
+    zellij_utils::consts::check_sock_dir_length();
+}
+
+/// IPC pipe path for a NEW session: register it in the registry under a fresh
+/// id and return `ZELLIJ_SOCK_DIR/<id>`. The session name is read from the
+/// environment (set by the caller just before).
+fn create_ipc_pipe(teardown: Option<TerminalTeardown>) -> PathBuf {
+    prepare_sock_dir(teardown);
+    let name = envs::get_session_name().unwrap();
+    let id = zellij_utils::sessions::register_session(&name).unwrap_or_else(|e| {
+        eprintln!("Failed to register session {:?}: {}", name, e);
+        std::process::exit(1);
+    });
+    ZELLIJ_SOCK_DIR.join(id)
+}
+
+/// IPC pipe path for an EXISTING session: resolve its id via the registry,
+/// falling back to the legacy name-based path for pre-registry sessions.
+fn resolve_ipc_pipe(teardown: Option<TerminalTeardown>) -> PathBuf {
+    prepare_sock_dir(teardown);
+    let name = envs::get_session_name().unwrap();
+    zellij_utils::sessions::resolve_session_socket_path(&name)
+        .unwrap_or_else(|| ZELLIJ_SOCK_DIR.join(name))
 }
 
 /// Spawn the Zellij server process.
@@ -1002,7 +1025,7 @@ pub fn start_client(
         ClientInfo::Attach(name, config_options) => {
             envs::set_session_name(name.clone());
             os_input.update_session_name(name);
-            let ipc_pipe = create_ipc_pipe(Some(terminal_teardown));
+            let ipc_pipe = resolve_ipc_pipe(Some(terminal_teardown));
             let is_web_client = false;
 
             let cli_assets = CliAssets {
@@ -1053,7 +1076,7 @@ pub fn start_client(
         ClientInfo::Watch(name, _config_options) => {
             envs::set_session_name(name.clone());
             os_input.update_session_name(name);
-            let ipc_pipe = create_ipc_pipe(Some(terminal_teardown));
+            let ipc_pipe = resolve_ipc_pipe(Some(terminal_teardown));
             let is_web_client = false;
 
             (

--- a/zellij-client/src/web_client/server_listener.rs
+++ b/zellij-client/src/web_client/server_listener.rs
@@ -62,8 +62,8 @@ pub fn zellij_server_listener(
                 'reconnect_loop: loop {
                     let reconnect_info = reconnect_to_session.take();
                     let initial_layout = reconnect_info.as_ref().and_then(|r| r.layout.clone());
-                    let path = {
-                        let Some(session_name) = reconnect_info
+                    let session_name = {
+                        let Some(name) = reconnect_info
                             .as_ref()
                             .and_then(|r| r.name.clone())
                             .or_else(generate_unique_session_name)
@@ -72,14 +72,12 @@ pub fn zellij_server_listener(
                             client_connection_bus.close_connection();
                             return;
                         };
-                        let mut sock_dir = zellij_utils::consts::ZELLIJ_SOCK_DIR.clone();
-                        if let Err(e) = zellij_utils::sessions::validate_session_name(&session_name) {
+                        if let Err(e) = zellij_utils::sessions::validate_session_name(&name) {
                             log::error!("Invalid session name: {}", e);
                             client_connection_bus.close_connection();
                             return;
                         }
-                        sock_dir.push(session_name.clone());
-                        sock_dir.to_str().unwrap().to_owned()
+                        name
                     };
 
                     reload_config_from_disk(&mut config, &mut config_options, &config_file_path);
@@ -100,13 +98,6 @@ pub fn zellij_server_listener(
                         },
                     };
 
-                    let session_name = PathBuf::from(path.clone())
-                        .file_name()
-                        .unwrap()
-                        .to_str()
-                        .unwrap()
-                        .to_owned();
-
                     // Look up read-only status from connection table
                     let is_read_only = connection_table
                         .lock()
@@ -124,7 +115,7 @@ pub fn zellij_server_listener(
 
                     let should_create_new_session = !session_exists;
                     let first_message = create_first_message(is_read_only, config_file_path.clone(), client_attributes.clone(), config_options.clone(), should_create_new_session, &session_name, initial_layout);
-                    let zellij_ipc_pipe = create_ipc_pipe(&session_name);
+                    let zellij_ipc_pipe = create_ipc_pipe(&session_name, session_exists);
 
                     session_manager.spawn_session_if_needed(
                         &session_name,

--- a/zellij-client/src/web_client/session_management.rs
+++ b/zellij-client/src/web_client/session_management.rs
@@ -135,17 +135,25 @@ pub fn create_first_message(
     }
 }
 
-pub fn create_ipc_pipe(session_name: &str) -> PathBuf {
+pub fn create_ipc_pipe(session_name: &str, session_exists: bool) -> PathBuf {
     if let Err(e) = zellij_utils::sessions::validate_session_name(session_name) {
         log::error!("Invalid session name: {}", e);
         panic!("Invalid session name: {}", e);
     }
-    let zellij_ipc_pipe: PathBuf = {
-        let mut sock_dir = zellij_utils::consts::ZELLIJ_SOCK_DIR.clone();
-        fs::create_dir_all(&sock_dir).unwrap();
-        zellij_utils::shared::set_permissions(&sock_dir, 0o700).unwrap();
-        sock_dir.push(session_name);
-        sock_dir
+    let sock_dir = zellij_utils::consts::ZELLIJ_SOCK_DIR.clone();
+    fs::create_dir_all(&sock_dir).unwrap();
+    zellij_utils::shared::set_permissions(&sock_dir, 0o700).unwrap();
+    let zellij_ipc_pipe: PathBuf = if session_exists {
+        // Existing session: resolve its id via the registry.
+        zellij_utils::sessions::resolve_session_socket_path(session_name)
+            .unwrap_or_else(|| sock_dir.join(session_name))
+    } else {
+        // New session: register it under a fresh id.
+        let id = zellij_utils::sessions::register_session(session_name).unwrap_or_else(|e| {
+            log::error!("Failed to register session {:?}: {}", session_name, e);
+            panic!("Failed to register session {:?}: {}", session_name, e);
+        });
+        sock_dir.join(id)
     };
     crate::check_ipc_pipe_length(&zellij_ipc_pipe);
     zellij_ipc_pipe

--- a/zellij-client/src/web_client/session_management.rs
+++ b/zellij-client/src/web_client/session_management.rs
@@ -67,10 +67,10 @@ pub fn create_first_message(
     let resurrection_layout = resurrection_layout(&session_name).ok().flatten();
 
     let layout_info = if resurrection_layout.is_some() {
+        let id = zellij_utils::sessions::resolve_session_id(session_name)
+            .unwrap_or_else(|| session_name.to_string());
         Some(LayoutInfo::File(
-            session_layout_cache_file_name(&session_name)
-                .display()
-                .to_string(),
+            session_layout_cache_file_name(&id).display().to_string(),
             LayoutMetadata::default(),
         ))
     } else {

--- a/zellij-integration-tests/src/runner.rs
+++ b/zellij-integration-tests/src/runner.rs
@@ -448,6 +448,23 @@ impl TestSession {
         }
     }
 
+    /// Attach a new client to a session by an explicit name — used to verify
+    /// reattaching to a session by a name it was renamed to.
+    pub fn attach_client_by_name(&self, session_name: &str, size: Size) -> TestClient {
+        let (fake_client_os_api, fake_client_handle) = FakeClientOsApi::new(size, None);
+        let thread = spawn_client_thread(
+            fake_client_os_api,
+            self.cli_args.clone(),
+            self.config.clone(),
+            self.config_options.clone(),
+            ClientInfo::Attach(session_name.to_string(), self.config_options.clone()),
+        );
+        TestClient {
+            fake_client_handle,
+            thread: Some(thread),
+        }
+    }
+
     pub fn attach_watcher(&self, size: Size) -> TestClient {
         let (fake_client_os_api, fake_client_handle) = FakeClientOsApi::new(size, None);
         let thread = spawn_client_thread(
@@ -495,7 +512,10 @@ impl TestSession {
     }
 
     pub fn wait_for_serialized_session(&self) {
-        let layout_path = zellij_utils::consts::session_layout_cache_file_name(&self.session_name);
+        // The session-info cache is keyed by session id, not the display name.
+        let id = zellij_utils::sessions::resolve_session_id(&self.session_name)
+            .unwrap_or_else(|| self.session_name.clone());
+        let layout_path = zellij_utils::consts::session_layout_cache_file_name(&id);
         let session_dir = layout_path.parent().map(|parent| parent.to_path_buf());
         let deadline = std::time::Instant::now() + crate::default_timeout();
         loop {
@@ -518,7 +538,12 @@ impl TestSession {
     }
 
     pub fn resurrect(&mut self, size: Size) {
-        let layout_path = zellij_utils::consts::session_layout_cache_file_name(&self.session_name);
+        // The session-info cache is keyed by session id, not the display name.
+        // register_session reuses this id when resurrecting, so the resurrected
+        // server writes back to the same folder.
+        let id = zellij_utils::sessions::resolve_session_id(&self.session_name)
+            .unwrap_or_else(|| self.session_name.clone());
+        let layout_path = zellij_utils::consts::session_layout_cache_file_name(&id);
         assert!(
             layout_path.exists(),
             "no serialized layout to resurrect from at {}",

--- a/zellij-integration-tests/tests/session_rename.rs
+++ b/zellij-integration-tests/tests/session_rename.rs
@@ -1,0 +1,72 @@
+#![cfg(unix)]
+
+use std::time::{Duration, Instant};
+
+use zellij_integration_tests::{
+    claim_first_terminal_and_wait_for_prompt, col, default_timeout, TestRunner, TERMINAL_SIZE,
+};
+use zellij_utils::cli::CliAction;
+use zellij_utils::sessions::resolve_session_socket_path;
+
+/// Renaming a session must not move its socket / named pipe — named pipes cannot
+/// be renamed on Windows, which is the bug this whole registry exists to fix.
+/// Instead the registry remaps the new display name onto the same, unchanged
+/// pipe, so a client can reattach using the new name.
+#[test]
+fn rename_keeps_socket_and_reattaches_by_new_name() {
+    let zellij = TestRunner::new(TERMINAL_SIZE)
+        .with_config("mirror_session true")
+        .start();
+    claim_first_terminal_and_wait_for_prompt(&zellij);
+
+    let old_name = zellij.session_name().to_string();
+    let pipe_before = resolve_session_socket_path(&old_name)
+        .expect("the running session should resolve to a socket path before rename");
+
+    let new_name = "renamed-by-integration-test";
+    assert_eq!(
+        zellij.run_cli_action(CliAction::RenameSession {
+            name: new_name.to_string(),
+        }),
+        0,
+        "the rename cli action should exit successfully"
+    );
+
+    // The server processes the rename asynchronously; wait for the registry to
+    // reflect it (the new name resolving to a running session).
+    let deadline = Instant::now() + default_timeout();
+    while resolve_session_socket_path(new_name).is_none() {
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for the session to be renamed to {:?}",
+            new_name
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    // The socket / pipe was NOT renamed: the new name resolves to the exact same
+    // path the old name did.
+    let pipe_after = resolve_session_socket_path(new_name)
+        .expect("the new name should resolve after the rename");
+    assert_eq!(
+        pipe_before, pipe_after,
+        "renaming a session must not move its socket/pipe"
+    );
+
+    // The old name no longer refers to a running session.
+    assert!(
+        resolve_session_socket_path(&old_name).is_none(),
+        "the old session name should no longer resolve to a running session"
+    );
+
+    // A fresh client can reattach using the new name and load the app.
+    let reattached = zellij.attach_client_by_name(new_name, TERMINAL_SIZE);
+    reattached.wait_until(
+        "reattached client loads the app by the new name",
+        |grid_snapshot| {
+            grid_snapshot.tab_bar_appears()
+                && grid_snapshot.status_bar_appears()
+                && grid_snapshot.cursor_is_at(col(2).row(1))
+        },
+    );
+}

--- a/zellij-server/src/background_jobs.rs
+++ b/zellij-server/src/background_jobs.rs
@@ -719,8 +719,21 @@ pub(crate) fn background_jobs_main(
                     nested_guest_ping.store(false, Ordering::SeqCst);
                 }
 
-                let cache_file_name =
-                    session_info_cache_file_name(&current_session_name.lock().unwrap().to_owned());
+                // Flush the current layout to disk before shutting down so the
+                // session is resurrectable even if it exited before the periodic
+                // SESSION_METADATA_WRITE_INTERVAL_MS ticker fired. This writes
+                // session-layout.kdl, which list-sessions uses to mark the
+                // session as resurrectable.
+                let name = current_session_name.lock().unwrap().clone();
+                if !name.is_empty() {
+                    let info = current_session_info.lock().unwrap().clone();
+                    let layout = current_session_layout.lock().unwrap().clone();
+                    write_session_state_to_disk(name.clone(), info, layout);
+                }
+
+                // Remove the metadata cache file so the session is no longer
+                // considered live (the layout file is kept for resurrection).
+                let cache_file_name = session_info_cache_file_name(&name);
                 let _ = std::fs::remove_file(cache_file_name);
                 return Ok(());
             },

--- a/zellij-server/src/background_jobs.rs
+++ b/zellij-server/src/background_jobs.rs
@@ -145,6 +145,7 @@ pub(crate) fn background_jobs_main(
     serialization_interval: Option<u64>,
     disable_session_metadata: bool,
     web_server_base_url: String,
+    session_id: String,
 ) -> Result<()> {
     let err_context = || "failed to write to pty".to_string();
     let mut running_jobs: HashMap<BackgroundJob, Instant> = HashMap::new();
@@ -212,6 +213,7 @@ pub(crate) fn background_jobs_main(
         let current_session_name = current_session_name.clone();
         let current_session_info = current_session_info.clone();
         let current_session_layout = current_session_layout.clone();
+        let session_id = session_id.clone();
         runtime.spawn(async move {
             let mut ticker = tokio::time::interval(std::time::Duration::from_millis(
                 SESSION_METADATA_WRITE_INTERVAL_MS,
@@ -222,13 +224,12 @@ pub(crate) fn background_jobs_main(
                 // Guard on the name (only set once the session is initialised),
                 // but key the cache folder by the stable session id.
                 let name = current_session_name.lock().unwrap().clone();
-                let id = zellij_utils::envs::get_session_id().unwrap_or_default();
-                if name.is_empty() || id.is_empty() {
+                if name.is_empty() || session_id.is_empty() {
                     continue;
                 }
                 let info = current_session_info.lock().unwrap().clone();
                 let layout = current_session_layout.lock().unwrap().clone();
-                write_session_state_to_disk(id, info, layout);
+                write_session_state_to_disk(session_id.clone(), info, layout);
             }
         });
     }
@@ -728,17 +729,16 @@ pub(crate) fn background_jobs_main(
                 // session-layout.kdl, which list-sessions uses to mark the
                 // session as resurrectable.
                 let name = current_session_name.lock().unwrap().clone();
-                let id = zellij_utils::envs::get_session_id().unwrap_or_default();
-                if !name.is_empty() && !id.is_empty() {
+                if !name.is_empty() && !session_id.is_empty() {
                     let info = current_session_info.lock().unwrap().clone();
                     let layout = current_session_layout.lock().unwrap().clone();
-                    write_session_state_to_disk(id.clone(), info, layout);
+                    write_session_state_to_disk(session_id.clone(), info, layout);
                 }
 
                 // Remove the metadata cache file so the session is no longer
                 // considered live (the layout file is kept for resurrection).
-                if !id.is_empty() {
-                    let _ = std::fs::remove_file(session_info_cache_file_name(&id));
+                if !session_id.is_empty() {
+                    let _ = std::fs::remove_file(session_info_cache_file_name(&session_id));
                 }
                 return Ok(());
             },

--- a/zellij-server/src/background_jobs.rs
+++ b/zellij-server/src/background_jobs.rs
@@ -219,13 +219,16 @@ pub(crate) fn background_jobs_main(
             ticker.tick().await;
             loop {
                 ticker.tick().await;
+                // Guard on the name (only set once the session is initialised),
+                // but key the cache folder by the stable session id.
                 let name = current_session_name.lock().unwrap().clone();
-                if name.is_empty() {
+                let id = zellij_utils::envs::get_session_id().unwrap_or_default();
+                if name.is_empty() || id.is_empty() {
                     continue;
                 }
                 let info = current_session_info.lock().unwrap().clone();
                 let layout = current_session_layout.lock().unwrap().clone();
-                write_session_state_to_disk(name, info, layout);
+                write_session_state_to_disk(id, info, layout);
             }
         });
     }
@@ -725,16 +728,18 @@ pub(crate) fn background_jobs_main(
                 // session-layout.kdl, which list-sessions uses to mark the
                 // session as resurrectable.
                 let name = current_session_name.lock().unwrap().clone();
-                if !name.is_empty() {
+                let id = zellij_utils::envs::get_session_id().unwrap_or_default();
+                if !name.is_empty() && !id.is_empty() {
                     let info = current_session_info.lock().unwrap().clone();
                     let layout = current_session_layout.lock().unwrap().clone();
-                    write_session_state_to_disk(name.clone(), info, layout);
+                    write_session_state_to_disk(id.clone(), info, layout);
                 }
 
                 // Remove the metadata cache file so the session is no longer
                 // considered live (the layout file is kept for resurrection).
-                let cache_file_name = session_info_cache_file_name(&name);
-                let _ = std::fs::remove_file(cache_file_name);
+                if !id.is_empty() {
+                    let _ = std::fs::remove_file(session_info_cache_file_name(&id));
+                }
                 return Ok(());
             },
         }
@@ -771,31 +776,29 @@ fn file_content_changed(path: &std::path::Path, new_content: &[u8]) -> bool {
 }
 
 pub fn write_session_state_to_disk(
-    current_session_name: String,
+    session_id: String,
     current_session_info: SessionInfo,
     current_session_layout: (String, BTreeMap<String, String>),
 ) {
-    let metadata_cache_file_name = session_info_cache_file_name(&current_session_name);
+    let metadata_cache_file_name = session_info_cache_file_name(&session_id);
     let (current_session_layout, layout_files_to_write) = current_session_layout;
     let new_metadata = current_session_info.to_string();
     if file_content_changed(&metadata_cache_file_name, new_metadata.as_bytes()) {
-        let _wrote_metadata_file = std::fs::create_dir_all(
-            session_info_folder_for_session(&current_session_name).as_path(),
-        )
-        .and_then(|_| std::fs::File::create(&metadata_cache_file_name))
-        .and_then(|mut f| write!(f, "{}", new_metadata));
+        let _wrote_metadata_file =
+            std::fs::create_dir_all(session_info_folder_for_session(&session_id).as_path())
+                .and_then(|_| std::fs::File::create(&metadata_cache_file_name))
+                .and_then(|mut f| write!(f, "{}", new_metadata));
     }
 
     if !current_session_layout.is_empty() {
-        let layout_cache_file_name = session_layout_cache_file_name(&current_session_name);
+        let layout_cache_file_name = session_layout_cache_file_name(&session_id);
         if file_content_changed(&layout_cache_file_name, current_session_layout.as_bytes()) {
-            let _wrote_layout_file = std::fs::create_dir_all(
-                session_info_folder_for_session(&current_session_name).as_path(),
-            )
-            .and_then(|_| std::fs::File::create(&layout_cache_file_name))
-            .and_then(|mut f| write!(f, "{}", current_session_layout));
+            let _wrote_layout_file =
+                std::fs::create_dir_all(session_info_folder_for_session(&session_id).as_path())
+                    .and_then(|_| std::fs::File::create(&layout_cache_file_name))
+                    .and_then(|mut f| write!(f, "{}", current_session_layout));
         }
-        let session_info_folder = session_info_folder_for_session(&current_session_name);
+        let session_info_folder = session_info_folder_for_session(&session_id);
         for (external_file_name, external_file_contents) in layout_files_to_write {
             let external_file_path = session_info_folder.join(&external_file_name);
             if file_content_changed(&external_file_path, external_file_contents.as_bytes()) {
@@ -850,6 +853,9 @@ fn find_resurrectable_sessions(
     session_infos_on_machine: &BTreeMap<String, SessionInfo>,
     session_info_cache_dir: &Path,
 ) -> BTreeMap<String, Duration> {
+    // Cache folders are keyed by session id; map each to its display name so we
+    // can compare against the (name-keyed) live set and report a readable name.
+    let registry = zellij_utils::sessions::ensure_registry();
     match fs::read_dir(session_info_cache_dir) {
         Ok(files_in_session_info_folder) => {
             let files_that_are_folders = files_in_session_info_folder
@@ -857,7 +863,11 @@ fn find_resurrectable_sessions(
                 .filter(|f| f.is_dir());
             files_that_are_folders
                 .filter_map(|folder_name| {
-                    let session_name = folder_name.file_name()?.to_str()?.to_owned();
+                    let id = folder_name.file_name()?.to_str()?.to_owned();
+                    let session_name = registry
+                        .find_by_id(&id)
+                        .map(|e| e.display_name.clone())
+                        .unwrap_or_else(|| id.clone());
                     if session_infos_on_machine.contains_key(&session_name) {
                         // this is not a dead session...
                         return None;

--- a/zellij-server/src/background_jobs.rs
+++ b/zellij-server/src/background_jobs.rs
@@ -723,20 +723,9 @@ pub(crate) fn background_jobs_main(
                     nested_guest_ping.store(false, Ordering::SeqCst);
                 }
 
-                // Flush the current layout to disk before shutting down so the
-                // session is resurrectable even if it exited before the periodic
-                // SESSION_METADATA_WRITE_INTERVAL_MS ticker fired. This writes
-                // session-layout.kdl, which list-sessions uses to mark the
-                // session as resurrectable.
-                let name = current_session_name.lock().unwrap().clone();
-                if !name.is_empty() && !session_id.is_empty() {
-                    let info = current_session_info.lock().unwrap().clone();
-                    let layout = current_session_layout.lock().unwrap().clone();
-                    write_session_state_to_disk(session_id.clone(), info, layout);
-                }
-
-                // Remove the metadata cache file so the session is no longer
-                // considered live (the layout file is kept for resurrection).
+                // Remove the metadata cache file (keyed by session id) so the
+                // session is no longer considered live; the layout file is kept
+                // for resurrection.
                 if !session_id.is_empty() {
                     let _ = std::fs::remove_file(session_info_cache_file_name(&session_id));
                 }

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -907,13 +907,14 @@ pub fn start_server_impl(
     envs::set_zellij("0".to_string());
 
     // The socket/pipe filename is the stable session id, decoupled from the
-    // (renameable) display name. Publish it so the screen and background-jobs
-    // threads can key session-info cache and registry updates by id.
+    // (renameable) display name. It is threaded into the per-session threads
+    // (screen / pty / background_jobs) so they key the session-info cache and
+    // registry updates by id — NOT via a process-global, which would collide
+    // between the many sessions an integration test runs in one process.
     let session_id = socket_path
         .file_name()
         .map(|f| f.to_string_lossy().to_string())
         .unwrap_or_default();
-    envs::set_session_id(session_id.clone());
 
     // Record the real server PID in the registry (post-daemonize on Unix).
     if let Err(e) = zellij_utils::sessions::with_registry(|reg| {
@@ -1063,6 +1064,7 @@ pub fn start_server_impl(
                     config.clone(),
                     config.plugins.clone(),
                     client_id,
+                    session_id.clone(),
                 );
                 info!("FirstClientConnected: session initialized, spawning tabs");
                 let mut runtime_configuration = config.clone();
@@ -2113,6 +2115,7 @@ fn init_session(
     mut config: Config,
     plugin_aliases: PluginAliases,
     client_id: ClientId,
+    session_id: String,
 ) -> SessionMetaData {
     config.options = config.options.merge(*config_options.clone());
 
@@ -2190,7 +2193,8 @@ fn init_session(
                 config_options.post_command_discovery_hook.clone(),
             );
 
-            move || pty_thread_main(pty, layout.clone()).fatal()
+            let session_id = session_id.clone();
+            move || pty_thread_main(pty, layout.clone(), session_id).fatal()
         })
         .unwrap();
 
@@ -2214,6 +2218,7 @@ fn init_session(
             let debug = cli_assets.is_debug;
             let layout = layout.clone();
             let config = config.clone();
+            let session_id = session_id.clone();
             move || {
                 screen_thread_main(
                     screen_bus,
@@ -2222,6 +2227,7 @@ fn init_session(
                     config,
                     debug,
                     layout,
+                    session_id,
                 )
                 .fatal();
             }
@@ -2316,12 +2322,14 @@ fn init_session(
                 has_certificate,
                 enforce_https_for_localhost,
             );
+            let session_id = session_id.clone();
             move || {
                 background_jobs_main(
                     background_jobs_bus,
                     serialization_interval,
                     disable_session_metadata,
                     web_server_base_url,
+                    session_id,
                 )
                 .fatal()
             }

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -531,31 +531,23 @@ impl SessionMetaData {
 
 impl Drop for SessionMetaData {
     fn drop(&mut self) {
-        // Force a final serialization so the session shows up as resurrectable
-        // even if it exited before the periodic serialization interval fired.
-        // The Screen -> Plugin -> PTY pipeline must drain fully before any thread
-        // sees its Exit, otherwise the disk write is lost — so we exit threads in
-        // pipeline order, joining each before queuing Exit on the next.
-        let _ = self
-            .senders
-            .send_to_screen(ScreenInstruction::SerializeLayoutForResurrection);
+        let _ = self.senders.send_to_pty(PtyInstruction::Exit);
         let _ = self.senders.send_to_screen(ScreenInstruction::Exit);
+        let _ = self.senders.send_to_plugin(PluginInstruction::Exit);
+        let _ = self.senders.send_to_pty_writer(PtyWriteInstruction::Exit);
+        let _ = self.senders.send_to_background_jobs(BackgroundJob::Exit);
         if let Some(screen_thread) = self.screen_thread.take() {
             let _ = screen_thread.join();
         }
-        let _ = self.senders.send_to_plugin(PluginInstruction::Exit);
-        if let Some(plugin_thread) = self.plugin_thread.take() {
-            let _ = plugin_thread.join();
-        }
-        let _ = self.senders.send_to_pty(PtyInstruction::Exit);
         if let Some(pty_thread) = self.pty_thread.take() {
             let _ = pty_thread.join();
         }
-        let _ = self.senders.send_to_pty_writer(PtyWriteInstruction::Exit);
+        if let Some(plugin_thread) = self.plugin_thread.take() {
+            let _ = plugin_thread.join();
+        }
         if let Some(pty_writer_thread) = self.pty_writer_thread.take() {
             let _ = pty_writer_thread.join();
         }
-        let _ = self.senders.send_to_background_jobs(BackgroundJob::Exit);
         if let Some(background_jobs_thread) = self.background_jobs_thread.take() {
             let _ = background_jobs_thread.join();
         }

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -531,23 +531,31 @@ impl SessionMetaData {
 
 impl Drop for SessionMetaData {
     fn drop(&mut self) {
-        let _ = self.senders.send_to_pty(PtyInstruction::Exit);
+        // Force a final serialization so the session shows up as resurrectable
+        // even if it exited before the periodic serialization interval fired.
+        // The Screen -> Plugin -> PTY pipeline must drain fully before any thread
+        // sees its Exit, otherwise the disk write is lost — so we exit threads in
+        // pipeline order, joining each before queuing Exit on the next.
+        let _ = self
+            .senders
+            .send_to_screen(ScreenInstruction::SerializeLayoutForResurrection);
         let _ = self.senders.send_to_screen(ScreenInstruction::Exit);
-        let _ = self.senders.send_to_plugin(PluginInstruction::Exit);
-        let _ = self.senders.send_to_pty_writer(PtyWriteInstruction::Exit);
-        let _ = self.senders.send_to_background_jobs(BackgroundJob::Exit);
         if let Some(screen_thread) = self.screen_thread.take() {
             let _ = screen_thread.join();
         }
-        if let Some(pty_thread) = self.pty_thread.take() {
-            let _ = pty_thread.join();
-        }
+        let _ = self.senders.send_to_plugin(PluginInstruction::Exit);
         if let Some(plugin_thread) = self.plugin_thread.take() {
             let _ = plugin_thread.join();
         }
+        let _ = self.senders.send_to_pty(PtyInstruction::Exit);
+        if let Some(pty_thread) = self.pty_thread.take() {
+            let _ = pty_thread.join();
+        }
+        let _ = self.senders.send_to_pty_writer(PtyWriteInstruction::Exit);
         if let Some(pty_writer_thread) = self.pty_writer_thread.take() {
             let _ = pty_writer_thread.join();
         }
+        let _ = self.senders.send_to_background_jobs(BackgroundJob::Exit);
         if let Some(background_jobs_thread) = self.background_jobs_thread.take() {
             let _ = background_jobs_thread.join();
         }
@@ -897,6 +905,24 @@ pub fn start_server_impl(
     install_panic_hook: bool,
 ) {
     envs::set_zellij("0".to_string());
+
+    // The socket/pipe filename is the stable session id, decoupled from the
+    // (renameable) display name. Publish it so the screen and background-jobs
+    // threads can key session-info cache and registry updates by id.
+    let session_id = socket_path
+        .file_name()
+        .map(|f| f.to_string_lossy().to_string())
+        .unwrap_or_default();
+    envs::set_session_id(session_id.clone());
+
+    // Record the real server PID in the registry (post-daemonize on Unix).
+    if let Err(e) = zellij_utils::sessions::with_registry(|reg| {
+        if let Some(entry) = reg.find_by_id_mut(&session_id) {
+            entry.pid = Some(std::process::id());
+        }
+    }) {
+        log::error!("Failed to update PID in session registry: {:?}", e);
+    }
 
     let (to_server, server_receiver): ChannelWithContext<ServerInstruction> = channels::bounded(50);
     let to_server = SenderWithContext::new(to_server);
@@ -2056,6 +2082,23 @@ pub fn start_server_impl(
 
     // Drop cached session data before exit.
     *session_data.write().unwrap() = None;
+
+    // Mark the session exited in the registry (clear PID, stamp exit time) so it
+    // is listed as resurrectable rather than running.
+    if let Err(e) = zellij_utils::sessions::with_registry(|reg| {
+        if let Some(entry) = reg.find_by_id_mut(&session_id) {
+            entry.state = zellij_utils::sessions::SessionState::Exited;
+            entry.pid = None;
+            entry.exited_at = Some(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0),
+            );
+        }
+    }) {
+        log::error!("Failed to update session registry on exit: {:?}", e);
+    }
 
     drop(std::fs::remove_file(&socket_path));
 }

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -3006,19 +3006,14 @@ fn delete_dead_session(session_name: String) -> Result<()> {
 }
 
 fn delete_all_dead_sessions() -> Result<()> {
-    use zellij_utils::consts::is_ipc_socket;
-    let mut live_sessions = vec![];
-    if let Ok(files) = std::fs::read_dir(&*ZELLIJ_SOCK_DIR) {
-        files.for_each(|file| {
-            if let Ok(file) = file {
-                if let Ok(file_name) = file.file_name().into_string() {
-                    if is_ipc_socket(&file.file_type().unwrap()) {
-                        live_sessions.push(file_name);
-                    }
-                }
-            }
-        });
-    }
+    // Live sessions come from the registry (their display names). Sockets are
+    // named by id, so scanning ZELLIJ_SOCK_DIR would compare ids against the
+    // name-keyed cache folders and wrongly treat every session as dead.
+    let registry = zellij_utils::sessions::ensure_registry();
+    let live_sessions: Vec<String> = registry
+        .running_sessions()
+        .map(|e| e.display_name.clone())
+        .collect();
     let dead_sessions: Vec<String> = match std::fs::read_dir(&*ZELLIJ_SESSION_INFO_CACHE_DIR) {
         Ok(files_in_session_info_folder) => {
             let files_that_are_folders = files_in_session_info_folder
@@ -3400,7 +3395,9 @@ fn disconnect_other_clients(env: &PluginEnv) {
 
 fn kill_sessions(session_names: Vec<String>) {
     for session_name in session_names {
-        let path = &*ZELLIJ_SOCK_DIR.join(&session_name);
+        let resolved = zellij_utils::sessions::resolve_session_socket_path(&session_name)
+            .unwrap_or_else(|| ZELLIJ_SOCK_DIR.join(&session_name));
+        let path = &*resolved;
         match ipc_connect(path) {
             Ok(stream) => {
                 #[cfg(windows)]
@@ -3443,7 +3440,8 @@ fn kill_sessions_and_reply(env: &PluginEnv, session_names: Vec<String>) {
     let result: Result<(), String> = runtime.block_on(async {
         let mut set: JoinSet<(String, std::io::Result<()>)> = JoinSet::new();
         for name in session_names {
-            let path = ZELLIJ_SOCK_DIR.join(&name);
+            let path = zellij_utils::sessions::resolve_session_socket_path(&name)
+                .unwrap_or_else(|| ZELLIJ_SOCK_DIR.join(&name));
             set.spawn(async move {
                 let res = zellij_utils::ipc::async_send_kill_and_await(&path).await;
                 (name, res)

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -3001,42 +3001,43 @@ fn switch_session(
 }
 
 fn delete_dead_session(session_name: String) -> Result<()> {
-    std::fs::remove_dir_all(&*ZELLIJ_SESSION_INFO_CACHE_DIR.join(&session_name))
+    // The cache folder is keyed by session id; resolve the name (falling back to
+    // treating the argument as the id, e.g. when called with an id directly).
+    let id = zellij_utils::sessions::resolve_session_id(&session_name)
+        .unwrap_or_else(|| session_name.clone());
+    let _ = zellij_utils::sessions::with_registry(|reg| {
+        reg.sessions
+            .retain(|s| s.id != id && s.display_name != session_name);
+    });
+    std::fs::remove_dir_all(&*ZELLIJ_SESSION_INFO_CACHE_DIR.join(&id))
         .with_context(|| format!("Failed to delete dead session: {:?}", &session_name))
 }
 
 fn delete_all_dead_sessions() -> Result<()> {
-    // Live sessions come from the registry (their display names). Sockets are
-    // named by id, so scanning ZELLIJ_SOCK_DIR would compare ids against the
-    // name-keyed cache folders and wrongly treat every session as dead.
+    // Live sessions are the running registry entries. The cache is keyed by id,
+    // so compare folder ids against running ids and delete the rest by id.
     let registry = zellij_utils::sessions::ensure_registry();
-    let live_sessions: Vec<String> = registry
-        .running_sessions()
-        .map(|e| e.display_name.clone())
-        .collect();
-    let dead_sessions: Vec<String> = match std::fs::read_dir(&*ZELLIJ_SESSION_INFO_CACHE_DIR) {
-        Ok(files_in_session_info_folder) => {
-            let files_that_are_folders = files_in_session_info_folder
-                .filter_map(|f| f.ok().map(|f| f.path()))
-                .filter(|f| f.is_dir());
-            files_that_are_folders
-                .filter_map(|folder_name| {
-                    let session_name = folder_name.file_name()?.to_str()?.to_owned();
-                    if live_sessions.contains(&session_name) {
-                        // this is not a dead session...
-                        return None;
-                    }
-                    Some(session_name)
-                })
-                .collect()
-        },
+    let live_ids: Vec<String> = registry.running_sessions().map(|e| e.id.clone()).collect();
+    let dead_ids: Vec<String> = match std::fs::read_dir(&*ZELLIJ_SESSION_INFO_CACHE_DIR) {
+        Ok(entries) => entries
+            .filter_map(|f| f.ok().map(|f| f.path()))
+            .filter(|p| p.is_dir())
+            .filter_map(|folder| {
+                let id = folder.file_name()?.to_str()?.to_owned();
+                if live_ids.contains(&id) {
+                    None
+                } else {
+                    Some(id)
+                }
+            })
+            .collect(),
         Err(e) => {
             log::error!("Failed to read session info cache dir: {:?}", e);
             vec![]
         },
     };
-    for session in dead_sessions {
-        delete_dead_session(session)?;
+    for id in dead_ids {
+        delete_dead_session(id)?;
     }
     Ok(())
 }
@@ -3487,14 +3488,20 @@ fn kill_sessions_and_reply(env: &PluginEnv, session_names: Vec<String>) {
 }
 
 fn delete_dead_session_and_reply(env: &PluginEnv, session_name: String) {
-    let response =
-        match std::fs::remove_dir_all(&*ZELLIJ_SESSION_INFO_CACHE_DIR.join(&session_name)) {
-            Ok(()) => DeleteDeadSessionResponse::Ok,
-            Err(e) => DeleteDeadSessionResponse::Err(format!(
-                "Failed to delete dead session {}: {}",
-                session_name, e
-            )),
-        };
+    // Cache folder is keyed by session id; resolve the display name.
+    let id = zellij_utils::sessions::resolve_session_id(&session_name)
+        .unwrap_or_else(|| session_name.clone());
+    let _ = zellij_utils::sessions::with_registry(|reg| {
+        reg.sessions
+            .retain(|s| s.id != id && s.display_name != session_name);
+    });
+    let response = match std::fs::remove_dir_all(&*ZELLIJ_SESSION_INFO_CACHE_DIR.join(&id)) {
+        Ok(()) => DeleteDeadSessionResponse::Ok,
+        Err(e) => DeleteDeadSessionResponse::Err(format!(
+            "Failed to delete dead session {}: {}",
+            session_name, e
+        )),
+    };
     let protobuf_response = ProtobufDeleteDeadSessionResponse::from(response);
     wasi_write_object(env, &protobuf_response.encode_to_vec())
         .with_context(|| "failed to write delete_dead_session response".to_string())

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -211,11 +211,7 @@ pub(crate) struct Pty {
     terminal_foreground_cmds: HashMap<u32, Vec<String>>,
 }
 
-pub(crate) fn pty_thread_main(
-    mut pty: Pty,
-    layout: Box<Layout>,
-    session_id: String,
-) -> Result<()> {
+pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>, session_id: String) -> Result<()> {
     loop {
         let (event, mut err_ctx) = pty.bus.recv().expect("failed to receive event on channel");
         err_ctx.add_call(ContextType::Pty((&event).into()));

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -803,8 +803,11 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                     session_layout_metadata.into(),
                 ) {
                     Ok(kdl_and_files) => {
+                        // Cache is keyed by the stable session id, not the name.
+                        let session_id = zellij_utils::envs::get_session_id()
+                            .unwrap_or_else(|_| session_name.clone());
                         write_session_state_to_disk(
-                            session_name,
+                            session_id,
                             session_info,
                             kdl_and_files.clone(),
                         );

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -211,7 +211,11 @@ pub(crate) struct Pty {
     terminal_foreground_cmds: HashMap<u32, Vec<String>>,
 }
 
-pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
+pub(crate) fn pty_thread_main(
+    mut pty: Pty,
+    layout: Box<Layout>,
+    session_id: String,
+) -> Result<()> {
     loop {
         let (event, mut err_ctx) = pty.bus.recv().expect("failed to receive event on channel");
         err_ctx.add_call(ContextType::Pty((&event).into()));
@@ -793,7 +797,9 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                 }
             },
             PtyInstruction::SaveSessionToDisk {
-                session_name,
+                // The cache is keyed by the server's own session id; the name in
+                // the instruction is no longer needed.
+                session_name: _,
                 session_info,
                 mut session_layout_metadata,
                 completion_tx: _completion_tx, // Dropped at end to signal completion
@@ -804,10 +810,8 @@ pub(crate) fn pty_thread_main(mut pty: Pty, layout: Box<Layout>) -> Result<()> {
                 ) {
                     Ok(kdl_and_files) => {
                         // Cache is keyed by the stable session id, not the name.
-                        let session_id = zellij_utils::envs::get_session_id()
-                            .unwrap_or_else(|_| session_name.clone());
                         write_session_state_to_disk(
-                            session_id,
+                            session_id.clone(),
                             session_info,
                             kdl_and_files.clone(),
                         );

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -63,7 +63,7 @@ use zellij_utils::ipc::{
 use zellij_utils::pane_size::{PaneGeom, Size, SizeInPixels};
 use zellij_utils::shared::{clean_string_from_control_and_linebreak, detect_theme_hue};
 use zellij_utils::{
-    consts::{session_info_folder_for_session, ZELLIJ_SOCK_DIR},
+    consts::ZELLIJ_SOCK_DIR,
     envs::set_session_name,
     input::command::TerminalAction,
     input::layout::{
@@ -11362,7 +11362,6 @@ pub(crate) fn screen_thread_main(
                     }
                 } else {
                     let err_context = || format!("Failed to rename session");
-                    let old_session_name = screen.session_name.clone();
 
                     // update state
                     screen.session_name = name.clone();
@@ -11374,9 +11373,11 @@ pub(crate) fn screen_thread_main(
                         tab.rename_session(name.clone()).with_context(err_context)?;
                     }
 
-                    // Update the display name in the registry. The socket/pipe
-                    // (named by the stable session id) is never renamed — that
-                    // is what makes rename work for Windows named pipes.
+                    // Update the display name in the registry. Nothing on disk is
+                    // renamed: the socket/pipe and the session-info cache folder
+                    // are both named by the stable session id, so this is a
+                    // pure registry update — which is what makes rename work for
+                    // Windows named pipes (they cannot be renamed).
                     let session_id = zellij_utils::envs::get_session_id().unwrap_or_default();
                     if let Err(e) = zellij_utils::sessions::with_registry(|reg| {
                         if let Some(entry) = reg.find_by_id_mut(&session_id) {
@@ -11384,17 +11385,6 @@ pub(crate) fn screen_thread_main(
                         }
                     }) {
                         log::error!("Failed to update session registry: {:?}", e);
-                    }
-
-                    // rename session_info folder (still keyed by name in Stage A;
-                    // Stage B keys it by session id, dropping this move entirely)
-                    let old_session_info_folder =
-                        session_info_folder_for_session(&old_session_name);
-                    let new_session_info_folder = session_info_folder_for_session(&name);
-                    if let Err(e) =
-                        std::fs::rename(old_session_info_folder, new_session_info_folder)
-                    {
-                        log::error!("Failed to rename session_info folder: {:?}", e);
                     }
 
                     // report

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -5392,7 +5392,9 @@ impl Screen {
         }
         let available_layouts = self.cached_layouts.clone();
         let creation_time = {
-            let sock_path = ZELLIJ_SOCK_DIR.join(&self.session_name);
+            // The socket is named by the stable session id, not the display name.
+            let session_id = zellij_utils::envs::get_session_id().unwrap_or_default();
+            let sock_path = ZELLIJ_SOCK_DIR.join(&session_id);
             std::fs::metadata(&sock_path)
                 .ok()
                 .and_then(|f| f.created().ok().or_else(|| f.modified().ok()))
@@ -11277,7 +11279,9 @@ pub(crate) fn screen_thread_main(
                 let available_layouts = vec![];
 
                 let creation_time = {
-                    let sock_path = ZELLIJ_SOCK_DIR.join(&screen.session_name);
+                    // The socket is named by the stable session id, not the display name.
+                    let session_id = zellij_utils::envs::get_session_id().unwrap_or_default();
+                    let sock_path = ZELLIJ_SOCK_DIR.join(&session_id);
                     std::fs::metadata(&sock_path)
                         .ok()
                         .and_then(|f| f.created().ok().or_else(|| f.modified().ok()))
@@ -11370,16 +11374,20 @@ pub(crate) fn screen_thread_main(
                         tab.rename_session(name.clone()).with_context(err_context)?;
                     }
 
-                    // rename socket file
-                    let old_socket_file_path = ZELLIJ_SOCK_DIR.join(&old_session_name);
-                    let new_socket_file_path = ZELLIJ_SOCK_DIR.join(&name);
-                    if let Err(e) = std::fs::rename(old_socket_file_path, new_socket_file_path) {
-                        log::error!("Failed to rename ipc socket: {:?}", e);
+                    // Update the display name in the registry. The socket/pipe
+                    // (named by the stable session id) is never renamed — that
+                    // is what makes rename work for Windows named pipes.
+                    let session_id = zellij_utils::envs::get_session_id().unwrap_or_default();
+                    if let Err(e) = zellij_utils::sessions::with_registry(|reg| {
+                        if let Some(entry) = reg.find_by_id_mut(&session_id) {
+                            entry.display_name = name.clone();
+                        }
+                    }) {
+                        log::error!("Failed to update session registry: {:?}", e);
                     }
 
-                    // rename session_info folder (TODO: make this atomic, right now there is a
-                    // chance background_jobs will re-create this folder before it knows the
-                    // session was renamed)
+                    // rename session_info folder (still keyed by name in Stage A;
+                    // Stage B keys it by session id, dropping this move entirely)
                     let old_session_info_folder =
                         session_info_folder_for_session(&old_session_name);
                     let new_session_info_folder = session_info_folder_for_session(&name);

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -1536,6 +1536,8 @@ pub(crate) struct Screen {
     copy_options: CopyOptions,
     debug: bool,
     session_name: String,
+    /// Stable session id (socket/pipe filename), decoupled from `session_name`.
+    session_id: String,
     peer_sessions_cache: BTreeMap<String, SessionInfo>, // String is the session name, can
     // also be this session
     resurrectable_sessions_cache: BTreeMap<String, Duration>, // String is the session name,
@@ -1697,6 +1699,7 @@ impl Screen {
         web_server_ip: IpAddr,
         web_server_port: u16,
         nested_session_handling: NestedSessionHandling,
+        session_id: String,
     ) -> Self {
         let session_name = mode_info.session_name.clone().unwrap_or_default();
         let session_info = SessionInfo::new(session_name.clone());
@@ -1735,6 +1738,7 @@ impl Screen {
             copy_options,
             debug,
             session_name,
+            session_id,
             peer_sessions_cache,
             default_layout,
             default_layout_name,
@@ -5393,8 +5397,7 @@ impl Screen {
         let available_layouts = self.cached_layouts.clone();
         let creation_time = {
             // The socket is named by the stable session id, not the display name.
-            let session_id = zellij_utils::envs::get_session_id().unwrap_or_default();
-            let sock_path = ZELLIJ_SOCK_DIR.join(&session_id);
+            let sock_path = ZELLIJ_SOCK_DIR.join(&self.session_id);
             std::fs::metadata(&sock_path)
                 .ok()
                 .and_then(|f| f.created().ok().or_else(|| f.modified().ok()))
@@ -7905,6 +7908,7 @@ pub(crate) fn screen_thread_main(
     config: Config,
     debug: bool,
     default_layout: Box<Layout>,
+    session_id: String,
 ) -> Result<()> {
     // Resolve `theme_dark` / `theme_light` to concrete `Styling` from the
     // bundled themes BEFORE `config.options` is moved out below. These
@@ -8056,6 +8060,7 @@ pub(crate) fn screen_thread_main(
         web_server_ip,
         web_server_port,
         nested_session_handling,
+        session_id,
     );
     screen.host_theme_dark_styling = host_theme_dark_styling;
     screen.host_theme_light_styling = host_theme_light_styling;
@@ -11280,8 +11285,7 @@ pub(crate) fn screen_thread_main(
 
                 let creation_time = {
                     // The socket is named by the stable session id, not the display name.
-                    let session_id = zellij_utils::envs::get_session_id().unwrap_or_default();
-                    let sock_path = ZELLIJ_SOCK_DIR.join(&session_id);
+                    let sock_path = ZELLIJ_SOCK_DIR.join(&screen.session_id);
                     std::fs::metadata(&sock_path)
                         .ok()
                         .and_then(|f| f.created().ok().or_else(|| f.modified().ok()))
@@ -11378,7 +11382,7 @@ pub(crate) fn screen_thread_main(
                     // are both named by the stable session id, so this is a
                     // pure registry update — which is what makes rename work for
                     // Windows named pipes (they cannot be renamed).
-                    let session_id = zellij_utils::envs::get_session_id().unwrap_or_default();
+                    let session_id = screen.session_id.clone();
                     if let Err(e) = zellij_utils::sessions::with_registry(|reg| {
                         if let Some(entry) = reg.find_by_id_mut(&session_id) {
                             entry.display_name = name.clone();

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -393,6 +393,7 @@ fn create_new_screen_with_capture(
         web_server_ip,
         web_server_port,
         NestedSessionHandling::default(),
+        "test-session-id".to_string(),
     );
     (
         seed_first_client_size(screen, size),
@@ -465,6 +466,7 @@ impl MockScreen {
                     config,
                     debug,
                     Box::new(Layout::default()),
+                    "test-session-id".to_string(),
                 )
                 .expect("TEST")
             })
@@ -551,6 +553,7 @@ impl MockScreen {
                     config,
                     debug,
                     Box::new(Layout::default()),
+                    "test-session-id".to_string(),
                 )
                 .expect("TEST")
             })
@@ -5825,6 +5828,7 @@ fn create_new_screen_with_message_capture(
         web_server_ip,
         web_server_port,
         NestedSessionHandling::default(),
+        "test-session-id".to_string(),
     );
     (seed_first_client_size(screen, size), messages)
 }
@@ -8936,6 +8940,7 @@ fn create_new_screen_with_forward_capture(size: Size) -> (Screen, ForwardCapture
         web_server_ip,
         web_server_port,
         NestedSessionHandling::default(),
+        "test-session-id".to_string(),
     );
     (
         seed_first_client_size(screen, size),
@@ -9787,6 +9792,7 @@ fn create_new_screen_with_theme_capture(size: Size) -> (Screen, ThemeCapture) {
         web_server_ip,
         web_server_port,
         NestedSessionHandling::default(),
+        "test-session-id".to_string(),
     );
     (
         seed_first_client_size(screen, size),
@@ -10320,6 +10326,7 @@ fn create_non_mirrored_screen(size: Size) -> Screen {
         IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
         8080,
         NestedSessionHandling::default(),
+        "test-session-id".to_string(),
     );
     seed_first_client_size(screen, size)
 }

--- a/zellij-utils/Cargo.toml
+++ b/zellij-utils/Cargo.toml
@@ -63,6 +63,8 @@ nix = { workspace = true, features = ["user"] }
 crossterm = { workspace = true, features = ["events"] }
 windows-sys = { workspace = true, features = [
     "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+    "Win32_System_IO",
     "Win32_System_Threading",
 ] }
 winapi = { version = "0.3.9", default-features = false }

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -28,26 +28,9 @@ const CLI_STYLES: Styles = Styles::styled()
     .invalid(ansi(AnsiColor::Yellow));
 
 fn validate_session(name: &str) -> Result<String, String> {
-    #[cfg(unix)]
-    {
-        use crate::consts::ZELLIJ_SOCK_MAX_LENGTH;
-
-        let mut socket_path = crate::consts::ZELLIJ_SOCK_DIR.clone();
-        socket_path.push(name);
-
-        if socket_path.as_os_str().len() >= ZELLIJ_SOCK_MAX_LENGTH {
-            // socket path must be less than 108 bytes
-            let available_length = ZELLIJ_SOCK_MAX_LENGTH
-                .saturating_sub(socket_path.as_os_str().len())
-                .saturating_sub(1);
-
-            return Err(format!(
-                "session name must be less than {} characters",
-                available_length
-            ));
-        };
-    };
-
+    // Socket paths are now named by session id (a UUID), not the session name,
+    // so the name no longer contributes to the socket-path length limit. The
+    // directory length is validated once at startup via `check_sock_dir_length`.
     Ok(name.to_owned())
 }
 

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -37,6 +37,36 @@ pub fn session_info_folder_for_session(session_name: &str) -> PathBuf {
     ZELLIJ_SESSION_INFO_CACHE_DIR.join(session_name)
 }
 
+/// Length of a hyphenated UUID v4 string (e.g., "a3f7b9c1-e29b-41d4-a716-446655440000").
+pub const SESSION_ID_LENGTH: usize = 36;
+
+/// Validate that `ZELLIJ_SOCK_DIR` is short enough to fit a UUID-based socket
+/// filename within the platform's Unix domain socket path limit.
+///
+/// Should be called once at startup. Exits with an error message if the
+/// directory is too long.
+pub fn check_sock_dir_length() {
+    let dir_len = ZELLIJ_SOCK_DIR.as_os_str().len();
+    // +1 for the path separator between dir and filename.
+    let required = dir_len + 1 + SESSION_ID_LENGTH;
+    if required >= ZELLIJ_SOCK_MAX_LENGTH {
+        let max_dir_len = ZELLIJ_SOCK_MAX_LENGTH.saturating_sub(1 + SESSION_ID_LENGTH + 1);
+        eprintln!(
+            "Error: the socket directory path is too long ({} bytes, max {}):\n  {}\n\n\
+             Session socket paths use UUIDs ({} bytes) as filenames, leaving\n\
+             at most {} bytes for the directory.\n\
+             To fix this, set a shorter socket directory, eg.:\n  \
+             ZELLIJ_SOCKET_DIR=/tmp/zellij zellij",
+            dir_len,
+            max_dir_len,
+            ZELLIJ_SOCK_DIR.display(),
+            SESSION_ID_LENGTH,
+            max_dir_len,
+        );
+        std::process::exit(1);
+    }
+}
+
 pub fn create_config_and_cache_folders() {
     if let Err(e) = std::fs::create_dir_all(&ZELLIJ_CACHE_DIR.as_path()) {
         log::error!("Failed to create cache dir: {:?}", e);
@@ -106,6 +136,8 @@ lazy_static! {
     pub static ref ZELLIJ_SESSION_INFO_CACHE_DIR: PathBuf = ZELLIJ_CACHE_DIR
         .join(CLIENT_SERVER_CONTRACT_DIR.clone())
         .join("session_info");
+    pub static ref ZELLIJ_SESSIONS_KDL: PathBuf = ZELLIJ_SOCK_DIR.join("sessions.kdl");
+    pub static ref ZELLIJ_SESSIONS_LOCK: PathBuf = ZELLIJ_SOCK_DIR.join("sessions.kdl.lock");
     pub static ref ZELLIJ_PLUGIN_ARTIFACT_DIR: PathBuf = ZELLIJ_CACHE_DIR.join(VERSION);
     pub static ref ZELLIJ_SEEN_RELEASE_NOTES_CACHE_FILE: PathBuf =
         ZELLIJ_CACHE_DIR.join(VERSION).join("seen_release_notes");

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -25,16 +25,19 @@ pub static ZELLIJ_DEFAULT_THEMES: Dir = include_dir!("$CARGO_MANIFEST_DIR/assets
 
 pub const CLIENT_SERVER_CONTRACT_VERSION: usize = 1;
 
-pub fn session_info_cache_file_name(session_name: &str) -> PathBuf {
-    session_info_folder_for_session(session_name).join("session-metadata.kdl")
+// The session-info cache is keyed by session id (a UUID for new sessions, or the
+// legacy session name for pre-registry sessions), NOT the user-visible display
+// name — so renaming a session never moves its cache folder.
+pub fn session_info_cache_file_name(session_id: &str) -> PathBuf {
+    session_info_folder_for_session(session_id).join("session-metadata.kdl")
 }
 
-pub fn session_layout_cache_file_name(session_name: &str) -> PathBuf {
-    session_info_folder_for_session(session_name).join("session-layout.kdl")
+pub fn session_layout_cache_file_name(session_id: &str) -> PathBuf {
+    session_info_folder_for_session(session_id).join("session-layout.kdl")
 }
 
-pub fn session_info_folder_for_session(session_name: &str) -> PathBuf {
-    ZELLIJ_SESSION_INFO_CACHE_DIR.join(session_name)
+pub fn session_info_folder_for_session(session_id: &str) -> PathBuf {
+    ZELLIJ_SESSION_INFO_CACHE_DIR.join(session_id)
 }
 
 /// Length of a hyphenated UUID v4 string (e.g., "a3f7b9c1-e29b-41d4-a716-446655440000").

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -40,10 +40,12 @@ pub fn session_info_folder_for_session(session_id: &str) -> PathBuf {
     ZELLIJ_SESSION_INFO_CACHE_DIR.join(session_id)
 }
 
-/// Length of a hyphenated UUID v4 string (e.g., "a3f7b9c1-e29b-41d4-a716-446655440000").
-pub const SESSION_ID_LENGTH: usize = 36;
+/// Length of a generated session id (hex chars). Kept short so the socket/pipe
+/// path stays within the platform limit (104 bytes on macOS) even under a long
+/// temp dir — a full 36-char UUID would overflow it. See `generate_session_id`.
+pub const SESSION_ID_LENGTH: usize = 12;
 
-/// Validate that `ZELLIJ_SOCK_DIR` is short enough to fit a UUID-based socket
+/// Validate that `ZELLIJ_SOCK_DIR` is short enough to fit an id-based socket
 /// filename within the platform's Unix domain socket path limit.
 ///
 /// Should be called once at startup. Exits with an error message if the
@@ -56,7 +58,7 @@ pub fn check_sock_dir_length() {
         let max_dir_len = ZELLIJ_SOCK_MAX_LENGTH.saturating_sub(1 + SESSION_ID_LENGTH + 1);
         eprintln!(
             "Error: the socket directory path is too long ({} bytes, max {}):\n  {}\n\n\
-             Session socket paths use UUIDs ({} bytes) as filenames, leaving\n\
+             Session socket paths use a {}-byte id as the filename, leaving\n\
              at most {} bytes for the directory.\n\
              To fix this, set a shorter socket directory, eg.:\n  \
              ZELLIJ_SOCKET_DIR=/tmp/zellij zellij",

--- a/zellij-utils/src/envs.rs
+++ b/zellij-utils/src/envs.rs
@@ -26,6 +26,19 @@ pub fn set_session_name(v: String) {
     set_var(SESSION_NAME_ENV_KEY, v);
 }
 
+pub const SESSION_ID_ENV_KEY: &str = "ZELLIJ_SESSION_ID";
+
+/// The stable per-session identifier (also the socket / named-pipe filename).
+/// Decoupled from the user-visible session name so that renaming a session does
+/// not require renaming its socket/pipe (see `zellij_utils::sessions`).
+pub fn get_session_id() -> Result<String> {
+    Ok(var(SESSION_ID_ENV_KEY)?)
+}
+
+pub fn set_session_id(v: String) {
+    set_var(SESSION_ID_ENV_KEY, v);
+}
+
 pub const SOCKET_DIR_ENV_KEY: &str = "ZELLIJ_SOCKET_DIR";
 pub fn get_socket_dir() -> Result<String> {
     Ok(var(SOCKET_DIR_ENV_KEY)?)

--- a/zellij-utils/src/envs.rs
+++ b/zellij-utils/src/envs.rs
@@ -26,19 +26,6 @@ pub fn set_session_name(v: String) {
     set_var(SESSION_NAME_ENV_KEY, v);
 }
 
-pub const SESSION_ID_ENV_KEY: &str = "ZELLIJ_SESSION_ID";
-
-/// The stable per-session identifier (also the socket / named-pipe filename).
-/// Decoupled from the user-visible session name so that renaming a session does
-/// not require renaming its socket/pipe (see `zellij_utils::sessions`).
-pub fn get_session_id() -> Result<String> {
-    Ok(var(SESSION_ID_ENV_KEY)?)
-}
-
-pub fn set_session_id(v: String) {
-    set_var(SESSION_ID_ENV_KEY, v);
-}
-
 pub const SOCKET_DIR_ENV_KEY: &str = "ZELLIJ_SOCKET_DIR";
 pub fn get_socket_dir() -> Result<String> {
     Ok(var(SOCKET_DIR_ENV_KEY)?)

--- a/zellij-utils/src/sessions.rs
+++ b/zellij-utils/src/sessions.rs
@@ -1,7 +1,7 @@
 use crate::{
     consts::{
         is_ipc_socket, session_info_folder_for_session, session_layout_cache_file_name,
-        ZELLIJ_SESSION_INFO_CACHE_DIR, ZELLIJ_SOCK_DIR,
+        ZELLIJ_SESSIONS_KDL, ZELLIJ_SESSIONS_LOCK, ZELLIJ_SESSION_INFO_CACHE_DIR, ZELLIJ_SOCK_DIR,
     },
     data::SessionInfo,
     envs,
@@ -10,38 +10,500 @@ use crate::{
 };
 use anyhow;
 use humantime::format_duration;
+use kdl::{KdlDocument, KdlNode, KdlValue};
 use std::collections::{BTreeMap, HashMap};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 use std::{fs, io, process};
 use suggest::Suggest;
+use uuid::Uuid;
+
+// ============================================================================
+// Session registry (`sessions.kdl`)
+//
+// Decouples the user-visible session name from the socket / named-pipe
+// filename. The socket/pipe is named by a stable `id` (a UUID for new sessions,
+// or the legacy session name for pre-registry sessions); `sessions.kdl` maps
+// `id -> display_name`. This is what lets a session be renamed without renaming
+// its socket/pipe — impossible for Windows named pipes (see PR #5103).
+// ============================================================================
+
+/// A single session entry in the registry.
+#[derive(Debug, Clone)]
+pub struct SessionEntry {
+    /// Stable identifier, also the socket/marker filename (a UUID for new
+    /// sessions, or the legacy session name for pre-registry sessions).
+    pub id: String,
+    /// User-visible session name.
+    pub display_name: String,
+    /// Server PID (only meaningful while `state == Running`).
+    pub pid: Option<u32>,
+    /// Running or exited.
+    pub state: SessionState,
+    /// Unix epoch seconds when the session was created.
+    pub created_at: Option<u64>,
+    /// Unix epoch seconds when the session exited (only for `Exited`).
+    pub exited_at: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionState {
+    Running,
+    Exited,
+}
+
+impl SessionState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SessionState::Running => "running",
+            SessionState::Exited => "exited",
+        }
+    }
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "running" => Some(SessionState::Running),
+            "exited" => Some(SessionState::Exited),
+            _ => None,
+        }
+    }
+}
+
+/// Current time as unix epoch seconds.
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// A file's creation (or, failing that, modification) time as unix epoch seconds.
+fn file_created_epoch(path: &Path) -> Option<u64> {
+    std::fs::metadata(path)
+        .ok()
+        .and_then(|m| m.created().ok().or_else(|| m.modified().ok()))
+        .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs())
+}
+
+/// Generate a new session identifier (UUID v4, hyphenated).
+pub fn generate_session_id() -> String {
+    Uuid::new_v4().as_hyphenated().to_string()
+}
+
+fn is_registry_file(file_name: &str) -> bool {
+    file_name == "sessions.kdl" || file_name == "sessions.kdl.lock"
+}
+
+/// The full session registry.
+#[derive(Debug, Clone, Default)]
+pub struct SessionRegistry {
+    pub sessions: Vec<SessionEntry>,
+}
+
+impl SessionRegistry {
+    pub fn new() -> Self {
+        Self {
+            sessions: Vec::new(),
+        }
+    }
+
+    /// Parse a `sessions.kdl` string into a registry.
+    pub fn from_kdl(raw: &str) -> Result<Self, String> {
+        let doc: KdlDocument = raw
+            .parse()
+            .map_err(|e| format!("Failed to parse sessions.kdl: {}", e))?;
+        let mut sessions = Vec::new();
+        for node in doc.nodes() {
+            if node.name().value() != "session" {
+                continue;
+            }
+            let id = node
+                .entries()
+                .iter()
+                .find(|e| e.name().is_none())
+                .and_then(|e| e.value().as_string())
+                .unwrap_or("")
+                .to_string();
+            if id.is_empty() {
+                continue;
+            }
+            let children = match node.children() {
+                Some(c) => c,
+                None => continue,
+            };
+            let child_string = |key: &str| -> Option<String> {
+                children
+                    .get(key)
+                    .and_then(|n| n.entries().iter().next())
+                    .and_then(|e| e.value().as_string())
+                    .map(|s| s.to_string())
+            };
+            let child_i64 = |key: &str| -> Option<i64> {
+                children
+                    .get(key)
+                    .and_then(|n| n.entries().iter().next())
+                    .and_then(|e| e.value().as_i64())
+            };
+            let display_name = child_string("display_name").unwrap_or_default();
+            let pid = child_i64("pid").map(|v| v as u32);
+            let state = child_string("state")
+                .as_deref()
+                .and_then(SessionState::from_str)
+                .unwrap_or(SessionState::Running);
+            let created_at = child_i64("created_at").map(|v| v as u64);
+            let exited_at = child_i64("exited_at").map(|v| v as u64);
+            sessions.push(SessionEntry {
+                id,
+                display_name,
+                pid,
+                state,
+                created_at,
+                exited_at,
+            });
+        }
+        Ok(SessionRegistry { sessions })
+    }
+
+    /// Serialize the registry to a KDL string.
+    pub fn to_kdl(&self) -> String {
+        let mut doc = KdlDocument::new();
+        for entry in &self.sessions {
+            let mut node = KdlNode::new("session");
+            node.push(KdlValue::String(entry.id.clone()));
+
+            let mut children = KdlDocument::new();
+            let mut push_child = |name: &str, value: KdlValue| {
+                let mut n = KdlNode::new(name);
+                n.push(value);
+                children.nodes_mut().push(n);
+            };
+
+            push_child("display_name", KdlValue::String(entry.display_name.clone()));
+            if let Some(pid) = entry.pid {
+                push_child("pid", KdlValue::Base10(pid as i64));
+            }
+            push_child("state", KdlValue::String(entry.state.as_str().to_string()));
+            if let Some(created_at) = entry.created_at {
+                push_child("created_at", KdlValue::Base10(created_at as i64));
+            }
+            if let Some(exited_at) = entry.exited_at {
+                push_child("exited_at", KdlValue::Base10(exited_at as i64));
+            }
+
+            node.set_children(children);
+            doc.nodes_mut().push(node);
+        }
+        doc.fmt();
+        doc.to_string()
+    }
+
+    /// Find a running session by display name.
+    pub fn find_running_by_name(&self, name: &str) -> Option<&SessionEntry> {
+        self.sessions
+            .iter()
+            .find(|s| s.display_name == name && s.state == SessionState::Running)
+    }
+
+    /// Find a session (any state) by display name.
+    pub fn find_by_name(&self, name: &str) -> Option<&SessionEntry> {
+        self.sessions.iter().find(|s| s.display_name == name)
+    }
+
+    /// Find a session by id.
+    pub fn find_by_id(&self, id: &str) -> Option<&SessionEntry> {
+        self.sessions.iter().find(|s| s.id == id)
+    }
+
+    /// Find a mutable session by id.
+    pub fn find_by_id_mut(&mut self, id: &str) -> Option<&mut SessionEntry> {
+        self.sessions.iter_mut().find(|s| s.id == id)
+    }
+
+    /// Iterate over running sessions.
+    pub fn running_sessions(&self) -> impl Iterator<Item = &SessionEntry> {
+        self.sessions
+            .iter()
+            .filter(|s| s.state == SessionState::Running)
+    }
+
+    /// Remove a session by id.
+    pub fn remove_by_id(&mut self, id: &str) {
+        self.sessions.retain(|s| s.id != id);
+    }
+
+    /// Resolve a running session display name to its socket path.
+    pub fn resolve_socket_path(&self, name: &str) -> Option<PathBuf> {
+        self.find_running_by_name(name)
+            .map(|entry| ZELLIJ_SOCK_DIR.join(&entry.id))
+    }
+}
+
+#[cfg(unix)]
+mod file_lock {
+    use std::fs::{File, OpenOptions};
+    use std::os::unix::io::AsRawFd;
+    use std::path::Path;
+
+    /// An advisory exclusive lock held for the lifetime of the value. The lock
+    /// is released when the file is dropped (fd closed → `flock` released).
+    pub struct FileLock {
+        _file: File,
+    }
+
+    impl FileLock {
+        pub fn exclusive(path: &Path) -> std::io::Result<Self> {
+            let file = OpenOptions::new().create(true).write(true).open(path)?;
+            let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+            if ret != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(FileLock { _file: file })
+        }
+    }
+}
+
+#[cfg(windows)]
+mod file_lock {
+    use std::fs::{File, OpenOptions};
+    use std::os::windows::io::AsRawHandle;
+    use std::path::Path;
+
+    /// An exclusive lock held for the lifetime of the value. The lock is
+    /// released when the file is dropped (handle closed → lock released).
+    pub struct FileLock {
+        _file: File,
+    }
+
+    impl FileLock {
+        pub fn exclusive(path: &Path) -> std::io::Result<Self> {
+            let file = OpenOptions::new().create(true).write(true).open(path)?;
+            let handle = file.as_raw_handle();
+            unsafe {
+                use windows_sys::Win32::Foundation::HANDLE;
+                use windows_sys::Win32::Storage::FileSystem::{LockFileEx, LOCKFILE_EXCLUSIVE_LOCK};
+                let mut overlapped: windows_sys::Win32::System::IO::OVERLAPPED =
+                    std::mem::zeroed();
+                let ret = LockFileEx(
+                    handle as HANDLE,
+                    LOCKFILE_EXCLUSIVE_LOCK,
+                    0,
+                    u32::MAX,
+                    u32::MAX,
+                    &mut overlapped,
+                );
+                if ret == 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+            }
+            Ok(FileLock { _file: file })
+        }
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+mod file_lock {
+    use std::fs::{File, OpenOptions};
+    use std::path::Path;
+
+    pub struct FileLock {
+        _file: File,
+    }
+
+    impl FileLock {
+        pub fn exclusive(path: &Path) -> std::io::Result<Self> {
+            let file = OpenOptions::new().create(true).write(true).open(path)?;
+            Ok(FileLock { _file: file })
+        }
+    }
+}
+
+use file_lock::FileLock;
+
+/// Ensure the socket dir exists so the lock/registry files can live in it.
+fn ensure_sock_dir() -> io::Result<()> {
+    fs::create_dir_all(&*ZELLIJ_SOCK_DIR)
+}
+
+/// Returns true if the session registry file exists on disk.
+pub fn registry_exists() -> bool {
+    ZELLIJ_SESSIONS_KDL.exists()
+}
+
+/// Read the registry from disk, returning an empty one if it's missing/corrupt.
+pub fn read_registry() -> SessionRegistry {
+    match fs::read_to_string(&*ZELLIJ_SESSIONS_KDL) {
+        Ok(raw) => SessionRegistry::from_kdl(&raw).unwrap_or_else(|e| {
+            log::error!("{}", e);
+            SessionRegistry::new()
+        }),
+        Err(_) => SessionRegistry::new(),
+    }
+}
+
+/// Ensure the registry exists, migrating from the legacy socket-named layout on
+/// first use. Returns the current registry.
+pub fn ensure_registry() -> SessionRegistry {
+    if registry_exists() {
+        read_registry()
+    } else {
+        migrate_legacy_sessions()
+    }
+}
+
+/// Migrate legacy (pre-registry) sessions into a new `sessions.kdl`.
+///
+/// Scans `ZELLIJ_SOCK_DIR` for old socket/marker files (named by session name)
+/// and the session-info cache for resurrectable sessions, creating registry
+/// entries with `id == existing_name` so lookups keep working without moving
+/// any files. Called once when `sessions.kdl` doesn't exist yet.
+pub fn migrate_legacy_sessions() -> SessionRegistry {
+    let mut registry = SessionRegistry::new();
+
+    // Live legacy sessions: socket/marker files named directly by session name.
+    if let Ok(files) = fs::read_dir(&*ZELLIJ_SOCK_DIR) {
+        for file in files.flatten() {
+            let file_name = match file.file_name().into_string() {
+                Ok(n) => n,
+                Err(_) => continue,
+            };
+            if is_registry_file(&file_name) {
+                continue;
+            }
+            let file_type = match file.file_type() {
+                Ok(ft) => ft,
+                Err(_) => continue,
+            };
+            if !is_ipc_socket(&file_type) {
+                continue;
+            }
+            if !assert_socket(&file_name) {
+                continue;
+            }
+            // The filename IS the legacy session name; keep it as the id so
+            // ipc_connect still finds it by joining ZELLIJ_SOCK_DIR with the id.
+            #[cfg(windows)]
+            let pid = fs::read_to_string(file.path())
+                .ok()
+                .and_then(|s| s.lines().next().and_then(|l| l.trim().parse::<u32>().ok()));
+            #[cfg(not(windows))]
+            let pid: Option<u32> = None;
+
+            registry.sessions.push(SessionEntry {
+                id: file_name.clone(),
+                display_name: file_name,
+                pid,
+                state: SessionState::Running,
+                created_at: file_created_epoch(&file.path()),
+                exited_at: None,
+            });
+        }
+    }
+
+    // Resurrectable legacy sessions from the (name-keyed) session-info cache.
+    if let Ok(dirs) = fs::read_dir(&*ZELLIJ_SESSION_INFO_CACHE_DIR) {
+        for dir in dirs.flatten() {
+            let path = dir.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let session_name = match path.file_name().and_then(|f| f.to_str()) {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+            if registry.find_by_name(&session_name).is_some() {
+                continue;
+            }
+            let layout_file = session_layout_cache_file_name(&session_name);
+            if !Path::new(&layout_file).exists() {
+                continue;
+            }
+            let created_at = file_created_epoch(&layout_file);
+            // Legacy resurrectable entry: id == name so the (name-keyed) cache
+            // folder is still found by id.
+            registry.sessions.push(SessionEntry {
+                id: session_name.clone(),
+                display_name: session_name,
+                pid: None,
+                state: SessionState::Exited,
+                created_at,
+                exited_at: created_at,
+            });
+        }
+    }
+
+    if let Err(e) = write_registry(&registry) {
+        log::error!("Failed to write migrated session registry: {:?}", e);
+    }
+    registry
+}
+
+/// Write the session registry to disk, holding an exclusive lock.
+pub fn write_registry(registry: &SessionRegistry) -> io::Result<()> {
+    ensure_sock_dir()?;
+    let _lock = FileLock::exclusive(&ZELLIJ_SESSIONS_LOCK)?;
+    fs::write(&*ZELLIJ_SESSIONS_KDL, registry.to_kdl())
+}
+
+/// Read the registry under an exclusive lock, apply a mutation, and write it
+/// back. Returns the closure's return value.
+///
+/// The closure MUST NOT call back into the registry (`with_registry`,
+/// `write_registry`, `ensure_registry`) — the lock is not reentrant.
+pub fn with_registry<F, R>(f: F) -> io::Result<R>
+where
+    F: FnOnce(&mut SessionRegistry) -> R,
+{
+    ensure_sock_dir()?;
+    let _lock = FileLock::exclusive(&ZELLIJ_SESSIONS_LOCK)?;
+    let mut registry = match fs::read_to_string(&*ZELLIJ_SESSIONS_KDL) {
+        Ok(raw) => SessionRegistry::from_kdl(&raw).unwrap_or_default(),
+        Err(_) => SessionRegistry::new(),
+    };
+    let result = f(&mut registry);
+    fs::write(&*ZELLIJ_SESSIONS_KDL, registry.to_kdl())?;
+    Ok(result)
+}
+
+/// Register a new session in the registry. Returns the generated id (UUID).
+pub fn register_session(display_name: &str) -> io::Result<String> {
+    let id = generate_session_id();
+    let entry = SessionEntry {
+        id: id.clone(),
+        display_name: display_name.to_string(),
+        pid: None,
+        state: SessionState::Running,
+        created_at: Some(now_secs()),
+        exited_at: None,
+    };
+    with_registry(|reg| reg.sessions.push(entry))?;
+    Ok(id)
+}
+
+/// Resolve a session display name to its socket path via the registry.
+pub fn resolve_session_socket_path(name: &str) -> Option<PathBuf> {
+    ensure_registry().resolve_socket_path(name)
+}
 
 pub fn get_sessions() -> Result<Vec<(String, Duration)>, io::ErrorKind> {
-    match fs::read_dir(&*ZELLIJ_SOCK_DIR) {
-        Ok(files) => {
-            let mut sessions = Vec::new();
-            files.for_each(|file| {
-                if let Ok(file) = file {
-                    let file_name = file.file_name().into_string().unwrap();
-                    // try to get creation time, fall back to modification time on platforms where it's not supported (e.g., musl)
-                    // for session creation time these are almost always identical (notable
-                    // exceptions are session name changes)
-                    let ctime = std::fs::metadata(&file.path())
-                        .ok()
-                        .and_then(|f| f.created().ok().or_else(|| f.modified().ok()))
-                        .and_then(|d| d.elapsed().ok())
-                        .unwrap_or_default();
-                    let duration = Duration::from_secs(ctime.as_secs());
-                    if is_ipc_socket(&file.file_type().unwrap()) && assert_socket(&file_name) {
-                        sessions.push((file_name, duration));
-                    }
-                }
-            });
-            Ok(sessions)
-        },
-        Err(err) if io::ErrorKind::NotFound != err.kind() => Err(err.kind()),
-        Err(_) => Ok(Vec::with_capacity(0)),
+    let registry = ensure_registry();
+    let mut sessions = Vec::new();
+    for entry in registry.running_sessions() {
+        // Probe liveness (and clean up stale sockets) via the id-named socket.
+        if !assert_socket(&entry.id) {
+            continue;
+        }
+        let sock_path = ZELLIJ_SOCK_DIR.join(&entry.id);
+        let ctime = std::fs::metadata(&sock_path)
+            .ok()
+            .and_then(|f| f.created().ok().or_else(|| f.modified().ok()))
+            .and_then(|d| d.elapsed().ok())
+            .unwrap_or_default();
+        sessions.push((
+            entry.display_name.clone(),
+            Duration::from_secs(ctime.as_secs()),
+        ));
     }
+    Ok(sessions)
 }
 
 pub fn get_resurrectable_sessions() -> Vec<(String, Duration)> {
@@ -119,25 +581,19 @@ pub fn get_resurrectable_session_names() -> Vec<String> {
 }
 
 pub fn get_sessions_sorted_by_mtime() -> anyhow::Result<Vec<String>> {
-    match fs::read_dir(&*ZELLIJ_SOCK_DIR) {
-        Ok(files) => {
-            let mut sessions_with_mtime: Vec<(String, SystemTime)> = Vec::new();
-            for file in files {
-                let file = file?;
-                let file_name = file.file_name().into_string().unwrap();
-                let file_modified_at = file.metadata()?.modified()?;
-                if is_ipc_socket(&file.file_type()?) && assert_socket(&file_name) {
-                    sessions_with_mtime.push((file_name, file_modified_at));
-                }
-            }
-            sessions_with_mtime.sort_by_key(|x| x.1); // the oldest one will be the first
-
-            let sessions = sessions_with_mtime.iter().map(|x| x.0.clone()).collect();
-            Ok(sessions)
-        },
-        Err(err) if io::ErrorKind::NotFound != err.kind() => Err(err.into()),
-        Err(_) => Ok(Vec::with_capacity(0)),
+    let registry = ensure_registry();
+    let mut sessions_with_mtime: Vec<(String, SystemTime)> = Vec::new();
+    for entry in registry.running_sessions() {
+        if !assert_socket(&entry.id) {
+            continue;
+        }
+        let sock_path = ZELLIJ_SOCK_DIR.join(&entry.id);
+        if let Ok(mtime) = std::fs::metadata(&sock_path).and_then(|m| m.modified()) {
+            sessions_with_mtime.push((entry.display_name.clone(), mtime));
+        }
     }
+    sessions_with_mtime.sort_by_key(|x| x.1); // the oldest one will be the first
+    Ok(sessions_with_mtime.into_iter().map(|x| x.0).collect())
 }
 
 /// Probe a session socket to check if a server is alive.
@@ -294,7 +750,8 @@ pub fn get_active_session() -> ActiveSession {
 
 pub fn kill_session(name: &str) {
     use crate::consts::ipc_connect;
-    let path = &*ZELLIJ_SOCK_DIR.join(name);
+    let resolved = resolve_session_socket_path(name).unwrap_or_else(|| ZELLIJ_SOCK_DIR.join(name));
+    let path = &*resolved;
     match ipc_connect(path) {
         Ok(stream) => {
             // On Windows, the server uses a dual-pipe architecture: the main pipe
@@ -331,7 +788,9 @@ pub fn kill_session(name: &str) {
 pub fn delete_session(name: &str, force: bool) {
     if force {
         use crate::consts::ipc_connect;
-        let path = &*ZELLIJ_SOCK_DIR.join(name);
+        let resolved =
+            resolve_session_socket_path(name).unwrap_or_else(|| ZELLIJ_SOCK_DIR.join(name));
+        let path = &*resolved;
         let _ = ipc_connect(path).ok().map(|stream| {
             #[cfg(windows)]
             {
@@ -573,30 +1032,39 @@ pub fn read_live_session_states(
     sock_dir: &Path,
     session_info_cache_dir: &Path,
 ) -> BTreeMap<String, SessionInfo> {
-    let mut other_session_names: Vec<(String, Duration)> = vec![];
     let mut session_infos_on_machine = BTreeMap::new();
-    if let Ok(files) = fs::read_dir(sock_dir) {
-        files.for_each(|file| {
-            if let Ok(file) = file {
-                if let Ok(file_name) = file.file_name().into_string() {
-                    if file
-                        .file_type()
-                        .map(|file_type| is_ipc_socket(&file_type))
-                        .unwrap_or(false)
-                    {
-                        let creation_time = std::fs::metadata(&file.path())
-                            .ok()
-                            .and_then(|f| f.created().ok().or_else(|| f.modified().ok()))
-                            .and_then(|d| d.elapsed().ok())
-                            .unwrap_or_default();
-                        other_session_names.push((file_name, creation_time));
-                    }
-                }
-            }
-        });
-    }
-
-    for (session_name, creation_time) in other_session_names {
+    // The registry maps id-named sockets to their user-visible display names.
+    // For legacy or test sockets named directly after the session, the lookup
+    // misses and we fall back to the filename.
+    let registry = ensure_registry();
+    let files = match fs::read_dir(sock_dir) {
+        Ok(files) => files,
+        Err(_) => return session_infos_on_machine,
+    };
+    for file in files.flatten() {
+        let file_name = match file.file_name().into_string() {
+            Ok(n) => n,
+            Err(_) => continue,
+        };
+        if is_registry_file(&file_name) {
+            continue;
+        }
+        let is_socket = file
+            .file_type()
+            .map(|file_type| is_ipc_socket(&file_type))
+            .unwrap_or(false);
+        if !is_socket {
+            continue;
+        }
+        let session_name = registry
+            .find_by_id(&file_name)
+            .map(|e| e.display_name.clone())
+            .unwrap_or(file_name);
+        let creation_time = std::fs::metadata(file.path())
+            .ok()
+            .and_then(|f| f.created().ok().or_else(|| f.modified().ok()))
+            .and_then(|d| d.elapsed().ok())
+            .unwrap_or_default();
         let session_cache_file_name = session_info_cache_dir
             .join(&session_name)
             .join("session-metadata.kdl");
@@ -802,3 +1270,160 @@ const NOUNS: &[&'static str] = &[
     "yak",
     "zebra",
 ];
+
+#[cfg(test)]
+mod registry_tests {
+    use super::*;
+
+    const UUID_1: &str = "a3f7b9c1-e29b-41d4-a716-446655440001";
+    const UUID_2: &str = "550e8400-e29b-41d4-a716-446655440002";
+    const UUID_3: &str = "6ba7b810-9dad-41d4-80b4-00c04fd430c3";
+
+    fn running(id: &str, name: &str, pid: u32) -> SessionEntry {
+        SessionEntry {
+            id: id.to_string(),
+            display_name: name.to_string(),
+            pid: Some(pid),
+            state: SessionState::Running,
+            created_at: Some(1_700_000_000),
+            exited_at: None,
+        }
+    }
+
+    fn exited(id: &str, name: &str) -> SessionEntry {
+        SessionEntry {
+            id: id.to_string(),
+            display_name: name.to_string(),
+            pid: None,
+            state: SessionState::Exited,
+            created_at: Some(1_700_000_000),
+            exited_at: Some(1_700_000_500),
+        }
+    }
+
+    #[test]
+    fn kdl_roundtrip() {
+        let registry = SessionRegistry {
+            sessions: vec![
+                running(UUID_1, "my-session", 12345),
+                exited(UUID_2, "old-session"),
+            ],
+        };
+        let parsed = SessionRegistry::from_kdl(&registry.to_kdl()).unwrap();
+        assert_eq!(parsed.sessions.len(), 2);
+
+        let r = parsed.find_by_id(UUID_1).unwrap();
+        assert_eq!(r.display_name, "my-session");
+        assert_eq!(r.pid, Some(12345));
+        assert_eq!(r.state, SessionState::Running);
+        assert_eq!(r.created_at, Some(1_700_000_000));
+        assert!(r.exited_at.is_none());
+
+        let e = parsed.find_by_id(UUID_2).unwrap();
+        assert_eq!(e.state, SessionState::Exited);
+        assert!(e.pid.is_none());
+        assert_eq!(e.exited_at, Some(1_700_000_500));
+    }
+
+    #[test]
+    fn kdl_omits_pid_for_exited() {
+        let registry = SessionRegistry {
+            sessions: vec![exited(UUID_1, "dead")],
+        };
+        let kdl = registry.to_kdl();
+        assert!(
+            !kdl.contains("pid"),
+            "exited session should have no pid node: {}",
+            kdl
+        );
+        assert!(SessionRegistry::from_kdl(&kdl).unwrap().sessions[0]
+            .pid
+            .is_none());
+    }
+
+    #[test]
+    fn find_running_by_name_prefers_running() {
+        let registry = SessionRegistry {
+            sessions: vec![
+                exited(UUID_1, "foo"),
+                running(UUID_2, "foo", 100),
+                running(UUID_3, "bar", 200),
+            ],
+        };
+        let found = registry.find_running_by_name("foo").unwrap();
+        assert_eq!(found.id, UUID_2);
+        assert_eq!(found.state, SessionState::Running);
+        assert!(registry.find_running_by_name("missing").is_none());
+    }
+
+    #[test]
+    fn resolve_socket_path_uses_id() {
+        let registry = SessionRegistry {
+            sessions: vec![running(UUID_1, "my-session", 100)],
+        };
+        let path = registry.resolve_socket_path("my-session").unwrap();
+        assert!(path.ends_with(UUID_1));
+        assert!(registry.resolve_socket_path("nope").is_none());
+    }
+
+    #[test]
+    fn remove_by_id() {
+        let mut registry = SessionRegistry {
+            sessions: vec![
+                running(UUID_1, "a", 1),
+                running(UUID_2, "b", 2),
+                running(UUID_3, "c", 3),
+            ],
+        };
+        registry.remove_by_id(UUID_2);
+        assert_eq!(registry.sessions.len(), 2);
+        assert!(registry.find_by_id(UUID_2).is_none());
+        assert!(registry.find_by_id(UUID_1).is_some());
+    }
+
+    #[test]
+    fn running_sessions_filters_state() {
+        let registry = SessionRegistry {
+            sessions: vec![
+                running(UUID_1, "a", 1),
+                exited(UUID_2, "b"),
+                running(UUID_3, "c", 3),
+            ],
+        };
+        let names: Vec<_> = registry
+            .running_sessions()
+            .map(|e| e.display_name.clone())
+            .collect();
+        assert_eq!(names, vec!["a", "c"]);
+    }
+
+    #[test]
+    fn generated_id_is_uuid_shaped() {
+        let id = generate_session_id();
+        assert_eq!(id.len(), 36);
+        assert_eq!(id.as_bytes()[8], b'-');
+        assert_eq!(id.as_bytes()[13], b'-');
+        assert_eq!(id.as_bytes()[18], b'-');
+        assert_eq!(id.as_bytes()[23], b'-');
+    }
+
+    #[test]
+    fn session_state_str_roundtrip() {
+        assert_eq!(
+            SessionState::from_str(SessionState::Running.as_str()),
+            Some(SessionState::Running)
+        );
+        assert_eq!(
+            SessionState::from_str(SessionState::Exited.as_str()),
+            Some(SessionState::Exited)
+        );
+        assert_eq!(SessionState::from_str("bogus"), None);
+    }
+
+    #[test]
+    fn unknown_state_defaults_to_running() {
+        let kdl = "session \"id-x\" {\n    display_name \"x\"\n    state \"weird\"\n}";
+        let parsed = SessionRegistry::from_kdl(kdl).unwrap();
+        assert_eq!(parsed.sessions[0].state, SessionState::Running);
+    }
+}

--- a/zellij-utils/src/sessions.rs
+++ b/zellij-utils/src/sessions.rs
@@ -91,7 +91,52 @@ pub fn generate_session_id() -> String {
 }
 
 fn is_registry_file(file_name: &str) -> bool {
-    file_name == "sessions.kdl" || file_name == "sessions.kdl.lock"
+    // Covers sessions.kdl, sessions.kdl.lock, sessions.kdl.bak, and the
+    // sessions.kdl.tmp.<pid> scratch files written by atomic_write. On Windows
+    // these are regular files that would otherwise look like socket markers.
+    file_name.starts_with("sessions.kdl")
+}
+
+/// The `<path>.bak` sibling used to keep the last good registry.
+fn backup_path(path: &Path) -> PathBuf {
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(".bak");
+    path.with_file_name(name)
+}
+
+/// Atomically replace `path` with `contents`: write a sibling temp file, flush
+/// it, back up the current file to `<path>.bak`, then rename over the target
+/// (atomic on the same filesystem). A crash mid-write leaves the old file (or
+/// its backup) intact rather than a truncated one.
+fn atomic_write(path: &Path, contents: &str) -> io::Result<()> {
+    use std::io::Write;
+    let mut tmp_name = path.file_name().unwrap_or_default().to_os_string();
+    tmp_name.push(format!(".tmp.{}", process::id()));
+    let tmp = path.with_file_name(tmp_name);
+    {
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(contents.as_bytes())?;
+        f.flush()?;
+        let _ = f.sync_all();
+    }
+    if path.exists() {
+        // Best-effort backup of the last good file before we replace it.
+        let _ = fs::copy(path, backup_path(path));
+    }
+    fs::rename(&tmp, path)
+}
+
+/// Load a registry for a read-modify-write. Unlike the read-only path, a
+/// corrupt (non-empty, unparseable) *existing* file is an error here: we must
+/// not overwrite real session data with an empty registry.
+fn load_registry_for_write(read: io::Result<String>) -> io::Result<SessionRegistry> {
+    match read {
+        Ok(raw) if raw.trim().is_empty() => Ok(SessionRegistry::new()),
+        Ok(raw) => SessionRegistry::from_kdl(&raw)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e)),
+        Err(ref e) if e.kind() == io::ErrorKind::NotFound => Ok(SessionRegistry::new()),
+        Err(e) => Err(e),
+    }
 }
 
 /// The full session registry.
@@ -329,15 +374,26 @@ pub fn registry_exists() -> bool {
     ZELLIJ_SESSIONS_KDL.exists()
 }
 
-/// Read the registry from disk, returning an empty one if it's missing/corrupt.
+/// Read the registry from disk, returning an empty one if it's missing. A
+/// corrupt file falls back to the `.bak` backup before giving up empty.
 pub fn read_registry() -> SessionRegistry {
     match fs::read_to_string(&*ZELLIJ_SESSIONS_KDL) {
         Ok(raw) => SessionRegistry::from_kdl(&raw).unwrap_or_else(|e| {
-            log::error!("{}", e);
-            SessionRegistry::new()
+            log::error!(
+                "Corrupt {}: {}; falling back to backup",
+                ZELLIJ_SESSIONS_KDL.display(),
+                e
+            );
+            read_registry_backup().unwrap_or_default()
         }),
         Err(_) => SessionRegistry::new(),
     }
+}
+
+/// Try to read the last good registry from the `.bak` backup file.
+fn read_registry_backup() -> Option<SessionRegistry> {
+    let raw = fs::read_to_string(backup_path(&ZELLIJ_SESSIONS_KDL)).ok()?;
+    SessionRegistry::from_kdl(&raw).ok()
 }
 
 /// Ensure the registry exists, migrating from the legacy socket-named layout on
@@ -437,15 +493,19 @@ pub fn migrate_legacy_sessions() -> SessionRegistry {
     registry
 }
 
-/// Write the session registry to disk, holding an exclusive lock.
+/// Write the session registry to disk atomically, holding an exclusive lock.
 pub fn write_registry(registry: &SessionRegistry) -> io::Result<()> {
     ensure_sock_dir()?;
     let _lock = FileLock::exclusive(&ZELLIJ_SESSIONS_LOCK)?;
-    fs::write(&*ZELLIJ_SESSIONS_KDL, registry.to_kdl())
+    atomic_write(&ZELLIJ_SESSIONS_KDL, &registry.to_kdl())
 }
 
 /// Read the registry under an exclusive lock, apply a mutation, and write it
-/// back. Returns the closure's return value.
+/// back atomically. Returns the closure's return value.
+///
+/// If the existing file is present but corrupt, the mutation is aborted (an
+/// error is returned) rather than overwriting real session data with an empty
+/// registry.
 ///
 /// The closure MUST NOT call back into the registry (`with_registry`,
 /// `write_registry`, `ensure_registry`) — the lock is not reentrant.
@@ -455,28 +515,48 @@ where
 {
     ensure_sock_dir()?;
     let _lock = FileLock::exclusive(&ZELLIJ_SESSIONS_LOCK)?;
-    let mut registry = match fs::read_to_string(&*ZELLIJ_SESSIONS_KDL) {
-        Ok(raw) => SessionRegistry::from_kdl(&raw).unwrap_or_default(),
-        Err(_) => SessionRegistry::new(),
-    };
+    let mut registry = load_registry_for_write(fs::read_to_string(&*ZELLIJ_SESSIONS_KDL))
+        .map_err(|e| {
+            log::error!(
+                "Refusing to modify corrupt {}: {}",
+                ZELLIJ_SESSIONS_KDL.display(),
+                e
+            );
+            e
+        })?;
     let result = f(&mut registry);
-    fs::write(&*ZELLIJ_SESSIONS_KDL, registry.to_kdl())?;
+    atomic_write(&ZELLIJ_SESSIONS_KDL, &registry.to_kdl())?;
     Ok(result)
 }
 
 /// Register a new session in the registry. Returns the generated id (UUID).
 pub fn register_session(display_name: &str) -> io::Result<String> {
-    let id = generate_session_id();
-    let entry = SessionEntry {
-        id: id.clone(),
-        display_name: display_name.to_string(),
-        pid: None,
-        state: SessionState::Running,
-        created_at: Some(now_secs()),
-        exited_at: None,
-    };
-    with_registry(|reg| reg.sessions.push(entry))?;
-    Ok(id)
+    with_registry(|reg| {
+        // Resurrecting a dead session reuses its id (and therefore its id-keyed
+        // cache folder / layout), rather than orphaning the old folder under a
+        // fresh id.
+        if let Some(existing) = reg
+            .sessions
+            .iter_mut()
+            .find(|s| s.display_name == display_name && s.state == SessionState::Exited)
+        {
+            existing.state = SessionState::Running;
+            existing.pid = None;
+            existing.exited_at = None;
+            existing.created_at = Some(now_secs());
+            return existing.id.clone();
+        }
+        let id = generate_session_id();
+        reg.sessions.push(SessionEntry {
+            id: id.clone(),
+            display_name: display_name.to_string(),
+            pid: None,
+            state: SessionState::Running,
+            created_at: Some(now_secs()),
+            exited_at: None,
+        });
+        id
+    })
 }
 
 /// Resolve a session display name to its socket path via the registry.
@@ -484,14 +564,129 @@ pub fn resolve_session_socket_path(name: &str) -> Option<PathBuf> {
     ensure_registry().resolve_socket_path(name)
 }
 
-pub fn get_sessions() -> Result<Vec<(String, Duration)>, io::ErrorKind> {
+/// Resolve a session display name to its id via the registry (running first,
+/// then any state). Returns None if the name isn't in the registry — callers
+/// fall back to treating the name itself as the id (legacy sessions).
+pub fn resolve_session_id(name: &str) -> Option<String> {
     let registry = ensure_registry();
+    registry
+        .find_running_by_name(name)
+        .or_else(|| registry.find_by_name(name))
+        .map(|e| e.id.clone())
+}
+
+/// The display name for an id, or the id itself if it isn't in the registry
+/// (legacy / orphaned cache folders whose id is the old session name).
+fn display_name_for_id(registry: &SessionRegistry, id: &str) -> String {
+    registry
+        .find_by_id(id)
+        .map(|e| e.display_name.clone())
+        .unwrap_or_else(|| id.to_string())
+}
+
+/// Scan the session-info cache for folders that hold a resurrectable layout,
+/// returning (folder_id, age). The cache is keyed by session id.
+fn resurrectable_folder_entries() -> Vec<(String, Duration)> {
+    let Ok(dirs) = fs::read_dir(&*ZELLIJ_SESSION_INFO_CACHE_DIR) else {
+        return vec![];
+    };
+    dirs.filter_map(|f| f.ok().map(|f| f.path()))
+        .filter(|p| p.is_dir())
+        .filter_map(|folder| {
+            let id = folder.file_name()?.to_str()?.to_owned();
+            let layout_file = folder.join("session-layout.kdl");
+            if !layout_file.exists() {
+                return None;
+            }
+            // Try creation time, fall back to modification time (e.g. musl).
+            let elapsed = std::fs::metadata(&layout_file)
+                .ok()
+                .and_then(|m| m.created().ok().or_else(|| m.modified().ok()))
+                .and_then(|t| t.elapsed().ok())
+                .map(|d| Duration::from_secs(d.as_secs()))
+                .unwrap_or_default();
+            Some((id, elapsed))
+        })
+        .collect()
+}
+
+/// What to do with a registry entry during reconciliation, given the current
+/// filesystem reality.
+#[derive(Debug, PartialEq, Eq)]
+enum ReconcileAction {
+    /// Keep the entry unchanged.
+    Keep,
+    /// The server is gone but a resurrection layout exists — mark it exited.
+    MarkExited,
+    /// The server is gone and nothing is resurrectable — drop the entry.
+    Drop,
+}
+
+fn reconcile_decision(
+    state: SessionState,
+    socket_alive: bool,
+    layout_exists: bool,
+) -> ReconcileAction {
+    match state {
+        SessionState::Running if socket_alive => ReconcileAction::Keep,
+        SessionState::Running if layout_exists => ReconcileAction::MarkExited,
+        SessionState::Running => ReconcileAction::Drop,
+        SessionState::Exited if layout_exists => ReconcileAction::Keep,
+        SessionState::Exited => ReconcileAction::Drop,
+    }
+}
+
+/// Reconcile the registry with the filesystem, bounding its growth: running
+/// entries whose socket is gone become exited (if a resurrection layout exists)
+/// or are dropped; exited entries whose layout is gone are dropped. Probing also
+/// cleans up stale socket files (via `assert_socket`). The file is only
+/// rewritten when something actually changed. Returns the reconciled registry.
+pub fn reconcile_registry() -> SessionRegistry {
+    // Make sure legacy sessions are migrated in before reconciling.
+    ensure_registry();
+    if let Err(e) = reconcile_locked() {
+        log::error!("Failed to reconcile session registry: {:?}", e);
+    }
+    read_registry()
+}
+
+fn reconcile_locked() -> io::Result<()> {
+    ensure_sock_dir()?;
+    let _lock = FileLock::exclusive(&ZELLIJ_SESSIONS_LOCK)?;
+    let mut registry = load_registry_for_write(fs::read_to_string(&*ZELLIJ_SESSIONS_KDL))?;
+    let mut changed = false;
+    registry.sessions.retain_mut(|e| {
+        let socket_alive = e.state == SessionState::Running && assert_socket(&e.id);
+        let layout_exists = session_layout_cache_file_name(&e.id).exists();
+        match reconcile_decision(e.state, socket_alive, layout_exists) {
+            ReconcileAction::Keep => true,
+            ReconcileAction::MarkExited => {
+                e.state = SessionState::Exited;
+                e.pid = None;
+                if e.exited_at.is_none() {
+                    e.exited_at = Some(now_secs());
+                }
+                changed = true;
+                true
+            },
+            ReconcileAction::Drop => {
+                changed = true;
+                false
+            },
+        }
+    });
+    if changed {
+        atomic_write(&ZELLIJ_SESSIONS_KDL, &registry.to_kdl())?;
+    }
+    Ok(())
+}
+
+pub fn get_sessions() -> Result<Vec<(String, Duration)>, io::ErrorKind> {
+    // Reconcile first: prunes dead entries and probes liveness, so the remaining
+    // running entries are known to be alive.
+    let registry = reconcile_registry();
     let mut sessions = Vec::new();
     for entry in registry.running_sessions() {
-        // Probe liveness (and clean up stale sockets) via the id-named socket.
-        if !assert_socket(&entry.id) {
-            continue;
-        }
         let sock_path = ZELLIJ_SOCK_DIR.join(&entry.id);
         let ctime = std::fs::metadata(&sock_path)
             .ok()
@@ -507,86 +702,25 @@ pub fn get_sessions() -> Result<Vec<(String, Duration)>, io::ErrorKind> {
 }
 
 pub fn get_resurrectable_sessions() -> Vec<(String, Duration)> {
-    match fs::read_dir(&*ZELLIJ_SESSION_INFO_CACHE_DIR) {
-        Ok(files_in_session_info_folder) => {
-            let files_that_are_folders = files_in_session_info_folder
-                .filter_map(|f| f.ok().map(|f| f.path()))
-                .filter(|f| f.is_dir());
-            files_that_are_folders
-                .filter_map(|folder_name| {
-                    let layout_file_name =
-                        session_layout_cache_file_name(&folder_name.display().to_string());
-                    // Try to get creation time, fall back to modification time on platforms where it's not supported (e.g., musl)
-                    let ctime = std::fs::metadata(&layout_file_name)
-                        .ok()
-                        .and_then(|metadata| {
-                            metadata.created().ok().or_else(|| metadata.modified().ok())
-                        });
-                    let elapsed_duration = ctime
-                        .map(|ctime| {
-                            Duration::from_secs(ctime.elapsed().ok().unwrap_or_default().as_secs())
-                        })
-                        .unwrap_or_default();
-                    let session_name = folder_name
-                        .file_name()
-                        .map(|f| std::path::PathBuf::from(f).display().to_string())?;
-                    if std::path::Path::new(&layout_file_name).exists() {
-                        Some((session_name, elapsed_duration))
-                    } else {
-                        None
-                    }
-                })
-                .collect()
-        },
-        Err(e) => {
-            log::error!(
-                "Failed to read session_info cache folder: \"{:?}\": {:?}",
-                &*ZELLIJ_SESSION_INFO_CACHE_DIR,
-                e
-            );
-            vec![]
-        },
-    }
+    let registry = ensure_registry();
+    resurrectable_folder_entries()
+        .into_iter()
+        .map(|(id, elapsed)| (display_name_for_id(&registry, &id), elapsed))
+        .collect()
 }
 
 pub fn get_resurrectable_session_names() -> Vec<String> {
-    match fs::read_dir(&*ZELLIJ_SESSION_INFO_CACHE_DIR) {
-        Ok(files_in_session_info_folder) => {
-            let files_that_are_folders = files_in_session_info_folder
-                .filter_map(|f| f.ok().map(|f| f.path()))
-                .filter(|f| f.is_dir());
-            files_that_are_folders
-                .filter_map(|folder_name| {
-                    let folder = folder_name.display().to_string();
-                    let resurrection_layout_file = session_layout_cache_file_name(&folder);
-                    if std::path::Path::new(&resurrection_layout_file).exists() {
-                        folder_name
-                            .file_name()
-                            .map(|f| format!("{}", f.to_string_lossy()))
-                    } else {
-                        None
-                    }
-                })
-                .collect()
-        },
-        Err(e) => {
-            log::error!(
-                "Failed to read session_info cache folder: \"{:?}\": {:?}",
-                &*ZELLIJ_SESSION_INFO_CACHE_DIR,
-                e
-            );
-            vec![]
-        },
-    }
+    let registry = ensure_registry();
+    resurrectable_folder_entries()
+        .into_iter()
+        .map(|(id, _)| display_name_for_id(&registry, &id))
+        .collect()
 }
 
 pub fn get_sessions_sorted_by_mtime() -> anyhow::Result<Vec<String>> {
-    let registry = ensure_registry();
+    let registry = reconcile_registry();
     let mut sessions_with_mtime: Vec<(String, SystemTime)> = Vec::new();
     for entry in registry.running_sessions() {
-        if !assert_socket(&entry.id) {
-            continue;
-        }
         let sock_path = ZELLIJ_SOCK_DIR.join(&entry.id);
         if let Ok(mtime) = std::fs::metadata(&sock_path).and_then(|m| m.modified()) {
             sessions_with_mtime.push((entry.display_name.clone(), mtime));
@@ -811,7 +945,12 @@ pub fn delete_session(name: &str, force: bool) {
             }
         });
     }
-    if let Err(e) = std::fs::remove_dir_all(session_info_folder_for_session(name)) {
+    // The cache folder is keyed by session id; resolve the name (fall back to
+    // treating the name as the id for legacy sessions).
+    let id = resolve_session_id(name).unwrap_or_else(|| name.to_string());
+    // Drop the registry entry (running or exited) so the id is not left dangling.
+    let _ = with_registry(|reg| reg.sessions.retain(|s| s.id != id && s.display_name != name));
+    if let Err(e) = std::fs::remove_dir_all(session_info_folder_for_session(&id)) {
         if e.kind() == std::io::ErrorKind::NotFound {
             eprintln!("Session: {:?} not found.", name);
             process::exit(2);
@@ -901,7 +1040,11 @@ pub fn session_exists(name: &str) -> Result<bool, io::ErrorKind> {
 
 // if the session is resurrecable, the returned layout is the one to be used to resurrect it
 pub fn resurrection_layout(session_name_to_resurrect: &str) -> Result<Option<Layout>, String> {
-    let layout_file_name = session_layout_cache_file_name(&session_name_to_resurrect);
+    // The layout cache is keyed by session id; resolve the name (fall back to
+    // treating the name as the id for legacy sessions).
+    let id = resolve_session_id(session_name_to_resurrect)
+        .unwrap_or_else(|| session_name_to_resurrect.to_string());
+    let layout_file_name = session_layout_cache_file_name(&id);
     let raw_layout = match std::fs::read_to_string(&layout_file_name) {
         Ok(raw_layout) => raw_layout,
         Err(_e) => {
@@ -1059,14 +1202,15 @@ pub fn read_live_session_states(
         let session_name = registry
             .find_by_id(&file_name)
             .map(|e| e.display_name.clone())
-            .unwrap_or(file_name);
+            .unwrap_or_else(|| file_name.clone());
         let creation_time = std::fs::metadata(file.path())
             .ok()
             .and_then(|f| f.created().ok().or_else(|| f.modified().ok()))
             .and_then(|d| d.elapsed().ok())
             .unwrap_or_default();
+        // The session-info cache is keyed by session id (the socket file name).
         let session_cache_file_name = session_info_cache_dir
-            .join(&session_name)
+            .join(&file_name)
             .join("session-metadata.kdl");
         if let Ok(raw_session_info) = fs::read_to_string(&session_cache_file_name) {
             if let Ok(mut session_info) =
@@ -1425,5 +1569,66 @@ mod registry_tests {
         let kdl = "session \"id-x\" {\n    display_name \"x\"\n    state \"weird\"\n}";
         let parsed = SessionRegistry::from_kdl(kdl).unwrap();
         assert_eq!(parsed.sessions[0].state, SessionState::Running);
+    }
+
+    #[test]
+    fn atomic_write_replaces_and_backs_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sessions.kdl");
+
+        atomic_write(&path, "first").unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "first");
+        assert!(!backup_path(&path).exists(), "no backup on first write");
+
+        atomic_write(&path, "second").unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "second");
+        assert_eq!(fs::read_to_string(backup_path(&path)).unwrap(), "first");
+
+        let leftovers: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp."))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind: {:?}", leftovers);
+    }
+
+    #[test]
+    fn load_for_write_rejects_corrupt_but_accepts_empty_and_missing() {
+        // Corrupt, non-empty → error, so we never overwrite real data with empty.
+        let err = load_registry_for_write(Ok("node {".to_string())).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+
+        // Empty / whitespace-only → fresh empty registry.
+        assert!(load_registry_for_write(Ok("   \n".to_string()))
+            .unwrap()
+            .sessions
+            .is_empty());
+
+        // Missing file → fresh empty registry.
+        let notfound = io::Error::new(io::ErrorKind::NotFound, "nope");
+        assert!(load_registry_for_write(Err(notfound))
+            .unwrap()
+            .sessions
+            .is_empty());
+
+        // Any other IO error → propagated (don't silently start empty).
+        let denied = io::Error::new(io::ErrorKind::PermissionDenied, "denied");
+        assert!(load_registry_for_write(Err(denied)).is_err());
+    }
+
+    #[test]
+    fn reconcile_decisions() {
+        use ReconcileAction::*;
+        use SessionState::*;
+        // Running + live socket → keep, regardless of layout.
+        assert_eq!(reconcile_decision(Running, true, false), Keep);
+        assert_eq!(reconcile_decision(Running, true, true), Keep);
+        // Running + dead socket → exit if resurrectable, else drop.
+        assert_eq!(reconcile_decision(Running, false, true), MarkExited);
+        assert_eq!(reconcile_decision(Running, false, false), Drop);
+        // Exited → keep only while the resurrection layout exists.
+        assert_eq!(reconcile_decision(Exited, false, true), Keep);
+        assert_eq!(reconcile_decision(Exited, false, false), Drop);
     }
 }

--- a/zellij-utils/src/sessions.rs
+++ b/zellij-utils/src/sessions.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 // Session registry (`sessions.kdl`)
 //
 // Decouples the user-visible session name from the socket / named-pipe
-// filename. The socket/pipe is named by a stable `id` (a UUID for new sessions,
+// filename. The socket/pipe is named by a stable `id` (a short random id for new sessions,
 // or the legacy session name for pre-registry sessions); `sessions.kdl` maps
 // `id -> display_name`. This is what lets a session be renamed without renaming
 // its socket/pipe — impossible for Windows named pipes (see PR #5103).
@@ -31,8 +31,8 @@ use uuid::Uuid;
 /// A single session entry in the registry.
 #[derive(Debug, Clone)]
 pub struct SessionEntry {
-    /// Stable identifier, also the socket/marker filename (a UUID for new
-    /// sessions, or the legacy session name for pre-registry sessions).
+    /// Stable identifier, also the socket/marker filename (a short random id for
+    /// new sessions, or the legacy session name for pre-registry sessions).
     pub id: String,
     /// User-visible session name.
     pub display_name: String,
@@ -85,9 +85,18 @@ fn file_created_epoch(path: &Path) -> Option<u64> {
         .map(|d| d.as_secs())
 }
 
-/// Generate a new session identifier (UUID v4, hyphenated).
+/// Generate a new session identifier: a short random hex string (48 bits of a
+/// UUID v4). Kept short — SESSION_ID_LENGTH bytes — so the socket/pipe path stays
+/// within the platform limit (104 bytes on macOS) even under a long temp dir; a
+/// full 36-char UUID would overflow it. `register_session` guards against the
+/// (astronomically unlikely) collision.
 pub fn generate_session_id() -> String {
-    Uuid::new_v4().as_hyphenated().to_string()
+    let bytes = Uuid::new_v4().into_bytes();
+    let mut id = String::with_capacity(crate::consts::SESSION_ID_LENGTH);
+    for byte in &bytes[..crate::consts::SESSION_ID_LENGTH / 2] {
+        id.push_str(&format!("{:02x}", byte));
+    }
+    id
 }
 
 fn is_registry_file(file_name: &str) -> bool {
@@ -297,7 +306,11 @@ mod file_lock {
 
     impl FileLock {
         pub fn exclusive(path: &Path) -> std::io::Result<Self> {
-            let file = OpenOptions::new().create(true).write(true).truncate(false).open(path)?;
+            let file = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(false)
+                .open(path)?;
             let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
             if ret != 0 {
                 return Err(std::io::Error::last_os_error());
@@ -321,13 +334,18 @@ mod file_lock {
 
     impl FileLock {
         pub fn exclusive(path: &Path) -> std::io::Result<Self> {
-            let file = OpenOptions::new().create(true).write(true).truncate(false).open(path)?;
+            let file = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(false)
+                .open(path)?;
             let handle = file.as_raw_handle();
             unsafe {
                 use windows_sys::Win32::Foundation::HANDLE;
-                use windows_sys::Win32::Storage::FileSystem::{LockFileEx, LOCKFILE_EXCLUSIVE_LOCK};
-                let mut overlapped: windows_sys::Win32::System::IO::OVERLAPPED =
-                    std::mem::zeroed();
+                use windows_sys::Win32::Storage::FileSystem::{
+                    LockFileEx, LOCKFILE_EXCLUSIVE_LOCK,
+                };
+                let mut overlapped: windows_sys::Win32::System::IO::OVERLAPPED = std::mem::zeroed();
                 let ret = LockFileEx(
                     handle as HANDLE,
                     LOCKFILE_EXCLUSIVE_LOCK,
@@ -356,7 +374,11 @@ mod file_lock {
 
     impl FileLock {
         pub fn exclusive(path: &Path) -> std::io::Result<Self> {
-            let file = OpenOptions::new().create(true).write(true).truncate(false).open(path)?;
+            let file = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(false)
+                .open(path)?;
             Ok(FileLock { _file: file })
         }
     }
@@ -515,8 +537,8 @@ where
 {
     ensure_sock_dir()?;
     let _lock = FileLock::exclusive(&ZELLIJ_SESSIONS_LOCK)?;
-    let mut registry = load_registry_for_write(fs::read_to_string(&*ZELLIJ_SESSIONS_KDL))
-        .map_err(|e| {
+    let mut registry =
+        load_registry_for_write(fs::read_to_string(&*ZELLIJ_SESSIONS_KDL)).map_err(|e| {
             log::error!(
                 "Refusing to modify corrupt {}: {}",
                 ZELLIJ_SESSIONS_KDL.display(),
@@ -529,7 +551,7 @@ where
     Ok(result)
 }
 
-/// Register a new session in the registry. Returns the generated id (UUID).
+/// Register a new session in the registry. Returns the generated id.
 pub fn register_session(display_name: &str) -> io::Result<String> {
     with_registry(|reg| {
         // Resurrecting a dead session reuses its id (and therefore its id-keyed
@@ -546,7 +568,14 @@ pub fn register_session(display_name: &str) -> io::Result<String> {
             existing.created_at = Some(now_secs());
             return existing.id.clone();
         }
-        let id = generate_session_id();
+        // Generate a fresh id, guarding against the unlikely collision with an
+        // existing entry (the id space is short — see generate_session_id).
+        let id = loop {
+            let candidate = generate_session_id();
+            if !reg.sessions.iter().any(|s| s.id == candidate) {
+                break candidate;
+            }
+        };
         reg.sessions.push(SessionEntry {
             id: id.clone(),
             display_name: display_name.to_string(),
@@ -949,7 +978,10 @@ pub fn delete_session(name: &str, force: bool) {
     // treating the name as the id for legacy sessions).
     let id = resolve_session_id(name).unwrap_or_else(|| name.to_string());
     // Drop the registry entry (running or exited) so the id is not left dangling.
-    let _ = with_registry(|reg| reg.sessions.retain(|s| s.id != id && s.display_name != name));
+    let _ = with_registry(|reg| {
+        reg.sessions
+            .retain(|s| s.id != id && s.display_name != name)
+    });
     if let Err(e) = std::fs::remove_dir_all(session_info_folder_for_session(&id)) {
         if e.kind() == std::io::ErrorKind::NotFound {
             eprintln!("Session: {:?} not found.", name);
@@ -1542,13 +1574,16 @@ mod registry_tests {
     }
 
     #[test]
-    fn generated_id_is_uuid_shaped() {
+    fn generated_id_is_short_hex() {
         let id = generate_session_id();
-        assert_eq!(id.len(), 36);
-        assert_eq!(id.as_bytes()[8], b'-');
-        assert_eq!(id.as_bytes()[13], b'-');
-        assert_eq!(id.as_bytes()[18], b'-');
-        assert_eq!(id.as_bytes()[23], b'-');
+        assert_eq!(id.len(), crate::consts::SESSION_ID_LENGTH);
+        assert!(
+            id.bytes().all(|b| b.is_ascii_hexdigit()),
+            "id should be hex: {}",
+            id
+        );
+        // Two calls should differ (random).
+        assert_ne!(id, generate_session_id());
     }
 
     #[test]
@@ -1590,7 +1625,11 @@ mod registry_tests {
             .map(|e| e.file_name().to_string_lossy().into_owned())
             .filter(|n| n.contains(".tmp."))
             .collect();
-        assert!(leftovers.is_empty(), "temp files left behind: {:?}", leftovers);
+        assert!(
+            leftovers.is_empty(),
+            "temp files left behind: {:?}",
+            leftovers
+        );
     }
 
     #[test]

--- a/zellij-utils/src/sessions.rs
+++ b/zellij-utils/src/sessions.rs
@@ -59,7 +59,7 @@ impl SessionState {
             SessionState::Exited => "exited",
         }
     }
-    pub fn from_str(s: &str) -> Option<Self> {
+    pub fn parse(s: &str) -> Option<Self> {
         match s {
             "running" => Some(SessionState::Running),
             "exited" => Some(SessionState::Exited),
@@ -193,7 +193,7 @@ impl SessionRegistry {
             let pid = child_i64("pid").map(|v| v as u32);
             let state = child_string("state")
                 .as_deref()
-                .and_then(SessionState::from_str)
+                .and_then(SessionState::parse)
                 .unwrap_or(SessionState::Running);
             let created_at = child_i64("created_at").map(|v| v as u64);
             let exited_at = child_i64("exited_at").map(|v| v as u64);
@@ -297,7 +297,7 @@ mod file_lock {
 
     impl FileLock {
         pub fn exclusive(path: &Path) -> std::io::Result<Self> {
-            let file = OpenOptions::new().create(true).write(true).open(path)?;
+            let file = OpenOptions::new().create(true).write(true).truncate(false).open(path)?;
             let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
             if ret != 0 {
                 return Err(std::io::Error::last_os_error());
@@ -321,7 +321,7 @@ mod file_lock {
 
     impl FileLock {
         pub fn exclusive(path: &Path) -> std::io::Result<Self> {
-            let file = OpenOptions::new().create(true).write(true).open(path)?;
+            let file = OpenOptions::new().create(true).write(true).truncate(false).open(path)?;
             let handle = file.as_raw_handle();
             unsafe {
                 use windows_sys::Win32::Foundation::HANDLE;
@@ -356,7 +356,7 @@ mod file_lock {
 
     impl FileLock {
         pub fn exclusive(path: &Path) -> std::io::Result<Self> {
-            let file = OpenOptions::new().create(true).write(true).open(path)?;
+            let file = OpenOptions::new().create(true).write(true).truncate(false).open(path)?;
             Ok(FileLock { _file: file })
         }
     }
@@ -1554,14 +1554,14 @@ mod registry_tests {
     #[test]
     fn session_state_str_roundtrip() {
         assert_eq!(
-            SessionState::from_str(SessionState::Running.as_str()),
+            SessionState::parse(SessionState::Running.as_str()),
             Some(SessionState::Running)
         );
         assert_eq!(
-            SessionState::from_str(SessionState::Exited.as_str()),
+            SessionState::parse(SessionState::Exited.as_str()),
             Some(SessionState::Exited)
         );
-        assert_eq!(SessionState::from_str("bogus"), None);
+        assert_eq!(SessionState::parse("bogus"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Decouple session names from socket / pipe filenames via a registry

## TL;DR

Sockets/pipes are now named by a stable **id**, not the session name. A KDL
registry (`sessions.kdl`) maps id → display name. Renaming a session just updates
the registry — nothing on disk is renamed — which is what fixes
[**reattach-after-rename on Windows** (#4998)](https://github.com/zellij-org/zellij/issues/4998) (named pipes can't be renamed).

## What changes

- Socket/pipe **and** the session-info cache folder are keyed by id; the registry
  is the single source of truth for name ↔ id.
- Rename = a registry update (no socket rename, no cache-folder move).
- Listing / kill / delete / resurrection resolve name ↔ id via the registry.
- Reconciliation prunes dead entries so `sessions.kdl` stays bounded after
  crashes; writes are atomic (temp + rename, with a `.bak` fallback).
- Legacy sessions migrate in with `id == name`; no protocol/plugin-API changes.

## Notes

- Ids are short (12 hex chars, collision-guarded) so the socket path fits the
  platform limit (104 bytes on macOS) — a full UUID overflows it.
- The server's id is threaded per-session (not a global env), which matters for
  the in-process integration-test harness.

## vs #5103

Supersedes it — a rework, not an update: registry is now the single source of
truth, rebuilt on current `main`, and drops the earlier exit-time re-serialization
that broke multi-tab resurrection.

## Testing

Unit tests for the registry (round-trip, reconcile, atomic/corrupt-file
handling) and a new integration test asserting the socket path is unchanged
across a rename and reattach-by-new-name works. Verified on Windows + Linux; CI
green.

supersedes #5103 and #5006