### PR TITLE
fix(plugins): release a CLI pipe when the plugin handling it crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * feat: allow setting explicit_theme_hue (light/dark) (https://github.com/zellij-org/zellij/pull/5536)
 * fix: input mode updates when switching tabs (https://github.com/zellij-org/zellij/pull/5535)
 * feat: allow starting a session with an initial command, eg. `zellij attach -a my-session -- htop` (https://github.com/zellij-org/zellij/pull/5543)
+* fix: release a CLI pipe when the plugin handling it crashes, instead of blocking the `zellij pipe` client until the plugin is unloaded (https://github.com/zellij-org/zellij/pull/5537)
 
 ## [0.45.0] - 2026-08-20
 * feat: allow tabs to have different sizes if clients aren't focused on the same one (https://github.com/zellij-org/zellij/pull/5133)

--- a/default-plugins/fixture-plugin-for-tests/src/main.rs
+++ b/default-plugins/fixture-plugin-for-tests/src/main.rs
@@ -993,6 +993,8 @@ impl ZellijPlugin for State {
             );
         } else if name == "message_to_plugin" {
             self.message_to_plugin_payload = payload.clone();
+        } else if name == "panic_while_handling_pipe" {
+            panic!("intentional panic for the pipe-release-on-crash test");
         }
         let should_render = true;
         should_render

--- a/zellij-server/src/plugins/pipes.rs
+++ b/zellij-server/src/plugins/pipes.rs
@@ -145,6 +145,47 @@ pub fn apply_pipe_message_to_plugin(
     plugin_render_assets: &mut Vec<PluginRenderAsset>,
     senders: &ThreadSenders,
 ) -> Result<()> {
+    let result = apply_pipe_message_to_plugin_inner(
+        plugin_id,
+        client_id,
+        running_plugin,
+        pipe_message,
+        plugin_render_assets,
+        senders,
+    );
+    if result.is_err() {
+        release_pipe_of_crashed_plugin(plugin_id, client_id, pipe_message, senders);
+    }
+    result
+}
+
+fn release_pipe_of_crashed_plugin(
+    plugin_id: PluginId,
+    client_id: ClientId,
+    pipe_message: &PipeMessage,
+    senders: &ThreadSenders,
+) {
+    if let PipeSource::Cli(pipe_id) = &pipe_message.source {
+        let mut pipe_state_changes = HashMap::new();
+        pipe_state_changes.insert(pipe_id.to_owned(), PipeStateChange::NoChange);
+        let plugin_render_asset =
+            PluginRenderAsset::new(plugin_id, client_id, vec![]).with_pipes(pipe_state_changes);
+        let _ = senders
+            .send_to_plugin(PluginInstruction::UnblockCliPipes(vec![
+                plugin_render_asset,
+            ]))
+            .context("failed to unblock input pipe of crashed plugin");
+    }
+}
+
+fn apply_pipe_message_to_plugin_inner(
+    plugin_id: PluginId,
+    client_id: ClientId,
+    running_plugin: &mut RunningPlugin,
+    pipe_message: &PipeMessage,
+    plugin_render_assets: &mut Vec<PluginRenderAsset>,
+    senders: &ThreadSenders,
+) -> Result<()> {
     let instance = &running_plugin.instance;
     let rows = running_plugin.rows;
     let columns = running_plugin.columns;

--- a/zellij-server/src/plugins/unit/plugin_tests.rs
+++ b/zellij-server/src/plugins/unit/plugin_tests.rs
@@ -13211,3 +13211,91 @@ pub fn reconfiguration_resends_keybinds_to_opted_in_plugins() {
         last_render
     );
 }
+
+#[test]
+#[ignore]
+pub fn cli_pipe_is_released_when_plugin_panics_while_handling_it() {
+    let temp_folder = tempdir().unwrap();
+    let plugin_host_folder = PathBuf::from(temp_folder.path());
+    let cache_path = plugin_host_folder.join("permissions_test.kdl");
+    let (plugin_thread_sender, server_receiver, screen_receiver, teardown) =
+        create_plugin_thread_with_server_receiver(Some(plugin_host_folder), None);
+    let plugin_should_float = Some(false);
+    let plugin_title = Some("test_plugin".to_owned());
+    let run_plugin = RunPluginOrAlias::RunPlugin(RunPlugin {
+        _allow_exec_host_cmd: false,
+        location: RunPluginLocation::File(PathBuf::from(&*PLUGIN_FIXTURE)),
+        configuration: Default::default(),
+        ..Default::default()
+    });
+    let tab_index = 1;
+    let client_id = 1;
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let received_screen_instructions = Arc::new(Mutex::new(vec![]));
+    let _screen_thread = grant_permissions_and_log_actions_in_thread_naked_variant!(
+        received_screen_instructions,
+        ScreenInstruction::Exit,
+        screen_receiver,
+        1,
+        &PermissionType::ReadCliPipes,
+        cache_path,
+        plugin_thread_sender,
+        client_id
+    );
+    let received_server_instruction = Arc::new(Mutex::new(vec![]));
+    let server_thread = log_actions_in_thread!(
+        received_server_instruction,
+        ServerInstruction::UnblockCliPipeInput,
+        server_receiver,
+        1
+    );
+
+    let _ = plugin_thread_sender.send(PluginInstruction::AddClient(client_id));
+    let _ = plugin_thread_sender.send(PluginInstruction::Load(
+        plugin_should_float,
+        false,
+        false,
+        plugin_title,
+        run_plugin,
+        Some(tab_index),
+        None,
+        client_id,
+        size,
+        None,
+        None,
+        false,
+        None,
+        None,
+        None,
+    ));
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    let _ = plugin_thread_sender.send(PluginInstruction::CliPipe {
+        pipe_id: "input_pipe_id".to_owned(),
+        name: "panic_while_handling_pipe".to_owned(),
+        payload: None,
+        plugin: None,
+        args: None,
+        configuration: None,
+        floating: None,
+        pane_id_to_replace: None,
+        pane_title: None,
+        cwd: None,
+        skip_cache: false,
+        cli_client_id: client_id,
+    });
+    std::thread::sleep(std::time::Duration::from_millis(1000));
+    let unblocked = received_server_instruction.lock().unwrap().iter().any(
+        |i| matches!(i, ServerInstruction::UnblockCliPipeInput(pipe_name) if pipe_name == "input_pipe_id"),
+    );
+    teardown();
+    let _ = server_thread.join();
+    assert!(
+        unblocked,
+        "a plugin panicking while handling a CLI pipe must release that pipe when it crashes, \
+         otherwise the `zellij pipe` client stays blocked until the plugin is unloaded"
+    );
+}


### PR DESCRIPTION
@imsnif — you were right, thanks for the pointer. I've dropped the `catch_unwind` commits entirely and force-pushed a different fix based on your suggestion. Rebased onto current `main`.

## What's actually going on

`apply_pipe_message_to_plugin` (`zellij-server/src/plugins/pipes.rs`) sends `UnblockCliPipes` on **every success path** — including the `Err(_e)` arm for old plugins that don't export `pipe` — but **not** when the call into the plugin fails.

When a plugin traps while handling a pipe message, both call sites (`wasm_bridge.rs`, in `pipe_messages` and in `apply_cached_events_and_resizes_for_plugin`) log the error and call `handle_plugin_crash`, which only sends `ScreenInstruction::UpdatePluginLoadingStage` with a "Panic!" loading indication. It does not unload the plugin, so `PendingPipes` keeps the `(plugin_id, client_id)` entry and the pipe is never released. The `zellij pipe` client stays blocked until the plugin is unloaded or the session ends.

I confirmed this by adding a `panic_while_handling_pipe` branch to the fixture plugin and logging the instruction stream. The crash is visible, and the unblock arrives only after `KillSession`:

```
server instructions: [ KillSession, UnblockCliPipeInput("input_pipe_id") ]
screen instructions: ... UpdatePluginLoadingStage(0, error: "intentional panic ...") ... Exit
```

## The fix

`apply_pipe_message_to_plugin` becomes a thin wrapper that releases the pipe on any `Err` and re-returns it; the old body moves to `apply_pipe_message_to_plugin_inner`. Doing it at that single choke point means neither call site can forget, and it covers the pre-call failures (protobuf conversion) too.

The regression test asserts `UnblockCliPipeInput` is emitted *at crash time* rather than at teardown — the earlier version of the test, which checked after `teardown()`, passed against the unfixed code, which is what made the teardown-only release visible in the first place.

## Verification

- New test fails before the change, passes after.
- `cargo test -p zellij-server --lib`: 1566 passed, 0 failed.
- Ignored plugin suite: 141 passed. 10 failures are pre-existing Windows-only path-snapshot mismatches (`/foo/bar` vs `C:/foo/bar`); they fail identically on an unmodified tree here.
- `cargo fmt --all --check` clean.

The fixture plugin `.wasm` was built locally and staged at `target/e2e-data/plugins/` to run the ignored tests.

## Separate observation about the `CliPipe` log line

Worth flagging since it's what sent me down the wrong path originally: the `Action CliPipe did not complete within 1s timeout` spam is **not** evidence of a blocked pipe, and it isn't a timeout.

`route.rs` deliberately does `drop(completion_tx)` in the `Action::CliPipe` arm, but the call to `wait_for_action_completion` at the end of `route_action` is unconditional. A dropped sender resolves the oneshot as `Err(RecvError)` immediately, which lands in the `Err(_) | Ok(Err(_))` arm and logs the timeout message. So every single `zellij pipe` invocation logs an error instantly, regardless of whether anything blocked — in my case ~21,000 lines over 9 days of normal use.

I've deliberately left that alone rather than bundling it here. Happy to open a separate PR if you'd like it silenced.
