### PR TITLE
fix unlock-first keybinding preset's nested session keybinds

### DIFF
--- a/default-plugins/configuration/src/presets.rs
+++ b/default-plugins/configuration/src/presets.rs
@@ -129,9 +129,9 @@ keybinds clear-defaults=true {{
     session {{
         bind "o" {{ SwitchToMode "Normal"; }}
         bind "d" {{ Detach; }}
-        bind "]" {{ FocusHostSession; SwitchToMode "Normal"; }}
-        bind "[" {{ FocusGuestSession; SwitchToMode "Normal"; }}
-        bind "f" {{ ToggleHostFullscreen; SwitchToMode "Normal"; }}
+        bind "]" {{ FocusHostSession; SwitchToMode "Locked"; }}
+        bind "[" {{ FocusGuestSession; SwitchToMode "Locked"; }}
+        bind "f" {{ ToggleHostFullscreen; SwitchToMode "Locked"; }}
         bind "w" {{
             LaunchOrFocusPlugin "session-manager" {{
                 floating true


### PR DESCRIPTION
The first run wizard generated incorrect unlock first preset keybind action set for the nested session handling keybinds that return to "Normal" mode instead of "Locked" mode.

Fixes #5529