### PR TITLE
feat(clipboard): add 'both' option to copy_clipboard to synchronize system and primary clipboards

### DIFF
--- a/zellij-server/src/tab/clipboard.rs
+++ b/zellij-server/src/tab/clipboard.rs
@@ -24,21 +24,28 @@ impl ClipboardProvider {
                 command.set(content.to_string())?;
             },
             ClipboardProvider::Osc52(clipboard) => {
-                let dest = match clipboard {
+                let destinations: &[char] = match clipboard {
                     #[cfg(not(target_os = "macos"))]
-                    Clipboard::Primary => 'p',
+                    Clipboard::Primary => &['p'],
                     #[cfg(target_os = "macos")] // primary selection does not exist on macos
-                    Clipboard::Primary => 'c',
-                    Clipboard::System => 'c',
+                    Clipboard::Primary => &['c'],
+                    Clipboard::System => &['c'],
+                    #[cfg(not(target_os = "macos"))]
+                    Clipboard::Both => &['c', 'p'],
+                    #[cfg(target_os = "macos")]
+                    Clipboard::Both => &['c'],
                 };
-                output.add_pre_vte_instruction_to_multiple_clients(
-                    client_ids,
-                    &format!(
-                        "\u{1b}]52;{};{}\u{1b}\\",
-                        dest,
-                        BASE64_STANDARD.encode(content)
-                    ),
-                );
+                let client_ids_vec: Vec<ClientId> = client_ids.collect();
+                for &dest in destinations {
+                    output.add_pre_vte_instruction_to_multiple_clients(
+                        client_ids_vec.iter().copied(),
+                        &format!(
+                            "\u{1b}]52;{};{}\u{1b}\\",
+                            dest,
+                            BASE64_STANDARD.encode(content)
+                        ),
+                    );
+                }
             },
         };
         Ok(())
@@ -49,8 +56,41 @@ impl ClipboardProvider {
             ClipboardProvider::Command(_) => CopyDestination::Command,
             ClipboardProvider::Osc52(clipboard) => match clipboard {
                 Clipboard::Primary => CopyDestination::Primary,
-                Clipboard::System => CopyDestination::System,
+                Clipboard::System | Clipboard::Both => CopyDestination::System,
             },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_osc52_copy_both_destinations() {
+        use crate::tab::LinkHandler;
+        use std::cell::RefCell;
+        use std::collections::HashSet;
+        use std::rc::Rc;
+
+        let provider = ClipboardProvider::Osc52(Clipboard::Both);
+        let mut output = Output::default();
+        let client_ids: HashSet<ClientId> = vec![1].into_iter().collect();
+        let link_handler = Rc::new(RefCell::new(LinkHandler::new()));
+        output.add_clients(&client_ids, link_handler, None);
+        provider
+            .set_content("test data", &mut output, client_ids.iter().copied())
+            .unwrap();
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            let serialized = output.serialize().unwrap();
+            let encoded = BASE64_STANDARD.encode("test data");
+            let expected_c = format!("\u{1b}]52;c;{}\u{1b}\\", encoded);
+            let expected_p = format!("\u{1b}]52;p;{}\u{1b}\\", encoded);
+            let serialized_str = serialized.get(&1).expect("client output");
+            assert!(serialized_str.contains(&expected_c));
+            assert!(serialized_str.contains(&expected_p));
         }
     }
 }

