### PR TITLE
fix(scrollback): cap the width of rows entering scrollback

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -27,7 +27,7 @@ use std::{
 
 use vte;
 use zellij_utils::{
-    consts::{DEFAULT_SCROLL_BUFFER_SIZE, SCROLL_BUFFER_SIZE},
+    consts::{DEFAULT_SCROLL_BUFFER_SIZE, MAX_ROW_COLUMNS, SCROLL_BUFFER_SIZE},
     data::{Palette, PaletteColor, Styling},
     input::mouse::{MouseEvent, MouseEventType},
     input::options::DEFAULT_WORD_SEPARATORS,
@@ -469,8 +469,9 @@ fn bounded_push(
     vec: &mut VecDeque<Row>,
     sixel_grid: &mut SixelGrid,
     kitty_grid: &mut KittyGrid,
-    value: Row,
+    mut value: Row,
 ) -> Option<usize> {
+    value.truncate_to_max_columns(MAX_ROW_COLUMNS);
     let mut dropped_line_width = None;
     if vec.len() >= *SCROLL_BUFFER_SIZE.get().unwrap() {
         let line = vec.pop_front();
@@ -5984,6 +5985,14 @@ impl Row {
         }
         self.osc133_markers.retain(|marker| marker.column <= x);
         self.width = None;
+    }
+    pub fn truncate_to_max_columns(&mut self, max_columns: usize) {
+        if self.columns.len() > max_columns {
+            self.columns.truncate(max_columns);
+            self.osc133_markers
+                .retain(|marker| marker.column <= max_columns);
+            self.width = None;
+        }
     }
     pub fn position_accounting_for_widechars(&self, x: usize) -> usize {
         let mut position = x;

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -9318,3 +9318,47 @@ fn a_character_wider_than_two_columns_advances_the_cursor_by_its_full_width() {
     assert_eq!(row.width(), 4);
     assert_eq!(cursor_position(&grid), Some((4, 0)));
 }
+
+#[test]
+fn bounded_push_caps_the_columns_of_a_merged_canonical_row() {
+    use super::{bounded_push, KittyGrid, Row, SixelGrid};
+    use crate::panes::terminal_character::TerminalCharacter;
+    use std::collections::VecDeque;
+    use zellij_utils::consts::{DEFAULT_SCROLL_BUFFER_SIZE, MAX_ROW_COLUMNS};
+
+    let _ = SCROLL_BUFFER_SIZE.set(DEFAULT_SCROLL_BUFFER_SIZE);
+    let character_cell_size = Rc::new(RefCell::new(None));
+    let mut sixel_grid = SixelGrid::new(
+        character_cell_size.clone(),
+        Rc::new(RefCell::new(SixelImageStore::default())),
+    );
+    let mut kitty_grid = KittyGrid::new(
+        character_cell_size,
+        Rc::new(RefCell::new(KittyImageStore::default())),
+    );
+    let mut lines_above: VecDeque<Row> = VecDeque::new();
+
+    let overshoot = 2_000;
+    let mut row = Row::new().canonical();
+    row.columns
+        .push_back(TerminalCharacter::new_singlewidth('A'));
+    for _ in 1..MAX_ROW_COLUMNS + overshoot {
+        row.columns
+            .push_back(TerminalCharacter::new_singlewidth('x'));
+    }
+
+    bounded_push(&mut lines_above, &mut sixel_grid, &mut kitty_grid, row);
+
+    let stored = lines_above.back().expect("the row should have been pushed");
+    assert_eq!(
+        stored.columns.len(),
+        MAX_ROW_COLUMNS,
+        "a row entering scrollback should be capped at MAX_ROW_COLUMNS",
+    );
+    assert!(stored.is_canonical);
+    assert_eq!(
+        stored.columns.front().unwrap().character,
+        'A',
+        "the cap should shed the tail of the line, never its head",
+    );
+}

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -12,6 +12,7 @@ pub const ZELLIJ_CONFIG_DIR_ENV: &str = "ZELLIJ_CONFIG_DIR";
 pub const ZELLIJ_LAYOUT_DIR_ENV: &str = "ZELLIJ_LAYOUT_DIR";
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const DEFAULT_SCROLL_BUFFER_SIZE: usize = 10_000;
+pub const MAX_ROW_COLUMNS: usize = 1_000_000;
 pub static SCROLL_BUFFER_SIZE: OnceLock<usize> = OnceLock::new();
 pub static DEBUG_MODE: OnceLock<bool> = OnceLock::new();
 


### PR DESCRIPTION
## Summary

When a wrapped line scrolls off screen, zellij stitches its pieces back into a single scrollback row. The scrollback limit counts rows, so one long line with no newline is one row that can grow forever — 16 bytes per character — until the server is OOM-killed or aborts on a failed allocation. Measured on `main` (910339e2): printing a 1,002,000-character line into a 10-column pane grew one scrollback row to 1,001,960 columns. This is the mechanism behind #2104.

The fix caps a row at the one place rows enter scrollback (`bounded_push`): `MAX_ROW_COLUMNS = 1_000_000`, about 16 MiB — the head of an oversized line is kept, the tail dropped. The visible screen and resize re-wrapping are unaffected.

Same shed-on-overflow policy the other queues already use: #4818 capped pending pty-stdin writes, #2068 bounded the server→client queue.

Closes #2104.

## Test plan

- [x] `cargo test -p zellij-server bounded_push_caps` — 1 passed (0.04 s); asserts the stored row is capped at exactly `MAX_ROW_COLUMNS` *and* that its head survives; fails with the guard removed
- [x] One-off end-to-end check (not committed, 190 s): 1,002,000 chars through `Grid::add_character` on a 10-column grid — scrollback row reaches 1,001,960 columns before the fix, exactly 1,000,000 with head intact after
- [x] `cargo test -p zellij-server` — 1573 passed, 0 failed, 150 ignored
- [x] `cargo xtask format --check` — clean
