### PR TITLE
feat: allow starting a session with an initial command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * fix: properly fire visibility event to plugins when their tab/floating-layer is hidden/shown (https://github.com/zellij-org/zellij/pull/5518 and https://github.com/zellij-org/zellij/pull/5534)
 * feat: allow setting explicit_theme_hue (light/dark) (https://github.com/zellij-org/zellij/pull/5536)
 * fix: input mode updates when switching tabs (https://github.com/zellij-org/zellij/pull/5535)
+* feat: allow starting a session with an initial command, eg. `zellij attach -a my-session -- htop` (https://github.com/zellij-org/zellij/pull/5543)
 
 ## [0.45.0] - 2026-08-20
 * feat: allow tabs to have different sizes if clients aren't focused on the same one (https://github.com/zellij-org/zellij/pull/5133)

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -37,7 +37,7 @@ use zellij_utils::{
     data::ConnectToSession,
     envs,
     input::{
-        actions::Action,
+        actions::{initial_panes_from_cli, Action},
         config::{Config, ConfigError},
         options::Options,
     },
@@ -229,7 +229,7 @@ pub(crate) fn start_web_server(
 }
 
 fn create_new_client() -> ClientInfo {
-    ClientInfo::New(generate_unique_session_name_or_exit(), None, None)
+    ClientInfo::New(generate_unique_session_name_or_exit(), None, None, None)
 }
 
 #[cfg(feature = "web_server_capability")]
@@ -559,7 +559,7 @@ fn attach_with_session_name(
     match &session_name {
         Some(session) if create => match session_exists(session) {
             Ok(true) => ClientInfo::Attach(session_name.unwrap(), config_options),
-            Ok(false) => ClientInfo::New(session_name.unwrap(), None, None),
+            Ok(false) => ClientInfo::New(session_name.unwrap(), None, None, None),
             Err(kind) => {
                 eprintln!("{}", session_listing_error_message(kind));
                 process::exit(1);
@@ -665,6 +665,9 @@ pub(crate) fn start_client(opts: CliArgs) {
                     forget: false,
                     ca_cert: None,
                     insecure: false,
+                    initial_command: vec![],
+                    close_on_exit: false,
+                    start_suspended: false,
                 }));
             } else {
                 opts.command = None;
@@ -700,6 +703,9 @@ pub(crate) fn start_client(opts: CliArgs) {
             forget,
             ca_cert,
             insecure,
+            initial_command,
+            close_on_exit,
+            start_suspended,
         })) = opts.command.clone()
         {
             if let Some(remote_session_url) = session_name.as_ref().and_then(|s| {
@@ -716,6 +722,11 @@ pub(crate) fn start_client(opts: CliArgs) {
 
                 if options.is_some() || create || create_background || force_run_commands {
                     eprintln!("Cannot attach to remote session with options.");
+                    std::process::exit(2);
+                }
+
+                if !initial_command.is_empty() {
+                    eprintln!("Cannot run an initial command on a remote session.");
                     std::process::exit(2);
                 }
 
@@ -803,6 +814,18 @@ pub(crate) fn start_client(opts: CliArgs) {
                     client.set_cwd(new_session_cwd);
                 }
 
+                let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+                if let Some(initial_panes) = initial_panes_from_cli(
+                    initial_command,
+                    None,
+                    Some(current_dir.clone()),
+                    current_dir,
+                    close_on_exit,
+                    start_suspended,
+                ) {
+                    client.set_initial_panes(initial_panes);
+                }
+
                 let tab_position_to_focus = reconnect_to_session
                     .as_ref()
                     .and_then(|r| r.tab_position.clone());
@@ -829,7 +852,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                     opts,
                     config,
                     config_options,
-                    ClientInfo::New(session_name, layout_info, new_session_cwd),
+                    ClientInfo::New(session_name, layout_info, new_session_cwd, None),
                     None,
                     None,
                     is_a_reconnect,
@@ -876,7 +899,12 @@ pub(crate) fn start_client(opts: CliArgs) {
                                 opts,
                                 config,
                                 config_options.clone(),
-                                ClientInfo::New(session_name.clone(), layout_info, new_session_cwd),
+                                ClientInfo::New(
+                                    session_name.clone(),
+                                    layout_info,
+                                    new_session_cwd,
+                                    None,
+                                ),
                                 None,
                                 None,
                                 is_a_reconnect,
@@ -899,7 +927,7 @@ pub(crate) fn start_client(opts: CliArgs) {
                     opts,
                     config,
                     config_options,
-                    ClientInfo::New(session_name, layout_info, new_session_cwd),
+                    ClientInfo::New(session_name, layout_info, new_session_cwd, None),
                     None,
                     None,
                     is_a_reconnect,

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -157,7 +157,9 @@ use zellij_utils::cli::CliArgs;
 use zellij_utils::{
     channels::{self, ChannelWithContext, SenderWithContext},
     consts::{set_permissions, ZELLIJ_SOCK_DIR},
-    data::{ClientId, ConnectToSession, KeyWithModifier, LayoutInfo, LayoutMetadata},
+    data::{
+        ClientId, CommandOrPlugin, ConnectToSession, KeyWithModifier, LayoutInfo, LayoutMetadata,
+    },
     envs,
     errors::{ClientContext, ContextType, ErrorInstruction},
     input::{
@@ -503,7 +505,12 @@ pub fn spawn_server(socket_path: &Path, debug: bool) -> io::Result<()> {
 #[derive(Debug, Clone)]
 pub enum ClientInfo {
     Attach(String, Options),
-    New(String, Option<LayoutInfo>, Option<PathBuf>), // PathBuf -> explicit cwd
+    New(
+        String,
+        Option<LayoutInfo>,
+        Option<PathBuf>,
+        Option<Vec<CommandOrPlugin>>,
+    ), // PathBuf -> explicit cwd
     Resurrect(String, PathBuf, bool, Option<PathBuf>), // (name, path_to_layout, force_run_commands, cwd)
     Watch(String, Options),                            // Watch mode (read-only)
 }
@@ -512,21 +519,27 @@ impl ClientInfo {
     pub fn get_session_name(&self) -> &str {
         match self {
             Self::Attach(ref name, _) => name,
-            Self::New(ref name, _layout_info, _layout_cwd) => name,
+            Self::New(ref name, _layout_info, _layout_cwd, _initial_panes) => name,
             Self::Resurrect(ref name, _, _, _) => name,
             Self::Watch(ref name, _) => name,
         }
     }
     pub fn set_layout_info(&mut self, new_layout_info: LayoutInfo) {
         match self {
-            ClientInfo::New(_, layout_info, _) => *layout_info = Some(new_layout_info),
+            ClientInfo::New(_, layout_info, _, _) => *layout_info = Some(new_layout_info),
             _ => {},
         }
     }
     pub fn set_cwd(&mut self, new_cwd: PathBuf) {
         match self {
-            ClientInfo::New(_, _, cwd) => *cwd = Some(new_cwd),
+            ClientInfo::New(_, _, cwd, _) => *cwd = Some(new_cwd),
             ClientInfo::Resurrect(_, _, _, cwd) => *cwd = Some(new_cwd),
+            _ => {},
+        }
+    }
+    pub fn set_initial_panes(&mut self, new_initial_panes: Vec<CommandOrPlugin>) {
+        match self {
+            ClientInfo::New(_, _, _, initial_panes) => *initial_panes = Some(new_initial_panes),
             _ => {},
         }
     }
@@ -1031,6 +1044,7 @@ pub fn start_client(
                 force_run_layout_commands: false,
                 cwd: None,
                 host_terminal_env: host_terminal_env(),
+                initial_panes: None,
             };
             (
                 ClientToServerMsg::AttachClient {
@@ -1077,6 +1091,7 @@ pub fn start_client(
                 force_run_layout_commands: force_run_commands,
                 cwd,
                 host_terminal_env: host_terminal_env(),
+                initial_panes: None,
             };
 
             os_input.update_session_name(name);
@@ -1101,7 +1116,7 @@ pub fn start_client(
                 ipc_pipe,
             )
         },
-        ClientInfo::New(name, layout_info, layout_cwd) => {
+        ClientInfo::New(name, layout_info, layout_cwd, initial_panes) => {
             envs::set_session_name(name.clone());
 
             let cli_assets = CliAssets {
@@ -1134,6 +1149,7 @@ pub fn start_client(
                 force_run_layout_commands: false,
                 cwd: layout_cwd,
                 host_terminal_env: host_terminal_env(),
+                initial_panes,
             };
 
             os_input.update_session_name(name);
@@ -1652,6 +1668,7 @@ pub fn start_server_detached(
                 force_run_layout_commands: force_run_commands,
                 cwd,
                 host_terminal_env: host_terminal_env(),
+                initial_panes: None,
             };
 
             os_input.update_session_name(name);
@@ -1676,7 +1693,7 @@ pub fn start_server_detached(
                 ipc_pipe,
             )
         },
-        ClientInfo::New(name, layout_info, layout_cwd) => {
+        ClientInfo::New(name, layout_info, layout_cwd, initial_panes) => {
             envs::set_session_name(name.clone());
 
             let cli_assets = CliAssets {
@@ -1710,6 +1727,7 @@ pub fn start_server_detached(
                 force_run_layout_commands: false,
                 cwd: layout_cwd,
                 host_terminal_env: host_terminal_env(),
+                initial_panes,
             };
 
             os_input.update_session_name(name);

--- a/zellij-client/src/web_client/session_management.rs
+++ b/zellij-client/src/web_client/session_management.rs
@@ -103,6 +103,7 @@ pub fn create_first_message(
             force_run_layout_commands: false,
             cwd: None,
             host_terminal_env: Default::default(),
+            initial_panes: None,
         };
 
         ClientToServerMsg::FirstClientConnected {
@@ -123,6 +124,7 @@ pub fn create_first_message(
             force_run_layout_commands: false,
             cwd: None,
             host_terminal_env: Default::default(),
+            initial_panes: None,
         };
         let is_web_client = true;
 

--- a/zellij-integration-tests/src/lib.rs
+++ b/zellij-integration-tests/src/lib.rs
@@ -23,7 +23,10 @@ pub use nested::{
     host_descended_bar_with_ascend_keys_settled, wait_for_settled_composite,
     NestedDepthThreeHarness, NestedHarness,
 };
-pub use runner::{assert_same_rendered_grid, normalized, TestClient, TestRunner, TestSession};
+pub use runner::{
+    assert_same_rendered_grid, normalized, BackgroundTestSession, TestClient, TestRunner,
+    TestSession,
+};
 pub use zellij_utils::data::LayoutInfo;
 pub use zellij_utils::pane_size::Size;
 

--- a/zellij-integration-tests/src/runner.rs
+++ b/zellij-integration-tests/src/runner.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 use zellij_client::os_input_output::SignalEvent;
 use zellij_client::ClientInfo;
 use zellij_utils::cli::{CliAction, CliArgs};
-use zellij_utils::data::{ConnectToSession, LayoutInfo};
-use zellij_utils::input::actions::Action;
+use zellij_utils::data::{CommandOrPlugin, ConnectToSession, LayoutInfo};
+use zellij_utils::input::actions::{Action, RunCommandAction};
 use zellij_utils::input::options::Options;
 use zellij_utils::pane_size::Size;
 use zellij_utils::setup::Setup;
@@ -25,6 +25,7 @@ pub struct TestRunner {
     size: Size,
     extra_config_kdl: String,
     layout: Option<LayoutInfo>,
+    initial_panes: Option<Vec<CommandOrPlugin>>,
     env: std::collections::HashMap<String, String>,
     stdout_tap: Option<crossbeam::channel::Sender<Vec<u8>>>,
     skip_concurrency_slot: bool,
@@ -36,6 +37,7 @@ impl TestRunner {
             size,
             extra_config_kdl: String::new(),
             layout: None,
+            initial_panes: None,
             env: std::collections::HashMap::new(),
             stdout_tap: None,
             skip_concurrency_slot: false,
@@ -53,6 +55,18 @@ impl TestRunner {
         self
     }
 
+    pub fn with_initial_command(mut self, command: &[&str]) -> Self {
+        let mut command: Vec<String> = command.iter().map(|part| part.to_string()).collect();
+        let run_command_action = RunCommandAction {
+            command: PathBuf::from(command.remove(0)),
+            args: command,
+            hold_on_close: true,
+            ..Default::default()
+        };
+        self.initial_panes = Some(vec![CommandOrPlugin::Command(run_command_action)]);
+        self
+    }
+
     pub fn with_stdout_tap(mut self, sender: crossbeam::channel::Sender<Vec<u8>>) -> Self {
         self.stdout_tap = Some(sender);
         self
@@ -64,6 +78,54 @@ impl TestRunner {
     }
 
     pub fn start(self) -> TestSession {
+        let (session_context, fake_client_os_api, fake_client_handle, client_info) = self.boot();
+        let client_thread = spawn_client_thread(
+            fake_client_os_api,
+            session_context.cli_args.clone(),
+            session_context.config.clone(),
+            session_context.config_options.clone(),
+            client_info,
+        );
+        session_context.into_session(TestClient {
+            fake_client_handle,
+            thread: Some(client_thread),
+        })
+    }
+
+    pub fn start_in_background(self) -> BackgroundTestSession {
+        let (session_context, fake_client_os_api, _fake_client_handle, client_info) = self.boot();
+        let cli_args = session_context.cli_args.clone();
+        let config = session_context.config.clone();
+        let config_options = session_context.config_options.clone();
+        let detaching_client_thread = std::thread::Builder::new()
+            .name("in_process_zellij_detached_client".to_string())
+            .spawn(move || {
+                let start_detached_and_exit = true;
+                zellij_client::start_client(
+                    Box::new(fake_client_os_api),
+                    cli_args,
+                    config,
+                    config_options,
+                    client_info,
+                    None,
+                    None,
+                    false,
+                    start_detached_and_exit,
+                );
+            })
+            .unwrap();
+        join_detaching_client_thread_with_timeout(detaching_client_thread);
+        BackgroundTestSession { session_context }
+    }
+
+    fn boot(
+        self,
+    ) -> (
+        SessionContext,
+        FakeClientOsApi,
+        FakeClientHandle,
+        ClientInfo,
+    ) {
         test_env::init();
         let session_name = test_env::unique_session_name();
         let config_path = test_env::write_config(&session_name, &self.extra_config_kdl);
@@ -93,28 +155,111 @@ impl TestRunner {
             fake_client_handle.client_screen.set_stdout_tap(stdout_tap);
         }
         let layout_info = self.layout.or(default_layout_info);
+        let client_info =
+            ClientInfo::New(session_name.clone(), layout_info, None, self.initial_panes);
+
+        (
+            SessionContext {
+                session_name,
+                size: self.size,
+                cli_args,
+                config,
+                config_options,
+                fake_server_os_api,
+                server_thread,
+                concurrency_slot,
+            },
+            fake_client_os_api,
+            fake_client_handle,
+            client_info,
+        )
+    }
+}
+
+struct SessionContext {
+    session_name: String,
+    size: Size,
+    cli_args: CliArgs,
+    config: zellij_utils::input::config::Config,
+    config_options: Options,
+    fake_server_os_api: FakeServerOsApi,
+    server_thread: Arc<Mutex<Option<JoinHandle<()>>>>,
+    concurrency_slot: Option<test_env::ConcurrencySlot>,
+}
+
+impl SessionContext {
+    fn into_session(self, main_client: TestClient) -> TestSession {
+        TestSession {
+            session_name: self.session_name,
+            size: self.size,
+            cli_args: self.cli_args,
+            config: self.config,
+            config_options: self.config_options,
+            fake_server_os_api: self.fake_server_os_api,
+            server_thread: self.server_thread,
+            main_client,
+            _concurrency_slot: self.concurrency_slot,
+        }
+    }
+}
+
+pub struct BackgroundTestSession {
+    session_context: SessionContext,
+}
+
+impl BackgroundTestSession {
+    pub fn session_name(&self) -> &str {
+        &self.session_context.session_name
+    }
+
+    pub fn expect_pty_spawn(&self) -> FakePtyHandle {
+        expect_pty_spawn(&self.session_context.fake_server_os_api)
+    }
+
+    pub fn attach(self, size: Size) -> TestSession {
+        let (fake_client_os_api, fake_client_handle) = FakeClientOsApi::new(size, None);
         let client_thread = spawn_client_thread(
             fake_client_os_api,
-            cli_args.clone(),
-            config.clone(),
-            config_options.clone(),
-            ClientInfo::New(session_name.clone(), layout_info, None),
+            self.session_context.cli_args.clone(),
+            self.session_context.config.clone(),
+            self.session_context.config_options.clone(),
+            ClientInfo::Attach(
+                self.session_context.session_name.clone(),
+                self.session_context.config_options.clone(),
+            ),
         );
+        self.session_context.into_session(TestClient {
+            fake_client_handle,
+            thread: Some(client_thread),
+        })
+    }
+}
 
-        TestSession {
-            session_name,
-            size: self.size,
-            cli_args,
-            config,
-            config_options,
-            fake_server_os_api,
-            server_thread,
-            main_client: TestClient {
-                fake_client_handle,
-                thread: Some(client_thread),
-            },
-            _concurrency_slot: concurrency_slot,
-        }
+fn expect_pty_spawn(fake_server_os_api: &FakeServerOsApi) -> FakePtyHandle {
+    let terminal_id = fake_server_os_api
+        .shared_ptys
+        .wait_for("a pty spawn", |fake_pty_registry| {
+            fake_pty_registry.spawn_queue.pop_front()
+        });
+    FakePtyHandle {
+        terminal_id,
+        shared_ptys: fake_server_os_api.shared_ptys.clone(),
+    }
+}
+
+fn join_detaching_client_thread_with_timeout(join_handle: JoinHandle<()>) {
+    let (done_tx, done_rx) = mpsc::channel();
+    std::thread::Builder::new()
+        .name("detaching_client_join_watchdog".to_string())
+        .spawn(move || {
+            let result = join_handle.join();
+            let _ = done_tx.send(result);
+        })
+        .unwrap();
+    match done_rx.recv_timeout(CLIENT_JOIN_TIMEOUT) {
+        Ok(Ok(())) => {},
+        Ok(Err(_)) => panic!("detaching client thread panicked"),
+        Err(_) => panic!("timed out starting a session in the background"),
     }
 }
 
@@ -356,16 +501,7 @@ impl TestSession {
     }
 
     pub fn expect_pty_spawn(&self) -> FakePtyHandle {
-        let terminal_id = self
-            .fake_server_os_api
-            .shared_ptys
-            .wait_for("a pty spawn", |fake_pty_registry| {
-                fake_pty_registry.spawn_queue.pop_front()
-            });
-        FakePtyHandle {
-            terminal_id,
-            shared_ptys: self.fake_server_os_api.shared_ptys.clone(),
-        }
+        expect_pty_spawn(&self.fake_server_os_api)
     }
 
     pub fn main_client(&self) -> &TestClient {

--- a/zellij-integration-tests/tests/initial_command.rs
+++ b/zellij-integration-tests/tests/initial_command.rs
@@ -1,0 +1,157 @@
+#![cfg(unix)]
+
+use insta::assert_snapshot;
+use zellij_integration_tests::{
+    col, normalized, FakePtyHandle, LayoutInfo, TestRunner, TestSession, PROMPT, TERMINAL_SIZE,
+};
+use zellij_utils::input::command::TerminalAction;
+
+const TWO_TABS_SECOND_FOCUSED: &str = r#"
+layout {
+    tab name="first"
+    tab name="second" focus=true
+}
+"#;
+
+fn command_line_of(terminal: &FakePtyHandle) -> Vec<String> {
+    match terminal.terminal_action() {
+        Some(TerminalAction::RunCommand(run_command)) => {
+            let mut command_line = vec![run_command.command.display().to_string()];
+            command_line.extend(run_command.args);
+            command_line
+        },
+        other => panic!("expected a command pane, got {:?}", other),
+    }
+}
+
+fn runs_initial_command(terminal: &FakePtyHandle) -> bool {
+    command_line_of(terminal)
+        .first()
+        .is_some_and(|command| command.ends_with("initial-command"))
+}
+
+fn wait_for_loaded_app(zellij: &TestSession) {
+    zellij.wait_until("app loaded", |grid_snapshot| {
+        grid_snapshot.tab_bar_appears() && grid_snapshot.status_bar_appears()
+    });
+}
+
+#[test]
+fn a_session_started_with_an_initial_command_runs_it_in_its_first_pane() {
+    let mut zellij = TestRunner::new(TERMINAL_SIZE)
+        .with_initial_command(&["initial-command", "--flag", "value"])
+        .start();
+
+    let initial_terminal = zellij.expect_pty_spawn();
+    assert_eq!(
+        command_line_of(&initial_terminal),
+        vec!["initial-command", "--flag", "value"],
+        "the initial command is spawned instead of the default shell"
+    );
+
+    initial_terminal.output(b"initial-command output\r\n");
+    let grid_snapshot = zellij.wait_until("initial command output rendered", |grid_snapshot| {
+        grid_snapshot.status_bar_appears() && grid_snapshot.contains("initial-command output")
+    });
+    assert_snapshot!(normalized(&grid_snapshot));
+    zellij.quit();
+}
+
+#[test]
+fn an_initial_command_pane_is_held_open_when_the_command_exits() {
+    let mut zellij = TestRunner::new(TERMINAL_SIZE)
+        .with_initial_command(&["initial-command"])
+        .start();
+
+    let initial_terminal = zellij.expect_pty_spawn();
+    wait_for_loaded_app(&zellij);
+
+    initial_terminal.exit(Some(42));
+    let grid_snapshot = zellij.wait_until("exited command pane held open", |grid_snapshot| {
+        grid_snapshot.contains("EXIT CODE: 42")
+    });
+    assert_snapshot!(normalized(&grid_snapshot));
+    zellij.quit();
+}
+
+#[test]
+fn an_initial_command_lands_in_the_focused_tab_of_a_layout() {
+    let mut zellij = TestRunner::new(TERMINAL_SIZE)
+        .with_layout(LayoutInfo::Stringified(TWO_TABS_SECOND_FOCUSED.to_string()))
+        .with_initial_command(&["initial-command"])
+        .start();
+
+    let first_tab_terminal = zellij.expect_pty_spawn();
+    let second_tab_terminal = zellij.expect_pty_spawn();
+    first_tab_terminal.output(b"unfocused tab shell\r\n");
+    second_tab_terminal.output(b"initial-command output\r\n");
+
+    assert!(
+        !runs_initial_command(&first_tab_terminal),
+        "the unfocused tab keeps its default shell"
+    );
+    assert_eq!(
+        command_line_of(&second_tab_terminal),
+        vec!["initial-command"],
+        "the focused tab runs the initial command"
+    );
+
+    let grid_snapshot = zellij
+        .wait_until("focused tab shows the command output", |grid_snapshot| {
+            grid_snapshot.contains("initial-command output")
+        });
+    assert!(
+        !grid_snapshot.contains("unfocused tab shell"),
+        "the unfocused tab is not the one being displayed"
+    );
+    assert_snapshot!(normalized(&grid_snapshot));
+    zellij.quit();
+}
+
+#[test]
+fn attaching_to_a_background_session_shows_its_initial_command() {
+    let background_session = TestRunner::new(TERMINAL_SIZE)
+        .with_initial_command(&["initial-command"])
+        .start_in_background();
+
+    let initial_terminal = background_session.expect_pty_spawn();
+    assert_eq!(
+        command_line_of(&initial_terminal),
+        vec!["initial-command"],
+        "the background session runs the initial command without a client attached"
+    );
+    initial_terminal.output(b"output while detached\r\n");
+
+    let mut zellij = background_session.attach(TERMINAL_SIZE);
+    let grid_snapshot = zellij.wait_until(
+        "attached client renders the initial command output",
+        |grid_snapshot| {
+            grid_snapshot.status_bar_appears() && grid_snapshot.contains("output while detached")
+        },
+    );
+    assert_snapshot!(normalized(&grid_snapshot));
+
+    initial_terminal.output(b"output while attached\r\n");
+    zellij.wait_until(
+        "attached client renders live command output",
+        |grid_snapshot| grid_snapshot.contains("output while attached"),
+    );
+    zellij.quit();
+}
+
+#[test]
+fn a_session_started_without_an_initial_command_runs_the_default_shell() {
+    let mut zellij = TestRunner::new(TERMINAL_SIZE).start();
+
+    let first_terminal = zellij.expect_pty_spawn();
+    assert!(
+        !runs_initial_command(&first_terminal),
+        "the first pane is the default shell"
+    );
+
+    first_terminal.output(PROMPT);
+    zellij.wait_until("default shell prompt rendered", |grid_snapshot| {
+        grid_snapshot.status_bar_appears() && grid_snapshot.cursor_is_at(col(2).row(1))
+    });
+    zellij.quit();
+}

--- a/zellij-integration-tests/tests/snapshots/initial_command__a_session_started_with_an_initial_command_runs_it_in_its_first_pane.snap
+++ b/zellij-integration-tests/tests/snapshots/initial_command__a_session_started_with_an_initial_command_runs_it_in_its_first_pane.snap
@@ -1,0 +1,8 @@
+---
+source: zellij-integration-tests/tests/initial_command.rs
+expression: normalized(&grid_snapshot)
+---
+ Zellij (test)  Tab #1  + 
+initial-command output
+█
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/zellij-integration-tests/tests/snapshots/initial_command__an_initial_command_lands_in_the_focused_tab_of_a_layout.snap
+++ b/zellij-integration-tests/tests/snapshots/initial_command__an_initial_command_lands_in_the_focused_tab_of_a_layout.snap
@@ -1,0 +1,6 @@
+---
+source: zellij-integration-tests/tests/initial_command.rs
+expression: normalized(&grid_snapshot)
+---
+initial-command output
+█

--- a/zellij-integration-tests/tests/snapshots/initial_command__an_initial_command_pane_is_held_open_when_the_command_exits.snap
+++ b/zellij-integration-tests/tests/snapshots/initial_command__an_initial_command_pane_is_held_open_when_the_command_exits.snap
@@ -1,0 +1,7 @@
+---
+source: zellij-integration-tests/tests/initial_command.rs
+expression: normalized(&grid_snapshot)
+---
+ Zellij (test)  Tab #1 [ EXIT CODE: 42 ]   + 
+█
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/zellij-integration-tests/tests/snapshots/initial_command__attaching_to_a_background_session_shows_its_initial_command.snap
+++ b/zellij-integration-tests/tests/snapshots/initial_command__attaching_to_a_background_session_shows_its_initial_command.snap
@@ -1,0 +1,8 @@
+---
+source: zellij-integration-tests/tests/initial_command.rs
+expression: normalized(&grid_snapshot)
+---
+ Zellij (test)  Tab #1  + 
+output while detached
+█
+ Ctrl + <g> LOCK  <p> PANE  <t> TAB  <n> RESIZE  <h> MOVE  <s> SEARCH  <o> SESSION  <q> QUIT        ...

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -993,6 +993,7 @@ pub fn start_server_impl(
         match instruction {
             ServerInstruction::FirstClientConnected(cli_assets, is_web_client, client_id) => {
                 let host_terminal_env = cli_assets.host_terminal_env.clone();
+                let mut initial_panes = cli_assets.initial_panes.clone();
                 let (config, layout) = cli_assets.load_config_and_layout();
                 let layout_is_welcome_screen = cli_assets.layout
                     == Some(LayoutInfo::BuiltIn("welcome".to_owned()))
@@ -1085,11 +1086,16 @@ pub fn start_server_impl(
                     .cwd
                     .or_else(|| runtime_config_options.default_cwd);
 
-                let spawn_tabs = |tab_layout,
-                                  floating_panes_layout,
-                                  tab_name,
-                                  swap_layouts,
-                                  should_focus_tab| {
+                let mut spawn_tabs = |tab_layout,
+                                      floating_panes_layout,
+                                      tab_name,
+                                      swap_layouts,
+                                      should_focus_tab| {
+                    let initial_panes = if should_focus_tab {
+                        initial_panes.take()
+                    } else {
+                        None
+                    };
                     session_data
                         .read()
                         .unwrap()
@@ -1103,7 +1109,7 @@ pub fn start_server_impl(
                             floating_panes_layout,
                             tab_name,
                             swap_layouts,
-                            None,  // initial_panes
+                            initial_panes,
                             false, // block_on_first_terminal
                             should_focus_tab,
                             (client_id, is_web_client),

--- a/zellij-utils/assets/prost_ipc/client_server_contract.rs
+++ b/zellij-utils/assets/prost_ipc/client_server_contract.rs
@@ -1381,6 +1381,8 @@ pub struct CliAssets {
     pub cwd: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(map="string, string", tag="12")]
     pub host_terminal_env: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    #[prost(message, repeated, tag="13")]
+    pub initial_panes: ::prost::alloc::vec::Vec<CommandOrPlugin>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -369,6 +369,18 @@ pub enum Sessions {
         /// Skip TLS certificate validation (DANGEROUS — development only)
         #[clap(long, value_parser)]
         insecure: bool,
+
+        /// Command to run in the first pane of the session, if it is created
+        #[clap(value_parser, last(true))]
+        initial_command: Vec<String>,
+
+        /// Close the initial command's pane immediately when it exits
+        #[clap(long, requires("initial_command"))]
+        close_on_exit: bool,
+
+        /// Start the initial command suspended, only running it after you first press ENTER
+        #[clap(long, requires("initial_command"))]
+        start_suspended: bool,
     },
 
     /// Watch a session (read-only)

--- a/zellij-utils/src/client_server_contract/common_types.proto
+++ b/zellij-utils/src/client_server_contract/common_types.proto
@@ -811,6 +811,7 @@ message CliAssets {
   bool force_run_layout_commands = 10;
   optional string cwd = 11;
   map<string, string> host_terminal_env = 12;
+  repeated CommandOrPlugin initial_panes = 13;
 }
 
 message LayoutInfo {

--- a/zellij-utils/src/input/actions.rs
+++ b/zellij-utils/src/input/actions.rs
@@ -25,6 +25,50 @@ use std::str::FromStr;
 
 use crate::position::Position;
 
+pub fn initial_panes_from_cli(
+    initial_command: Vec<String>,
+    initial_plugin: Option<String>,
+    cwd: Option<PathBuf>,
+    caller_cwd: PathBuf,
+    close_on_exit: bool,
+    start_suspended: bool,
+) -> Option<Vec<CommandOrPlugin>> {
+    if let Some(plugin_url) = initial_plugin {
+        let plugin = match RunPluginLocation::parse(&plugin_url, cwd.clone()) {
+            Ok(location) => RunPluginOrAlias::RunPlugin(RunPlugin {
+                _allow_exec_host_cmd: false,
+                location,
+                configuration: Default::default(),
+                initial_cwd: cwd,
+            }),
+            Err(_) => {
+                let mut plugin_alias = PluginAlias::new(&plugin_url, &None, cwd);
+                plugin_alias.set_caller_cwd_if_not_set(Some(caller_cwd));
+                RunPluginOrAlias::Alias(plugin_alias)
+            },
+        };
+        Some(vec![CommandOrPlugin::Plugin(plugin)])
+    } else if !initial_command.is_empty() {
+        let mut initial_command = initial_command;
+        let (command, args) = (
+            PathBuf::from(initial_command.remove(0)),
+            initial_command.into_iter().collect(),
+        );
+        let run_command_action = RunCommandAction {
+            command,
+            args,
+            cwd,
+            direction: None,
+            hold_on_close: !close_on_exit,
+            hold_on_start: start_suspended,
+            ..Default::default()
+        };
+        Some(vec![CommandOrPlugin::Command(run_command_action)])
+    } else {
+        None
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub enum ResizeDirection {
     Left,
@@ -1478,44 +1522,14 @@ impl Action {
                     None
                 };
 
-                // Parse initial_panes from initial_command or initial_plugin
-                let initial_panes = if let Some(plugin_url) = initial_plugin {
-                    let plugin = match RunPluginLocation::parse(&plugin_url, cwd.clone()) {
-                        Ok(location) => RunPluginOrAlias::RunPlugin(RunPlugin {
-                            _allow_exec_host_cmd: false,
-                            location,
-                            configuration: Default::default(),
-                            initial_cwd: cwd.clone(),
-                        }),
-                        Err(_) => {
-                            let mut plugin_alias =
-                                PluginAlias::new(&plugin_url, &None, cwd.clone());
-                            plugin_alias.set_caller_cwd_if_not_set(Some(current_dir.clone()));
-                            RunPluginOrAlias::Alias(plugin_alias)
-                        },
-                    };
-                    Some(vec![CommandOrPlugin::Plugin(plugin)])
-                } else if !initial_command.is_empty() {
-                    let mut command: Vec<String> = initial_command.clone();
-                    let (command, args) = (
-                        PathBuf::from(command.remove(0)),
-                        command.into_iter().collect(),
-                    );
-                    let hold_on_close = !close_on_exit;
-                    let hold_on_start = start_suspended;
-                    let run_command_action = RunCommandAction {
-                        command,
-                        args,
-                        cwd: cwd.clone(),
-                        direction: None,
-                        hold_on_close,
-                        hold_on_start,
-                        ..Default::default()
-                    };
-                    Some(vec![CommandOrPlugin::Command(run_command_action)])
-                } else {
-                    None
-                };
+                let initial_panes = initial_panes_from_cli(
+                    initial_command,
+                    initial_plugin,
+                    cwd.clone(),
+                    current_dir.clone(),
+                    close_on_exit,
+                    start_suspended,
+                );
                 if let Some(raw_layout) = layout_string {
                     let layout_source_name = "layout-string".to_owned();
                     let path_to_raw_layout = layout_source_name.clone();

--- a/zellij-utils/src/input/cli_assets.rs
+++ b/zellij-utils/src/input/cli_assets.rs
@@ -1,4 +1,4 @@
-use crate::data::LayoutInfo;
+use crate::data::{CommandOrPlugin, LayoutInfo};
 use crate::input::options::Options;
 use crate::pane_size::Size;
 use crate::{
@@ -47,6 +47,7 @@ pub struct CliAssets {
     pub force_run_layout_commands: bool,
     pub cwd: Option<PathBuf>,
     pub host_terminal_env: BTreeMap<String, String>,
+    pub initial_panes: Option<Vec<CommandOrPlugin>>,
 }
 
 impl CliAssets {

--- a/zellij-utils/src/ipc/protobuf_conversion.rs
+++ b/zellij-utils/src/ipc/protobuf_conversion.rs
@@ -845,6 +845,10 @@ impl From<crate::input::cli_assets::CliAssets>
             force_run_layout_commands: cli_assets.force_run_layout_commands,
             cwd: cli_assets.cwd.map(|p| p.to_string_lossy().to_string()),
             host_terminal_env: cli_assets.host_terminal_env.into_iter().collect(),
+            initial_panes: cli_assets
+                .initial_panes
+                .map(|panes| panes.into_iter().map(|p| p.into()).collect())
+                .unwrap_or_default(),
         }
     }
 }
@@ -875,6 +879,17 @@ impl TryFrom<crate::client_server_contract::client_server_contract::CliAssets>
             force_run_layout_commands: cli_assets.force_run_layout_commands,
             cwd: cli_assets.cwd.map(PathBuf::from),
             host_terminal_env: cli_assets.host_terminal_env.into_iter().collect(),
+            initial_panes: if cli_assets.initial_panes.is_empty() {
+                None
+            } else {
+                Some(
+                    cli_assets
+                        .initial_panes
+                        .into_iter()
+                        .map(|p| p.try_into())
+                        .collect::<Result<Vec<_>>>()?,
+                )
+            },
         })
     }
 }

--- a/zellij-utils/src/ipc/tests/roundtrip_tests.rs
+++ b/zellij-utils/src/ipc/tests/roundtrip_tests.rs
@@ -424,6 +424,7 @@ fn test_client_messages() {
             host_terminal_env: [("TERM".to_owned(), "xterm-kitty".to_owned())]
                 .into_iter()
                 .collect(),
+            initial_panes: None,
         },
         is_web_client: true,
     });
@@ -443,6 +444,7 @@ fn test_client_messages() {
             host_terminal_env: [("TERM".to_owned(), "xterm-kitty".to_owned())]
                 .into_iter()
                 .collect(),
+            initial_panes: None,
         },
         is_web_client: true,
     });
@@ -522,6 +524,16 @@ fn test_client_messages() {
             host_terminal_env: [("TERM".to_owned(), "xterm-kitty".to_owned())]
                 .into_iter()
                 .collect(),
+            initial_panes: Some(vec![
+                CommandOrPlugin::Command(RunCommandAction {
+                    command: PathBuf::from("htop"),
+                    args: vec!["-d".to_owned(), "5".to_owned()],
+                    cwd: Some(PathBuf::from("/path/to/cwd")),
+                    hold_on_close: true,
+                    ..Default::default()
+                }),
+                CommandOrPlugin::Plugin(RunPluginOrAlias::RunPlugin(RunPlugin::default())),
+            ]),
         },
         is_web_client: true,
     });


### PR DESCRIPTION
This allows us to start a new session (in the foreground or background) with a specific running command instead of an initial terminal:

```bash
zellij attach -c -- htop # foreground
zellij attach -b -- htop # background
```