--- a/zellij-utils/assets/prost_ipc/client_server_contract.rs
+++ b/zellij-utils/assets/prost_ipc/client_server_contract.rs
@@ -2915,6 +2915,7 @@ pub enum Clipboard {
     Unspecified = 0,
     System = 1,
     Primary = 2,
+    Both = 3,
 }
 impl Clipboard {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -2926,6 +2927,7 @@ impl Clipboard {
             Clipboard::Unspecified => "CLIPBOARD_UNSPECIFIED",
             Clipboard::System => "CLIPBOARD_SYSTEM",
             Clipboard::Primary => "CLIPBOARD_PRIMARY",
+            Clipboard::Both => "CLIPBOARD_BOTH",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -2934,6 +2936,7 @@ impl Clipboard {
             "CLIPBOARD_UNSPECIFIED" => Some(Self::Unspecified),
             "CLIPBOARD_SYSTEM" => Some(Self::System),
             "CLIPBOARD_PRIMARY" => Some(Self::Primary),
+            "CLIPBOARD_BOTH" => Some(Self::Both),
             _ => None,
         }
     }

--- a/zellij-utils/src/client_server_contract/common_types.proto
+++ b/zellij-utils/src/client_server_contract/common_types.proto
@@ -1237,6 +1237,7 @@ enum Clipboard {
   CLIPBOARD_UNSPECIFIED = 0;
   CLIPBOARD_SYSTEM = 1;
   CLIPBOARD_PRIMARY = 2;
+  CLIPBOARD_BOTH = 3;
 }
 
 enum StackDirection {

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -434,6 +434,8 @@ pub enum Clipboard {
     System,
     #[serde(alias = "primary")]
     Primary,
+    #[serde(alias = "both")]
+    Both,
 }
 
 impl Default for Clipboard {
@@ -494,6 +496,7 @@ impl FromStr for Clipboard {
         match s {
             "System" | "system" => Ok(Self::System),
             "Primary" | "primary" => Ok(Self::Primary),
+            "Both" | "both" => Ok(Self::Both),
             _ => Err(format!("No such clipboard: {}", s)),
         }
     }

--- a/zellij-utils/src/ipc/protobuf_conversion.rs
+++ b/zellij-utils/src/ipc/protobuf_conversion.rs
@@ -915,6 +915,7 @@ impl From<crate::input::options::Options>
             copy_clipboard: options.copy_clipboard.map(|c| match c {
                 crate::input::options::Clipboard::System => ProtoClipboard::System as i32,
                 crate::input::options::Clipboard::Primary => ProtoClipboard::Primary as i32,
+                crate::input::options::Clipboard::Both => ProtoClipboard::Both as i32,
             }),
             copy_on_select: options.copy_on_select,
             osc8_hyperlinks: options.osc8_hyperlinks,
@@ -1047,6 +1048,7 @@ impl TryFrom<crate::client_server_contract::client_server_contract::Options>
                 .map(|c| match ProtoClipboard::try_from(c).ok() {
                     Some(ProtoClipboard::System) => Ok(crate::input::options::Clipboard::System),
                     Some(ProtoClipboard::Primary) => Ok(crate::input::options::Clipboard::Primary),
+                    Some(ProtoClipboard::Both) => Ok(crate::input::options::Clipboard::Both),
                     _ => Err(anyhow!("Invalid Clipboard value: {}", c)),
                 })
                 .transpose()?,

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -3648,6 +3648,7 @@ impl Options {
             let mut node = match copy_clipboard {
                 Clipboard::Primary => create_node("primary"),
                 Clipboard::System => create_node("system"),
+                Clipboard::Both => create_node("both"),
             };
             if add_comments {
                 node.set_leading(format!("{}\n", comment_text));
@@ -7910,6 +7911,16 @@ fn config_options_to_string_with_comments() {
         "Deserialized serialized config equals original config"
     );
     insta::assert_snapshot!(fake_document.to_string());
+}
+
+#[test]
+fn test_copy_clipboard_both() {
+    let fake_config = r#"
+        copy_clipboard "both"
+    "#;
+    let document: KdlDocument = fake_config.parse().unwrap();
+    let deserialized = Options::from_kdl(&document).unwrap();
+    assert_eq!(deserialized.copy_clipboard, Some(Clipboard::Both));
 }
 
 #[test]


### PR DESCRIPTION
This PR adds "both" as a valid option for the copy_clipboard configuration setting (copy_clipboard "both").

Helps braindead people like me who keep forgetting which clipboard is which when copying and pasting.

Linux keeps confusing me with dual clipboards, so I just want to copy everywhere. Might not be
everyone's cup of tea, so this is an option to copy_clipboard.

It's done through manipulating OSC 52 (and ofc you need your terminal client to support that, mine does)

What was done:


Added Clipboard::Both variant with deserialization alias "both", FromStr support, and KDL parsing.

Updated client-server contract protobuf definitions and conversions for CLIPBOARD_BOTH.

Updated ClipboardProvider::set_content to emit OSC 52 write sequences for both 'c' and 'p' when "both" is configured.

Added unit tests in zellij-utils and zellij-server for KDL option parsing and OSC 52 multi-destination write.
