### PR TITLE
fix(web-client): guard the standalone session poll against overlapping runs

### DIFF
--- a/zellij-client/assets/app.js
+++ b/zellij-client/assets/app.js
@@ -1636,6 +1636,7 @@ let els = null;
 let activityTimer = null;
 let initialized = false;
 let standalone = null;
+let standaloneRefreshInFlight = false;
 
 function initMobileUi(context) {
     ctx = context;
@@ -1773,9 +1774,10 @@ function showStandaloneSessionMenu({ fetchSessions }) {
 }
 
 async function refreshStandaloneSessions() {
-    if (!standalone) {
+    if (!standalone || standaloneRefreshInFlight) {
         return;
     }
+    standaloneRefreshInFlight = true;
     try {
         const sessions = await standalone.fetchSessions();
         if (!standalone) {
@@ -1785,7 +1787,10 @@ async function refreshStandaloneSessions() {
         state.data.now_secs = Math.floor(Date.now() / 1000);
         state.dataReceivedAt = Date.now();
         render();
-    } catch (_) {}
+    } catch (_) {
+    } finally {
+        standaloneRefreshInFlight = false;
+    }
 }
 
 function finishStandalone(outcome) {

--- a/zellij-client/assets/index.html
+++ b/zellij-client/assets/index.html
@@ -19,6 +19,6 @@
     <body>
         <div id="terminal" tabindex="0"></div>
         <script src="assets/modals.js" integrity="sha384-iDRet9veierC1HWbStHC4LLKCSzjeIZTrPRePuKxiUxr7UvdmJ5epb+PYqgHYqte"></script>
-        <script type="module" src="assets/app.js" integrity="sha384-ltsszp8xHOJbHDX+dpNDmfCym1Er/n7QxGBoDF10vsccseNqSK7lDkkAz1jPVg9U"></script>
+        <script type="module" src="assets/app.js" integrity="sha384-e/DiucVeaJmQyhp0Ga2Nn9aZDCm9A/6pqW2zBMHqW9h/ytnvovxmVEKEfncpC44M"></script>
     </body>
 </html>

--- a/zellij-client/assets/integrity.json
+++ b/zellij-client/assets/integrity.json
@@ -3,7 +3,7 @@
   "addon-fit.js": "sha384-zZmjmUWgxteKU0acxOtNmpWCMwSnn1/pSIhFBXVx6ARJ4pD/eD3E0dDCccITHWWD",
   "addon-web-links.js": "sha384-Zb/L38m4THfRbsxxv8gWAi8cQ6xcWQnv0BgR0qwbTDwtBDaPi6pkyfgfBIH6C8ZG",
   "addon-webgl.js": "sha384-AkzdQDeATxpW8V7I2EPcwg17qAoLQMjEFHb//1QaAAIyIlbDAHGKno5+huH7RKxq",
-  "app.js": "sha384-ltsszp8xHOJbHDX+dpNDmfCym1Er/n7QxGBoDF10vsccseNqSK7lDkkAz1jPVg9U",
+  "app.js": "sha384-e/DiucVeaJmQyhp0Ga2Nn9aZDCm9A/6pqW2zBMHqW9h/ytnvovxmVEKEfncpC44M",
   "modals.js": "sha384-iDRet9veierC1HWbStHC4LLKCSzjeIZTrPRePuKxiUxr7UvdmJ5epb+PYqgHYqte",
   "style.css": "sha384-qvSJURWrtlva+87171/c2KHjzg2kzTYgjlEkCLTCdadhZtJA5MyGgt7VgOj9dE0D",
   "xterm.css": "sha384-Mz9RDc16Iua5vrzALPqUZn39WVfelFzZvwpqCNkMKji5gpYeP3kNCMPGypMFf0AD",

--- a/zellij-client/assets/mobile-ui.js
+++ b/zellij-client/assets/mobile-ui.js
@@ -48,6 +48,7 @@ let els = null;
 let activityTimer = null;
 let initialized = false;
 let standalone = null;
+let standaloneRefreshInFlight = false;
 
 export function initMobileUi(context) {
     ctx = context;
@@ -185,9 +186,10 @@ export function showStandaloneSessionMenu({ fetchSessions }) {
 }
 
 async function refreshStandaloneSessions() {
-    if (!standalone) {
+    if (!standalone || standaloneRefreshInFlight) {
         return;
     }
+    standaloneRefreshInFlight = true;
     try {
         const sessions = await standalone.fetchSessions();
         if (!standalone) {
@@ -197,7 +199,10 @@ async function refreshStandaloneSessions() {
         state.data.now_secs = Math.floor(Date.now() / 1000);
         state.dataReceivedAt = Date.now();
         render();
-    } catch (_) {}
+    } catch (_) {
+    } finally {
+        standaloneRefreshInFlight = false;
+    }
 }
 
 function finishStandalone(outcome) {


### PR DESCRIPTION
## What

`refreshStandaloneSessions()` in `zellij-client/assets/mobile-ui.js` is `async` and driven by `setInterval(..., STANDALONE_REFRESH_MS)` (3000ms) with nothing tracking whether a previous run is still outstanding. This adds an in-flight flag so a pending poll suppresses the following tick.

## Why it matters

On a mobile viewport the bare root URL opens the standalone session menu, which polls `/session-list` every 3 seconds. While logged out every poll is rejected with a 401 and parks inside `authorizedFetch()`'s retry loop on its own `getSecurityToken()` dialog, which appends to `document.body` unconditionally. A new "Security Token Required" dialog therefore appears every 3 seconds for as long as the page is open.

Entering the token into the topmost dialog authenticates successfully — and uncovers the one from three seconds earlier. From the outside it reads as "the token does nothing", when it has in fact already worked. Cancel does not help: it resolves `null` into `waitForSecurityToken()`'s `while (!token)` loop, which shows an error and opens a replacement.

The flag is set synchronously before the first `await`, which also collapses the duplicate initial refresh: `openOverlay("sessions")` already calls `refreshStandaloneSessions()` for `kind === "sessions"`, so the explicit call on the following line now returns early instead of opening a second dialog.

## How it showed up

Chromium under its Pixel 7 device profile, against a plain `http://127.0.0.1:8082/` with no proxy in front of it, counting `.security-modal` elements:

```
          before   after
t≈0.4s       2       1
t≈3.4s       3       1
t≈6.4s       4       1
t≈9.4s       5       1
t≈12.4s      6       1
```

Linear, one dialog per poll, no ceiling. On the unpatched build Playwright cannot even click Authenticate — it times out with `<div class="security-modal"> subtree intercepts pointer events`, because a later dialog sits over the button. That is the same wall a person hits on a phone.

After the change: one dialog, zero once authenticated, and `/session-list` resumes polling (+3 calls over the next 9s), which confirms the flag clears rather than wedging the refresh permanently.

## Test

There is no JS test harness in the tree, so this is verified against a real build rather than with a unit test. `cargo xtask assets` regenerates `app.js`, `integrity.json` and `index.html`; the numbers above come from `target/dev-opt/zellij web` serving those embedded assets (`include_dir!` resolves them at compile time), with an unpatched 0.45.0 binary on a second port as the control. Both runs used the same script and the same device profile.

- `cargo xtask test` — pass
- `cargo test -p zellij-client --lib --features web_server_capability` — 193 passed, 0 failed
- `cargo xtask assets --check` — clean

Reported as #5540.

---

I've read that you're prioritising roadmap work and are selective about outside contributions, so please treat this as a report with a patch attached rather than a claim on your time.

There is an alternative PR, #5542, which fixes the same issue in `auth.js` instead of here. They are two approaches to one bug rather than a pair, so whichever you prefer, please close the other. A short comparison is in that PR.
