### PR TITLE
fix: save room for title in fixed-size layout panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix: focus event in remote attach (https://github.com/zellij-org/zellij/pull/5527)
 * fix: editing scrollback issue with a fullscreen floating pane (https://github.com/zellij-org/zellij/pull/5528)
 * feat: allow opting-out of scroll mode sync (https://github.com/zellij-org/zellij/pull/5532)
+* fix: save space for title row in fixed-layout panes in titles only mode (https://github.com/zellij-org/zellij/pull/5533)
 
 ## [0.45.0] - 2026-08-20
 * feat: allow tabs to have different sizes if clients aren't focused on the same one (https://github.com/zellij-org/zellij/pull/5133)

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -678,6 +678,7 @@ impl TiledPanes {
                 let mut position_and_size = pane.current_geom();
                 let is_stacked = position_and_size.is_stacked();
                 let is_flexible = !position_and_size.rows.is_fixed();
+                let is_one_liner_in_stack = is_stacked && !is_flexible;
                 let pane_is_borderless = pane.borderless();
                 if let Some(position_and_size_of_stack) = position_and_size
                     .stacked
@@ -688,7 +689,7 @@ impl TiledPanes {
                 let (pane_columns_offset, pane_rows_offset) =
                     pane_content_offset(&position_and_size, pane_viewport);
                 let reserve_title_row = if draws_titles {
-                    !pane_is_borderless && is_flexible && !single_selectable_tiled_pane
+                    !pane_is_borderless && !single_selectable_tiled_pane && !is_one_liner_in_stack
                 } else {
                     is_stacked && is_flexible
                 };

--- a/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__titles_frame_style_with_fixed_size_pane.snap
+++ b/zellij-server/src/tab/unit/snapshots/zellij_server__tab__tab_integration_tests__titles_frame_style_with_fixed_size_pane.snap
@@ -1,0 +1,24 @@
+---
+source: zellij-server/src/tab/./unit/tab_integration_tests.rs
+expression: snapshot
+---
+00 (C):                                                            foo                                                           
+01 (C): I am the fixed size pane                                                                                                 
+02 (C):                                                                                                                          
+03 (C):                                                                                                                          
+04 (C):                                                                                                                          
+05 (C):                                                                                                                          
+06 (C): ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+07 (C):                                                          Pane #2                                                         
+08 (C): I am the flexible pane                                                                                                   
+09 (C):                                                                                                                          
+10 (C):                                                                                                                          
+11 (C):                                                                                                                          
+12 (C):                                                                                                                          
+13 (C):                                                                                                                          
+14 (C):                                                                                                                          
+15 (C):                                                                                                                          
+16 (C):                                                                                                                          
+17 (C):                                                                                                                          
+18 (C):                                                                                                                          
+19 (C):

--- a/zellij-server/src/tab/unit/tab_integration_tests.rs
+++ b/zellij-server/src/tab/unit/tab_integration_tests.rs
@@ -5043,6 +5043,40 @@ fn tab_with_layout_that_has_floating_panes() {
 }
 
 #[test]
+fn titles_frame_style_with_fixed_size_pane() {
+    let layout = r#"
+        layout {
+            pane split_direction="horizontal" {
+                pane name="foo" {
+                    size 7
+                }
+                pane
+            }
+        }
+    "#;
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let client_id = 1;
+    let mut tab = create_new_tab_with_layout(size, ModeInfo::default(), layout);
+    tab.set_pane_frames(PaneFrameStyle::Titles);
+    tab.handle_pty_bytes(0, Vec::from("I am the fixed size pane".as_bytes()))
+        .unwrap();
+    tab.handle_pty_bytes(1, Vec::from("I am the flexible pane".as_bytes()))
+        .unwrap();
+    let mut output = Output::default();
+    tab.render(&mut output, None).unwrap();
+    let snapshot = take_snapshot(
+        output.serialize().unwrap().get(&client_id).unwrap(),
+        size.rows,
+        size.cols,
+        Palette::default(),
+    );
+    assert_snapshot!(snapshot);
+}
+
+#[test]
 fn tab_with_nested_layout() {
     let layout = r#"
         layout {


### PR DESCRIPTION
Fixes https://github.com/zellij-org/zellij/issues/5514

The issue was that we wouldn't save a space for the title line in this mode when the layout pane was fixed-size.