### PR TITLE
fix(plugins): notify floating panes when their tab is hidden

### DIFF
--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -6591,10 +6591,18 @@ impl Tab {
         Ok(())
     }
     pub fn visible(&mut self, visible: bool) -> Result<()> {
-        let pids_in_this_tab = self.tiled_panes.pane_ids().filter_map(|p| match p {
-            PaneId::Plugin(pid) => Some(pid),
-            _ => None,
-        });
+        // Floating panes must be included here as well: a plugin in a floating pane is just as
+        // hidden as a tiled one when its tab goes away, and plugins that idle on a timer (eg. the
+        // session-manager, which polls the session list once a second) keep that timer armed until
+        // they are told otherwise.
+        let pids_in_this_tab = self
+            .tiled_panes
+            .pane_ids()
+            .chain(self.floating_panes.pane_ids())
+            .filter_map(|p| match p {
+                PaneId::Plugin(pid) => Some(pid),
+                _ => None,
+            });
         let mut plugin_updates = vec![];
         for pid in pids_in_this_tab {
             plugin_updates.push((Some(*pid), None, Event::Visible(visible)));

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -2,14 +2,16 @@ use super::Tab;
 use crate::pane_groups::PaneGroups;
 use crate::panes::kitty_graphics::KittyImageStore;
 use crate::panes::sixel::SixelImageStore;
+use crate::plugins::PluginInstruction;
 use crate::pty_writer::PtyWriteInstruction;
 use crate::screen::CopyOptions;
 use crate::{os_input_output::ServerOsApi, panes::PaneId, thread_bus::ThreadSenders, ClientId};
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
-use zellij_utils::channels::{unbounded, Receiver, SenderWithContext};
-use zellij_utils::data::{Direction, NewPanePlacement, Resize, ResizeStrategy, WebSharing};
+use zellij_utils::channels::{unbounded, ChannelWithContext, Receiver, SenderWithContext};
+use zellij_utils::data::{Direction, Event, NewPanePlacement, Resize, ResizeStrategy, WebSharing};
 use zellij_utils::errors::prelude::*;
+use zellij_utils::errors::ErrorContext;
 use zellij_utils::input::layout::{SplitDirection, SplitSize, TiledPaneLayout};
 use zellij_utils::input::options::PaneFrameStyle;
 use zellij_utils::ipc::IpcReceiverWithContext;
@@ -150,11 +152,20 @@ fn tab_resize_right(tab: &mut Tab, id: ClientId) {
 }
 
 fn create_new_tab(size: Size, stacked_resize: bool) -> Tab {
+    create_new_tab_with_plugin_receiver(size, stacked_resize).0
+}
+
+fn create_new_tab_with_plugin_receiver(
+    size: Size,
+    stacked_resize: bool,
+) -> (Tab, Receiver<(PluginInstruction, ErrorContext)>) {
     let index = 0;
     let position = 0;
     let name = String::new();
     let os_api = Box::new(FakeInputOutput {});
-    let senders = ThreadSenders::default().silently_fail_on_send();
+    let mut senders = ThreadSenders::default().silently_fail_on_send();
+    let (to_plugin, plugin_receiver): ChannelWithContext<PluginInstruction> = unbounded();
+    senders.replace_to_plugin(SenderWithContext::new(to_plugin));
     let max_panes = None;
     let mode_info = ModeInfo::default();
     let style = Style::default();
@@ -237,7 +248,7 @@ fn create_new_tab(size: Size, stacked_resize: bool) -> Tab {
         None,
     )
     .unwrap();
-    tab
+    (tab, plugin_receiver)
 }
 
 fn create_new_tab_with_layout(size: Size, layout: TiledPaneLayout) -> Tab {
@@ -17630,4 +17641,46 @@ pub fn scroll_terminal_down_nonexistent_pane_id_is_a_noop() {
 
     let writes = drain_pty_writer(&rx);
     assert!(writes.is_empty());
+}
+
+#[test]
+fn floating_plugin_panes_are_notified_when_their_tab_is_hidden() {
+    // Regression test: Tab::visible() used to only walk the tiled panes, so a plugin living in a
+    // floating pane never learned that its tab had gone away. Plugins that idle on a timer (the
+    // session-manager re-reads the whole session list once a second) went on doing that work
+    // forever, even with no client attached to the session at all.
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let (mut tab, plugin_receiver) = create_new_tab_with_plugin_receiver(size, true);
+    let plugin_pane_id = PaneId::Plugin(1);
+    tab.new_pane(
+        plugin_pane_id,
+        None,
+        None,
+        false,
+        true,
+        NewPanePlacement::Floating(None),
+        Some(1),
+        None,
+    )
+    .unwrap();
+
+    tab.visible(false).unwrap();
+
+    let mut told_the_floating_plugin = false;
+    while let Ok((instruction, _)) = plugin_receiver.try_recv() {
+        if let PluginInstruction::Update(updates) = instruction {
+            for (pid, _client_id, event) in updates {
+                if pid == Some(1) && matches!(event, Event::Visible(false)) {
+                    told_the_floating_plugin = true;
+                }
+            }
+        }
+    }
+    assert!(
+        told_the_floating_plugin,
+        "a plugin in a floating pane should be sent Event::Visible(false) when its tab is hidden"
+    );
 }


### PR DESCRIPTION
## What

`Tab::visible()` only iterates `self.tiled_panes.pane_ids()`, so a plugin running in a **floating** pane is never sent `Event::Visible(false)` when its tab is hidden. This patch includes `self.floating_panes.pane_ids()` in the same broadcast.

## Why it matters

Plugins that idle on a timer keep that timer armed until they are told they are no longer visible. `session-manager` is the case that surfaced this:

- it is normally opened as a **floating** pane (`LaunchOrFocusPlugin "session-manager" { floating true }`)
- it arms a **1 second** timer and calls `get_session_list()` on every tick
- its `Event::Timer` arm correctly bails out with `if !self.is_visible { return false; }` — but `is_visible` never becomes `false`, because the event that would set it is not delivered to floating panes

So once the picker is opened it polls the entire session list once a second, forever. It survives the pane being hidden, and it survives every client detaching — including the last-client path in `screen.rs`, which explicitly calls `tab.visible(false)` when `has_no_connected_clients()` precisely to stop this kind of work.

## How it showed up

On a machine running 21 zellij sessions:

- servers with a `session-manager` instance loaded: **8–93% CPU each**
- servers without one: **0.0%**
- one server with **zero clients attached and no visible plugin pane**: **130% CPU**, ~45 CPU-hours accumulated over 7 days

Per-thread profiling put ~89% of each affected server's CPU in a single `plugin-exec` thread. Cost scales with the number of sessions the picker enumerates — deleting 59 stale resurrectable sessions cut per-instance cost roughly 6x, which matches `get_session_list()` being the hot call.

## Test

`floating_plugin_panes_are_notified_when_their_tab_is_hidden` in `zellij-server/src/tab/unit/tab_tests.rs`: opens a plugin pane with `NewPanePlacement::Floating(None)`, calls `tab.visible(false)`, and asserts the plugin receives `Event::Visible(false)`.

Verified red before the change and green after. To let the test observe plugin instructions, `create_new_tab` is split into a thin wrapper over `create_new_tab_with_plugin_receiver`, which wires a real channel instead of `silently_fail_on_send`; existing callers are unaffected.

`cargo test -p zellij-server --lib`: 1532 passed, 0 failed. `cargo fmt` clean.

---

Opened as a draft — I've read that you're prioritising roadmap work and are selective about outside contributions, so please treat this as a report with a patch attached rather than a claim on your time. Happy to close it and just leave the analysis if that's more useful.