### PR TITLE
fix(web-client): coalesce concurrent authentication onto a single prompt

### DIFF
--- a/zellij-client/assets/app.js
+++ b/zellij-client/assets/app.js
@@ -265,6 +265,37 @@ async function login(token, rememberMe) {
     return true;
 }
 
+let pendingAuthentication = null;
+let authenticationGeneration = 0;
+
+/**
+ * Authenticate, coalescing concurrent callers onto a single prompt.
+ *
+ * Any number of requests may be rejected at once - the session menu polls while
+ * the page is still booting, for example. Each one asking the user separately
+ * would stack a dialog per rejection, so the first caller owns the prompt and
+ * the rest await its result. They all resume together once it settles, and
+ * retry against the credentials it established.
+ *
+ * @returns {Promise<boolean>} true when the login succeeded
+ */
+function authenticate() {
+    if (!pendingAuthentication) {
+        pendingAuthentication = (async () => {
+            try {
+                const { token, remember } = await waitForSecurityToken();
+                return await login(token, remember);
+            } finally {
+                // Cleared before the awaiting callers run, so a later rejection
+                // opens a fresh prompt rather than reusing this settled one.
+                authenticationGeneration += 1;
+                pendingAuthentication = null;
+            }
+        })();
+    }
+    return pendingAuthentication;
+}
+
 /**
  * Perform a request, authenticating and retrying for as long as it is rejected.
  * @param {string} url - Absolute URL to request
@@ -273,6 +304,8 @@ async function login(token, rememberMe) {
  */
 async function authorizedFetch(url, options = {}) {
     while (true) {
+        const generation = authenticationGeneration;
+
         const response = await fetch(url, {
             credentials: "include",
             ...options,
@@ -289,8 +322,14 @@ async function authorizedFetch(url, options = {}) {
             );
         }
 
-        const { token, remember } = await waitForSecurityToken();
-        await login(token, remember);
+        // A request in flight across an authentication was answered against the
+        // credentials of the moment it was sent, so its rejection says nothing
+        // about the ones we hold now. Retry it before asking the user again.
+        if (authenticationGeneration !== generation) {
+            continue;
+        }
+
+        await authenticate();
     }
 }
 

--- a/zellij-client/assets/auth.js
+++ b/zellij-client/assets/auth.js
@@ -61,6 +61,37 @@ async function login(token, rememberMe) {
     return true;
 }
 
+let pendingAuthentication = null;
+let authenticationGeneration = 0;
+
+/**
+ * Authenticate, coalescing concurrent callers onto a single prompt.
+ *
+ * Any number of requests may be rejected at once - the session menu polls while
+ * the page is still booting, for example. Each one asking the user separately
+ * would stack a dialog per rejection, so the first caller owns the prompt and
+ * the rest await its result. They all resume together once it settles, and
+ * retry against the credentials it established.
+ *
+ * @returns {Promise<boolean>} true when the login succeeded
+ */
+function authenticate() {
+    if (!pendingAuthentication) {
+        pendingAuthentication = (async () => {
+            try {
+                const { token, remember } = await waitForSecurityToken();
+                return await login(token, remember);
+            } finally {
+                // Cleared before the awaiting callers run, so a later rejection
+                // opens a fresh prompt rather than reusing this settled one.
+                authenticationGeneration += 1;
+                pendingAuthentication = null;
+            }
+        })();
+    }
+    return pendingAuthentication;
+}
+
 /**
  * Perform a request, authenticating and retrying for as long as it is rejected.
  * @param {string} url - Absolute URL to request
@@ -69,6 +100,8 @@ async function login(token, rememberMe) {
  */
 export async function authorizedFetch(url, options = {}) {
     while (true) {
+        const generation = authenticationGeneration;
+
         const response = await fetch(url, {
             credentials: "include",
             ...options,
@@ -85,8 +118,14 @@ export async function authorizedFetch(url, options = {}) {
             );
         }
 
-        const { token, remember } = await waitForSecurityToken();
-        await login(token, remember);
+        // A request in flight across an authentication was answered against the
+        // credentials of the moment it was sent, so its rejection says nothing
+        // about the ones we hold now. Retry it before asking the user again.
+        if (authenticationGeneration !== generation) {
+            continue;
+        }
+
+        await authenticate();
     }
 }
 

--- a/zellij-client/assets/index.html
+++ b/zellij-client/assets/index.html
@@ -19,6 +19,6 @@
     <body>
         <div id="terminal" tabindex="0"></div>
         <script src="assets/modals.js" integrity="sha384-iDRet9veierC1HWbStHC4LLKCSzjeIZTrPRePuKxiUxr7UvdmJ5epb+PYqgHYqte"></script>
-        <script type="module" src="assets/app.js" integrity="sha384-ltsszp8xHOJbHDX+dpNDmfCym1Er/n7QxGBoDF10vsccseNqSK7lDkkAz1jPVg9U"></script>
+        <script type="module" src="assets/app.js" integrity="sha384-zEYVY/2DhkJGDOJDhP5qx+pWO6zp80b3z6IXnbDUlNjRjCHgSdwSSwpRU5rQLndq"></script>
     </body>
 </html>

--- a/zellij-client/assets/integrity.json
+++ b/zellij-client/assets/integrity.json
@@ -3,7 +3,7 @@
   "addon-fit.js": "sha384-zZmjmUWgxteKU0acxOtNmpWCMwSnn1/pSIhFBXVx6ARJ4pD/eD3E0dDCccITHWWD",
   "addon-web-links.js": "sha384-Zb/L38m4THfRbsxxv8gWAi8cQ6xcWQnv0BgR0qwbTDwtBDaPi6pkyfgfBIH6C8ZG",
   "addon-webgl.js": "sha384-AkzdQDeATxpW8V7I2EPcwg17qAoLQMjEFHb//1QaAAIyIlbDAHGKno5+huH7RKxq",
-  "app.js": "sha384-ltsszp8xHOJbHDX+dpNDmfCym1Er/n7QxGBoDF10vsccseNqSK7lDkkAz1jPVg9U",
+  "app.js": "sha384-zEYVY/2DhkJGDOJDhP5qx+pWO6zp80b3z6IXnbDUlNjRjCHgSdwSSwpRU5rQLndq",
   "modals.js": "sha384-iDRet9veierC1HWbStHC4LLKCSzjeIZTrPRePuKxiUxr7UvdmJ5epb+PYqgHYqte",
   "style.css": "sha384-qvSJURWrtlva+87171/c2KHjzg2kzTYgjlEkCLTCdadhZtJA5MyGgt7VgOj9dE0D",
   "xterm.css": "sha384-Mz9RDc16Iua5vrzALPqUZn39WVfelFzZvwpqCNkMKji5gpYeP3kNCMPGypMFf0AD",


### PR DESCRIPTION
## What

`authorizedFetch()` in `zellij-client/assets/auth.js` asks the user for a token every time a request is rejected. Concurrent callers each open their own dialog, because `getSecurityToken()` appends to `document.body` with no singleton and no shared pending promise. This routes every rejected caller through one shared authentication attempt instead.

## Why it matters

Any two requests rejected at the same time produce two dialogs. Authenticating one does not release the other: each parked call is blocked on its own `await waitForSecurityToken()` and never re-checks the now-valid cookie, so the token has to be entered once per dialog.

The mobile standalone session menu is the case that surfaced this, because it polls `/session-list` every 3 seconds — so while logged out a dialog stacks every 3 seconds, and clearing the topmost one only uncovers the next. But the mechanism is not specific to that caller: two dialogs already land before the first tick, because `openOverlay("sessions")` and the explicit refresh that follows it both fire during boot.

With this change the first rejected caller owns the prompt and the rest await its result. They resume together once it settles and retry against the credentials it established.

Requests can also be rejected *across* an authentication rather than during it. A request sent before login is answered against the credentials of the moment it was sent, so its 401 can arrive after login has already succeeded — and coalescing alone does not help, because the shared attempt has settled and been cleared by then. `authorizedFetch()` therefore samples an `authenticationGeneration` counter before each fetch, incremented in the same `finally` that clears the shared promise:

```js
if (authenticationGeneration !== generation) {
    continue;
}
```

If it has advanced by the time the rejection arrives, that rejection predates the credentials now held, so the request is retried once rather than prompting again. This cannot spin — the generation only advances when an authentication settles, which requires user interaction. Unpatched `main` loses this race too, prompting per rejection regardless.

## How it showed up

Chromium under its Pixel 7 device profile, against a plain `http://127.0.0.1:8084/` with no proxy in front of it, counting `.security-modal` elements:

```
          before   after
t≈0.4s       2       1
t≈3.5s       3       1
t≈6.5s       4       1
t≈9.5s       5       1
t≈12.5s      6       1
```

On the unpatched build Playwright cannot even click Authenticate — it times out with `<div class="security-modal"> subtree intercepts pointer events`, because a later dialog sits over the button. After the change: one dialog, zero once authenticated, and polling continues normally afterwards.

One honest difference from the alternative PR below. Because this fixes authentication rather than the poll, the timer keeps firing while the prompt is open: 13 `/session-list` requests were made before authenticating here, against 3 with the `mobile-ui.js` guard. Each is a cheap 401, but they do accumulate a parked promise apiece. The two changes are complementary rather than redundant — this one fixes the cause and covers every caller, the other stops the wasted polling.

## Scope

Deliberately not included: cancellation. #5540 also suggests making Cancel propagate to the caller instead of re-prompting. That requires `fetchSession()`'s boot path in `index.js` to decide what a cancelled login means for a page that cannot continue without one, which is a UX decision rather than a bug fix, and I did not want to invent it in a patch. With this change Cancel still re-prompts — but into a single dialog rather than a growing stack. Happy to take it further if you would like that.

## Test

There is no JS test harness in the tree, so this is verified against a real build rather than with a unit test. `cargo xtask assets` regenerates `app.js`, `integrity.json` and `index.html`; the browser numbers above come from `target/dev-opt/zellij web` serving those embedded assets (`include_dir!` resolves them at compile time), with an unpatched 0.45.0 binary on a second port as the control. Both runs used the same script and the same device profile.

The stale-rejection path is not reachable from the browser on demand, so it is covered separately by driving the module directly with stubbed collaborators: two requests issued while logged out, the second's response withheld until after a successful login.

```
main (unpatched)                 prompts: 2   authenticated: true
coalescing alone                 prompts: 2   authenticated: true
coalescing + generation counter   prompts: 1   authenticated: true
```

- `cargo xtask test` — pass
- `cargo test -p zellij-client --lib --features web_server_capability` — 193 passed, 0 failed
- `cargo xtask assets --check` — clean

I would rather have left a regression test behind than a paragraph, but there is no JS test harness in the repository to put one in — no `package.json`, no runner, and CI is cargo-only. The harness above is out-of-tree. If you would like a small JS test harness added, with this race as its first case, I am glad to contribute one; that seemed like an infrastructure decision for you rather than something to fold into a bug fix.

Reported as #5540.

---

I've read that you're prioritising roadmap work and are selective about outside contributions, so please treat this as a report with a patch attached rather than a claim on your time.

This is the alternative to #5541, which fixes the same issue by guarding the poll in `mobile-ui.js`. They are two approaches to one bug rather than a pair — that one is a smaller change confined to the caller that surfaced it, this one is broader and fixes the shared authentication path. Whichever you prefer, please close the other.
