### PR TITLE
fix: don't require nested reading of env var to detect nested sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+* fix: nested-session detection over SSH (https://github.com/zellij-org/zellij/pull/5522)
 
 ## [0.45.0] - 2026-08-20
 * feat: allow tabs to have different sizes if clients aren't focused on the same one (https://github.com/zellij-org/zellij/pull/5133)

--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -37,7 +37,7 @@ struct InputHandler {
     receive_input_instructions: Receiver<(InputInstruction, ErrorContext)>,
     mouse_old_event: MouseEvent,
     mouse_mode_active: bool,
-    nested_reannounce: Option<NestedReannounce>,
+    nested_reannounce: NestedReannounce,
 }
 
 fn termwiz_mouse_convert(original_event: &mut MouseEvent, event: &TermwizMouseEvent) {
@@ -139,7 +139,7 @@ impl InputHandler {
         mode: InputMode, // TODO: we can probably get rid of this now that we're tracking it on the
         // server instead
         receive_input_instructions: Receiver<(InputInstruction, ErrorContext)>,
-        nested_reannounce: Option<NestedReannounce>,
+        nested_reannounce: NestedReannounce,
     ) -> Self {
         InputHandler {
             mode,
@@ -353,9 +353,7 @@ impl InputHandler {
         }
     }
     fn handle_nested_session_frame_from_host(&mut self, payload_bytes: Vec<u8>) {
-        if let Some(nested_reannounce) = &self.nested_reannounce {
-            nested_reannounce.note_host_contact();
-        }
+        self.nested_reannounce.note_host_contact();
         match nested_session::decode_payload(&payload_bytes) {
             Some(NestedSessionMessage::Ping) => {
                 self.send_client_instructions
@@ -496,7 +494,7 @@ pub(crate) fn input_loop(
     send_client_instructions: SenderWithContext<ClientInstruction>,
     default_mode: InputMode,
     receive_input_instructions: Receiver<(InputInstruction, ErrorContext)>,
-    nested_reannounce: Option<NestedReannounce>,
+    nested_reannounce: NestedReannounce,
 ) {
     let _handler = InputHandler::new(
         os_input,

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -557,6 +557,7 @@ pub async fn run_remote_client_terminal_loop(
     os_input: Box<dyn ClientOsApi>,
     mut connections: remote_attach::WebSocketConnections,
     nested_session_name: Option<String>,
+    host_contacted: Arc<std::sync::atomic::AtomicBool>,
 ) -> Result<Option<ConnectToSession>, RemoteClientError> {
     use crate::os_input_output::{AsyncSignals, AsyncStdin};
 
@@ -592,7 +593,8 @@ pub async fn run_remote_client_terminal_loop(
     }
 
     let mut nested_frame_extractor = nested_session::NestedFrameExtractor::new();
-    let mut last_heard_from_host = std::time::Instant::now();
+    let mut reannounce_scheduler =
+        nested_session::ReannounceScheduler::new(std::time::Instant::now());
     let mut reannounce_check = tokio::time::interval(std::time::Duration::from_millis(
         nested_session::reannounce_check_interval_ms(),
     ));
@@ -606,7 +608,8 @@ pub async fn run_remote_client_terminal_loop(
                     Ok(buf) if !buf.is_empty() => {
                         let (cleaned, nested_frames) = nested_frame_extractor.extract(&buf);
                         for payload_bytes in nested_frames {
-                            last_heard_from_host = std::time::Instant::now();
+                            reannounce_scheduler.note_host_contact(std::time::Instant::now());
+                            host_contacted.store(true, std::sync::atomic::Ordering::Relaxed);
                             match nested_session::decode_payload(&payload_bytes) {
                                 Some(nested_session::NestedSessionMessage::Ping) => {
                                     let mut stdout = os_input.get_stdout_writer();
@@ -653,9 +656,7 @@ pub async fn run_remote_client_terminal_loop(
 
             _ = reannounce_check.tick() => {
                 if let Some(session_name) = &nested_session_name {
-                    if last_heard_from_host.elapsed()
-                        >= std::time::Duration::from_millis(nested_session::reannounce_silence_ms())
-                    {
+                    if reannounce_scheduler.on_tick(std::time::Instant::now()) {
                         let announce = nested_session::NestedSessionMessage::Announce {
                             session_name: session_name.clone(),
                             capabilities: vec![nested_session::NestedSessionCapability::NestedControl],
@@ -810,7 +811,6 @@ pub fn start_remote_client(
 ) -> Result<Option<ConnectToSession>, RemoteClientError> {
     info!("Starting Zellij client!");
 
-    let is_nested_inside_zellij_pane = os_input.env_variable("ZELLIJ").is_some();
     let remote_session_name = remote_session_url
         .trim_end_matches('/')
         .rsplit('/')
@@ -854,16 +854,15 @@ pub fn start_remote_client(
     os_input.set_raw_mode();
     stdout.write_all(ENABLE_BRACKETED_PASTE.as_bytes()).unwrap();
     stdout.write_all(ENABLE_FOCUS_REPORTING.as_bytes()).unwrap();
-    if is_nested_inside_zellij_pane {
-        let announce = nested_session::NestedSessionMessage::Announce {
-            session_name: remote_session_name.clone(),
-            capabilities: vec![nested_session::NestedSessionCapability::NestedControl],
-        };
-        stdout
-            .write_all(&nested_session::encode_frame(&announce))
-            .unwrap();
-        let _ = stdout.flush();
-    }
+    let announce = nested_session::NestedSessionMessage::Announce {
+        session_name: remote_session_name.clone(),
+        capabilities: vec![nested_session::NestedSessionCapability::NestedControl],
+    };
+    stdout
+        .write_all(&nested_session::encode_frame(&announce))
+        .unwrap();
+    let _ = stdout.flush();
+    let host_contacted = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
     std::panic::set_hook({
         use zellij_utils::errors::handle_panic;
@@ -893,18 +892,14 @@ pub fn start_remote_client(
         std::process::exit(exit_status);
     };
 
-    let nested_session_name = if is_nested_inside_zellij_pane {
-        Some(remote_session_name.clone())
-    } else {
-        None
-    };
     runtime.block_on(run_remote_client_terminal_loop(
         os_input.clone(),
         connections,
-        nested_session_name,
+        Some(remote_session_name.clone()),
+        host_contacted.clone(),
     ))?;
 
-    if is_nested_inside_zellij_pane {
+    if host_contacted.load(std::sync::atomic::Ordering::Relaxed) {
         let mut stdout = os_input.get_stdout_writer();
         let _ = stdout.write_all(&nested_session::encode_frame(
             &nested_session::NestedSessionMessage::Bye,
@@ -944,7 +939,6 @@ pub fn start_client(
     }
     info!("Starting Zellij client!");
 
-    let is_nested_inside_zellij_pane = os_input.env_variable("ZELLIJ").is_some();
     let own_session_name = info.get_session_name().to_owned();
 
     let explicitly_disable_kitty_keyboard_protocol = config_options
@@ -1175,22 +1169,18 @@ pub fn start_client(
     let mut stdout = os_input.get_stdout_writer();
     stdout.write_all(ENABLE_BRACKETED_PASTE.as_bytes()).unwrap();
     stdout.write_all(ENABLE_FOCUS_REPORTING.as_bytes()).unwrap();
-    let nested_reannounce = if is_nested_inside_zellij_pane {
-        let announce = nested_session::NestedSessionMessage::Announce {
-            session_name: own_session_name.clone(),
-            capabilities: vec![nested_session::NestedSessionCapability::NestedControl],
-        };
-        stdout
-            .write_all(&nested_session::encode_frame(&announce))
-            .unwrap();
-        let _ = stdout.flush();
-        Some(crate::nested_reannounce::NestedReannounce::spawn(
-            os_input.clone(),
-            own_session_name.clone(),
-        ))
-    } else {
-        None
+    let announce = nested_session::NestedSessionMessage::Announce {
+        session_name: own_session_name.clone(),
+        capabilities: vec![nested_session::NestedSessionCapability::NestedControl],
     };
+    stdout
+        .write_all(&nested_session::encode_frame(&announce))
+        .unwrap();
+    let _ = stdout.flush();
+    let nested_reannounce = crate::nested_reannounce::NestedReannounce::spawn(
+        os_input.clone(),
+        own_session_name.clone(),
+    );
 
     let (send_client_instructions, receive_client_instructions): ChannelWithContext<
         ClientInstruction,
@@ -1580,7 +1570,7 @@ pub fn start_client(
                 let _ = out.flush();
             },
             ClientInstruction::EmitNestedSessionFrame(payload_bytes) => {
-                if is_nested_inside_zellij_pane {
+                if nested_reannounce.host_contacted() {
                     let frame = nested_session::encode_frame_from_payload(&payload_bytes);
                     let mut out = os_input.get_stdout_writer();
                     let _ = out.write_all(&frame);
@@ -1591,13 +1581,11 @@ pub fn start_client(
         }
     }
 
-    if let Some(nested_reannounce) = &nested_reannounce {
-        nested_reannounce.stop();
-    }
+    nested_reannounce.stop();
 
     router_thread.join().unwrap();
 
-    if is_nested_inside_zellij_pane {
+    if nested_reannounce.host_contacted() {
         let mut stdout = os_input.get_stdout_writer();
         let _ = stdout.write_all(&nested_session::encode_frame(
             &nested_session::NestedSessionMessage::Bye,

--- a/zellij-client/src/nested_reannounce.rs
+++ b/zellij-client/src/nested_reannounce.rs
@@ -1,52 +1,61 @@
 use crate::os_input_output::ClientOsApi;
 use std::io::Write;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 use std::time::{Duration, Instant};
 use zellij_utils::nested_session::{
-    self, reannounce_check_interval_ms, reannounce_silence_ms, NestedSessionCapability,
-    NestedSessionMessage,
+    self, reannounce_check_interval_ms, NestedSessionCapability, NestedSessionMessage,
+    ReannounceScheduler,
 };
 
 #[derive(Clone)]
 pub struct NestedReannounce {
-    last_heard_from_host: Arc<Mutex<Instant>>,
+    scheduler: Arc<Mutex<ReannounceScheduler>>,
+    wakeup: Arc<Condvar>,
     stop: Arc<AtomicBool>,
 }
 
 impl NestedReannounce {
     pub fn spawn(os_input: Box<dyn ClientOsApi>, session_name: String) -> Self {
         let handle = NestedReannounce {
-            last_heard_from_host: Arc::new(Mutex::new(Instant::now())),
+            scheduler: Arc::new(Mutex::new(ReannounceScheduler::new(Instant::now()))),
+            wakeup: Arc::new(Condvar::new()),
             stop: Arc::new(AtomicBool::new(false)),
         };
-        let last_heard_from_host = handle.last_heard_from_host.clone();
+        let scheduler = handle.scheduler.clone();
+        let wakeup = handle.wakeup.clone();
         let stop = handle.stop.clone();
         let _ = std::thread::Builder::new()
             .name("nested_reannounce".to_string())
             .spawn(move || {
                 let check_interval = Duration::from_millis(reannounce_check_interval_ms());
                 loop {
-                    std::thread::sleep(check_interval);
+                    let mut current = scheduler.lock().unwrap();
+                    while !stop.load(Ordering::Relaxed) && current.budget_exhausted() {
+                        current = wakeup.wait(current).unwrap();
+                    }
                     if stop.load(Ordering::Relaxed) {
                         break;
                     }
-                    let silent_for = {
-                        let last = last_heard_from_host.lock().unwrap();
-                        last.elapsed()
+                    let (mut current, _) = wakeup.wait_timeout(current, check_interval).unwrap();
+                    if stop.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    let should_announce = current.on_tick(Instant::now());
+                    drop(current);
+                    if !should_announce {
+                        continue;
+                    }
+                    let announce = NestedSessionMessage::Announce {
+                        session_name: session_name.clone(),
+                        capabilities: vec![NestedSessionCapability::NestedControl],
                     };
-                    if silent_for >= Duration::from_millis(reannounce_silence_ms()) {
-                        let announce = NestedSessionMessage::Announce {
-                            session_name: session_name.clone(),
-                            capabilities: vec![NestedSessionCapability::NestedControl],
-                        };
-                        let mut stdout = os_input.get_stdout_writer();
-                        if stdout
-                            .write_all(&nested_session::encode_frame(&announce))
-                            .is_ok()
-                        {
-                            let _ = stdout.flush();
-                        }
+                    let mut stdout = os_input.get_stdout_writer();
+                    if stdout
+                        .write_all(&nested_session::encode_frame(&announce))
+                        .is_ok()
+                    {
+                        let _ = stdout.flush();
                     }
                 }
             });
@@ -54,10 +63,22 @@ impl NestedReannounce {
     }
 
     pub fn note_host_contact(&self) {
-        *self.last_heard_from_host.lock().unwrap() = Instant::now();
+        let first_contact = self
+            .scheduler
+            .lock()
+            .unwrap()
+            .note_host_contact(Instant::now());
+        if first_contact {
+            self.wakeup.notify_all();
+        }
+    }
+
+    pub fn host_contacted(&self) -> bool {
+        self.scheduler.lock().unwrap().host_contacted()
     }
 
     pub fn stop(&self) {
         self.stop.store(true, Ordering::Relaxed);
+        self.wakeup.notify_all();
     }
 }

--- a/zellij-client/src/unit/terminal_loop_tests.rs
+++ b/zellij-client/src/unit/terminal_loop_tests.rs
@@ -362,10 +362,15 @@ async fn test_stdin_forwarded_to_terminal_websocket() {
 
     let os_input = Box::new(TestClientOsApi::new(stdin_rx, signal_rx));
 
-    let loop_handle =
-        tokio::spawn(
-            async move { run_remote_client_terminal_loop(os_input, connections, None).await },
-        );
+    let loop_handle = tokio::spawn(async move {
+        run_remote_client_terminal_loop(
+            os_input,
+            connections,
+            None,
+            Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        )
+        .await
+    });
 
     let test_data = b"hello from stdin\n".to_vec();
     stdin_tx.send(test_data.clone()).unwrap();
@@ -433,10 +438,15 @@ async fn test_terminal_output_written_to_stdout() {
     let stdout_buffer = os_input.stdout_buffer.clone();
     let os_input = Box::new(os_input);
 
-    let loop_handle =
-        tokio::spawn(
-            async move { run_remote_client_terminal_loop(os_input, connections, None).await },
-        );
+    let loop_handle = tokio::spawn(async move {
+        run_remote_client_terminal_loop(
+            os_input,
+            connections,
+            None,
+            Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        )
+        .await
+    });
 
     let test_output = "Hello from terminal";
     server
@@ -505,10 +515,15 @@ async fn test_resize_signal_sends_control_message() {
 
     let os_input = Box::new(TestClientOsApi::new(stdin_rx, signal_rx));
 
-    let loop_handle =
-        tokio::spawn(
-            async move { run_remote_client_terminal_loop(os_input, connections, None).await },
-        );
+    let loop_handle = tokio::spawn(async move {
+        run_remote_client_terminal_loop(
+            os_input,
+            connections,
+            None,
+            Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        )
+        .await
+    });
 
     tokio::time::sleep(Duration::from_millis(200)).await;
 
@@ -593,10 +608,15 @@ async fn test_quit_signal_exits_loop() {
 
     let os_input = Box::new(TestClientOsApi::new(stdin_rx, signal_rx));
 
-    let loop_handle =
-        tokio::spawn(
-            async move { run_remote_client_terminal_loop(os_input, connections, None).await },
-        );
+    let loop_handle = tokio::spawn(async move {
+        run_remote_client_terminal_loop(
+            os_input,
+            connections,
+            None,
+            Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        )
+        .await
+    });
 
     signal_tx.send(SignalEvent::Quit).unwrap();
 
@@ -648,10 +668,15 @@ async fn test_websocket_close_exits_loop() {
 
     let os_input = Box::new(TestClientOsApi::new(stdin_rx, signal_rx));
 
-    let loop_handle =
-        tokio::spawn(
-            async move { run_remote_client_terminal_loop(os_input, connections, None).await },
-        );
+    let loop_handle = tokio::spawn(async move {
+        run_remote_client_terminal_loop(
+            os_input,
+            connections,
+            None,
+            Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        )
+        .await
+    });
 
     server
         .terminal_to_client_tx
@@ -708,10 +733,15 @@ async fn test_control_message_handling() {
     let terminal_size = os_input.terminal_size;
     let os_input = Box::new(os_input);
 
-    let loop_handle =
-        tokio::spawn(
-            async move { run_remote_client_terminal_loop(os_input, connections, None).await },
-        );
+    let loop_handle = tokio::spawn(async move {
+        run_remote_client_terminal_loop(
+            os_input,
+            connections,
+            None,
+            Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        )
+        .await
+    });
 
     tokio::time::sleep(Duration::from_millis(200)).await;
 
@@ -816,10 +846,15 @@ async fn test_nested_ping_frame_is_answered_locally_and_stripped_from_forwarded_
     let stdout_buffer = os_input.stdout_buffer.clone();
     let os_input = Box::new(os_input);
 
-    let loop_handle =
-        tokio::spawn(
-            async move { run_remote_client_terminal_loop(os_input, connections, None).await },
-        );
+    let loop_handle = tokio::spawn(async move {
+        run_remote_client_terminal_loop(
+            os_input,
+            connections,
+            None,
+            Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        )
+        .await
+    });
 
     let mut chunk = b"abc".to_vec();
     chunk.extend_from_slice(&zellij_utils::nested_session::encode_frame(
@@ -870,10 +905,15 @@ async fn test_nested_announce_ack_is_relayed_over_control_websocket() {
     let (_signal_tx, signal_rx) = mpsc::unbounded_channel();
     let os_input = Box::new(TestClientOsApi::new(stdin_rx, signal_rx));
 
-    let loop_handle =
-        tokio::spawn(
-            async move { run_remote_client_terminal_loop(os_input, connections, None).await },
-        );
+    let loop_handle = tokio::spawn(async move {
+        run_remote_client_terminal_loop(
+            os_input,
+            connections,
+            None,
+            Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        )
+        .await
+    });
 
     let announce_ack = zellij_utils::nested_session::NestedSessionMessage::AnnounceAck {
         ancestry: vec!["outer-host".to_owned()],

--- a/zellij-integration-tests/src/nested.rs
+++ b/zellij-integration-tests/src/nested.rs
@@ -198,15 +198,13 @@ struct GuestBridge {
 
 fn bridge_guest_into_pane_for_host(
     host_pane: &FakePtyHandle,
-    host_session_name: &str,
     frozen: Arc<AtomicBool>,
 ) -> GuestBridge {
-    bridge_guest_into_pane_for_host_with_config(host_pane, host_session_name, frozen, "")
+    bridge_guest_into_pane_for_host_with_config(host_pane, frozen, "")
 }
 
 fn bridge_guest_into_pane_for_host_with_config(
     host_pane: &FakePtyHandle,
-    host_session_name: &str,
     frozen: Arc<AtomicBool>,
     guest_config_kdl: &str,
 ) -> GuestBridge {
@@ -221,7 +219,6 @@ fn bridge_guest_into_pane_for_host_with_config(
         cols: guest_cols as usize,
         rows: guest_rows as usize,
     })
-    .as_nested_guest(host_session_name)
     .with_config(guest_config_kdl)
     .with_stdout_tap(guest_stdout_tx)
     .skip_concurrency_slot()
@@ -274,12 +271,10 @@ impl NestedHarness {
             .start();
         host.wait_for_app_load();
         let host_pane = host.expect_pty_spawn();
-        let host_session_name = host.session_name().to_string();
 
         let frozen = Arc::new(AtomicBool::new(false));
         let bridge = bridge_guest_into_pane_for_host_with_config(
             &host_pane,
-            &host_session_name,
             frozen.clone(),
             guest_config_kdl,
         );
@@ -469,20 +464,16 @@ impl NestedDepthThreeHarness {
         let outer = TestRunner::new(outer_size).start();
         outer.wait_for_app_load();
         let middle_pane = outer.expect_pty_spawn();
-        let outer_session_name = outer.session_name().to_string();
 
         let frozen = Arc::new(AtomicBool::new(false));
-        let outer_to_middle_bridge =
-            bridge_guest_into_pane_for_host(&middle_pane, &outer_session_name, frozen.clone());
+        let outer_to_middle_bridge = bridge_guest_into_pane_for_host(&middle_pane, frozen.clone());
         let middle = outer_to_middle_bridge.guest;
         let outer_to_middle = outer_to_middle_bridge.host_to_guest;
 
         middle.wait_for_app_load();
         let inner_pane = middle.expect_pty_spawn();
-        let middle_session_name = middle.session_name().to_string();
 
-        let middle_to_inner_bridge =
-            bridge_guest_into_pane_for_host(&inner_pane, &middle_session_name, frozen.clone());
+        let middle_to_inner_bridge = bridge_guest_into_pane_for_host(&inner_pane, frozen.clone());
         let inner = middle_to_inner_bridge.guest;
         let middle_to_inner = middle_to_inner_bridge.host_to_guest;
         let inner_to_middle = middle_to_inner_bridge.guest_to_host;

--- a/zellij-integration-tests/src/runner.rs
+++ b/zellij-integration-tests/src/runner.rs
@@ -53,12 +53,6 @@ impl TestRunner {
         self
     }
 
-    pub fn as_nested_guest(mut self, host_session_name: &str) -> Self {
-        self.env
-            .insert("ZELLIJ".to_string(), host_session_name.to_string());
-        self
-    }
-
     pub fn with_stdout_tap(mut self, sender: crossbeam::channel::Sender<Vec<u8>>) -> Self {
         self.stdout_tap = Some(sender);
         self

--- a/zellij-utils/src/nested_session.rs
+++ b/zellij-utils/src/nested_session.rs
@@ -7,6 +7,7 @@ use base64::engine::general_purpose::{
 use base64::engine::{DecodePaddingMode, Engine as _};
 use prost::Message;
 use std::str::FromStr;
+use std::time::{Duration, Instant};
 
 const BASE64_DECODER: GeneralPurpose = GeneralPurpose::new(
     &BASE64_STANDARD_ALPHABET,
@@ -19,6 +20,7 @@ pub const NESTED_FRAME_TERMINATOR: &[u8] = b"\x1b\\";
 
 pub const REANNOUNCE_SILENCE_MS: u64 = 3000;
 pub const REANNOUNCE_CHECK_INTERVAL_MS: u64 = 1000;
+pub const MAX_UNACKED_ANNOUNCES: usize = 5;
 
 pub fn reannounce_silence_ms() -> u64 {
     std::env::var("ZELLIJ_NESTED_REANNOUNCE_SILENCE_MS")
@@ -32,6 +34,64 @@ pub fn reannounce_check_interval_ms() -> u64 {
         .ok()
         .and_then(|value| value.parse().ok())
         .unwrap_or(REANNOUNCE_CHECK_INTERVAL_MS)
+}
+
+pub fn max_unacked_announces() -> usize {
+    std::env::var("ZELLIJ_NESTED_MAX_UNACKED_ANNOUNCES")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(MAX_UNACKED_ANNOUNCES)
+}
+
+pub struct ReannounceScheduler {
+    last_heard_from_host: Instant,
+    host_contacted: bool,
+    announces_without_host_contact: usize,
+    silence: Duration,
+    budget: usize,
+}
+
+impl ReannounceScheduler {
+    pub fn new(now: Instant) -> Self {
+        ReannounceScheduler::with_settings(
+            now,
+            Duration::from_millis(reannounce_silence_ms()),
+            max_unacked_announces(),
+        )
+    }
+    pub fn with_settings(now: Instant, silence: Duration, budget: usize) -> Self {
+        ReannounceScheduler {
+            last_heard_from_host: now,
+            host_contacted: false,
+            announces_without_host_contact: 1,
+            silence,
+            budget,
+        }
+    }
+    pub fn note_host_contact(&mut self, now: Instant) -> bool {
+        self.last_heard_from_host = now;
+        let first_contact = !self.host_contacted;
+        self.host_contacted = true;
+        first_contact
+    }
+    pub fn on_tick(&mut self, now: Instant) -> bool {
+        if self.budget_exhausted() {
+            return false;
+        }
+        if now.duration_since(self.last_heard_from_host) < self.silence {
+            return false;
+        }
+        if !self.host_contacted {
+            self.announces_without_host_contact += 1;
+        }
+        true
+    }
+    pub fn host_contacted(&self) -> bool {
+        self.host_contacted
+    }
+    pub fn budget_exhausted(&self) -> bool {
+        !self.host_contacted && self.announces_without_host_contact >= self.budget
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -476,5 +536,58 @@ mod tests {
     #[test]
     fn empty_payload_is_rejected() {
         assert_eq!(decode_payload(&[]), None);
+    }
+
+    fn test_scheduler(now: Instant) -> ReannounceScheduler {
+        ReannounceScheduler::with_settings(now, Duration::from_millis(3000), 5)
+    }
+
+    #[test]
+    fn unacked_announces_stop_at_the_budget() {
+        let start = Instant::now();
+        let mut scheduler = test_scheduler(start);
+        let mut announces = 1;
+        for tick in 1..=30 {
+            if scheduler.on_tick(start + Duration::from_millis(tick * 1000)) {
+                announces += 1;
+            }
+        }
+        assert_eq!(announces, 5);
+        assert!(scheduler.budget_exhausted());
+        assert!(!scheduler.host_contacted());
+    }
+
+    #[test]
+    fn silence_threshold_is_respected_before_announcing() {
+        let start = Instant::now();
+        let mut scheduler = test_scheduler(start);
+        assert!(!scheduler.on_tick(start + Duration::from_millis(1000)));
+        assert!(!scheduler.on_tick(start + Duration::from_millis(2999)));
+        assert!(scheduler.on_tick(start + Duration::from_millis(3000)));
+    }
+
+    #[test]
+    fn host_contact_lifts_the_budget_and_resets_the_silence_window() {
+        let start = Instant::now();
+        let mut scheduler = test_scheduler(start);
+        for tick in 1..=30 {
+            scheduler.on_tick(start + Duration::from_millis(tick * 1000));
+        }
+        assert!(scheduler.budget_exhausted());
+        assert!(scheduler.note_host_contact(start + Duration::from_millis(31_000)));
+        assert!(scheduler.host_contacted());
+        assert!(!scheduler.budget_exhausted());
+        assert!(!scheduler.on_tick(start + Duration::from_millis(32_000)));
+        for tick in 34..=100 {
+            assert!(scheduler.on_tick(start + Duration::from_millis(tick * 1000)));
+        }
+    }
+
+    #[test]
+    fn repeated_host_contact_is_only_first_contact_once() {
+        let start = Instant::now();
+        let mut scheduler = test_scheduler(start);
+        assert!(scheduler.note_host_contact(start));
+        assert!(!scheduler.note_host_contact(start + Duration::from_millis(1000)));
     }
 }


### PR DESCRIPTION
This fixes an issue in the recently released nested-sessions feature, where we would require the `ZELLIJ` env var to be present before attempting the negotiation that will allow the inner session to take over the UI of the outer session. This meant that they did not work by default over SSH - which is one of the main use cases.

This was an oversight on my part, since my main use-case for this feature is developing Zellij itself inside my own Zellij session (which does not require SSH).