### PR TITLE
fix(kitty): apply reported pixel dimensions to existing ptys and clear images of collapsed stack members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 * fix: nested-session detection over SSH (https://github.com/zellij-org/zellij/pull/5522)
 * fix: some issues with notification parsing (eg. neovim notification on save) (https://github.com/zellij-org/zellij/pull/5523)
+* fix: kitty image size on startup and clearing with stacked unlisted full framed panes (https://github.com/zellij-org/zellij/pull/5526)
 
 ## [0.45.0] - 2026-08-20
 * feat: allow tabs to have different sizes if clients aren't focused on the same one (https://github.com/zellij-org/zellij/pull/5133)

--- a/zellij-server/src/output/unit/output_tests.rs
+++ b/zellij-server/src/output/unit/output_tests.rs
@@ -1207,6 +1207,22 @@ fn run_kitty_frame(
     output.serialize().unwrap().remove(&1).unwrap_or_default()
 }
 
+fn run_kitty_frame_for_panes(
+    parts: &KittyTestParts,
+    chunks_by_pane: Vec<(PaneId, Vec<KittyImageChunk>)>,
+    visible_panes: HashSet<PaneId>,
+) -> String {
+    let mut output = create_test_kitty_output(parts);
+    let client_ids: HashSet<ClientId> = create_test_clients(1);
+    let link_handler = Rc::new(RefCell::new(LinkHandler::new()));
+    output.add_clients(&client_ids, link_handler, None);
+    output.set_kitty_visible_panes(1, visible_panes);
+    for (pane_id, chunks) in chunks_by_pane {
+        output.add_kitty_image_chunks_to_client(1, pane_id, chunks, None);
+    }
+    output.serialize().unwrap().remove(&1).unwrap_or_default()
+}
+
 fn run_kitty_frame_with_host_clear(parts: &KittyTestParts, chunks: Vec<KittyImageChunk>) -> String {
     let mut output = create_test_kitty_output(parts);
     let client_ids: HashSet<ClientId> = create_test_clients(1);
@@ -1369,6 +1385,41 @@ fn kitty_diff_move_remove_free_retransmit() {
     let new_internal = store_test_kitty_image(&parts.0, 30, 40);
     let frame_5 = run_kitty_frame(&parts, vec![kitty_chunk(new_internal, 2, 0, 0)], None);
     assert!(frame_5.contains("\u{1b}_Ga=t,q=2,f=32,t=d,i=2000000001,"));
+}
+
+#[test]
+fn kitty_placements_of_pane_dropped_from_visible_set_are_deleted() {
+    let parts = create_test_kitty_parts();
+    let internal = store_test_kitty_image(&parts.0, 30, 40);
+    let both_panes_visible: HashSet<PaneId> = [PaneId::Terminal(1), PaneId::Terminal(2)]
+        .into_iter()
+        .collect();
+    let frame_1 = run_kitty_frame_for_panes(
+        &parts,
+        vec![
+            (PaneId::Terminal(1), vec![kitty_chunk(internal, 1, 0, 0)]),
+            (PaneId::Terminal(2), vec![kitty_chunk(internal, 2, 0, 10)]),
+        ],
+        both_panes_visible,
+    );
+    assert_eq!(frame_1.matches("\u{1b}_Ga=p,q=2,").count(), 2);
+    assert!(!frame_1.contains("a=d"));
+
+    let only_second_pane_visible: HashSet<PaneId> = [PaneId::Terminal(2)].into_iter().collect();
+    let frame_2 = run_kitty_frame_for_panes(
+        &parts,
+        vec![(PaneId::Terminal(2), vec![kitty_chunk(internal, 2, 0, 10)])],
+        only_second_pane_visible,
+    );
+    assert_eq!(
+        frame_2.matches("\u{1b}_Ga=d,q=2,d=i,").count(),
+        1,
+        "the placement of the pane that left the visible set must be deleted"
+    );
+    assert!(
+        frame_2.contains("\u{1b}_Ga=d,q=2,d=i,i=2000000000,p=1\u{1b}\\"),
+        "the deleted placement must be the one belonging to the invisible pane"
+    );
 }
 
 #[test]

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -564,10 +564,23 @@ impl TiledPanes {
     }
     pub fn rendered_pane_ids(&self) -> Vec<PaneId> {
         self.panes
-            .keys()
-            .filter(|pane_id| !self.panes_to_hide.contains(pane_id))
-            .copied()
+            .iter()
+            .filter(|(pane_id, pane)| {
+                if self.panes_to_hide.contains(pane_id) {
+                    return false;
+                }
+                let geom = pane.current_geom();
+                !(geom.is_stacked() && geom.rows.is_fixed())
+            })
+            .map(|(pane_id, _pane)| *pane_id)
             .collect()
+    }
+    pub fn resize_pty_all_panes(&mut self) -> Result<()> {
+        for pane in self.panes.values_mut() {
+            resize_pty!(pane, self.os_api, self.senders, self.character_cell_size)
+                .with_context(|| format!("failed to resize PTY in pane {:?}", pane.pid()))?;
+        }
+        Ok(())
     }
     pub fn relayout(&mut self, direction: SplitDirection) {
         let mut pane_grid = TiledPaneGrid::new(

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -2646,16 +2646,17 @@ impl Screen {
         &mut self,
         client_id: ClientId,
         pixel_dimensions: PixelDimensions,
-    ) {
+    ) -> bool {
+        let previous_character_cell_size = *self.character_cell_size.borrow();
         self.pixel_dimensions.merge(pixel_dimensions);
         if let Some(character_cell_size) = self.pixel_dimensions.character_cell_size {
             *self.character_cell_size.borrow_mut() = Some(character_cell_size);
         } else if let Some(text_area_size) = self.pixel_dimensions.text_area_size {
             let Some(client_size) = self.client_sizes.get(&client_id).copied() else {
-                return;
+                return false;
             };
             if client_size.rows == 0 || client_size.cols == 0 {
-                return;
+                return false;
             }
             let character_cell_size = SizeInPixels {
                 height: text_area_size.height / client_size.rows,
@@ -2663,6 +2664,15 @@ impl Screen {
             };
             *self.character_cell_size.borrow_mut() = Some(character_cell_size);
         }
+        *self.character_cell_size.borrow() != previous_character_cell_size
+    }
+
+    pub fn resize_pty_all_panes(&mut self) -> Result<()> {
+        for tab in self.tabs.values_mut() {
+            tab.resize_pty_all_panes()
+                .context("failed to re-apply pty sizes")?;
+        }
+        Ok(())
     }
 
     pub fn update_kitty_graphics_support(&mut self, client_id: ClientId, supported: bool) {
@@ -9931,7 +9941,11 @@ pub(crate) fn screen_thread_main(
                 }
             },
             ScreenInstruction::TerminalPixelDimensions(client_id, pixel_dimensions) => {
-                screen.update_pixel_dimensions(client_id, pixel_dimensions);
+                let character_cell_size_changed =
+                    screen.update_pixel_dimensions(client_id, pixel_dimensions);
+                if character_cell_size_changed {
+                    screen.resize_pty_all_panes()?;
+                }
             },
             ScreenInstruction::TerminalBackgroundColor(background_color_instruction) => {
                 screen.update_terminal_background_color(background_color_instruction);

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -5072,6 +5072,20 @@ impl Tab {
         let selectable_tiled_panes = self.tiled_panes.get_panes().filter(|(_, p)| p.selectable());
         selectable_tiled_panes.count() > 0
     }
+    pub fn resize_pty_all_panes(&mut self) -> Result<()> {
+        let err_context = || format!("failed to resize PTYs of all panes in tab {}", self.id);
+        self.tiled_panes
+            .resize_pty_all_panes()
+            .with_context(err_context)?;
+        self.floating_panes
+            .resize_pty_all_panes(&mut self.os_api)
+            .with_context(err_context)?;
+        for (_is_scrollback_editor, pane) in self.suppressed_panes.values_mut() {
+            resize_pty!(pane, self.os_api, self.senders, self.character_cell_size)
+                .with_context(err_context)?;
+        }
+        Ok(())
+    }
     pub fn resize_whole_tab(&mut self, new_screen_size: Size) -> Result<()> {
         let err_context = || format!("failed to resize whole tab (id {})", self.id);
         self.size = new_screen_size;

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -1573,6 +1573,51 @@ fn new_stacked_pane() {
     assert_snapshot!(snapshot);
 }
 
+fn sorted_kitty_visible_pane_ids(tab: &Tab) -> Vec<PaneId> {
+    let mut pane_ids: Vec<PaneId> = tab.kitty_visible_pane_ids().into_iter().collect();
+    pane_ids.sort();
+    pane_ids
+}
+
+#[test]
+fn kitty_visible_panes_exclude_collapsed_stack_members() {
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let client_id = 1;
+    let mut tab = create_new_tab(size, ModeInfo::default());
+    for i in 2..4 {
+        tab.new_pane(
+            PaneId::Terminal(i),
+            None,
+            None,
+            false,
+            true,
+            NewPanePlacement::Stacked {
+                pane_id_to_stack_under: None,
+                borderless: None,
+            },
+            Some(client_id),
+            None,
+        )
+        .unwrap();
+    }
+    let visible_before_focus_change = sorted_kitty_visible_pane_ids(&tab);
+    tab.move_focus_up(client_id).unwrap();
+    let visible_after_focus_change = sorted_kitty_visible_pane_ids(&tab);
+    assert_eq!(
+        visible_before_focus_change,
+        vec![PaneId::Terminal(3)],
+        "only the expanded stack member is kitty visible"
+    );
+    assert_eq!(
+        visible_after_focus_change,
+        vec![PaneId::Terminal(2)],
+        "kitty visibility follows the expanded stack member"
+    );
+}
+
 #[test]
 fn floating_panes_persist_across_toggles() {
     let size = Size {

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -13171,3 +13171,75 @@ fn a_client_whose_host_focus_was_never_reported_counts_as_focused() {
         "a client is assumed focused until told otherwise, so this is not a transition"
     );
 }
+
+fn resize_pty_pixel_dimensions(
+    instruction: &PtyWriteInstruction,
+) -> Option<(Option<u16>, Option<u16>)> {
+    match instruction {
+        PtyWriteInstruction::ResizePty(_terminal_id, _cols, _rows, width, height) => {
+            Some((*width, *height))
+        },
+        _ => None,
+    }
+}
+
+#[test]
+pub fn reported_pixel_dimensions_are_applied_to_existing_ptys() {
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let mut mock_screen = MockScreen::new(size);
+    let pty_writer_receiver = mock_screen.pty_writer_receiver.take().unwrap();
+    let screen_thread = mock_screen.run(None, vec![]);
+    let received_pty_instructions = Arc::new(Mutex::new(vec![]));
+    let pty_writer_thread = log_actions_in_thread!(
+        received_pty_instructions,
+        PtyWriteInstruction::Exit,
+        pty_writer_receiver
+    );
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    let instruction_count_before_reply = received_pty_instructions.lock().unwrap().len();
+    let _ = mock_screen
+        .to_screen
+        .send(ScreenInstruction::TerminalPixelDimensions(
+            mock_screen.main_client_id,
+            PixelDimensions {
+                character_cell_size: Some(SizeInPixels {
+                    height: 21,
+                    width: 8,
+                }),
+                text_area_size: None,
+            },
+        ));
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    mock_screen.teardown(vec![pty_writer_thread, screen_thread]);
+
+    let received_pty_instructions = received_pty_instructions.lock().unwrap();
+    let (before_reply, after_reply) =
+        received_pty_instructions.split_at(instruction_count_before_reply);
+    let resizes_before_reply: Vec<(Option<u16>, Option<u16>)> = before_reply
+        .iter()
+        .filter_map(resize_pty_pixel_dimensions)
+        .collect();
+    let resizes_after_reply: Vec<(Option<u16>, Option<u16>)> = after_reply
+        .iter()
+        .filter_map(resize_pty_pixel_dimensions)
+        .collect();
+    assert!(
+        !resizes_before_reply.is_empty()
+            && resizes_before_reply
+                .iter()
+                .all(|dimensions| dimensions == &(None, None)),
+        "panes are created before the host reports its pixel dimensions, got: {:?}",
+        resizes_before_reply
+    );
+    assert!(
+        !resizes_after_reply.is_empty()
+            && resizes_after_reply
+                .iter()
+                .all(|(width, height)| width.is_some() && height.is_some()),
+        "existing ptys are resized with pixel dimensions once these are reported, got: {:?}",
+        resizes_after_reply
+    );
+}


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/5511 and https://github.com/zellij-org/zellij/issues/5512

Namely a few minor plumbing fixes to get both issues to work fine.