### PR TITLE
feat(kitty-graphics): support Unicode-placeholder (U=1) image placements

### DIFF
--- a/zellij-server/src/output/mod.rs
+++ b/zellij-server/src/output/mod.rs
@@ -190,7 +190,15 @@ fn serialize_chunks_with_newlines(
             )
             .with_context(err_context)?;
             chunk_width += t_character.width();
-            vte_output.push(t_character.character);
+            // Kitty Unicode-placeholder cells are stored as encoded PUA
+            // chars (see panes::kitty_graphics::placeholders); the image
+            // is drawn over them via kitty chunks, so the host terminal
+            // gets a plain space instead of an undefined-glyph box.
+            if crate::panes::kitty_graphics::is_in_encoded_range(t_character.character) {
+                vte_output.push(' ');
+            } else {
+                vte_output.push(t_character.character);
+            }
         }
     }
     Ok(vte_output)
@@ -256,7 +264,15 @@ fn serialize_chunks(
             )
             .with_context(err_context)?;
             chunk_width += t_character.width();
-            vte_output.push(t_character.character);
+            // Kitty Unicode-placeholder cells are stored as encoded PUA
+            // chars (see panes::kitty_graphics::placeholders); the image
+            // is drawn over them via kitty chunks, so the host terminal
+            // gets a plain space instead of an undefined-glyph box.
+            if crate::panes::kitty_graphics::is_in_encoded_range(t_character.character) {
+                vte_output.push(' ');
+            } else {
+                vte_output.push(t_character.character);
+            }
         }
     }
     if let Some(sixel_image_store) = sixel_image_store {

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -801,6 +801,12 @@ pub struct Grid {
     kitty_parser: KittyCommandParser,
     kitty_host_support: KittyHostSupport,
     sixel_host_support: bool,
+    /// (x, y, diacritics_seen) of a just-printed kitty image
+    /// placeholder cell, so the zero-width row/column/id diacritics
+    /// that follow it can be folded into the stored cell before the
+    /// generic zero-width drop discards them.
+    pending_kitty_placeholder: Option<(usize, usize, u8)>,
+    kitty_placeholder_interner: crate::panes::kitty_graphics::PlaceholderInterner,
     pub changed_colors: Option<[Option<AnsiCode>; 256]>,
     pub should_render: bool,
     pub lock_renders: bool,
@@ -872,6 +878,17 @@ pub struct Grid {
     osc133_command_selection: bool,
     command_output_flash: Option<Selection>,
     word_separators: String,
+}
+
+/// One horizontal run of adjacent, same-(image, placement, row) placeholder
+/// cells found in the viewport - see `Grid::scan_placeholder_runs`.
+struct PlaceholderRun {
+    start_x: usize,
+    length: usize,
+    image_id: u32,
+    placement_id: u32,
+    image_row: u32,
+    start_column: u32,
 }
 
 impl Grid {
@@ -1217,6 +1234,8 @@ impl Grid {
             kitty_parser: KittyCommandParser::new(),
             kitty_host_support: KittyHostSupport::Supported,
             sixel_host_support: true,
+            pending_kitty_placeholder: None,
+            kitty_placeholder_interner: Default::default(),
             pending_clipboard_update: None,
             pending_osc7_cwd: None,
             pending_desktop_notifications: Vec::new(),
@@ -1628,6 +1647,7 @@ impl Grid {
         if new_columns == 0 || new_rows == 0 {
             return;
         }
+        self.pending_kitty_placeholder = None;
         if self.alternate_screen_state.is_some() {
             // in alternate screen we do nothing but log the new size, the program in the terminal
             // is in control now...
@@ -1911,13 +1931,14 @@ impl Grid {
         if self.kitty_settle_placements_below_the_viewport() {
             self.kitty_reanchor_all_from_pixels();
         }
-        let kitty_image_chunks = self.kitty_grid.viewport_kitty_chunks(
+        let mut kitty_image_chunks = self.kitty_grid.viewport_kitty_chunks(
             self.height,
             self.lines_above.len(),
             self.width,
             x_offset,
             y_offset,
         );
+        kitty_image_chunks.extend(self.placeholder_kitty_chunks(x_offset, y_offset));
         self.output_buffer.clear();
 
         (
@@ -1925,6 +1946,217 @@ impl Grid {
             changed_sixel_image_chunks,
             kitty_image_chunks,
         )
+    }
+    /// Scan the visible viewport for kitty Unicode-placeholder cells
+    /// and emit one image chunk per horizontal run. Each cell selects
+    /// an image via its fg color (plus interned id-msb), optionally a
+    /// placement via its underline color, and an image row/column via
+    /// its interned entry. The scan is stateless -- whatever cells are
+    /// on screen right now define what is drawn -- so scrolling,
+    /// erasing and overwriting placeholder cells need no extra
+    /// lifecycle tracking.
+    fn placeholder_kitty_chunks(
+        &mut self,
+        x_offset: usize,
+        y_offset: usize,
+    ) -> Vec<KittyImageChunk> {
+        if !self.kitty_grid.has_virtual_placements() {
+            return vec![];
+        }
+        let cell = match *self.character_cell_size.borrow() {
+            Some(cell) => cell,
+            None => return vec![],
+        };
+        let store = self.kitty_grid.kitty_image_store.clone();
+        self.scan_placeholder_runs()
+            .into_iter()
+            .filter_map(|(y, run)| {
+                self.resolve_placeholder_run_chunk(&store, cell, x_offset, y_offset, y, run)
+            })
+            .collect()
+    }
+    /// Walk the visible viewport decoding placeholder cells back into
+    /// (image, placement, image-row/column) triples, and merge
+    /// horizontally-adjacent cells that belong to the same image row into
+    /// a single run - one run becomes one [`KittyImageChunk`].
+    fn scan_placeholder_runs(&self) -> Vec<(usize, PlaceholderRun)> {
+        fn color_bits(color: Option<AnsiCode>) -> Option<u32> {
+            match color {
+                Some(AnsiCode::RgbCode((r, g, b))) => {
+                    Some(((r as u32) << 16) | ((g as u32) << 8) | b as u32)
+                },
+                Some(AnsiCode::ColorIndex(index)) => Some(index as u32),
+                _ => None,
+            }
+        }
+        let mut runs: Vec<(usize, PlaceholderRun)> = vec![]; // (viewport_y, run)
+        for (y, row) in self.viewport.iter().enumerate().take(self.height) {
+            let mut current: Option<PlaceholderRun> = None;
+            let mut x = 0;
+            for character in row.columns.iter() {
+                let decoded = self
+                    .kitty_placeholder_interner
+                    .decode(character.character)
+                    .and_then(|placeholder| {
+                        let id_low = color_bits(character.styles.foreground)?;
+                        let image_id = ((placeholder.image_id_msb as u32) << 24) | id_low;
+                        let placement_id = color_bits(character.styles.underline_color)
+                            .unwrap_or(crate::panes::kitty_graphics::NO_PLACEMENT_ID);
+                        Some((image_id, placement_id, placeholder))
+                    });
+                match decoded {
+                    Some((image_id, placement_id, placeholder)) => match current.as_mut() {
+                        Some(run)
+                            if run.image_id == image_id
+                                && run.placement_id == placement_id
+                                && run.image_row == placeholder.image_row as u32
+                                && run.start_column + run.length as u32
+                                    == placeholder.image_column as u32 =>
+                        {
+                            run.length += 1;
+                        },
+                        _ => {
+                            if let Some(run) = current.take() {
+                                runs.push((y, run));
+                            }
+                            current = Some(PlaceholderRun {
+                                start_x: x,
+                                length: 1,
+                                image_id,
+                                placement_id,
+                                image_row: placeholder.image_row as u32,
+                                start_column: placeholder.image_column as u32,
+                            });
+                        },
+                    },
+                    None => {
+                        if let Some(run) = current.take() {
+                            runs.push((y, run));
+                        }
+                    },
+                }
+                x += character.width();
+            }
+            if let Some(run) = current.take() {
+                runs.push((y, run));
+            }
+        }
+        runs
+    }
+    /// Resolve one placeholder run's target placement and geometry, make
+    /// sure a scaled image variant exists for it, and emit the chunk that
+    /// paints it. Returns `None` for runs whose placement/image has since
+    /// disappeared, or that fall outside the placement's current bounds
+    /// (eg. after the placement was re-registered smaller).
+    fn resolve_placeholder_run_chunk(
+        &self,
+        store: &Rc<RefCell<KittyImageStore>>,
+        cell: SizeInPixels,
+        x_offset: usize,
+        y_offset: usize,
+        y: usize,
+        run: PlaceholderRun,
+    ) -> Option<KittyImageChunk> {
+        use crate::panes::kitty_graphics::grid_state::fit_rgba_into_box;
+        let placement = self
+            .kitty_grid
+            .virtual_placement(run.image_id, run.placement_id)?;
+        let (image_width, image_height) = {
+            let store = store.borrow();
+            let image = store.get(placement.internal_id)?;
+            (image.width as usize, image.height as usize)
+        };
+        if image_width == 0 || image_height == 0 {
+            return None;
+        }
+        // Sizing mirrors place(): a missing c= or r= is derived from
+        // the image's aspect ratio at the given axis, both missing
+        // means the image's own pixel size.
+        let ceil_div = |a: usize, b: usize| (a + b - 1) / b;
+        let (columns, rows) = match (placement.columns as usize, placement.rows as usize) {
+            (0, 0) => (
+                std::cmp::max(ceil_div(image_width, cell.width), 1),
+                std::cmp::max(ceil_div(image_height, cell.height), 1),
+            ),
+            (columns, 0) => {
+                let height_px =
+                    (columns * cell.width) as f64 * image_height as f64 / image_width as f64;
+                (
+                    columns,
+                    std::cmp::max((height_px / cell.height as f64).ceil() as usize, 1),
+                )
+            },
+            (0, rows) => {
+                let width_px =
+                    (rows * cell.height) as f64 * image_width as f64 / image_height as f64;
+                (
+                    std::cmp::max((width_px / cell.width as f64).ceil() as usize, 1),
+                    rows,
+                )
+            },
+            (columns, rows) => (columns, rows),
+        };
+        if run.image_row as usize >= rows || run.start_column as usize >= columns {
+            return None;
+        }
+        // The variant cache and the host-side image cache are both
+        // keyed by (internal image, dest_cells); flagging the high
+        // bit namespaces placeholder variants away from positioned
+        // placements of the same image, whose bytes are cropped
+        // differently under the same cell count.
+        let dest_cells = (
+            (columns as u16).min(0x7FFF) | 0x8000,
+            (rows as u16).min(0x7FFF),
+        );
+        let scaled_width = columns * cell.width;
+        let scaled_height = rows * cell.height;
+        let needs_variant = match store
+            .borrow()
+            .scaled_variant(placement.internal_id, dest_cells)
+        {
+            // The character cell size may have changed since the
+            // variant was generated; the byte length is the tell.
+            Some(bytes) => bytes.len() != scaled_width * scaled_height * 4,
+            None => true,
+        };
+        if needs_variant {
+            let fitted = {
+                let store = store.borrow();
+                let image = store.get(placement.internal_id)?;
+                fit_rgba_into_box(
+                    &image.rgba,
+                    image_width,
+                    image_height,
+                    scaled_width,
+                    scaled_height,
+                )
+            };
+            store
+                .borrow_mut()
+                .add_scaled_variant(placement.internal_id, dest_cells, fitted);
+        }
+        let visible_columns = std::cmp::min(
+            run.length,
+            columns.saturating_sub(run.start_column as usize),
+        );
+        if visible_columns == 0 {
+            return None;
+        }
+        Some(KittyImageChunk {
+            cell_x: x_offset + run.start_x,
+            cell_y: y_offset + y,
+            internal_image_id: placement.internal_id,
+            source_px_x: run.start_column as usize * cell.width,
+            source_px_y: run.image_row as usize * cell.height,
+            source_px_width: visible_columns * cell.width,
+            source_px_height: cell.height,
+            cell_offset_x: 0,
+            cell_offset_y: 0,
+            z_index: 0,
+            dest_cells,
+            scaled_px: Some((scaled_width, scaled_height)),
+            placement_uid: placement.placement_uid,
+        })
     }
     pub fn serialize(&self, scrollback_lines_to_serialize: Option<usize>) -> Option<String> {
         match scrollback_lines_to_serialize {
@@ -2376,6 +2608,7 @@ impl Grid {
     }
     pub fn move_cursor_to_beginning_of_line(&mut self) {
         self.cursor.x = 0;
+        self.pending_kitty_placeholder = None;
     }
     pub fn add_character_at_cursor_position(
         &mut self,
@@ -2442,7 +2675,14 @@ impl Grid {
         // This breaks unicode grapheme segmentation, and is the reason why some characters
         // aren't displayed correctly. Refer to this issue for more information:
         //     https://github.com/zellij-org/zellij/issues/1538
+        //
+        // One class of zero-width codepoints is intercepted before the
+        // drop: the kitty graphics protocol's row/column diacritics,
+        // which arrive right after a U+10EEEE image-placeholder cell
+        // and are folded into that cell's stored char (see
+        // kitty_graphics::placeholders).
         if character_width == 0 {
+            self.apply_kitty_placeholder_diacritic(terminal_character.character);
             return;
         }
         if self.cursor.x + character_width > self.width {
@@ -2451,8 +2691,134 @@ impl Grid {
             }
             self.line_wrap();
         }
+        let is_kitty_placeholder =
+            terminal_character.character == crate::panes::kitty_graphics::PLACEHOLDER_CHAR;
+        let terminal_character = if is_kitty_placeholder {
+            self.encode_kitty_placeholder(terminal_character)
+        } else {
+            terminal_character
+        };
+        // encode_kitty_placeholder falls back to a plain space once the
+        // pane's interner is exhausted (see its doc comment) - in that
+        // case there's no encoded cell to fold diacritics into, so don't
+        // arm pending_kitty_placeholder even though a placeholder was printed.
+        let placeholder_was_encoded = is_kitty_placeholder
+            && crate::panes::kitty_graphics::is_in_encoded_range(terminal_character.character);
         self.add_character_at_cursor_position(terminal_character, false);
         self.move_cursor_forward_until_edge(character_width);
+        self.pending_kitty_placeholder = if placeholder_was_encoded {
+            Some((self.cursor.x.saturating_sub(1), self.cursor.y, 0))
+        } else {
+            None
+        };
+    }
+    /// Replace a printed U+10EEEE cell's char with an interned entry
+    /// carrying (image row, image column, image-id msb). The values
+    /// start out inherited from the placeholder cell to the left when
+    /// its colors match (the protocol's omitted-diacritic rule:
+    /// same row, column + 1, same id), and the diacritics that follow
+    /// the cell override them. The image id itself stays in the cell's
+    /// fg color, untouched.
+    fn encode_kitty_placeholder(
+        &mut self,
+        terminal_character: TerminalCharacter,
+    ) -> TerminalCharacter {
+        use crate::panes::kitty_graphics::PlaceholderCell;
+        let inherited = if self.cursor.x > 0 {
+            self.get_absolute_character_index(self.cursor.x - 1, self.cursor.y)
+                .and_then(|absolute_x| {
+                    self.viewport
+                        .get(self.cursor.y)
+                        .and_then(|row| row.columns.get(absolute_x))
+                })
+                .filter(|left| {
+                    left.styles.foreground == terminal_character.styles.foreground
+                        && left.styles.underline_color == terminal_character.styles.underline_color
+                })
+                .and_then(|left| self.kitty_placeholder_interner.decode(left.character))
+        } else {
+            None
+        };
+        let cell = match inherited {
+            Some(left) => PlaceholderCell {
+                image_row: left.image_row,
+                image_column: left.image_column.saturating_add(1),
+                image_id_msb: left.image_id_msb,
+            },
+            None => PlaceholderCell::default(),
+        };
+        let mut encoded = terminal_character;
+        match self.kitty_placeholder_interner.encode(cell) {
+            Some(character) => encoded.character = character,
+            // the interner is capped (see MAX_ENCODED_ENTRIES) and this
+            // pane has exhausted it: fall back to a space rather than
+            // storing the raw U+10EEEE, which would otherwise reach the
+            // host terminal as an undefined glyph and leak into copied
+            // text (is_in_encoded_range - and so every place that blanks
+            // encoded cells for output/copy - excludes PLACEHOLDER_CHAR
+            // itself).
+            None => encoded.character = ' ',
+        }
+        encoded
+    }
+    /// Fold a kitty placeholder diacritic into the cell it follows:
+    /// the first diacritic is the image row, the second the image
+    /// column, the third the most significant byte of the image id.
+    /// Called for every zero-width codepoint; anything that isn't a
+    /// kitty diacritic trailing a just-printed placeholder cell is
+    /// ignored (and dropped, as before).
+    fn apply_kitty_placeholder_diacritic(&mut self, character: char) {
+        let (x, y, marks_seen) = match self.pending_kitty_placeholder {
+            Some(pending) => pending,
+            None => return,
+        };
+        if self.cursor.y != y || self.cursor.x != x + 1 || marks_seen > 2 {
+            self.pending_kitty_placeholder = None;
+            return;
+        }
+        let index = match crate::panes::kitty_graphics::diacritic_index(character) {
+            Some(index) => index,
+            None => {
+                self.pending_kitty_placeholder = None;
+                return;
+            },
+        };
+        let absolute_x = match self.get_absolute_character_index(x, y) {
+            Some(absolute_x) => absolute_x,
+            None => {
+                self.pending_kitty_placeholder = None;
+                return;
+            },
+        };
+        let current = self
+            .viewport
+            .get(y)
+            .and_then(|row| row.columns.get(absolute_x))
+            .map(|cell| cell.character)
+            .and_then(|character| self.kitty_placeholder_interner.decode(character));
+        let mut updated = match current {
+            Some(current) => current,
+            None => {
+                self.pending_kitty_placeholder = None;
+                return;
+            },
+        };
+        match marks_seen {
+            0 => updated.image_row = index as u16,
+            1 => updated.image_column = index as u16,
+            _ => updated.image_id_msb = index.min(u8::MAX as u32) as u8,
+        }
+        if let Some(encoded) = self.kitty_placeholder_interner.encode(updated) {
+            if let Some(cell) = self
+                .viewport
+                .get_mut(y)
+                .and_then(|row| row.columns.get_mut(absolute_x))
+            {
+                cell.character = encoded;
+                self.output_buffer.update_line(y);
+            }
+        }
+        self.pending_kitty_placeholder = Some((x, y, marks_seen + 1));
     }
     pub fn get_character_under_cursor(&self) -> Option<TerminalCharacter> {
         let absolute_x_in_line = self.get_absolute_character_index(self.cursor.x, self.cursor.y)?;
@@ -2467,6 +2833,7 @@ impl Grid {
     pub fn move_cursor_forward_until_edge(&mut self, count: usize) {
         let count_to_move = std::cmp::min(count, self.width.saturating_sub(self.cursor.x));
         self.cursor.x += count_to_move;
+        self.pending_kitty_placeholder = None;
     }
     pub fn replace_characters_in_line_after_cursor(&mut self, replace_with: TerminalCharacter) {
         if let Some(row) = self.viewport.get_mut(self.cursor.y) {
@@ -2588,8 +2955,10 @@ impl Grid {
         }
         self.pad_lines_until(self.cursor.y, pad_character.clone());
         self.pad_current_line_until(self.cursor.x, pad_character);
+        self.pending_kitty_placeholder = None;
     }
     pub fn move_cursor_up(&mut self, count: usize) {
+        self.pending_kitty_placeholder = None;
         let (scroll_region_top, scroll_region_bottom) = self.scroll_region;
         if self.cursor.y >= scroll_region_top && self.cursor.y <= scroll_region_bottom {
             self.cursor.y = std::cmp::max(self.cursor.y.saturating_sub(count), scroll_region_top);
@@ -2626,6 +2995,7 @@ impl Grid {
         count: usize,
         pad_character: TerminalCharacter,
     ) {
+        self.pending_kitty_placeholder = None;
         let (scroll_region_top, scroll_region_bottom) = self.scroll_region;
         if self.cursor.y >= scroll_region_top && self.cursor.y <= scroll_region_bottom {
             self.cursor.y = std::cmp::min(self.cursor.y + count, scroll_region_bottom);
@@ -2635,6 +3005,7 @@ impl Grid {
         self.pad_lines_until(self.cursor.y, pad_character);
     }
     pub fn move_cursor_back(&mut self, count: usize) {
+        self.pending_kitty_placeholder = None;
         if self.cursor.x == self.width {
             // on the rightmost screen edge, backspace skips one character
             self.cursor.x -= 1;
@@ -2712,12 +3083,14 @@ impl Grid {
         self.cursor.x = column;
         let pad_character = EMPTY_TERMINAL_CHARACTER;
         self.pad_current_line_until(self.cursor.x, pad_character);
+        self.pending_kitty_placeholder = None;
     }
     pub fn move_cursor_to_line(&mut self, line: usize, pad_character: TerminalCharacter) {
         self.cursor.y = std::cmp::min(self.height - 1, line);
         self.pad_lines_until(self.cursor.y, pad_character);
         let pad_character = EMPTY_TERMINAL_CHARACTER;
         self.pad_current_line_until(self.cursor.x, pad_character);
+        self.pending_kitty_placeholder = None;
     }
     pub fn replace_with_empty_chars(&mut self, count: usize, empty_char_style: RcCharacterStyles) {
         let mut empty_character = EMPTY_TERMINAL_CHARACTER;
@@ -3279,7 +3652,16 @@ impl Grid {
             let mut terminal_col = 0;
             for terminal_character in &row.columns {
                 if (start_column..end_column).contains(&terminal_col) {
-                    line_selection.push(terminal_character.character);
+                    // Kitty image placeholder cells hold an interned
+                    // codepoint that is meaningless outside this pane;
+                    // copy them as whitespace.
+                    if crate::panes::kitty_graphics::is_in_encoded_range(
+                        terminal_character.character,
+                    ) {
+                        line_selection.push(' ');
+                    } else {
+                        line_selection.push(terminal_character.character);
+                    }
                 }
 
                 terminal_col += terminal_character.width();
@@ -3702,6 +4084,7 @@ impl Grid {
             subtract_isize_from_usize(self.scrollback_buffer_lines, transferred_rows_count);
     }
     fn move_cursor_down_by_pixels(&mut self, pixel_count: usize) {
+        self.pending_kitty_placeholder = None;
         if let Some(character_cell_size) = {
             let c = *self.character_cell_size.borrow();
             c
@@ -3774,7 +4157,38 @@ impl Grid {
         let (result, was_query) = match parsed {
             Ok(command) => {
                 let was_query = command.action == KittyAction::Query;
-                (self.execute_kitty_command(command), was_query)
+                // U=1 marks a virtual placement: the image has no
+                // position of its own -- the placeholder cells the app
+                // prints are the placement, and the render pass paints
+                // matching image fragments wherever those cells are.
+                // Both protocol forms are supported: transmit-and-place
+                // in one command (a=T/a=t with U=1 and a payload), and
+                // placing an already-transmitted image (a=p with U=1).
+                if command.unicode_placeholder {
+                    let result = match command.action {
+                        KittyAction::Transmit | KittyAction::TransmitAndDisplay => {
+                            Some(self.kitty_grid.register_virtual_transmit(&command))
+                        },
+                        KittyAction::Display => {
+                            Some(self.kitty_grid.register_virtual_display(&command))
+                        },
+                        // Query/Delete/Animate and friends don't register or
+                        // move a placement, so U=1 has nothing to change
+                        // about how they run: fall through to the normal
+                        // command path rather than adding a case for each.
+                        _ => None,
+                    };
+                    if let Some(result) = result {
+                        if result.is_ok() {
+                            self.mark_for_rerender();
+                        }
+                        (result, was_query)
+                    } else {
+                        (self.execute_kitty_command(command), was_query)
+                    }
+                } else {
+                    (self.execute_kitty_command(command), was_query)
+                }
             },
             Err(e) => (Err(e), false),
         };
@@ -5028,6 +5442,7 @@ impl Perform for Grid {
                             }
                             self.alternate_screen_state = None;
                             self.clear_viewport_before_rendering = true;
+                            self.pending_kitty_placeholder = None;
                             self.force_change_size(self.height, self.width); // the alternative_viewport might have been of a different size...
                             self.mark_for_rerender();
                         },
@@ -5112,6 +5527,7 @@ impl Perform for Grid {
                         },
                         1049 => {
                             // enter alternate buffer
+                            self.pending_kitty_placeholder = None;
                             let current_lines_above =
                                 std::mem::replace(&mut self.lines_above, VecDeque::new());
                             let current_viewport = std::mem::replace(

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -1951,8 +1951,8 @@ impl Grid {
     /// and emit one image chunk per horizontal run. Each cell selects
     /// an image via its fg color (plus interned id-msb), optionally a
     /// placement via its underline color, and an image row/column via
-    /// its interned entry. The scan is stateless -- whatever cells are
-    /// on screen right now define what is drawn -- so scrolling,
+    /// its interned entry. The scan is stateless: whatever cells are
+    /// on screen right now define what is drawn, so scrolling,
     /// erasing and overwriting placeholder cells need no extra
     /// lifecycle tracking.
     fn placeholder_kitty_chunks(
@@ -4158,7 +4158,7 @@ impl Grid {
             Ok(command) => {
                 let was_query = command.action == KittyAction::Query;
                 // U=1 marks a virtual placement: the image has no
-                // position of its own -- the placeholder cells the app
+                // position of its own. The placeholder cells the app
                 // prints are the placement, and the render pass paints
                 // matching image fragments wherever those cells are.
                 // Both protocol forms are supported: transmit-and-place

--- a/zellij-server/src/panes/kitty_graphics/grid_state.rs
+++ b/zellij-server/src/panes/kitty_graphics/grid_state.rs
@@ -1,5 +1,6 @@
 use super::parser::{DecodedImage, KittyCommand, KittyError, KittyErrorCode};
 use super::store::{InternalImageId, KittyImageStore};
+use super::NO_PLACEMENT_ID;
 use crate::panes::sixel::PixelRect;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -65,6 +66,26 @@ impl KittyReplyData {
     }
 }
 
+/// A Unicode-placeholder (U=1) image registration. It carries no
+/// position of its own: the application draws U+10EEEE placeholder
+/// cells (image id in the fg color, optional placement id in the
+/// underline color, row/column in combining diacritics) and the render
+/// pass paints the matching fragment of this image wherever those
+/// cells currently are.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct KittyVirtualPlacement {
+    pub internal_id: InternalImageId,
+    /// From the p= key; 0 when the application didn't specify one, in
+    /// which case cells that don't select a placement via underline
+    /// color match it.
+    pub placement_id: u32,
+    /// Requested size in cells from the c=/r= keys; 0 = derive from
+    /// the image's pixel size at render time.
+    pub columns: u32,
+    pub rows: u32,
+    pub placement_uid: u64,
+}
+
 #[derive(Debug, Clone)]
 pub struct KittyGrid {
     character_cell_size: Rc<RefCell<Option<SizeInPixels>>>,
@@ -72,6 +93,7 @@ pub struct KittyGrid {
     image_ids: HashMap<u32, InternalImageId>,
     image_numbers: HashMap<u32, Vec<u32>>,
     placements: Vec<KittyPlacement>,
+    virtual_placements: HashMap<u32, Vec<KittyVirtualPlacement>>,
     next_synthetic_image_id: u32,
     front_drops: u64,
     merged_rows: u64,
@@ -121,6 +143,7 @@ impl KittyGrid {
             image_ids: HashMap::new(),
             image_numbers: HashMap::new(),
             placements: Vec::new(),
+            virtual_placements: HashMap::new(),
             next_synthetic_image_id: u32::MAX,
             front_drops: 0,
             merged_rows: 0,
@@ -206,6 +229,11 @@ impl KittyGrid {
                     }
                 }
                 self.placements = kept;
+                if let Some(previous_virtuals) = self.virtual_placements.remove(&pane_image_id) {
+                    for previous in previous_virtuals {
+                        store.remove_placement_ref(previous.internal_id);
+                    }
+                }
                 if store.get(old_internal).is_some() {
                     store.free(old_internal);
                 }
@@ -234,6 +262,125 @@ impl KittyGrid {
         self.image_ids.insert(pane_image_id, internal);
         self.kitty_image_store.borrow_mut().touch(internal);
         Ok(pane_image_id)
+    }
+    /// Register a Unicode-placeholder (U=1) transmission (a=T/a=t):
+    /// store the image and remember the placement's requested cell
+    /// size, but create no positioned placement -- the placeholder
+    /// cells the application draws are the placement.
+    pub fn register_virtual_transmit(
+        &mut self,
+        command: &KittyCommand,
+    ) -> Result<KittyReplyData, KittyError> {
+        let image = match command.image.clone() {
+            Some(image) => image,
+            None => return Err(einval(command, "missing image data")),
+        };
+        let pane_image_id = self.transmit(command, image)?;
+        let internal = match self.image_ids.get(&pane_image_id).copied() {
+            Some(internal) => internal,
+            None => return Err(enoent(command, "unknown image id")),
+        };
+        self.upsert_virtual_placement(pane_image_id, internal, command);
+        Ok(KittyReplyData {
+            image_id: Some(pane_image_id),
+            image_number: command.image_number,
+            placement_id: command.placement_id,
+            quiet: command.quiet,
+        })
+    }
+    /// Register a Unicode-placeholder (U=1) placement over an
+    /// already-transmitted image (a=p): the protocol's canonical
+    /// two-step flow is `a=t` with the data followed by `a=p,U=1` with
+    /// the placement geometry.
+    pub fn register_virtual_display(
+        &mut self,
+        command: &KittyCommand,
+    ) -> Result<KittyReplyData, KittyError> {
+        let (pane_image_id, internal) = self.resolve_display_target(command)?;
+        self.upsert_virtual_placement(pane_image_id, internal, command);
+        Ok(KittyReplyData {
+            image_id: Some(pane_image_id),
+            image_number: command.image_number,
+            placement_id: command.placement_id,
+            quiet: command.quiet,
+        })
+    }
+    fn delete_virtuals<F: Fn(u32, &KittyVirtualPlacement) -> bool>(
+        virtual_placements: &mut HashMap<u32, Vec<KittyVirtualPlacement>>,
+        store: &mut KittyImageStore,
+        free_image: bool,
+        matches: F,
+    ) {
+        for (image_id, placements) in virtual_placements.iter_mut() {
+            placements.retain(|placement| {
+                if matches(*image_id, placement) {
+                    if free_image {
+                        store.free(placement.internal_id);
+                    } else {
+                        store.remove_placement_ref(placement.internal_id);
+                    }
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+        virtual_placements.retain(|_, placements| !placements.is_empty());
+    }
+    fn upsert_virtual_placement(
+        &mut self,
+        pane_image_id: u32,
+        internal: InternalImageId,
+        command: &KittyCommand,
+    ) {
+        let placement_id = command.placement_id.unwrap_or(NO_PLACEMENT_ID);
+        let store = self.kitty_image_store.clone();
+        let placements = self.virtual_placements.entry(pane_image_id).or_default();
+        let mut reused_uid = None;
+        placements.retain(|placement| {
+            if placement.placement_id == placement_id {
+                store
+                    .borrow_mut()
+                    .remove_placement_ref(placement.internal_id);
+                reused_uid = Some(placement.placement_uid);
+                false
+            } else {
+                true
+            }
+        });
+        let placement_uid = match reused_uid {
+            Some(uid) => uid,
+            None => store.borrow_mut().next_placement_uid(),
+        };
+        store.borrow_mut().add_placement_ref(internal);
+        placements.push(KittyVirtualPlacement {
+            internal_id: internal,
+            placement_id,
+            columns: command.columns,
+            rows: command.rows,
+            placement_uid,
+        });
+    }
+    /// The virtual placement a placeholder cell selects: an exact
+    /// placement-id match when the cell's underline color names one,
+    /// otherwise the most recently registered placement of the image.
+    pub fn virtual_placement(
+        &self,
+        image_id: u32,
+        placement_id: u32,
+    ) -> Option<KittyVirtualPlacement> {
+        let placements = self.virtual_placements.get(&image_id)?;
+        if placement_id != NO_PLACEMENT_ID {
+            placements
+                .iter()
+                .find(|placement| placement.placement_id == placement_id)
+                .copied()
+        } else {
+            placements.last().copied()
+        }
+    }
+    pub fn has_virtual_placements(&self) -> bool {
+        !self.virtual_placements.is_empty()
     }
     pub fn resolve_display_target(
         &self,
@@ -559,6 +706,36 @@ impl KittyGrid {
                 }
             }
             self.placements = kept;
+            // Virtual (Unicode-placeholder) placements have no position,
+            // so of the delete specifiers only the id-addressed ones
+            // (d=i/n and the d=r id range) can match them.
+            match lower {
+                'i' | 'n' => {
+                    if let Some(target) = target_image_id {
+                        Self::delete_virtuals(
+                            &mut self.virtual_placements,
+                            &mut store,
+                            uppercase,
+                            |image_id, placement| {
+                                image_id == target
+                                    && command
+                                        .placement_id
+                                        .map(|placement_id| placement.placement_id == placement_id)
+                                        .unwrap_or(true)
+                            },
+                        );
+                    }
+                },
+                'r' => {
+                    Self::delete_virtuals(
+                        &mut self.virtual_placements,
+                        &mut store,
+                        uppercase,
+                        |image_id, _| image_id >= command.source_x && image_id <= command.source_y,
+                    );
+                },
+                _ => {},
+            }
         }
         if uppercase {
             match lower {
@@ -895,6 +1072,11 @@ impl KittyGrid {
         for placement in self.placements.drain(..) {
             store.free(placement.internal_id);
         }
+        for (_, previous_placements) in self.virtual_placements.drain() {
+            for previous in previous_placements {
+                store.free(previous.internal_id);
+            }
+        }
     }
     pub fn clear_visible_placements(&mut self, scrollback_size_in_lines: usize) {
         let cell_size = { *self.character_cell_size.borrow() };
@@ -1093,6 +1275,38 @@ pub fn crop_rgba(
         out.extend_from_slice(&src[row_start..row_end]);
     }
     out
+}
+
+/// Scale `src` into a `box_w` x `box_h` canvas preserving its aspect
+/// ratio, centered, with transparent padding -- the fit the protocol
+/// specifies for Unicode-placeholder placements.
+pub fn fit_rgba_into_box(
+    src: &[u8],
+    src_w: usize,
+    src_h: usize,
+    box_w: usize,
+    box_h: usize,
+) -> Vec<u8> {
+    if src_w == 0 || src_h == 0 || box_w == 0 || box_h == 0 {
+        return vec![0; box_w * box_h * 4];
+    }
+    let scale = f64::min(box_w as f64 / src_w as f64, box_h as f64 / src_h as f64);
+    let fit_w = std::cmp::max((src_w as f64 * scale).round() as usize, 1).min(box_w);
+    let fit_h = std::cmp::max((src_h as f64 * scale).round() as usize, 1).min(box_h);
+    let scaled = scale_rgba(src, src_w, src_h, fit_w, fit_h);
+    if fit_w == box_w && fit_h == box_h {
+        return scaled;
+    }
+    let mut canvas = vec![0; box_w * box_h * 4];
+    let offset_x = (box_w - fit_w) / 2;
+    let offset_y = (box_h - fit_h) / 2;
+    for row in 0..fit_h {
+        let src_start = row * fit_w * 4;
+        let dst_start = ((row + offset_y) * box_w + offset_x) * 4;
+        canvas[dst_start..dst_start + fit_w * 4]
+            .copy_from_slice(&scaled[src_start..src_start + fit_w * 4]);
+    }
+    canvas
 }
 
 pub fn scale_rgba(src: &[u8], src_w: usize, src_h: usize, dst_w: usize, dst_h: usize) -> Vec<u8> {

--- a/zellij-server/src/panes/kitty_graphics/grid_state.rs
+++ b/zellij-server/src/panes/kitty_graphics/grid_state.rs
@@ -265,7 +265,7 @@ impl KittyGrid {
     }
     /// Register a Unicode-placeholder (U=1) transmission (a=T/a=t):
     /// store the image and remember the placement's requested cell
-    /// size, but create no positioned placement -- the placeholder
+    /// size. No positioned placement is created; the placeholder
     /// cells the application draws are the placement.
     pub fn register_virtual_transmit(
         &mut self,
@@ -1278,8 +1278,8 @@ pub fn crop_rgba(
 }
 
 /// Scale `src` into a `box_w` x `box_h` canvas preserving its aspect
-/// ratio, centered, with transparent padding -- the fit the protocol
-/// specifies for Unicode-placeholder placements.
+/// ratio, centered, with transparent padding. This is the fit the
+/// protocol specifies for Unicode-placeholder placements.
 pub fn fit_rgba_into_box(
     src: &[u8],
     src_w: usize,

--- a/zellij-server/src/panes/kitty_graphics/mod.rs
+++ b/zellij-server/src/panes/kitty_graphics/mod.rs
@@ -1,13 +1,21 @@
 pub mod grid_state;
 pub mod interceptor;
 pub mod parser;
+pub mod placeholders;
 pub mod replies;
 pub mod store;
 pub use grid_state::*;
 pub use interceptor::*;
 pub use parser::*;
+pub use placeholders::*;
 pub use replies::*;
 pub use store::*;
+
+/// The kitty graphics protocol's sentinel for "no placement id was given" -
+/// both on the wire (an absent `p=` key) and in the underline-color channel
+/// placeholder cells carry it in (an unset/default underline color decodes
+/// to this).
+pub const NO_PLACEMENT_ID: u32 = 0;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum KittyHostSupport {

--- a/zellij-server/src/panes/kitty_graphics/parser.rs
+++ b/zellij-server/src/panes/kitty_graphics/parser.rs
@@ -102,6 +102,10 @@ pub struct KittyCommand {
     pub suppress_cursor_movement: bool,
     pub delete_specifier: Option<char>,
     pub image: Option<DecodedImage>,
+    /// U=1: this command creates a virtual (Unicode-placeholder)
+    /// placement rather than a positioned one. See
+    /// kitty_graphics::placeholders.
+    pub unicode_placeholder: bool,
 }
 
 impl Default for KittyCommand {
@@ -132,6 +136,7 @@ impl Default for KittyCommand {
             suppress_cursor_movement: false,
             delete_specifier: None,
             image: None,
+            unicode_placeholder: false,
         }
     }
 }
@@ -489,10 +494,7 @@ pub fn parse_control_data(control: &[u8]) -> Result<KittyCommand, KittyError> {
             b"U" => match parse_u32(value) {
                 Some(0) => {},
                 Some(_) => {
-                    return Err(echo.error(
-                        KittyErrorCode::Enotsupported,
-                        "unicode placeholders are not supported",
-                    ));
+                    command.unicode_placeholder = true;
                 },
                 None => {
                     return Err(echo.error(KittyErrorCode::Einval, "invalid value for key 'U'"));

--- a/zellij-server/src/panes/kitty_graphics/placeholders.rs
+++ b/zellij-server/src/panes/kitty_graphics/placeholders.rs
@@ -1,0 +1,126 @@
+//! Unicode-placeholder (U=1) placements for the kitty graphics protocol.
+//!
+//! Applications place images by printing U+10EEEE cells. The image id
+//! lives in the cell's foreground color (24-bit for truecolor SGR,
+//! 8-bit for a 256-color index), an optional placement id in the
+//! underline color, and up to three combining diacritics per cell
+//! encode the image row, image column and the most significant byte of
+//! the image id. Missing diacritics are inferred from the cell to the
+//! left.
+//!
+//! The grid drops zero-width codepoints from cells (see
+//! grid::add_character), so the diacritics cannot be kept as text.
+//! Instead they are folded, at print time, into an interned
+//! (row, column, id-msb) entry, and the placeholder cell's `char` is
+//! replaced with a Plane-16 PUA codepoint carrying the entry's index.
+//! The colors stay on the cell's styles, so a placeholder cell moves
+//! through scrollback, reflow and clears like any other styled
+//! character. A render-time viewport scan (grid::placeholder_kitty_chunks)
+//! resolves the visible cells back into image chunks.
+
+use std::collections::HashMap;
+
+/// The kitty graphics protocol's Unicode placeholder codepoint.
+pub const PLACEHOLDER_CHAR: char = '\u{10EEEE}';
+
+/// Base of the encoded range. Plane-16 PUA-B is effectively unused by
+/// real-world text (unlike Plane-15, which hosts icon fonts), which
+/// keeps the range check below from ever matching application output.
+pub const ENCODED_BASE: u32 = 0x100000;
+
+/// Capacity cap keeps every encoded codepoint below U+10EEEE itself
+/// (and well clear of the U+10FFFE/U+10FFFF noncharacters).
+pub const MAX_ENCODED_ENTRIES: usize = 0xEEE0;
+
+/// True for any codepoint inside the encoded range, whether or not it
+/// is currently assigned. Used by the output serializer, which has no
+/// access to the per-pane interner, to substitute a space so the host
+/// terminal doesn't render an undefined glyph under the image.
+pub fn is_in_encoded_range(character: char) -> bool {
+    let value = character as u32;
+    value >= ENCODED_BASE && value < ENCODED_BASE + MAX_ENCODED_ENTRIES as u32
+}
+
+/// What one placeholder cell encodes: the image row/column it shows,
+/// and the most significant byte of the image id (the low 24 bits ride
+/// in the cell's foreground color).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct PlaceholderCell {
+    pub image_row: u16,
+    pub image_column: u16,
+    pub image_id_msb: u8,
+}
+
+/// Interns (row, column, id-msb) triples so each placeholder cell can
+/// carry a single `char` indexing into it. Entries are deduplicated and
+/// live for the pane's lifetime; a 20x10 image visible in full costs
+/// 200 entries, so the cap is effectively unreachable outside of
+/// adversarial input.
+#[derive(Debug, Clone, Default)]
+pub struct PlaceholderInterner {
+    entries: Vec<PlaceholderCell>,
+    indices: HashMap<PlaceholderCell, u32>,
+}
+
+impl PlaceholderInterner {
+    pub fn encode(&mut self, cell: PlaceholderCell) -> Option<char> {
+        if let Some(index) = self.indices.get(&cell) {
+            return char::from_u32(ENCODED_BASE + index);
+        }
+        if self.entries.len() >= MAX_ENCODED_ENTRIES {
+            return None;
+        }
+        let index = self.entries.len() as u32;
+        self.entries.push(cell);
+        self.indices.insert(cell, index);
+        char::from_u32(ENCODED_BASE + index)
+    }
+    pub fn decode(&self, character: char) -> Option<PlaceholderCell> {
+        let index = (character as u32).checked_sub(ENCODED_BASE)? as usize;
+        self.entries.get(index).copied()
+    }
+}
+
+/// The 298-entry row/column diacritic table from kitty's
+/// rowcolumn-diacritics.txt: codepoint KITTY_DIACRITICS[i] encodes
+/// index i. Ascending, so lookups binary-search.
+pub const KITTY_DIACRITICS: [u32; 298] = [
+    0x0305, 0x030D, 0x030E, 0x0310, 0x0312, 0x033D, 0x033E, 0x033F, 0x0346, 0x034A, 0x034B, 0x034C,
+    0x0350, 0x0351, 0x0352, 0x0357, 0x035B, 0x0363, 0x0364, 0x0365, 0x0366, 0x0367, 0x0368, 0x0369,
+    0x036A, 0x036B, 0x036C, 0x036D, 0x036E, 0x036F, 0x0483, 0x0484, 0x0485, 0x0486, 0x0487, 0x0592,
+    0x0593, 0x0594, 0x0595, 0x0597, 0x0598, 0x0599, 0x059C, 0x059D, 0x059E, 0x059F, 0x05A0, 0x05A1,
+    0x05A8, 0x05A9, 0x05AB, 0x05AC, 0x05AF, 0x05C4, 0x0610, 0x0611, 0x0612, 0x0613, 0x0614, 0x0615,
+    0x0616, 0x0617, 0x0657, 0x0658, 0x0659, 0x065A, 0x065B, 0x065D, 0x065E, 0x06D6, 0x06D7, 0x06D8,
+    0x06D9, 0x06DA, 0x06DB, 0x06DC, 0x06DF, 0x06E0, 0x06E1, 0x06E2, 0x06E4, 0x06E7, 0x06E8, 0x06EB,
+    0x06EC, 0x0730, 0x0732, 0x0733, 0x0735, 0x0736, 0x073A, 0x073D, 0x073F, 0x0740, 0x0741, 0x0743,
+    0x0745, 0x0747, 0x0749, 0x074A, 0x07EB, 0x07EC, 0x07ED, 0x07EE, 0x07EF, 0x07F0, 0x07F1, 0x07F3,
+    0x0816, 0x0817, 0x0818, 0x0819, 0x081B, 0x081C, 0x081D, 0x081E, 0x081F, 0x0820, 0x0821, 0x0822,
+    0x0823, 0x0825, 0x0826, 0x0827, 0x0829, 0x082A, 0x082B, 0x082C, 0x082D, 0x0951, 0x0953, 0x0954,
+    0x0F82, 0x0F83, 0x0F86, 0x0F87, 0x135D, 0x135E, 0x135F, 0x17DD, 0x193A, 0x1A17, 0x1A75, 0x1A76,
+    0x1A77, 0x1A78, 0x1A79, 0x1A7A, 0x1A7B, 0x1A7C, 0x1B6B, 0x1B6D, 0x1B6E, 0x1B6F, 0x1B70, 0x1B71,
+    0x1B72, 0x1B73, 0x1CD0, 0x1CD1, 0x1CD2, 0x1CDA, 0x1CDB, 0x1CE0, 0x1DC0, 0x1DC1, 0x1DC3, 0x1DC4,
+    0x1DC5, 0x1DC6, 0x1DC7, 0x1DC8, 0x1DC9, 0x1DCB, 0x1DCC, 0x1DD1, 0x1DD2, 0x1DD3, 0x1DD4, 0x1DD5,
+    0x1DD6, 0x1DD7, 0x1DD8, 0x1DD9, 0x1DDA, 0x1DDB, 0x1DDC, 0x1DDD, 0x1DDE, 0x1DDF, 0x1DE0, 0x1DE1,
+    0x1DE2, 0x1DE3, 0x1DE4, 0x1DE5, 0x1DE6, 0x1DFE, 0x20D0, 0x20D1, 0x20D4, 0x20D5, 0x20D6, 0x20D7,
+    0x20DB, 0x20DC, 0x20E1, 0x20E7, 0x20E9, 0x20F0, 0x2CEF, 0x2CF0, 0x2CF1, 0x2DE0, 0x2DE1, 0x2DE2,
+    0x2DE3, 0x2DE4, 0x2DE5, 0x2DE6, 0x2DE7, 0x2DE8, 0x2DE9, 0x2DEA, 0x2DEB, 0x2DEC, 0x2DED, 0x2DEE,
+    0x2DEF, 0x2DF0, 0x2DF1, 0x2DF2, 0x2DF3, 0x2DF4, 0x2DF5, 0x2DF6, 0x2DF7, 0x2DF8, 0x2DF9, 0x2DFA,
+    0x2DFB, 0x2DFC, 0x2DFD, 0x2DFE, 0x2DFF, 0xA66F, 0xA67C, 0xA67D, 0xA6F0, 0xA6F1, 0xA8E0, 0xA8E1,
+    0xA8E2, 0xA8E3, 0xA8E4, 0xA8E5, 0xA8E6, 0xA8E7, 0xA8E8, 0xA8E9, 0xA8EA, 0xA8EB, 0xA8EC, 0xA8ED,
+    0xA8EE, 0xA8EF, 0xA8F0, 0xA8F1, 0xAAB0, 0xAAB2, 0xAAB3, 0xAAB7, 0xAAB8, 0xAABE, 0xAABF, 0xAAC1,
+    0xFB1E, 0xFE20, 0xFE21, 0xFE22, 0xFE23, 0xFE24, 0xFE25, 0xFE26, 0x10A0F, 0x10A38, 0x1D185,
+    0x1D186, 0x1D187, 0x1D188, 0x1D189, 0x1D1AA, 0x1D1AB, 0x1D1AC, 0x1D1AD, 0x1D242, 0x1D243,
+    0x1D244,
+];
+
+/// The row/column/id-msb value a kitty diacritic encodes, if any.
+pub fn diacritic_index(character: char) -> Option<u32> {
+    KITTY_DIACRITICS
+        .binary_search(&(character as u32))
+        .ok()
+        .map(|index| index as u32)
+}
+
+#[cfg(test)]
+#[path = "./unit/placeholders_tests.rs"]
+mod placeholders_tests;

--- a/zellij-server/src/panes/kitty_graphics/unit/grid_state_tests.rs
+++ b/zellij-server/src/panes/kitty_graphics/unit/grid_state_tests.rs
@@ -283,3 +283,194 @@ fn reverse_index_region_scroll_reaps_fully_below_margin() {
     grid.apply_region_scroll(0, 80, -20, 0, 0, false);
     assert_eq!(grid.placements.len(), 0);
 }
+
+mod virtual_placements {
+    use super::*;
+    use crate::panes::kitty_graphics::parser::{
+        DecodedImage, KittyAction, KittyCommand, KittyFormat,
+    };
+
+    fn virtual_transmit_command(image_id: u32, columns: u32, rows: u32) -> KittyCommand {
+        KittyCommand {
+            action: KittyAction::TransmitAndDisplay,
+            image_id: Some(image_id),
+            columns,
+            rows,
+            unicode_placeholder: true,
+            image: Some(DecodedImage {
+                bytes: vec![255; 4 * 4 * 4],
+                width: 4,
+                height: 4,
+                format: KittyFormat::Rgba32,
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn delete_command(specifier: char, image_id: Option<u32>) -> KittyCommand {
+        KittyCommand {
+            action: KittyAction::Delete,
+            delete_specifier: Some(specifier),
+            image_id,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn register_virtual_transmit_stores_image_and_placement() {
+        let mut grid = test_grid();
+        let reply = grid
+            .register_virtual_transmit(&virtual_transmit_command(7, 20, 5))
+            .unwrap();
+        assert_eq!(reply.image_id, Some(7));
+        assert!(grid.has_virtual_placements());
+        let placement = grid.virtual_placement(7, 0).unwrap();
+        assert_eq!((placement.columns, placement.rows), (20, 5));
+        assert_eq!(
+            grid.kitty_image_store.borrow().image_count(),
+            1,
+            "image is stored"
+        );
+        assert_eq!(
+            grid.kitty_image_store
+                .borrow()
+                .refcount(placement.internal_id),
+            Some(1),
+            "the virtual placement holds one ref"
+        );
+    }
+
+    #[test]
+    fn plain_retransmit_under_same_id_replaces_virtual_placement() {
+        let mut grid = test_grid();
+        grid.register_virtual_transmit(&virtual_transmit_command(7, 20, 5))
+            .unwrap();
+        let mut plain = virtual_transmit_command(7, 0, 0);
+        plain.unicode_placeholder = false;
+        let image = plain.image.take().unwrap();
+        grid.transmit(&plain, image).unwrap();
+        assert!(
+            !grid.has_virtual_placements(),
+            "the old virtual placement is dropped with its image"
+        );
+        assert_eq!(
+            grid.kitty_image_store.borrow().image_count(),
+            1,
+            "only the newly transmitted image remains"
+        );
+    }
+
+    #[test]
+    fn register_virtual_display_places_an_already_transmitted_image() {
+        let mut grid = test_grid();
+        let mut transmit = virtual_transmit_command(9, 0, 0);
+        transmit.unicode_placeholder = false;
+        let image = transmit.image.take().unwrap();
+        grid.transmit(&transmit, image).unwrap();
+        let display = KittyCommand {
+            action: KittyAction::Display,
+            image_id: Some(9),
+            columns: 10,
+            rows: 3,
+            unicode_placeholder: true,
+            ..Default::default()
+        };
+        grid.register_virtual_display(&display).unwrap();
+        let placement = grid.virtual_placement(9, 0).unwrap();
+        assert_eq!((placement.columns, placement.rows), (10, 3));
+    }
+
+    #[test]
+    fn register_virtual_display_for_unknown_image_errors() {
+        let mut grid = test_grid();
+        let display = KittyCommand {
+            action: KittyAction::Display,
+            image_id: Some(42),
+            unicode_placeholder: true,
+            ..Default::default()
+        };
+        assert!(grid.register_virtual_display(&display).is_err());
+    }
+
+    #[test]
+    fn placement_id_selection_and_reregistration() {
+        let mut grid = test_grid();
+        let mut first = virtual_transmit_command(7, 20, 5);
+        first.placement_id = Some(1);
+        grid.register_virtual_transmit(&first).unwrap();
+        let second = KittyCommand {
+            action: KittyAction::Display,
+            image_id: Some(7),
+            placement_id: Some(2),
+            columns: 10,
+            rows: 2,
+            unicode_placeholder: true,
+            ..Default::default()
+        };
+        grid.register_virtual_display(&second).unwrap();
+        assert_eq!(grid.virtual_placement(7, 1).unwrap().columns, 20);
+        assert_eq!(grid.virtual_placement(7, 2).unwrap().columns, 10);
+        // no placement selected -> the most recently registered one
+        assert_eq!(grid.virtual_placement(7, 0).unwrap().columns, 10);
+        let first_uid = grid.virtual_placement(7, 1).unwrap().placement_uid;
+        let mut replacement = second.clone();
+        replacement.placement_id = Some(1);
+        grid.register_virtual_display(&replacement).unwrap();
+        assert_eq!(
+            grid.virtual_placement(7, 1).unwrap().placement_uid,
+            first_uid,
+            "re-registering a placement id keeps its uid"
+        );
+    }
+
+    #[test]
+    fn id_and_range_deletes_remove_virtual_placements() {
+        let mut grid = test_grid();
+        grid.register_virtual_transmit(&virtual_transmit_command(7, 20, 5))
+            .unwrap();
+        grid.register_virtual_transmit(&virtual_transmit_command(8, 20, 5))
+            .unwrap();
+        grid.delete(&delete_command('i', Some(7)), (0, 0), (10, 10), 0)
+            .unwrap();
+        assert!(grid.virtual_placement(7, 0).is_none());
+        assert!(grid.virtual_placement(8, 0).is_some());
+        let range = KittyCommand {
+            action: KittyAction::Delete,
+            delete_specifier: Some('R'),
+            source_x: 1,
+            source_y: 100,
+            ..Default::default()
+        };
+        grid.delete(&range, (0, 0), (10, 10), 0).unwrap();
+        assert!(!grid.has_virtual_placements());
+        assert_eq!(
+            grid.kitty_image_store.borrow().image_count(),
+            0,
+            "an uppercase range delete frees the images"
+        );
+    }
+
+    #[test]
+    fn clear_all_placements_frees_virtual_images() {
+        let mut grid = test_grid();
+        grid.register_virtual_transmit(&virtual_transmit_command(7, 20, 5))
+            .unwrap();
+        grid.clear_all_placements();
+        assert!(!grid.has_virtual_placements());
+        assert_eq!(grid.kitty_image_store.borrow().image_count(), 0);
+    }
+
+    #[test]
+    fn fit_rgba_into_box_letterboxes_preserving_aspect() {
+        // a 2x1 white image into a 4x4 box: scaled to 4x2, centered
+        // vertically, transparent rows above and below
+        let src = vec![255; 2 * 1 * 4];
+        let out = super::super::fit_rgba_into_box(&src, 2, 1, 4, 4);
+        assert_eq!(out.len(), 4 * 4 * 4);
+        let row = |index: usize| &out[index * 4 * 4..(index + 1) * 4 * 4];
+        assert!(row(0).iter().all(|byte| *byte == 0), "top padding");
+        assert!(row(1).iter().all(|byte| *byte == 255), "image row");
+        assert!(row(2).iter().all(|byte| *byte == 255), "image row");
+        assert!(row(3).iter().all(|byte| *byte == 0), "bottom padding");
+    }
+}

--- a/zellij-server/src/panes/kitty_graphics/unit/parser_tests.rs
+++ b/zellij-server/src/panes/kitty_graphics/unit/parser_tests.rs
@@ -218,10 +218,22 @@ fn known_but_unsupported_keys_do_not_break_valid_command() {
 }
 
 #[test]
-fn unicode_placeholder_key_is_enotsupported() {
+fn unicode_placeholder_key_is_accepted_and_flagged() {
     let mut parser = KittyCommandParser::new();
-    let err = parse_one(&mut parser, b"a=T,U=1,f=24,s=1,v=1;AAAA").unwrap_err();
-    assert_eq!(err.code, KittyErrorCode::Enotsupported);
+    let command = parse_one(&mut parser, b"a=T,U=1,f=24,s=1,v=1,c=20,r=5;AAAA").unwrap();
+    assert!(command.unicode_placeholder);
+    assert_eq!(command.columns, 20);
+    assert_eq!(command.rows, 5);
+    assert!(command.image.is_some());
+}
+
+#[test]
+fn unicode_placeholder_key_absent_or_zero_is_not_flagged() {
+    let mut parser = KittyCommandParser::new();
+    let command = parse_one(&mut parser, b"a=T,U=0,f=24,s=1,v=1;AAAA").unwrap();
+    assert!(!command.unicode_placeholder);
+    let command = parse_one(&mut parser, b"a=T,f=24,s=1,v=1;AAAA").unwrap();
+    assert!(!command.unicode_placeholder);
 }
 
 #[test]

--- a/zellij-server/src/panes/kitty_graphics/unit/placeholders_tests.rs
+++ b/zellij-server/src/panes/kitty_graphics/unit/placeholders_tests.rs
@@ -1,0 +1,48 @@
+use super::super::placeholders::*;
+
+#[test]
+fn table_is_sorted_for_binary_search() {
+    for window in KITTY_DIACRITICS.windows(2) {
+        assert!(window[0] < window[1]);
+    }
+}
+
+#[test]
+fn interner_roundtrip_and_dedup() {
+    let mut interner = PlaceholderInterner::default();
+    let a = PlaceholderCell {
+        image_row: 3,
+        image_column: 7,
+        image_id_msb: 0,
+    };
+    let b = PlaceholderCell {
+        image_row: 297,
+        image_column: 297,
+        image_id_msb: 255,
+    };
+    let encoded_a = interner.encode(a).unwrap();
+    let encoded_b = interner.encode(b).unwrap();
+    assert_eq!(interner.encode(a), Some(encoded_a));
+    assert_eq!(interner.decode(encoded_a), Some(a));
+    assert_eq!(interner.decode(encoded_b), Some(b));
+    assert_ne!(encoded_a, encoded_b);
+    assert!(is_in_encoded_range(encoded_a));
+    assert!((encoded_b as u32) < PLACEHOLDER_CHAR as u32);
+}
+
+#[test]
+fn decode_rejects_foreign_codepoints() {
+    let interner = PlaceholderInterner::default();
+    assert_eq!(interner.decode(PLACEHOLDER_CHAR), None);
+    assert_eq!(interner.decode('a'), None);
+    assert!(!is_in_encoded_range(PLACEHOLDER_CHAR));
+    assert!(!is_in_encoded_range('\u{F0000}'));
+}
+
+#[test]
+fn diacritic_lookup() {
+    assert_eq!(diacritic_index('\u{0305}'), Some(0));
+    assert_eq!(diacritic_index('\u{030D}'), Some(1));
+    assert_eq!(diacritic_index('\u{1D244}'), Some(297));
+    assert_eq!(diacritic_index('a'), None);
+}

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -6788,6 +6788,104 @@ fn kitty_cursor_unmoved_with_c1() {
 }
 
 #[test]
+fn kitty_placeholder_diacritic_sequence_is_invalidated_by_cursor_reposition() {
+    use crate::panes::kitty_graphics::PLACEHOLDER_CHAR;
+    let (mut grid, _kitty_image_store) = new_kitty_grid(10, 10);
+    let mut vte_parser = vte::Parser::new();
+    let mut interceptor = KittyApcInterceptor::new();
+    // print a lone placeholder cell at (0, 0) with no diacritics yet - this arms
+    // pending_kitty_placeholder for (x: 0, y: 0), waiting at cursor (1, 0)
+    feed_kitty_bytes(
+        &mut grid,
+        &mut vte_parser,
+        &mut interceptor,
+        PLACEHOLDER_CHAR.to_string().as_bytes(),
+    );
+    let placeholder_char_before = grid.viewport[0].columns[0].character;
+    assert_ne!(placeholder_char_before, PLACEHOLDER_CHAR);
+    // CSI H repositions the cursor directly back to (1, 0) without printing
+    // anything - this must not leave pending_kitty_placeholder armed, or a
+    // real combining mark printed next would be folded into the placeholder
+    // cell's stored row/column/id-msb instead of being dropped as ordinary
+    // (if unsupported) zero-width text
+    feed_kitty_bytes(&mut grid, &mut vte_parser, &mut interceptor, b"\x1b[1;2H");
+    assert_eq!(grid.pending_kitty_placeholder, None);
+    // U+0305 is a real Unicode combining mark that also happens to be the
+    // first entry in the kitty row/column diacritic table
+    feed_kitty_bytes(
+        &mut grid,
+        &mut vte_parser,
+        &mut interceptor,
+        '\u{0305}'.to_string().as_bytes(),
+    );
+    assert_eq!(
+        grid.viewport[0].columns[0].character, placeholder_char_before,
+        "a stray combining mark after an unrelated cursor reposition must not mutate the earlier placeholder cell"
+    );
+}
+
+#[test]
+fn kitty_placeholder_diacritic_sequence_is_invalidated_by_alternate_screen_switch() {
+    use crate::panes::kitty_graphics::PLACEHOLDER_CHAR;
+    let (mut grid, _kitty_image_store) = new_kitty_grid(10, 10);
+    let mut vte_parser = vte::Parser::new();
+    let mut interceptor = KittyApcInterceptor::new();
+    feed_kitty_bytes(
+        &mut grid,
+        &mut vte_parser,
+        &mut interceptor,
+        PLACEHOLDER_CHAR.to_string().as_bytes(),
+    );
+    let placeholder_char_before = grid.viewport[0].columns[0].character;
+    // enter the alternate screen, then leave it - on return the cursor is
+    // restored to (1, 0), the exact position pending_kitty_placeholder was
+    // waiting at, even though a whole screen swap happened in between
+    feed_kitty_bytes(&mut grid, &mut vte_parser, &mut interceptor, b"\x1b[?1049h");
+    feed_kitty_bytes(&mut grid, &mut vte_parser, &mut interceptor, b"\x1b[?1049l");
+    assert_eq!(grid.pending_kitty_placeholder, None);
+    feed_kitty_bytes(
+        &mut grid,
+        &mut vte_parser,
+        &mut interceptor,
+        '\u{0305}'.to_string().as_bytes(),
+    );
+    assert_eq!(
+        grid.viewport[0].columns[0].character, placeholder_char_before,
+        "a stray combining mark after an alternate-screen round trip must not mutate the earlier placeholder cell"
+    );
+}
+
+#[test]
+fn kitty_placeholder_falls_back_to_space_once_interner_is_exhausted() {
+    use crate::panes::kitty_graphics::{PlaceholderCell, MAX_ENCODED_ENTRIES, PLACEHOLDER_CHAR};
+    let (mut grid, _kitty_image_store) = new_kitty_grid(10, 10);
+    let mut vte_parser = vte::Parser::new();
+    let mut interceptor = KittyApcInterceptor::new();
+    // fill every slot with a distinct cell that isn't PlaceholderCell::default()
+    // (row 0, column 0, id-msb 0) - that's what the placeholder below will
+    // encode to, since it has no left neighbor to inherit from, and encode()
+    // dedupes rather than allocating a fresh slot for an already-interned cell
+    for row in 1..=MAX_ENCODED_ENTRIES {
+        grid.kitty_placeholder_interner.encode(PlaceholderCell {
+            image_row: row as u16,
+            image_column: 0,
+            image_id_msb: 0,
+        });
+    }
+    feed_kitty_bytes(
+        &mut grid,
+        &mut vte_parser,
+        &mut interceptor,
+        PLACEHOLDER_CHAR.to_string().as_bytes(),
+    );
+    assert_eq!(grid.viewport[0].columns[0].character, ' ');
+    assert_eq!(
+        grid.pending_kitty_placeholder, None,
+        "a placeholder that failed to encode has no cell to fold diacritics into"
+    );
+}
+
+#[test]
 fn kitty_placement_survives_text_overwrite_and_erase() {
     let (mut grid, _kitty_image_store) = new_kitty_grid(20, 40);
     let mut vte_parser = vte::Parser::new();


### PR DESCRIPTION
## Summary

Fixes #5530.

Implements the kitty graphics protocol's Unicode-placeholder (`U=1`) placement mode. Zellij currently rejects it with `ENOTSUPPORTED`.

## Root cause

`parser.rs` only accepts `U=0`:

https://github.com/zellij-org/zellij/blob/main/zellij-server/src/panes/kitty_graphics/parser.rs#L489-L496

No code path registered or rendered a placement whose position comes from where the app prints placeholder cells, rather than `x=`/`y=` coordinates.

## What this does

- **Parser**: accepts and flags `U=1` (`parser.rs`).
- **Placeholder encoding** (`placeholders.rs`, new): a per-pane interner folds a placeholder cell's (image row, column, id most-significant byte) — read from its diacritics, or inherited from the left neighbor per the spec's omitted-diacritic rule — into a single Plane-16 PUA codepoint. The grid drops zero-width codepoints from stored cells, so the geometry has to live in the visible character to survive reflow and scrollback.
- **Grid integration** (`grid.rs`): builds the interned entry as the placeholder and its diacritics print, and scans the viewport at render time (`placeholder_kitty_chunks`, split into scan and per-run resolve) to turn visible placeholder cells into image chunks. Merges adjacent same-row cells into one chunk, and sizes aspect-ratio-preserving output when `c=`/`r=` gives only one axis, mirroring the existing positioned-placement logic.
- **Placement bookkeeping** (`grid_state.rs`): virtual placements key by image id with a `Vec` distinguished by placement id (carried in the cell's underline color), so multiple placements of one image coexist. Handles both `a=T,U=1` and the two-step `a=t` + `a=p,U=1` flow. Adds `d=r`/`d=R` range-delete for virtual placements, previously positioned-only.
- **Output/copy** (`output/mod.rs`, `grid.rs`): blanks interned placeholder codepoints to a space on serialize and copy, so they never leak as an undefined glyph.

## Edge cases

- A diacritic sequence interrupted by anything other than the next diacritic — cursor reposition, alternate-screen round trip, resize — ends the sequence, so a stray combining-mark character after a coincidental cursor jump can't corrupt an earlier placement.
- The interner has a capacity cap; once exhausted, new placeholder cells degrade to a space instead of leaking the raw undecodable character.
- Retransmitting under a reused image id drops the old virtual placement's reference. Re-placing under the same placement id reuses that placement's identity.

## Testing

- `cargo fmt` clean.
- `cargo test -p zellij-server`: 1568/1569 pass. The one failure, `temp_file_medium_outside_temp_dir_is_not_deleted`, is pre-existing: it assumes `CARGO_MANIFEST_DIR` sits outside the OS temp dir, false in my dev environment.
- New tests cover the interner, diacritic table, placement registration/re-registration/placement-id selection, id/range deletes, letterboxing, and the two edge cases above.
- Verified end-to-end against Ghostty running a Slack-client-style TUI: images that previously rendered nothing now display and track scroll and resize.

## Not verified

- Only tested against Ghostty. kitty and WezTerm should behave the same, since the output side is unchanged.
- `a=q,U=1` falls through to the existing query path unchanged; queries don't register a placement, so no placeholder-specific handling was needed.
- The scaled-variant cache namespaces placeholder variants from positioned ones via a high bit on the cell-count key, rather than a separate cache — a deliberate choice worth a second look.

Open to splitting this up if you'd rather review it in pieces.
