### PR TITLE
fix: various snotifications issues introduced in 045

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 * fix: nested-session detection over SSH (https://github.com/zellij-org/zellij/pull/5522)
+* fix: some issues with notification parsing (eg. neovim notification on save) (https://github.com/zellij-org/zellij/pull/5523)
 
 ## [0.45.0] - 2026-08-20
 * feat: allow tabs to have different sizes if clients aren't focused on the same one (https://github.com/zellij-org/zellij/pull/5133)

--- a/zellij-client/src/stdin_ansi_parser.rs
+++ b/zellij-client/src/stdin_ansi_parser.rs
@@ -482,6 +482,7 @@ impl StdinAnsiParser {
                     if payload.starts_with(b"99;") {
                         out.desktop_notifications
                             .push(payload.get(3..).unwrap_or_default().to_vec());
+                        continue;
                     } else if let Some(reply) = HostReply::from_osc_payload(&payload) {
                         out.replies.push(reply);
                     }

--- a/zellij-client/src/stdin_ansi_parser_tests.rs
+++ b/zellij-client/src/stdin_ansi_parser_tests.rs
@@ -378,6 +378,30 @@ fn osc_99_routes_into_desktop_notifications() {
 }
 
 #[test]
+fn osc_99_does_not_leak_into_an_open_forwarding_window() {
+    let mut parser = StdinAnsiParser::new();
+    parser.open_forward(7);
+    let mut chunk = Vec::new();
+    chunk.extend_from_slice(b"\x1b]99;i=p1.myid;\x1b\\");
+    chunk.extend_from_slice(b"\x1b]11;rgb:1111/1111/1111\x1b\\");
+    chunk.extend_from_slice(b"\x1b[c");
+    let out = parser.feed(&chunk);
+    assert_eq!(out.desktop_notifications.len(), 1);
+    let (token, reply_bytes) = out.completed_forward.unwrap();
+    assert_eq!(token, 7);
+    assert!(
+        reply_bytes.windows(4).any(|w| w == b"]11;"),
+        "the reply the pane asked for is forwarded: {:?}",
+        reply_bytes
+    );
+    assert!(
+        !reply_bytes.windows(4).any(|w| w == b"]99;"),
+        "the notification response is not: {:?}",
+        reply_bytes
+    );
+}
+
+#[test]
 fn fragmented_osc_99_emits_one_notification() {
     // Cross-chunk regression: OSC 99 split across two feed() calls
     // must still emit exactly one notification, with no leak into

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -44,106 +44,197 @@ const BASE64_DECODER: GeneralPurpose = GeneralPurpose::new(
     GeneralPurposeConfig::new().with_decode_padding_mode(DecodePaddingMode::Indifferent),
 );
 
+const MAX_TRACKED_NOTIFICATION_IDS: usize = 256;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PendingNotification {
-    Osc99 { payload: String, terminator: String },
-    Osc9 { body: String },
-    Osc777 { title: String, body: String },
+    Osc99 {
+        payload: String,
+        terminator: String,
+        wants_report: bool,
+        display: Option<(String, String)>,
+    },
+    Osc9 {
+        body: String,
+    },
+    Osc777 {
+        title: String,
+        body: String,
+    },
 }
 
 impl PendingNotification {
     pub fn title_and_body(&self) -> (String, String) {
         match self {
-            PendingNotification::Osc99 { payload, .. } => match payload.find(';') {
-                Some(idx) => (
-                    String::new(),
-                    payload.get(idx + 1..).unwrap_or_default().to_owned(),
-                ),
-                None => (String::new(), String::new()),
-            },
+            PendingNotification::Osc99 { display, .. } => display.clone().unwrap_or_default(),
             PendingNotification::Osc9 { body } => (String::new(), body.clone()),
             PendingNotification::Osc777 { title, body } => (title.clone(), body.clone()),
         }
     }
 }
 
-/// Rewrites OSC 99 metadata for multiplexer forwarding:
-///
-/// 1. Namespaces the `i=` value with a pane ID prefix and flags so responses
-///    can be routed back to the originating pane.
-///    Format: `i=p<pane_id>[r][q].<original_id>`
-///    - `r` flag: app requested `a=report` — activation response should be
-///      written back to the pane's PTY
-///    - `q` flag: this is a capability query (`p=?`) — response must be
-///      written back to the pane's PTY
-///    - Neither: activation response used only for focus routing, not forwarded
-///
-/// 2. Ensures `a=report` is always present so the host terminal sends the
-///    activation response back to Zellij (needed for pane focus routing).
-///
-/// If no `i=` key is present, one is added with an empty original ID.
-pub(crate) fn namespace_notification_id(metadata: &str, pane_id: u32) -> String {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Osc99PayloadType {
+    Title,
+    Body,
+    Close,
+    Query,
+    Alive,
+    Other,
+}
+
+impl Osc99PayloadType {
+    pub(crate) fn from_metadata_value(value: &str) -> Self {
+        match value {
+            "title" => Osc99PayloadType::Title,
+            "body" => Osc99PayloadType::Body,
+            "close" => Osc99PayloadType::Close,
+            "?" => Osc99PayloadType::Query,
+            "alive" => Osc99PayloadType::Alive,
+            _ => Osc99PayloadType::Other,
+        }
+    }
+    pub(crate) fn is_control_request(&self) -> bool {
+        matches!(
+            self,
+            Osc99PayloadType::Close | Osc99PayloadType::Query | Osc99PayloadType::Alive
+        )
+    }
+}
+
+pub(crate) fn split_osc99_payload(payload: &str) -> (&str, &str) {
+    match payload.find(';') {
+        Some(idx) => (
+            payload.get(..idx).unwrap_or_default(),
+            payload.get(idx + 1..).unwrap_or_default(),
+        ),
+        None => (payload, ""),
+    }
+}
+
+pub(crate) fn parse_osc99_metadata(metadata: &str) -> BTreeMap<&str, &str> {
+    metadata
+        .split(':')
+        .filter_map(|kv| kv.split_once('='))
+        .collect()
+}
+
+fn action_wants_report(action_value: &str) -> bool {
+    action_value.split(',').any(|value| value == "report")
+}
+
+#[derive(Debug, Clone, Default)]
+struct NotificationAssembly {
+    title: String,
+    body: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct NotificationTracker {
+    wants_report: HashMap<String, bool>,
+    assemblies: HashMap<String, NotificationAssembly>,
+    known_ids: VecDeque<String>,
+}
+
+impl NotificationTracker {
+    fn remember(&mut self, id: &str) {
+        if self.known_ids.iter().any(|known| known == id) {
+            return;
+        }
+        self.known_ids.push_back(id.to_owned());
+        while self.known_ids.len() > MAX_TRACKED_NOTIFICATION_IDS {
+            if let Some(evicted) = self.known_ids.pop_front() {
+                self.wants_report.remove(&evicted);
+                self.assemblies.remove(&evicted);
+            }
+        }
+    }
+    fn wants_report(&mut self, id: &str, action: Option<&str>) -> bool {
+        match action {
+            Some(action_value) => {
+                let wants_report = action_wants_report(action_value);
+                if !id.is_empty() {
+                    self.remember(id);
+                    self.wants_report.insert(id.to_owned(), wants_report);
+                }
+                wants_report
+            },
+            None => self.wants_report.get(id).copied().unwrap_or(false),
+        }
+    }
+    fn assemble(
+        &mut self,
+        id: &str,
+        payload_type: Osc99PayloadType,
+        is_done: bool,
+        payload: String,
+    ) -> Option<(String, String)> {
+        if payload_type == Osc99PayloadType::Close {
+            self.assemblies.remove(id);
+            return None;
+        }
+        if payload_type.is_control_request() {
+            return None;
+        }
+        if !payload.is_empty() {
+            self.remember(id);
+            let assembly = self.assemblies.entry(id.to_owned()).or_default();
+            match payload_type {
+                Osc99PayloadType::Title => assembly.title.push_str(&payload),
+                Osc99PayloadType::Body => assembly.body.push_str(&payload),
+                _ => {},
+            }
+        }
+        if !is_done {
+            return None;
+        }
+        let assembly = self.assemblies.remove(id)?;
+        if assembly.title.is_empty() && assembly.body.is_empty() {
+            None
+        } else {
+            Some((assembly.title, assembly.body))
+        }
+    }
+}
+
+pub(crate) fn namespace_notification_id(
+    metadata: &str,
+    pane_id: u32,
+    wants_report: bool,
+) -> String {
+    let flags = if wants_report { "r" } else { "" };
     let mut found_id = false;
     let mut found_action = false;
-    let mut app_wants_report = false;
-    let mut is_query = false;
-    let result = metadata
-        .split(':')
-        .map(|kv| {
-            if kv.starts_with("i=") {
-                found_id = true;
-                // Defer i= rewriting until we know the flags
-                kv.to_string()
-            } else if let Some(action_value) = kv.strip_prefix("a=") {
-                found_action = true;
-                app_wants_report = action_value.split(',').any(|v| v == "report");
-                if app_wants_report {
-                    kv.to_string()
-                } else {
-                    format!("a={},report", action_value)
-                }
-            } else if kv == "p=?" {
-                is_query = true;
-                kv.to_string()
+    let mut payload_type = Osc99PayloadType::Title;
+    let mut parts: Vec<String> = Vec::new();
+    for kv in metadata.split(':') {
+        if kv.is_empty() {
+            continue;
+        }
+        if let Some(id_value) = kv.strip_prefix("i=") {
+            found_id = true;
+            parts.push(format!("i=p{}{}.{}", pane_id, flags, id_value));
+        } else if let Some(action_value) = kv.strip_prefix("a=") {
+            found_action = true;
+            if action_wants_report(action_value) {
+                parts.push(kv.to_owned());
             } else {
-                kv.to_string()
+                parts.push(format!("a={},report", action_value));
             }
-        })
-        .collect::<Vec<_>>()
-        .join(":");
-
-    // Build flags suffix
-    let mut flags = String::new();
-    if app_wants_report {
-        flags.push('r');
-    }
-    if is_query {
-        flags.push('q');
-    }
-
-    // Rewrite i= with pane ID and flags
-    let result = result
-        .split(':')
-        .map(|kv| {
-            if let Some(id_value) = kv.strip_prefix("i=") {
-                format!("i=p{}{}.{}", pane_id, flags, id_value)
-            } else {
-                kv.to_string()
+        } else {
+            if let Some(payload_value) = kv.strip_prefix("p=") {
+                payload_type = Osc99PayloadType::from_metadata_value(payload_value);
             }
-        })
-        .collect::<Vec<_>>()
-        .join(":");
-
-    let result = if !found_id {
-        format!("i=p{}{}.:{}", pane_id, flags, result)
-    } else {
-        result
-    };
-    if !found_action {
-        format!("{}:a=report", result)
-    } else {
-        result
+            parts.push(kv.to_owned());
+        }
     }
+    if !found_id {
+        parts.insert(0, format!("i=p{}{}.", pane_id, flags));
+    }
+    if !found_action && !payload_type.is_control_request() {
+        parts.push("a=focus,report".to_owned());
+    }
+    parts.join(":")
 }
 
 use vte::{Params, Perform};
@@ -743,6 +834,7 @@ pub struct Grid {
     pub pending_clipboard_update: Option<String>,
     pub pending_osc7_cwd: Option<std::path::PathBuf>,
     pub pending_desktop_notifications: Vec<PendingNotification>,
+    notification_tracker: NotificationTracker,
     /// Whitelisted host-terminal queries intercepted from the app running
     /// in this pane (CSI 14t / 16t pixel-dim queries, OSC 10;? / 11;? /
     /// 4;N;? color queries). Each entry is the raw byte sequence that
@@ -1128,6 +1220,7 @@ impl Grid {
             pending_clipboard_update: None,
             pending_osc7_cwd: None,
             pending_desktop_notifications: Vec::new(),
+            notification_tracker: NotificationTracker::default(),
             pending_forwarded_queries: Vec::new(),
             pending_nested_session_messages: Vec::new(),
             ui_component_bytes: None,
@@ -4731,10 +4824,34 @@ impl Perform for Grid {
                         .collect::<Vec<&str>>()
                         .join(";");
                     if !payload.is_empty() {
+                        let (metadata, rest) = split_osc99_payload(&payload);
+                        let metadata = parse_osc99_metadata(metadata);
+                        let id = metadata.get("i").copied().unwrap_or_default();
+                        let payload_type = metadata
+                            .get("p")
+                            .map(|value| Osc99PayloadType::from_metadata_value(value))
+                            .unwrap_or(Osc99PayloadType::Title);
+                        let is_done = metadata.get("d").copied().unwrap_or("1") != "0";
+                        let decoded = if metadata.get("e").copied() == Some("1") {
+                            BASE64_DECODER
+                                .decode(rest.as_bytes())
+                                .map(|decoded| String::from_utf8_lossy(&decoded).into_owned())
+                                .unwrap_or_else(|_| rest.to_owned())
+                        } else {
+                            rest.to_owned()
+                        };
+                        let wants_report = self
+                            .notification_tracker
+                            .wants_report(id, metadata.get("a").copied());
+                        let display =
+                            self.notification_tracker
+                                .assemble(id, payload_type, is_done, decoded);
                         self.pending_desktop_notifications
                             .push(PendingNotification::Osc99 {
                                 payload,
                                 terminator: terminator.to_string(),
+                                wants_report,
+                                display,
                             });
                     }
                 }
@@ -4742,6 +4859,13 @@ impl Perform for Grid {
 
             b"9" => {
                 if params.len() > 1 {
+                    let is_conemu_subcommand = params.len() > 2
+                        && params
+                            .get(1)
+                            .and_then(|param| str::from_utf8(param).ok())
+                            .and_then(|param| param.parse::<u8>().ok())
+                            .map(|subcommand| (1..=12).contains(&subcommand))
+                            .unwrap_or(false);
                     let body = params
                         .get(1..)
                         .unwrap_or_default()
@@ -4749,7 +4873,7 @@ impl Perform for Grid {
                         .flat_map(|x| str::from_utf8(x))
                         .collect::<Vec<&str>>()
                         .join(";");
-                    if !body.is_empty() {
+                    if !body.is_empty() && !is_conemu_subcommand {
                         self.pending_desktop_notifications
                             .push(PendingNotification::Osc9 { body });
                     }

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -8906,11 +8906,182 @@ fn a_notification_carries_its_title_and_body_across_protocols() {
     );
     assert_eq!(
         PendingNotification::Osc99 {
-            payload: "i=1:d=0;the body".to_owned(),
-            terminator: "\u{7}".to_owned()
+            payload: "i=1;the title".to_owned(),
+            terminator: "\u{7}".to_owned(),
+            wants_report: false,
+            display: Some(("the title".to_owned(), "the body".to_owned())),
         }
         .title_and_body(),
-        (String::new(), "the body".to_owned())
+        ("the title".to_owned(), "the body".to_owned())
+    );
+}
+
+fn osc99_display(grid: &Grid, index: usize) -> Option<(String, String)> {
+    use crate::panes::grid::PendingNotification;
+    match grid.pending_desktop_notifications.get(index) {
+        Some(PendingNotification::Osc99 { display, .. }) => display.clone(),
+        other => panic!("expected an OSC 99 notification, got: {:?}", other),
+    }
+}
+
+#[test]
+fn an_osc_9_conemu_progress_report_is_not_a_notification() {
+    let mut grid = new_grid_for_forwarding_test();
+    let mut vte_parser = vte::Parser::new();
+    vte_parser.advance(&mut grid, b"\x1b]9;4;0;0\x1b\\");
+    vte_parser.advance(&mut grid, b"\x1b]9;4;1;50\x07");
+    assert!(
+        grid.pending_desktop_notifications.is_empty(),
+        "progress reports are not desktop notifications, got: {:?}",
+        grid.pending_desktop_notifications
+    );
+}
+
+#[test]
+fn other_osc_9_conemu_subcommands_are_not_notifications() {
+    let mut grid = new_grid_for_forwarding_test();
+    let mut vte_parser = vte::Parser::new();
+    vte_parser.advance(&mut grid, b"\x1b]9;9;/home/user\x07");
+    vte_parser.advance(&mut grid, b"\x1b]9;3;a tab title\x07");
+    assert!(
+        grid.pending_desktop_notifications.is_empty(),
+        "ConEmu subcommands are not desktop notifications, got: {:?}",
+        grid.pending_desktop_notifications
+    );
+}
+
+#[test]
+fn an_osc_9_notification_starting_with_a_number_is_still_a_notification() {
+    use crate::panes::grid::PendingNotification;
+    let mut grid = new_grid_for_forwarding_test();
+    let mut vte_parser = vte::Parser::new();
+    vte_parser.advance(&mut grid, b"\x1b]9;4 tests failed;in 2 crates\x07");
+    assert_eq!(
+        grid.pending_desktop_notifications,
+        vec![PendingNotification::Osc9 {
+            body: "4 tests failed;in 2 crates".to_owned()
+        }]
+    );
+}
+
+#[test]
+fn an_osc_99_notification_is_assembled_from_its_chunks() {
+    let mut grid = new_grid_for_forwarding_test();
+    let mut vte_parser = vte::Parser::new();
+    vte_parser.advance(&mut grid, b"\x1b]99;i=1:d=0;Hello world\x1b\\");
+    vte_parser.advance(&mut grid, b"\x1b]99;i=1:p=body;This is cool\x1b\\");
+    assert_eq!(
+        osc99_display(&grid, 0),
+        None,
+        "an unfinished notification has nothing to show yet"
+    );
+    assert_eq!(
+        osc99_display(&grid, 1),
+        Some(("Hello world".to_owned(), "This is cool".to_owned())),
+        "the finished notification carries all of its chunks"
+    );
+}
+
+#[test]
+fn an_osc_99_notification_payload_may_be_base64_encoded() {
+    let mut grid = new_grid_for_forwarding_test();
+    let mut vte_parser = vte::Parser::new();
+    vte_parser.advance(&mut grid, b"\x1b]99;i=1:e=1;dGhlIGJ1aWxkIGZpbmlzaGVk\x1b\\");
+    assert_eq!(
+        osc99_display(&grid, 0),
+        Some(("the build finished".to_owned(), String::new()))
+    );
+}
+
+#[test]
+fn osc_99_requests_that_display_nothing_are_not_downgraded() {
+    let mut grid = new_grid_for_forwarding_test();
+    let mut vte_parser = vte::Parser::new();
+    vte_parser.advance(&mut grid, b"\x1b]99;i=1:p=close;\x1b\\");
+    vte_parser.advance(&mut grid, b"\x1b]99;i=2:p=?;\x1b\\");
+    vte_parser.advance(&mut grid, b"\x1b]99;i=3:p=alive;\x1b\\");
+    assert_eq!(osc99_display(&grid, 0), None, "a close shows nothing");
+    assert_eq!(osc99_display(&grid, 1), None, "a query shows nothing");
+    assert_eq!(
+        osc99_display(&grid, 2),
+        None,
+        "a liveness poll shows nothing"
+    );
+}
+
+#[test]
+fn the_report_intent_of_an_osc_99_notification_is_remembered() {
+    use crate::panes::grid::PendingNotification;
+    let mut grid = new_grid_for_forwarding_test();
+    let mut vte_parser = vte::Parser::new();
+    vte_parser.advance(&mut grid, b"\x1b]99;i=1:a=report;the build finished\x1b\\");
+    vte_parser.advance(&mut grid, b"\x1b]99;i=1:p=close;\x1b\\");
+    let wants_report: Vec<bool> = grid
+        .pending_desktop_notifications
+        .iter()
+        .map(|notification| match notification {
+            PendingNotification::Osc99 { wants_report, .. } => *wants_report,
+            other => panic!("expected an OSC 99 notification, got: {:?}", other),
+        })
+        .collect();
+    assert_eq!(
+        wants_report,
+        vec![true, true],
+        "a close request inherits the intent of the notification it closes"
+    );
+}
+
+#[test]
+fn an_explicit_action_replaces_the_remembered_report_intent() {
+    use crate::panes::grid::PendingNotification;
+    let mut grid = new_grid_for_forwarding_test();
+    let mut vte_parser = vte::Parser::new();
+    vte_parser.advance(&mut grid, b"\x1b]99;i=1:a=report;the build started\x1b\\");
+    vte_parser.advance(&mut grid, b"\x1b]99;i=1:a=focus;the build finished\x1b\\");
+    vte_parser.advance(&mut grid, b"\x1b]99;i=1:p=close;\x1b\\");
+    let wants_report: Vec<bool> = grid
+        .pending_desktop_notifications
+        .iter()
+        .map(|notification| match notification {
+            PendingNotification::Osc99 { wants_report, .. } => *wants_report,
+            other => panic!("expected an OSC 99 notification, got: {:?}", other),
+        })
+        .collect();
+    assert_eq!(
+        wants_report,
+        vec![true, false, false],
+        "an escape that states its own action decides, and is remembered from then on"
+    );
+}
+
+#[test]
+fn an_osc_99_notification_is_finished_by_a_payload_it_cannot_show() {
+    let mut grid = new_grid_for_forwarding_test();
+    let mut vte_parser = vte::Parser::new();
+    vte_parser.advance(&mut grid, b"\x1b]99;i=1:d=0;the build finished\x1b\\");
+    vte_parser.advance(&mut grid, b"\x1b]99;i=1:p=buttons:d=1;retry\x1b\\");
+    assert_eq!(
+        osc99_display(&grid, 1),
+        Some(("the build finished".to_owned(), String::new())),
+        "the assembled text is shown even when the last chunk carries buttons"
+    );
+}
+
+#[test]
+fn the_notification_state_remembered_per_pane_is_bounded() {
+    let mut grid = new_grid_for_forwarding_test();
+    let mut vte_parser = vte::Parser::new();
+    for index in 0..1000 {
+        vte_parser.advance(
+            &mut grid,
+            format!("\x1b]99;i={}:a=report;notification\x1b\\", index).as_bytes(),
+        );
+    }
+    assert!(
+        grid.notification_tracker.known_ids.len() <= 256
+            && grid.notification_tracker.wants_report.len() <= 256
+            && grid.notification_tracker.assemblies.is_empty(),
+        "an app sending endless notifications does not grow the pane's state without bound"
     );
 }
 

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -78,7 +78,7 @@ use crate::notifications::NotificationProtocol;
 use crate::os_input_output::ResizeCache;
 use crate::pane_groups::PaneGroups;
 use crate::panes::alacritty_functions::xparse_color;
-use crate::panes::grid::{namespace_notification_id, PendingNotification};
+use crate::panes::grid::{namespace_notification_id, Osc99PayloadType, PendingNotification};
 use crate::panes::nested_session_modal::GuestModalShortcuts;
 use crate::panes::terminal_character::AnsiCode;
 use crate::panes::terminal_pane::{BRACKETED_PASTE_BEGIN, BRACKETED_PASTE_END};
@@ -118,16 +118,14 @@ use crate::mobile_web::MobileWebPrefs;
 /// Returns Some((terminal_id, full_osc_bytes)) where full_osc_bytes is
 /// the complete reconstructed OSC 99 sequence with original identifier,
 /// ready to write to the pane's PTY.
-/// Denormalizes a namespaced OSC 99 response.
-///
-/// Parses the namespaced `i=p<N>[r][q].<original_id>` format and returns:
-/// - `pane_id`: the terminal pane that originated the notification
-/// - `app_wants_report`: `r` flag — app originally requested `a=report`
-/// - `is_query`: `q` flag — this was a capability query (`p=?`)
-/// - `restored_response_bytes`: the response with the original `i=` value restored
-pub(crate) fn denormalize_notification_response(
-    payload: &[u8],
-) -> Option<(u32, bool, bool, Vec<u8>)> {
+pub(crate) struct NotificationResponse {
+    pub terminal_id: u32,
+    pub forward_to_pane: bool,
+    pub focus_pane: bool,
+    pub bytes: Vec<u8>,
+}
+
+pub(crate) fn denormalize_notification_response(payload: &[u8]) -> Option<NotificationResponse> {
     let payload_str = str::from_utf8(payload).ok()?;
 
     // Split into metadata and response payload on first ';'
@@ -142,42 +140,62 @@ pub(crate) fn denormalize_notification_response(
     // Find the i= key in colon-separated metadata
     let mut terminal_id = None;
     let mut app_wants_report = false;
-    let mut is_query = false;
+    let mut payload_type = Osc99PayloadType::Other;
     let mut restored_parts = Vec::new();
 
     for kv in metadata.split(':') {
         if let Some(namespaced_value) = kv.strip_prefix("i=p") {
-            // Parse "p<N>[r][q].<original_id>"
             if let Some(dot_pos) = namespaced_value.find('.') {
                 let flags_part = namespaced_value.get(..dot_pos).unwrap_or_default();
                 let original_id = namespaced_value.get(dot_pos + 1..).unwrap_or_default();
-                let pane_id_str = flags_part.trim_end_matches(|c| c == 'r' || c == 'q');
-                let flag_chars = flags_part.get(pane_id_str.len()..).unwrap_or_default();
+                let digits = flags_part
+                    .find(|c: char| !c.is_ascii_digit())
+                    .unwrap_or(flags_part.len());
+                let pane_id_str = flags_part.get(..digits).unwrap_or_default();
+                let flag_chars = flags_part.get(digits..).unwrap_or_default();
                 if let Ok(pid) = pane_id_str.parse::<u32>() {
                     terminal_id = Some(pid);
                     app_wants_report = flag_chars.contains('r');
-                    is_query = flag_chars.contains('q');
-                    // Empty original_id means the app never sent an i= key;
-                    // don't inject one into the response
-                    if !original_id.is_empty() {
+                    if original_id.is_empty() {
+                        restored_parts.push("i=0".to_owned());
+                    } else {
                         restored_parts.push(format!("i={}", original_id));
                     }
                     continue;
                 }
             }
         }
+        if let Some(payload_value) = kv.strip_prefix("p=") {
+            payload_type = Osc99PayloadType::from_metadata_value(payload_value);
+        }
         restored_parts.push(kv.to_string());
     }
 
     let terminal_id = terminal_id?;
+    let response_payload = if payload_type == Osc99PayloadType::Alive {
+        let prefix_with_report = format!("p{}r.", terminal_id);
+        let prefix = format!("p{}.", terminal_id);
+        let alive_ids: Vec<&str> = response_payload
+            .trim_start_matches(';')
+            .split(',')
+            .filter_map(|id| {
+                id.strip_prefix(&prefix_with_report)
+                    .or_else(|| id.strip_prefix(&prefix))
+            })
+            .map(|id| if id.is_empty() { "0" } else { id })
+            .collect();
+        format!(";{}", alive_ids.join(","))
+    } else {
+        response_payload.to_owned()
+    };
     let restored_metadata = restored_parts.join(":");
     let full_response = format!("\x1b]99;{}{}\x1b\\", restored_metadata, response_payload);
-    Some((
+    Some(NotificationResponse {
         terminal_id,
-        app_wants_report,
-        is_query,
-        full_response.into_bytes(),
-    ))
+        forward_to_pane: app_wants_report || payload_type.is_control_request(),
+        focus_pane: !payload_type.is_control_request(),
+        bytes: full_response.into_bytes(),
+    })
 }
 
 /// Get the active tab and call a closure on it
@@ -4513,6 +4531,8 @@ impl Screen {
                         PendingNotification::Osc99 {
                             payload,
                             terminator,
+                            wants_report,
+                            ..
                         },
                     ) => {
                         let (metadata, rest) = match payload.find(';') {
@@ -4522,12 +4542,16 @@ impl Screen {
                             ),
                             None => (payload.as_str(), ""),
                         };
-                        let namespaced_metadata = namespace_notification_id(metadata, pane_id);
+                        let namespaced_metadata =
+                            namespace_notification_id(metadata, pane_id, *wants_report);
                         Some(format!(
                             "\u{1b}]99;{}{}{}",
                             namespaced_metadata, rest, terminator
                         ))
                     },
+                    (_, PendingNotification::Osc99 { display, .. }) => display
+                        .as_ref()
+                        .and_then(|(title, body)| protocol.render(title, body)),
                     _ => {
                         let (title, body) = notification.title_and_body();
                         protocol.render(&title, &body)
@@ -12082,19 +12106,15 @@ pub(crate) fn screen_thread_main(
                 screen.render(None)?;
             },
             ScreenInstruction::DesktopNotificationResponse(raw_bytes, client_id) => {
-                if let Some((terminal_id, app_wants_report, is_query, rewritten_bytes)) =
-                    denormalize_notification_response(&raw_bytes)
-                {
-                    let pane_id = PaneId::Terminal(terminal_id);
-                    // Write response to the pane if the app expects it:
-                    // capability query answers (q flag) or activation reports (r flag)
-                    if app_wants_report || is_query {
+                if let Some(response) = denormalize_notification_response(&raw_bytes) {
+                    let pane_id = PaneId::Terminal(response.terminal_id);
+                    if response.forward_to_pane {
                         let all_tabs = screen.get_tabs_mut();
                         for tab in all_tabs.values_mut() {
                             if tab.has_pane_with_pid(&pane_id) {
                                 tab.write_to_pane_id(
                                     &None,
-                                    rewritten_bytes,
+                                    response.bytes,
                                     false,
                                     pane_id,
                                     None,
@@ -12105,8 +12125,7 @@ pub(crate) fn screen_thread_main(
                             }
                         }
                     }
-                    // Focus the pane on activation click (not on query responses)
-                    if !is_query {
+                    if response.focus_pane {
                         screen
                             .focus_pane_with_id(pane_id, false, false, client_id)
                             .non_fatal();

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -15679,6 +15679,8 @@ fn collect_render_output(receiver: &Receiver<(ScreenInstruction, ErrorContext)>)
                 if let PendingNotification::Osc99 {
                     payload,
                     terminator,
+                    wants_report,
+                    ..
                 } = notification
                 {
                     let (metadata, rest) = match payload.find(';') {
@@ -15688,7 +15690,8 @@ fn collect_render_output(receiver: &Receiver<(ScreenInstruction, ErrorContext)>)
                         ),
                         None => (payload.as_str(), ""),
                     };
-                    let namespaced_metadata = namespace_notification_id(metadata, pane_id);
+                    let namespaced_metadata =
+                        namespace_notification_id(metadata, pane_id, wants_report);
                     output.push_str(&format!(
                         "\u{1b}]99;{}{}{}",
                         namespaced_metadata, rest, terminator
@@ -15806,6 +15809,27 @@ fn osc99_multiple_notifications_forwarded() {
     assert!(
         output.contains("First") && output.contains("Second"),
         "Both payloads should be forwarded, got: {:?}",
+        output
+    );
+}
+
+#[test]
+fn osc99_chunks_of_one_notification_share_an_identifier() {
+    let size = Size { cols: 80, rows: 24 };
+    let (mut tab, server_receiver) = create_new_tab_with_server_receiver(size, ModeInfo::default());
+
+    tab.handle_pty_bytes(
+        1,
+        Vec::from("\x1b]99;i=chunked:a=report:d=0;Hello\x07\x1b]99;i=chunked:p=body;World\x07"),
+    )
+    .unwrap();
+
+    let output = collect_render_output(&server_receiver);
+
+    assert_eq!(
+        output.matches("i=p1r.chunked").count(),
+        2,
+        "both chunks address the same notification, got: {:?}",
         output
     );
 }
@@ -15939,7 +15963,7 @@ fn osc99_namespace_denormalize_roundtrip() {
     let pane_id: u32 = 42;
 
     // Namespace — a=report means 'r' flag is set
-    let namespaced = namespace_notification_id(original_metadata, pane_id);
+    let namespaced = namespace_notification_id(original_metadata, pane_id, true);
     assert!(
         namespaced.contains("i=p42r.mynotif"),
         "Should namespace to i=p42r.mynotif (a=report → 'r' flag), got: {:?}",
@@ -15947,19 +15971,22 @@ fn osc99_namespace_denormalize_roundtrip() {
     );
 
     // Simulate a response with the namespaced ID
-    let response_payload = format!("i=p42r.mynotif:p=close;activated");
+    let response_payload = format!("i=p42r.mynotif;activated");
     let result = denormalize_notification_response(response_payload.as_bytes());
     assert!(result.is_some(), "Should successfully denormalize");
 
-    let (terminal_id, app_wants_report, is_query, response_bytes) = result.unwrap();
-    assert_eq!(terminal_id, 42, "Should extract pane_id 42");
+    let response = result.unwrap();
+    assert_eq!(response.terminal_id, 42, "Should extract pane_id 42");
     assert!(
-        app_wants_report,
-        "'r' flag in i=p42r.mynotif means app_wants_report should be true"
+        response.forward_to_pane,
+        "'r' flag in i=p42r.mynotif means the response goes back to the app"
     );
-    assert!(!is_query, "No 'q' flag means is_query should be false");
+    assert!(
+        response.focus_pane,
+        "an activation report focuses the originating pane"
+    );
 
-    let response_str = String::from_utf8_lossy(&response_bytes);
+    let response_str = String::from_utf8_lossy(&response.bytes);
     assert!(
         response_str.contains("i=mynotif"),
         "Should restore original i=mynotif, got: {:?}",
@@ -15990,7 +16017,7 @@ fn osc99_namespace_without_identifier_adds_default() {
 
     // With a=report → 'r' flag
     let metadata = "p=title:a=report";
-    let namespaced = namespace_notification_id(metadata, 7);
+    let namespaced = namespace_notification_id(metadata, 7, true);
     assert!(
         namespaced.contains("i=p7r.:"),
         "Should add default i=p7r. when no i= present (a=report → 'r' flag), got: {:?}",
@@ -15999,7 +16026,7 @@ fn osc99_namespace_without_identifier_adds_default() {
 
     // Without a=report → no 'r' flag
     let metadata = "p=title";
-    let namespaced = namespace_notification_id(metadata, 7);
+    let namespaced = namespace_notification_id(metadata, 7, false);
     assert!(
         namespaced.contains("i=p7.:"),
         "Should add default i=p7. when no i= and no a=report, got: {:?}",
@@ -16008,11 +16035,41 @@ fn osc99_namespace_without_identifier_adds_default() {
 }
 
 #[test]
+fn osc99_namespace_does_not_leave_empty_metadata_entries() {
+    use crate::panes::grid::namespace_notification_id;
+
+    let namespaced = namespace_notification_id("", 1, false);
+    assert_eq!(
+        namespaced, "i=p1.:a=focus,report",
+        "an empty metadata section produces no empty key=value entries"
+    );
+}
+
+#[test]
+fn osc99_namespace_is_stable_across_the_escapes_of_one_notification() {
+    use crate::panes::grid::namespace_notification_id;
+
+    let notification = namespace_notification_id("i=myid:a=report", 4, true);
+    let close = namespace_notification_id("i=myid:p=close", 4, true);
+    assert!(
+        notification.contains("i=p4r.myid") && close.contains("i=p4r.myid"),
+        "a close request addresses the same identifier the notification got, got: {:?} and {:?}",
+        notification,
+        close
+    );
+    assert!(
+        !close.contains("a="),
+        "a close request is not turned into something the host reports on, got: {:?}",
+        close
+    );
+}
+
+#[test]
 fn osc99_namespace_ensures_report_action() {
     use crate::panes::grid::namespace_notification_id;
 
     // a=focus → a=focus,report
-    let result = namespace_notification_id("i=test:p=title:a=focus", 1);
+    let result = namespace_notification_id("i=test:p=title:a=focus", 1, false);
     assert!(
         result.contains("a=focus,report"),
         "a=focus should be augmented with report, got: {:?}",
@@ -16020,7 +16077,7 @@ fn osc99_namespace_ensures_report_action() {
     );
 
     // a=report → unchanged
-    let result = namespace_notification_id("i=test:p=title:a=report", 1);
+    let result = namespace_notification_id("i=test:p=title:a=report", 1, true);
     assert!(
         result.contains("a=report"),
         "a=report should be preserved, got: {:?}",
@@ -16033,18 +16090,17 @@ fn osc99_namespace_ensures_report_action() {
     );
 
     // a=focus,report → unchanged
-    let result = namespace_notification_id("i=test:p=title:a=focus,report", 1);
+    let result = namespace_notification_id("i=test:p=title:a=focus,report", 1, true);
     assert!(
         result.contains("a=focus,report"),
         "a=focus,report should be preserved, got: {:?}",
         result
     );
 
-    // No a= key → a=report added
-    let result = namespace_notification_id("i=test:p=title", 1);
+    let result = namespace_notification_id("i=test:p=title", 1, false);
     assert!(
-        result.contains("a=report"),
-        "Missing a= should get a=report appended, got: {:?}",
+        result.contains("a=focus,report"),
+        "Missing a= should keep the protocol's default focus action, got: {:?}",
         result
     );
 }
@@ -16054,21 +16110,21 @@ fn osc99_report_flag_roundtrip() {
     use crate::panes::grid::namespace_notification_id;
     use crate::screen::denormalize_notification_response;
 
-    // App sends a=report → namespaced with 'r' flag → denormalize returns app_wants_report=true
-    let namespaced = namespace_notification_id("i=myid:p=title:a=report", 5);
+    let namespaced = namespace_notification_id("i=myid:p=title:a=report", 5, true);
     assert!(
         namespaced.contains("i=p5r.myid"),
         "a=report should produce 'r' flag in namespace, got: {:?}",
         namespaced
     );
     let response = format!("i=p5r.myid;activated");
-    let (pane_id, wants_report, _is_query, _bytes) =
-        denormalize_notification_response(response.as_bytes()).unwrap();
-    assert_eq!(pane_id, 5);
-    assert!(wants_report, "Should detect 'r' flag as app_wants_report");
+    let response = denormalize_notification_response(response.as_bytes()).unwrap();
+    assert_eq!(response.terminal_id, 5);
+    assert!(
+        response.forward_to_pane,
+        "Should detect 'r' flag and hand the report to the app"
+    );
 
-    // App sends a=focus (no report) → namespaced without 'r' flag → denormalize returns false
-    let namespaced = namespace_notification_id("i=myid:p=title:a=focus", 5);
+    let namespaced = namespace_notification_id("i=myid:p=title:a=focus", 5, false);
     assert!(
         namespaced.contains("i=p5.myid"),
         "a=focus should NOT produce 'r' flag, got: {:?}",
@@ -16080,58 +16136,91 @@ fn osc99_report_flag_roundtrip() {
         namespaced
     );
     let response = format!("i=p5.myid;activated");
-    let (pane_id, wants_report, _is_query, _bytes) =
-        denormalize_notification_response(response.as_bytes()).unwrap();
-    assert_eq!(pane_id, 5);
-    assert!(!wants_report, "No 'r' flag means app did not want report");
+    let response = denormalize_notification_response(response.as_bytes()).unwrap();
+    assert_eq!(response.terminal_id, 5);
+    assert!(
+        !response.forward_to_pane,
+        "No 'r' flag means the app is not handed a report it never asked for"
+    );
+    assert!(
+        response.focus_pane,
+        "the pane is still focused when the notification is clicked"
+    );
 }
 
 #[test]
-fn osc99_query_flag_roundtrip() {
+fn osc99_query_response_is_handed_to_the_pane_without_focusing_it() {
     use crate::panes::grid::namespace_notification_id;
     use crate::screen::denormalize_notification_response;
 
-    // Capability query (p=?) gets 'q' flag
-    let namespaced = namespace_notification_id("i=qid:p=?", 3);
-    assert!(
-        namespaced.contains("i=p3q.qid"),
-        "p=? should produce 'q' flag, got: {:?}",
-        namespaced
+    let namespaced = namespace_notification_id("i=qid:p=?", 3, false);
+    assert_eq!(
+        namespaced, "i=p3.qid:p=?",
+        "a query is namespaced and otherwise left alone"
     );
-    let response = format!("i=p3q.qid;p=title,body");
-    let (pane_id, wants_report, is_query, _bytes) =
-        denormalize_notification_response(response.as_bytes()).unwrap();
-    assert_eq!(pane_id, 3);
-    assert!(!wants_report);
-    assert!(is_query, "Should detect 'q' flag");
+    let response = format!("i=p3.qid:p=?;a=focus,report:p=title,body");
+    let response = denormalize_notification_response(response.as_bytes()).unwrap();
+    assert_eq!(response.terminal_id, 3);
+    assert!(
+        response.forward_to_pane,
+        "the app is waiting for the answer to its query"
+    );
+    assert!(
+        !response.focus_pane,
+        "answering a query is not the user clicking a notification"
+    );
+    assert!(
+        String::from_utf8_lossy(&response.bytes).contains("i=qid:p=?"),
+        "the app's own identifier is restored, got: {:?}",
+        String::from_utf8_lossy(&response.bytes)
+    );
+}
 
-    // Both flags: a=report + p=? (unlikely but valid)
-    let namespaced = namespace_notification_id("i=both:p=?:a=report", 3);
-    assert!(
-        namespaced.contains("i=p3rq.both"),
-        "Both flags should be present, got: {:?}",
-        namespaced
-    );
-    let response = format!("i=p3rq.both;p=title,body");
-    let (pane_id, wants_report, is_query, _bytes) =
-        denormalize_notification_response(response.as_bytes()).unwrap();
-    assert_eq!(pane_id, 3);
-    assert!(wants_report);
-    assert!(is_query);
+#[test]
+fn osc99_close_report_does_not_steal_focus() {
+    use crate::screen::denormalize_notification_response;
 
-    // Regular notification (no p=?, no a=report) — no flags
-    let namespaced = namespace_notification_id("i=plain:p=title:a=focus", 3);
+    let response = denormalize_notification_response(b"i=p3.myid:p=close;").unwrap();
+    assert_eq!(response.terminal_id, 3);
     assert!(
-        namespaced.contains("i=p3.plain"),
-        "No flags expected, got: {:?}",
-        namespaced
+        response.forward_to_pane,
+        "close events only arrive when the app asked for them with c=1"
     );
-    let response = format!("i=p3.plain;activated");
-    let (pane_id, wants_report, is_query, _bytes) =
-        denormalize_notification_response(response.as_bytes()).unwrap();
-    assert_eq!(pane_id, 3);
-    assert!(!wants_report);
-    assert!(!is_query);
+    assert!(
+        !response.focus_pane,
+        "dismissing a notification is not activating it"
+    );
+}
+
+#[test]
+fn osc99_liveness_answer_is_restricted_to_the_asking_pane() {
+    use crate::screen::denormalize_notification_response;
+
+    let response =
+        denormalize_notification_response(b"i=p3.myid:p=alive;p3.one,p4r.other,p3r.two").unwrap();
+    let restored = String::from_utf8_lossy(&response.bytes).to_string();
+    assert!(
+        restored.contains(";one,two"),
+        "the pane's own identifiers are restored, got: {:?}",
+        restored
+    );
+    assert!(
+        !restored.contains("other"),
+        "identifiers belonging to other panes are not disclosed, got: {:?}",
+        restored
+    );
+}
+
+#[test]
+fn osc99_response_to_an_unidentified_notification_uses_the_protocol_default() {
+    use crate::screen::denormalize_notification_response;
+
+    let response = denormalize_notification_response(b"i=p3r.;activated").unwrap();
+    assert!(
+        String::from_utf8_lossy(&response.bytes).contains("i=0"),
+        "an app that sent no identifier is answered with i=0, got: {:?}",
+        String::from_utf8_lossy(&response.bytes)
+    );
 }
 
 #[test]

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -12893,8 +12893,10 @@ fn an_osc_99_notification_reaching_an_osc_9_host_is_translated_down() {
 
     screen.forward_desktop_notifications(
         vec![PendingNotification::Osc99 {
-            payload: "i=1:d=0;the build finished".to_owned(),
+            payload: "i=1;the build finished".to_owned(),
             terminator: "\u{7}".to_owned(),
+            wants_report: false,
+            display: Some(("the build finished".to_owned(), String::new())),
         }],
         1,
     );
@@ -12907,6 +12909,36 @@ fn an_osc_99_notification_reaching_an_osc_9_host_is_translated_down() {
 }
 
 #[test]
+fn an_osc_99_request_with_nothing_to_show_is_not_sent_to_an_osc_9_host() {
+    let (mut screen, server_receiver) =
+        screen_with_a_client_for_notifications(HostNotificationProtocol::Auto, BTreeMap::new());
+
+    screen.forward_desktop_notifications(
+        vec![
+            PendingNotification::Osc99 {
+                payload: "i=1:d=0;the build".to_owned(),
+                terminator: "\u{7}".to_owned(),
+                wants_report: false,
+                display: None,
+            },
+            PendingNotification::Osc99 {
+                payload: "i=1:p=close;".to_owned(),
+                terminator: "\u{7}".to_owned(),
+                wants_report: false,
+                display: None,
+            },
+        ],
+        1,
+    );
+
+    assert_eq!(
+        collect_forwarded_notifications(&server_receiver),
+        "",
+        "unfinished chunks and closes have no legacy equivalent to send"
+    );
+}
+
+#[test]
 fn an_osc_99_notification_reaching_an_osc_99_host_keeps_its_namespaced_identifier() {
     let (mut screen, server_receiver) =
         screen_with_a_client_for_notifications(HostNotificationProtocol::Auto, kitty_env());
@@ -12915,6 +12947,8 @@ fn an_osc_99_notification_reaching_an_osc_99_host_keeps_its_namespaced_identifie
         vec![PendingNotification::Osc99 {
             payload: "i=myid;the build finished".to_owned(),
             terminator: "\u{7}".to_owned(),
+            wants_report: false,
+            display: Some(("the build finished".to_owned(), String::new())),
         }],
         7,
     );


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/5504 as well as some issues related to desktop notifications introduced in 0.45.0.

The aforementioned issue was OSC9 being overloaded with conemu's original progress bar protocol. We now parse those out properly. Additionally I found some issues related to kitty notification fragmenting and other related problems, all fixed.