### PR TITLE
fix: focus event handling from external in web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix: nested-session detection over SSH (https://github.com/zellij-org/zellij/pull/5522)
 * fix: some issues with notification parsing (eg. neovim notification on save) (https://github.com/zellij-org/zellij/pull/5523)
 * fix: kitty image size on startup and clearing with stacked unlisted full framed panes (https://github.com/zellij-org/zellij/pull/5526)
+* fix: focus event in remote attach (https://github.com/zellij-org/zellij/pull/5527)
 
 ## [0.45.0] - 2026-08-20
 * feat: allow tabs to have different sizes if clients aren't focused on the same one (https://github.com/zellij-org/zellij/pull/5133)

--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -186,6 +186,16 @@ impl InputHandler {
                             let mouse_event = from_termwiz(&mut self.mouse_old_event, mouse_event);
                             self.handle_mouse_event(&mouse_event);
                         },
+                        InputEvent::FocusGained => {
+                            self.os_input.send_to_server(
+                                ClientToServerMsg::HostTerminalFocusChanged { focused: true },
+                            );
+                        },
+                        InputEvent::FocusLost => {
+                            self.os_input.send_to_server(
+                                ClientToServerMsg::HostTerminalFocusChanged { focused: false },
+                            );
+                        },
                         InputEvent::Paste(pasted_text) => {
                             if self.mode == InputMode::Normal || self.mode == InputMode::Locked {
                                 self.dispatch_action(

--- a/zellij-client/src/web_client/message_handlers.rs
+++ b/zellij-client/src/web_client/message_handlers.rs
@@ -91,6 +91,12 @@ fn dispatch_termwiz_event(
                 is_kitty_keyboard_protocol: false,
             });
         },
+        InputEvent::FocusGained => {
+            os_input.send_to_server(ClientToServerMsg::HostTerminalFocusChanged { focused: true });
+        },
+        InputEvent::FocusLost => {
+            os_input.send_to_server(ClientToServerMsg::HostTerminalFocusChanged { focused: false });
+        },
         InputEvent::Mouse(mouse_event) => {
             let mouse_event = from_termwiz(mouse_old_event, mouse_event);
             let action = Action::MouseEvent { event: mouse_event };
@@ -452,6 +458,65 @@ mod tests {
             },
             other => panic!("expected Key message, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn focus_reports_are_not_typed_into_the_session() {
+        let os_input = RecordingOsInput::default();
+        let mut mouse_old_event = MouseEvent::new();
+        let mut session = super::StdinSession::new(false);
+
+        parse_stdin(
+            b"\x1b[O",
+            Box::new(os_input.clone()),
+            &mut mouse_old_event,
+            &mut session,
+        );
+        parse_stdin(
+            b"\x1b[I",
+            Box::new(os_input.clone()),
+            &mut mouse_old_event,
+            &mut session,
+        );
+
+        let sent = os_input.take_sent_messages();
+        assert_eq!(
+            sent,
+            vec![
+                ClientToServerMsg::HostTerminalFocusChanged { focused: false },
+                ClientToServerMsg::HostTerminalFocusChanged { focused: true },
+            ],
+            "focus reports must become focus messages, never key events"
+        );
+    }
+
+    #[test]
+    fn fragmented_focus_report_resolves_across_frames() {
+        let os_input = RecordingOsInput::default();
+        let mut mouse_old_event = MouseEvent::new();
+        let mut session = super::StdinSession::new(false);
+
+        parse_stdin(
+            b"\x1b[",
+            Box::new(os_input.clone()),
+            &mut mouse_old_event,
+            &mut session,
+        );
+        assert!(
+            os_input.take_sent_messages().is_empty(),
+            "an incomplete focus report must not emit anything on frame 1"
+        );
+
+        parse_stdin(
+            b"I",
+            Box::new(os_input.clone()),
+            &mut mouse_old_event,
+            &mut session,
+        );
+        assert_eq!(
+            os_input.take_sent_messages(),
+            vec![ClientToServerMsg::HostTerminalFocusChanged { focused: true }],
+        );
     }
 
     /// Plain printable bytes that aren't a Kitty sequence must NOT be

--- a/zellij-utils/src/vendored/termwiz/input.rs
+++ b/zellij-utils/src/vendored/termwiz/input.rs
@@ -152,6 +152,8 @@ pub enum InputEvent {
         final_byte: u8,
         raw: Vec<u8>,
     },
+    FocusGained,
+    FocusLost,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1553,6 +1555,9 @@ impl InputParser {
                 modifiers: Modifiers::NONE,
             }),
         );
+        map.insert(b"\x1b[I", InputEvent::FocusGained);
+        map.insert(b"\x1b[O", InputEvent::FocusLost);
+
         map.insert(
             b"\x1b[",
             InputEvent::Key(KeyEvent {
@@ -3175,5 +3180,57 @@ mod test {
             panic!("wrong variant");
         };
         assert_eq!(&raw[..], bytes, "raw must be byte-identical to input");
+    }
+
+    #[test]
+    fn focus_reports_decode_as_focus_events() {
+        let mut p = InputParser::new();
+        assert_eq!(
+            p.parse_as_vec(b"\x1b[I", MAYBE_MORE),
+            vec![InputEvent::FocusGained],
+        );
+        assert_eq!(
+            p.parse_as_vec(b"\x1b[O", MAYBE_MORE),
+            vec![InputEvent::FocusLost],
+        );
+    }
+
+    #[test]
+    fn focus_report_split_across_reads_still_decodes_as_one_event() {
+        let mut p = InputParser::new();
+        assert_eq!(p.parse_as_vec(b"\x1b[", MAYBE_MORE), vec![]);
+        assert_eq!(
+            p.parse_as_vec(b"I", MAYBE_MORE),
+            vec![InputEvent::FocusGained],
+        );
+    }
+
+    #[test]
+    fn focus_reports_never_degrade_into_literal_characters() {
+        let mut p = InputParser::new();
+        let events = p.parse_as_vec(b"\x1b[O\x1b[I", MAYBE_MORE);
+        assert_eq!(
+            events,
+            vec![InputEvent::FocusLost, InputEvent::FocusGained],
+            "a focus report must not decode as Alt+[ plus a literal I/O keystroke"
+        );
+    }
+
+    #[test]
+    fn alt_bracket_is_still_recognized_for_other_following_bytes() {
+        let mut p = InputParser::new();
+        assert_eq!(
+            p.parse_as_vec(b"\x1b[x", MAYBE_MORE),
+            vec![
+                InputEvent::Key(KeyEvent {
+                    key: KeyCode::Char('['),
+                    modifiers: Modifiers::ALT,
+                }),
+                InputEvent::Key(KeyEvent {
+                    key: KeyCode::Char('x'),
+                    modifiers: Modifiers::NONE,
+                }),
+            ],
+        );
     }
 }


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/5505

This only happened in the web (remote attach). We were bypassing some parts of the input parser.