### PR TITLE
feat(server): interactive quit confirmation prompt

### DIFF
--- a/default-plugins/compact-bar/src/keybind_utils.rs
+++ b/default-plugins/compact-bar/src/keybind_utils.rs
@@ -729,6 +729,12 @@ impl KeybindProcessor {
                 ];
                 Self::find_predetermined_actions(mode_info, mode, ordered_predicates)
             },
+            InputMode::ConfirmQuit => {
+                vec![
+                    ("y".to_owned(), "Yes".to_owned()),
+                    ("n".to_owned(), "No".to_owned()),
+                ]
+            },
             InputMode::EnterSearch
             | InputMode::RenameTab
             | InputMode::RenamePane

--- a/default-plugins/compact-bar/src/line.rs
+++ b/default-plugins/compact-bar/src/line.rs
@@ -470,6 +470,21 @@ impl<'a> TabLinePrefixBuilder<'a> {
     }
 
     fn create_mode_part(&self, mode: InputMode, used_len: usize) -> Option<LinePart> {
+        if mode == InputMode::ConfirmQuit {
+            // Mirrors the status-bar confirm-quit prompt, shown as an orange
+            // "Quit?" label. No key hints are rendered.
+            let colors = self.get_text_colors();
+            let bg = colors.background;
+            let orange = self.palette.text_unselected.emphasis_0;
+
+            let quit_text = " Quit? ";
+            return Some(LinePart {
+                part: style!(orange, bg).bold().paint(quit_text).to_string(),
+                len: quit_text.width(),
+                tab_index: None,
+            });
+        }
+
         let mode_text = format!(" {} ", format!("{:?}", mode).to_uppercase());
         let mode_len = mode_text.width();
 

--- a/default-plugins/compact-bar/src/main.rs
+++ b/default-plugins/compact-bar/src/main.rs
@@ -406,6 +406,7 @@ impl State {
                 | InputMode::RenamePane
                 | InputMode::Prompt
                 | InputMode::Tmux
+                | InputMode::ConfirmQuit
         )
     }
 

--- a/default-plugins/status-bar/src/first_line.rs
+++ b/default-plugins/status-bar/src/first_line.rs
@@ -3,6 +3,7 @@ use zellij_tile::prelude::actions::Action;
 use zellij_tile::prelude::*;
 
 use crate::color_elements;
+use crate::one_line_ui::confirm_quit_hints;
 use crate::{
     action_key, action_key_group, get_common_modifiers, style_key_with_modifier, TO_NORMAL,
 };
@@ -589,7 +590,9 @@ fn get_key_shortcut_for_mode<'a>(
     mode: &InputMode,
 ) -> Option<&'a mut KeyShortcut> {
     let key_action = match mode {
-        InputMode::Normal | InputMode::Prompt | InputMode::Tmux => return None,
+        InputMode::Normal | InputMode::Prompt | InputMode::Tmux | InputMode::ConfirmQuit => {
+            return None
+        },
         InputMode::Locked => KeyAction::Lock,
         InputMode::Pane | InputMode::RenamePane => KeyAction::Pane,
         InputMode::Tab | InputMode::RenameTab => KeyAction::Tab,
@@ -615,6 +618,10 @@ pub fn first_line(
     let supports_arrow_fonts = !help.capabilities.arrow_fonts;
     let colored_elements = color_elements(help.style.colors, !supports_arrow_fonts, false);
     let binds = &help.get_mode_keybinds();
+
+    if help.mode == InputMode::ConfirmQuit {
+        return confirm_quit_hints(help);
+    }
     // Unselect all by default
     let mut default_keys = vec![
         KeyShortcut::new(

--- a/default-plugins/status-bar/src/one_line_ui.rs
+++ b/default-plugins/status-bar/src/one_line_ui.rs
@@ -48,6 +48,9 @@ pub fn one_line_ui(
     if clipboard_failure {
         return (system_clipboard_error(&help.style.colors), None, None);
     }
+    if help.mode == InputMode::ConfirmQuit {
+        return (confirm_quit_hints(help), None, None);
+    }
     let mut line_part_to_render = LinePart::default();
     let mut new_pane_range = None;
     let mut floating_range = None;
@@ -91,6 +94,59 @@ fn to_base_mode(base_mode: InputMode) -> Action {
     Action::SwitchToMode {
         input_mode: base_mode,
     }
+}
+
+/// Quit prompt. Keys are display only; the server intercepts input while the
+/// prompt is open.
+pub(crate) fn confirm_quit_hints(help: &ModeInfo) -> LinePart {
+    let dimmed = help.session_dimmed.unwrap_or(false);
+    let colors = help.style.colors;
+    let mut ret = LinePart::default();
+
+    // Wedge separator in theme orange (`text_unselected.emphasis_0`); using
+    // the ribbon accent instead would match the "Quit?" text colour closely
+    // enough that the wedge would be indistinguishable from it.
+    if !dimmed && !help.capabilities.arrow_fonts {
+        let outer = palette_match!(colors.text_unselected.background);
+        let orange = palette_match!(colors.text_unselected.emphasis_0);
+        let wedge = |fg, on| {
+            Style::new()
+                .fg(fg)
+                .on(on)
+                .bold()
+                .paint(crate::ARROW_SEPARATOR)
+                .to_string()
+        };
+        ret.part = format!("{}{}", wedge(outer, orange), wedge(orange, outer));
+        ret.len += 2;
+    }
+
+    // "Quit?" as a standalone accent-colored word
+    let quit_text = if dimmed {
+        Text::new(" Quit? ").disabled().opaque()
+    } else {
+        Text::new(" Quit? ").color_range(2, ..).opaque()
+    };
+    ret.part.push_str(&serialize_text(&quit_text));
+    ret.len += " Quit? ".width();
+
+    // Grey label ribbon, then its key
+    for (label, key) in [("Yes", 'y'), ("No", 'n')] {
+        let ribbon = if dimmed {
+            serialize_ribbon(&Text::new(label).disabled())
+        } else {
+            serialize_ribbon(&Text::new(label))
+        };
+        ret.part.push_str(&ribbon);
+        ret.len += label.width() + 4; // padding and arrow fonts
+        ret.append(&style_key_with_modifier(
+            &[KeyWithModifier::new(BareKey::Char(key))],
+            Some(2),
+            dimmed,
+        ));
+    }
+
+    ret
 }
 
 fn base_mode_locked_mode_indicators(help: &ModeInfo) -> HashMap<InputMode, Vec<KeyShortcut>> {

--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -408,14 +408,14 @@ impl InputHandler {
         match action {
             Action::NoOp => {},
             Action::Quit => {
+                // forward the Quit to the server, which either exits or shows
+                // a confirmation prompt; exiting locally would race the prompt
                 self.os_input.send_to_server(ClientToServerMsg::Action {
                     action,
                     terminal_id: None,
                     client_id,
                     is_cli_client: false,
                 });
-                self.exit(ExitReason::Normal);
-                should_break = true;
             },
             Action::Detach => {
                 self.os_input.send_to_server(ClientToServerMsg::Action {

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -128,6 +128,7 @@ macro_rules! apply_action {
             $env.default_shell.clone(),
             None,
             $env.default_mode.clone(),
+            false, // plugin-initiated quits should not require confirmation
             None,
         ) {
             Ok((_, result)) => result,
@@ -1465,6 +1466,7 @@ fn run_action(env: &PluginEnv, mut action: Action, context: BTreeMap<String, Str
             default_shell,
             None,
             default_mode,
+            false, // plugin-initiated quits should not require confirmation
             None,
         ) {
             Ok((_should_break, result)) => {
@@ -4722,6 +4724,7 @@ fn try_edit_layout(
         env.default_shell.clone(),
         None,
         env.default_mode.clone(),
+        false, // plugin-initiated quits should not require confirmation
         None,
     )
     .map(|_| ())

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -226,6 +226,7 @@ pub(crate) fn route_action(
     default_shell: Option<TerminalAction>,
     mut seen_cli_pipes: Option<&mut HashSet<String>>,
     default_mode: InputMode,
+    confirm_quit: bool,
     os_input: Option<Box<dyn ServerOsApi>>,
 ) -> Result<(bool, Option<ActionCompletionResult>)> {
     let mut should_break = false;
@@ -1177,13 +1178,22 @@ pub(crate) fn route_action(
                 .with_context(err_context)?;
         },
         Action::Quit => {
-            senders
-                .send_to_server(ServerInstruction::ClientExit(
-                    client_id,
-                    Some(NotificationEnd::new(completion_tx)),
-                ))
-                .with_context(err_context)?;
-            should_break = true;
+            if confirm_quit {
+                // interactive client: ask for confirmation before quitting, the answer
+                // (y/n/Esc) is intercepted in `route_thread_main` while the prompt is open
+                drop(completion_tx);
+                senders
+                    .send_to_screen(ScreenInstruction::ShowQuitPrompt(client_id))
+                    .with_context(err_context)?;
+            } else {
+                senders
+                    .send_to_server(ServerInstruction::ClientExit(
+                        client_id,
+                        Some(NotificationEnd::new(completion_tx)),
+                    ))
+                    .with_context(err_context)?;
+                should_break = true;
+            }
         },
         Action::Detach => {
             senders
@@ -2261,6 +2271,7 @@ pub(crate) fn route_thread_main(
     let mut retry_queue = VecDeque::new();
     let err_context = || format!("failed to handle instruction for client {client_id}");
     let mut seen_cli_pipes = HashSet::new();
+    let quit_prompt_active = std::cell::Cell::new(false);
     let mut consecutive_unknown_messages_received = 0;
     'route_loop: loop {
         match receiver.try_recv_client_msg() {
@@ -2323,6 +2334,36 @@ pub(crate) fn route_thread_main(
                         return Ok(should_break);
                     }
 
+                    // While the quit confirmation prompt is open for this client,
+                    // intercept all keys: only y/n (or Esc) are meaningful here
+                    if quit_prompt_active.get() {
+                        if let ClientToServerMsg::Key { key, .. } = &instruction {
+                            let is_yes = key.bare_key == BareKey::Char('y')
+                                || key.bare_key == BareKey::Char('Y');
+                            let is_no = key.bare_key == BareKey::Char('n')
+                                || key.bare_key == BareKey::Char('N')
+                                || key.bare_key == BareKey::Esc;
+                            if is_yes || is_no {
+                                quit_prompt_active.set(false);
+                                let _ = senders.as_ref().map(|s| {
+                                    s.send_to_screen(ScreenInstruction::HideQuitPrompt(client_id))
+                                });
+                                if is_yes {
+                                    let _ = to_server
+                                        .send(ServerInstruction::ClientExit(client_id, None));
+                                    should_break = true;
+                                }
+                            }
+                            // swallow every other key while the prompt is open
+                            return Ok(should_break);
+                        }
+                        if let ClientToServerMsg::Action { .. } = &instruction {
+                            // swallow mouse events and any other actions, including
+                            // repeated quit requests, while the prompt is open
+                            return Ok(false);
+                        }
+                    }
+
                     match instruction {
                         ClientToServerMsg::Key {
                             key,
@@ -2348,6 +2389,7 @@ pub(crate) fn route_thread_main(
                                             s.default_shell.clone(),
                                             s.session_configuration
                                                 .get_client_default_input_mode(&client_id),
+                                            false,
                                             vec![Action::Write {
                                                 key_with_modifier: Some(key),
                                                 bytes: raw_bytes,
@@ -2365,16 +2407,28 @@ pub(crate) fn route_thread_main(
                                             dim,
                                             is_kitty_keyboard_protocol,
                                         );
+                                    let confirm_quit = s
+                                        .session_configuration
+                                        .get_client_configuration(&client_id)
+                                        .options
+                                        .confirm_quit
+                                        .unwrap_or(true);
                                     Some((
                                         s.senders.clone(),
                                         s.default_shell.clone(),
                                         s.session_configuration
                                             .get_client_default_input_mode(&client_id),
+                                        confirm_quit,
                                         actions,
                                     ))
                                 });
-                            if let Some((senders, default_shell, client_input_mode, actions)) =
-                                dispatch_inputs
+                            if let Some((
+                                senders,
+                                default_shell,
+                                client_input_mode,
+                                confirm_quit,
+                                actions,
+                            )) = dispatch_inputs
                             {
                                 for action in actions {
                                     // Send user input to plugin thread for logging
@@ -2385,6 +2439,8 @@ pub(crate) fn route_thread_main(
                                         cli_client_id: None,
                                     });
 
+                                    let quit_with_confirmation =
+                                        confirm_quit && matches!(action, Action::Quit);
                                     match route_action(
                                         action,
                                         client_id,
@@ -2394,11 +2450,16 @@ pub(crate) fn route_thread_main(
                                         default_shell.clone(),
                                         Some(&mut seen_cli_pipes),
                                         client_input_mode,
+                                        confirm_quit,
                                         Some(os_input.clone()),
                                     ) {
                                         Ok(route_action_should_break) => {
                                             if route_action_should_break.0 {
                                                 should_break = true;
+                                            } else if quit_with_confirmation {
+                                                // the prompt was shown, wait for the
+                                                // answer before processing further keys
+                                                quit_prompt_active.set(true);
                                             }
                                         },
                                         Err(e) => {
@@ -2470,6 +2531,7 @@ pub(crate) fn route_thread_main(
                                     default_shell,
                                     Some(&mut seen_cli_pipes),
                                     client_input_mode,
+                                    false, // never prompt CLI clients for confirmation
                                     Some(os_input.clone()),
                                 ) {
                                     Ok(route_action_should_break) => {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -967,6 +967,8 @@ pub enum ScreenInstruction {
     FocusHostSession(ClientId, Option<NotificationEnd>),
     FocusGuestSession(ClientId, Option<NotificationEnd>),
     ToggleHostFullscreen(ClientId, Option<NotificationEnd>),
+    ShowQuitPrompt(ClientId),
+    HideQuitPrompt(ClientId),
 }
 
 impl From<&ScreenInstruction> for ScreenContext {
@@ -1137,6 +1139,8 @@ impl From<&ScreenInstruction> for ScreenContext {
             ScreenInstruction::MouseEvent(..) => ScreenContext::MouseEvent,
             ScreenInstruction::Copy(..) => ScreenContext::Copy,
             ScreenInstruction::ToggleTab(..) => ScreenContext::ToggleTab,
+            ScreenInstruction::ShowQuitPrompt(..) => ScreenContext::ShowQuitPrompt,
+            ScreenInstruction::HideQuitPrompt(..) => ScreenContext::HideQuitPrompt,
             ScreenInstruction::AddClient(..) => ScreenContext::AddClient,
             ScreenInstruction::RemoveClient(..) => ScreenContext::RemoveClient,
             ScreenInstruction::UpdateSearch(..) => ScreenContext::UpdateSearch,
@@ -1631,6 +1635,7 @@ pub(crate) struct Screen {
     client_notification_protocols: HashMap<ClientId, NotificationProtocol>,
     host_notification_protocol: HostNotificationProtocol,
     client_host_terminal_env: HashMap<ClientId, BTreeMap<String, String>>,
+    quit_prompt_clients: HashMap<ClientId, InputMode>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1799,6 +1804,7 @@ impl Screen {
             web_server_port,
             render_blocker: RenderBlocker::new(100),
             watcher_clients: HashMap::new(),
+            quit_prompt_clients: HashMap::new(),
             followed_client_id: None,
             cached_layouts: vec![],
             cached_layout_errors: vec![],
@@ -4620,6 +4626,55 @@ impl Screen {
         }
     }
 
+    /// Shows a "quit?" confirmation prompt for this client by switching it to
+    /// `InputMode::ConfirmQuit` so the status bar displays the prompt and its key hints.
+    pub fn show_quit_prompt(&mut self, client_id: ClientId) -> Result<()> {
+        let is_regular_client = self.connected_clients.borrow().contains_key(&client_id)
+            && !self.watcher_clients.contains_key(&client_id);
+        if is_regular_client {
+            let previous_mode = match self.mode_info.get(&client_id) {
+                Some(mode_info) => mode_info.mode,
+                None => self.default_mode_info.mode,
+            };
+            if self
+                .quit_prompt_clients
+                .insert(client_id, previous_mode)
+                .is_none()
+            {
+                // Route through the server like SwitchToMode does, so the client's
+                // authoritative input mode (current_input_modes, used for keybind
+                // resolution) stays in sync with the rendered status bar.
+                self.bus
+                    .senders
+                    .send_to_server(ServerInstruction::ChangeMode(
+                        client_id,
+                        InputMode::ConfirmQuit,
+                        None,
+                    ))
+                    .context("failed to switch to ConfirmQuit mode")?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Hides the quit confirmation prompt for this client by restoring the input mode
+    /// it was in before the prompt was shown.
+    pub fn hide_quit_prompt(&mut self, client_id: ClientId) -> Result<()> {
+        if let Some(previous_mode) = self.quit_prompt_clients.remove(&client_id) {
+            self.bus
+                .senders
+                .send_to_server(ServerInstruction::ChangeMode(
+                    client_id,
+                    previous_mode,
+                    None,
+                ))
+                .with_context(|| {
+                    format!("failed to restore mode after quit prompt for client {client_id}")
+                })?;
+        }
+        Ok(())
+    }
+
     /// Clear bell notification for the currently focused pane of the given client.
     /// Also cancels any running flash jobs if applicable.
     pub fn clear_bell_for_focused_pane(&mut self, client_id: ClientId) {
@@ -5171,6 +5226,7 @@ impl Screen {
         self.client_host_focused.remove(&client_id);
         self.client_notification_protocols.remove(&client_id);
         self.client_host_terminal_env.remove(&client_id);
+        self.quit_prompt_clients.remove(&client_id);
         self.revert_fit_disabled_without_reference_client()
             .with_context(err_context)?;
         if let Some(prev_tab_id) = previously_active_tab_id {
@@ -10163,6 +10219,12 @@ pub(crate) fn screen_thread_main(
                 active_tab!(screen, client_id, |tab: &mut Tab| tab
                     .copy_selection(client_id), ?);
                 screen.render(None)?;
+            },
+            ScreenInstruction::ShowQuitPrompt(client_id) => {
+                screen.show_quit_prompt(client_id)?;
+            },
+            ScreenInstruction::HideQuitPrompt(client_id) => {
+                screen.hide_quit_prompt(client_id)?;
             },
             ScreenInstruction::Exit => {
                 break;

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -147,6 +147,7 @@ fn send_cli_action_to_server(
             default_shell.clone(),
             None,
             default_mode,
+            false, // never prompt CLI actions for confirmation
             None,
         )
         .unwrap();
@@ -174,6 +175,7 @@ fn route_arbitrary_action_to_server(
         None,
         None,
         default_mode,
+        false, // never prompt CLI actions for confirmation
         None,
     )
     .unwrap();

--- a/zellij-utils/assets/config/default.kdl
+++ b/zellij-utils/assets/config/default.kdl
@@ -281,6 +281,14 @@ load_plugins {
 //
 // nested_session_handling "ask"
 
+// Whether to show a confirmation prompt before quitting (e.g. with Ctrl+q / the Quit action)
+// Quitting exits the current client from the session; the session ends when the last client quits
+// Options:
+//   - true (default)
+//   - false
+//
+// confirm_quit true
+
 //  Send a request for a simplified ui (without arrow fonts) to plugins
 //  Options:
 //    - true

--- a/zellij-utils/assets/prost/api.input_mode.rs
+++ b/zellij-utils/assets/prost/api.input_mode.rs
@@ -38,6 +38,8 @@ pub enum InputMode {
     Prompt = 12,
     /// / `Tmux` mode allows for basic tmux keybindings functionality
     Tmux = 13,
+    /// / `ConfirmQuit` mode is used transiently while the quit confirmation prompt is open
+    ConfirmQuit = 14,
 }
 impl InputMode {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -60,6 +62,7 @@ impl InputMode {
             InputMode::Move => "Move",
             InputMode::Prompt => "Prompt",
             InputMode::Tmux => "Tmux",
+            InputMode::ConfirmQuit => "ConfirmQuit",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -79,6 +82,7 @@ impl InputMode {
             "Move" => Some(Self::Move),
             "Prompt" => Some(Self::Prompt),
             "Tmux" => Some(Self::Tmux),
+            "ConfirmQuit" => Some(Self::ConfirmQuit),
             _ => None,
         }
     }

--- a/zellij-utils/assets/prost_ipc/client_server_contract.rs
+++ b/zellij-utils/assets/prost_ipc/client_server_contract.rs
@@ -2068,6 +2068,8 @@ pub struct Options {
     pub scroll_mode_sync: ::core::option::Option<bool>,
     #[prost(enumeration="ThemeHue", optional, tag="69")]
     pub explicit_theme_hue: ::core::option::Option<i32>,
+    #[prost(bool, optional, tag="70")]
+    pub confirm_quit: ::core::option::Option<bool>,
 }
 /// Pane-targeting action messages
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -2490,6 +2492,7 @@ pub enum InputMode {
     Move = 12,
     Prompt = 13,
     Tmux = 14,
+    ConfirmQuit = 15,
 }
 impl InputMode {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -2513,6 +2516,7 @@ impl InputMode {
             InputMode::Move => "INPUT_MODE_MOVE",
             InputMode::Prompt => "INPUT_MODE_PROMPT",
             InputMode::Tmux => "INPUT_MODE_TMUX",
+            InputMode::ConfirmQuit => "INPUT_MODE_CONFIRM_QUIT",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -2533,6 +2537,7 @@ impl InputMode {
             "INPUT_MODE_MOVE" => Some(Self::Move),
             "INPUT_MODE_PROMPT" => Some(Self::Prompt),
             "INPUT_MODE_TMUX" => Some(Self::Tmux),
+            "INPUT_MODE_CONFIRM_QUIT" => Some(Self::ConfirmQuit),
             _ => None,
         }
     }

--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -1659,4 +1659,12 @@ mod tests {
         let result = CliArgs::try_parse_from(["zellij", "subscribe"]);
         assert!(result.is_err());
     }
+
+    #[test]
+    fn options_confirm_quit_is_a_flag_not_a_positional() {
+        let cli =
+            CliArgs::try_parse_from(["zellij", "options", "--confirm-quit", "false"]).unwrap();
+        let options = cli.options().expect("expected Command::Options");
+        assert_eq!(options.confirm_quit, Some(false));
+    }
 }

--- a/zellij-utils/src/client_server_contract/common_types.proto
+++ b/zellij-utils/src/client_server_contract/common_types.proto
@@ -770,6 +770,7 @@ enum InputMode {
   INPUT_MODE_MOVE = 12;
   INPUT_MODE_PROMPT = 13;
   INPUT_MODE_TMUX = 14;
+  INPUT_MODE_CONFIRM_QUIT = 15;
 }
 
 enum Direction {
@@ -1226,6 +1227,7 @@ message Options {
   optional string host_notification_protocol = 67;
   optional bool scroll_mode_sync = 68;
   optional ThemeHue explicit_theme_hue = 69;
+  optional bool confirm_quit = 70;
 }
 
 enum OnForceClose {

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -1200,6 +1200,9 @@ pub enum InputMode {
     /// `Tmux` mode allows for basic tmux keybindings functionality
     #[serde(alias = "tmux")]
     Tmux,
+    /// `ConfirmQuit` mode is used transiently while the quit confirmation prompt is open
+    #[serde(alias = "confirmquit")]
+    ConfirmQuit,
 }
 
 impl Default for InputMode {
@@ -1387,6 +1390,7 @@ impl FromStr for InputMode {
             "move" | "Move" => Ok(InputMode::Move),
             "prompt" | "Prompt" => Ok(InputMode::Prompt),
             "tmux" | "Tmux" => Ok(InputMode::Tmux),
+            "confirmquit" | "ConfirmQuit" => Ok(InputMode::ConfirmQuit),
             "entersearch" | "Entersearch" | "EnterSearch" => Ok(InputMode::EnterSearch),
             e => Err(ConversionError::UnknownInputMode(e.into())),
         }

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -342,6 +342,8 @@ pub enum ScreenContext {
     MouseEvent,
     Copy,
     ToggleTab,
+    ShowQuitPrompt,
+    HideQuitPrompt,
     AddClient,
     RemoveClient,
     UpdateSearch,

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -367,6 +367,13 @@ pub struct Options {
     #[serde(default)]
     pub visual_bell: Option<bool>,
 
+    /// Whether to show a confirmation prompt before quitting (e.g. with Ctrl+q / the Quit action)
+    /// Quitting exits the current client from the session; the session ends when the last client quits
+    /// default is true
+    #[clap(long, value_parser)]
+    #[serde(default)]
+    pub confirm_quit: Option<bool>,
+
     /// Whether to focus panes on mouse hover (true or false)
     /// default is false
     #[clap(long, value_parser)]
@@ -570,6 +577,7 @@ impl Options {
         let mouse_hover_effects = other.mouse_hover_effects.or(self.mouse_hover_effects);
         let mouse_hover_tips = other.mouse_hover_tips.or(self.mouse_hover_tips);
         let visual_bell = other.visual_bell.or(self.visual_bell);
+        let confirm_quit = other.confirm_quit.or(self.confirm_quit);
         let focus_follows_mouse = other.focus_follows_mouse.or(self.focus_follows_mouse);
         let mouse_click_through = other.mouse_click_through.or(self.mouse_click_through);
         let osc133_command_selection = other
@@ -649,6 +657,7 @@ impl Options {
             mouse_hover_effects,
             mouse_hover_tips,
             visual_bell,
+            confirm_quit,
             focus_follows_mouse,
             mouse_click_through,
             osc133_command_selection,
@@ -741,6 +750,7 @@ impl Options {
         let mouse_hover_effects = other.mouse_hover_effects.or(self.mouse_hover_effects);
         let mouse_hover_tips = other.mouse_hover_tips.or(self.mouse_hover_tips);
         let visual_bell = other.visual_bell.or(self.visual_bell);
+        let confirm_quit = other.confirm_quit.or(self.confirm_quit);
         let focus_follows_mouse = merge_bool(other.focus_follows_mouse, self.focus_follows_mouse);
         let mouse_click_through = merge_bool(other.mouse_click_through, self.mouse_click_through);
         let osc133_command_selection = other
@@ -820,6 +830,7 @@ impl Options {
             mouse_hover_effects,
             mouse_hover_tips,
             visual_bell,
+            confirm_quit,
             focus_follows_mouse,
             mouse_click_through,
             osc133_command_selection,

--- a/zellij-utils/src/ipc/protobuf_conversion.rs
+++ b/zellij-utils/src/ipc/protobuf_conversion.rs
@@ -975,6 +975,7 @@ impl From<crate::input::options::Options>
             post_command_discovery_hook: options.post_command_discovery_hook,
             client_async_worker_tasks: options.client_async_worker_tasks.map(|v| v as u64),
             visual_bell: options.visual_bell,
+            confirm_quit: options.confirm_quit,
             focus_follows_mouse: options.focus_follows_mouse,
             mouse_click_through: options.mouse_click_through,
             osc133_command_selection: options.osc133_command_selection,
@@ -1113,6 +1114,7 @@ impl TryFrom<crate::client_server_contract::client_server_contract::Options>
             post_command_discovery_hook: options.post_command_discovery_hook,
             client_async_worker_tasks: options.client_async_worker_tasks.map(|v| v as usize),
             visual_bell: options.visual_bell,
+            confirm_quit: options.confirm_quit,
             focus_follows_mouse: options.focus_follows_mouse,
             mouse_click_through: options.mouse_click_through,
             osc133_command_selection: options.osc133_command_selection,
@@ -3496,6 +3498,7 @@ fn input_mode_to_proto_i32(mode: InputMode) -> i32 {
         InputMode::Move => ProtoInputMode::Move as i32,
         InputMode::Prompt => ProtoInputMode::Prompt as i32,
         InputMode::Tmux => ProtoInputMode::Tmux as i32,
+        InputMode::ConfirmQuit => ProtoInputMode::ConfirmQuit as i32,
     }
 }
 
@@ -3515,6 +3518,7 @@ fn proto_i32_to_input_mode(i: i32) -> Result<InputMode> {
         Some(ProtoInputMode::Move) => Ok(InputMode::Move),
         Some(ProtoInputMode::Prompt) => Ok(InputMode::Prompt),
         Some(ProtoInputMode::Tmux) => Ok(InputMode::Tmux),
+        Some(ProtoInputMode::ConfirmQuit) => Ok(InputMode::ConfirmQuit),
         _ => Err(anyhow!("Invalid InputMode value: {}", i)),
     }
 }

--- a/zellij-utils/src/ipc/tests/roundtrip_tests.rs
+++ b/zellij-utils/src/ipc/tests/roundtrip_tests.rs
@@ -506,6 +506,7 @@ fn test_client_messages() {
                 mouse_hover_effects: Some(false),
                 mouse_hover_tips: Some(false),
                 visual_bell: Some(true),
+                confirm_quit: Some(true),
                 focus_follows_mouse: Some(false),
                 mouse_click_through: Some(false),
                 osc133_command_selection: Some(false),

--- a/zellij-utils/src/kdl/mod.rs
+++ b/zellij-utils/src/kdl/mod.rs
@@ -2947,6 +2947,8 @@ impl Options {
             };
         let visual_bell =
             kdl_property_first_arg_as_bool_or_error!(kdl_options, "visual_bell").map(|(v, _)| v);
+        let confirm_quit =
+            kdl_property_first_arg_as_bool_or_error!(kdl_options, "confirm_quit").map(|(v, _)| v);
         let focus_follows_mouse =
             kdl_property_first_arg_as_bool_or_error!(kdl_options, "focus_follows_mouse")
                 .map(|(v, _)| v);
@@ -3037,6 +3039,7 @@ impl Options {
             mouse_hover_effects,
             mouse_hover_tips,
             visual_bell,
+            confirm_quit,
             focus_follows_mouse,
             mouse_click_through,
             osc133_command_selection,
@@ -4460,6 +4463,34 @@ impl Options {
             None
         }
     }
+    fn confirm_quit_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
+        let comment_text = format!(
+            "{}\n{}\n{}\n{}",
+            " ",
+            "// Whether to show a confirmation prompt before quitting (e.g. with Ctrl+q / the Quit action)",
+            "// Quitting exits the current client from the session; the session ends when the last client quits",
+            "// default is true",
+        );
+
+        let create_node = |node_value: bool| -> KdlNode {
+            let mut node = KdlNode::new("confirm_quit");
+            node.push(KdlValue::Bool(node_value));
+            node
+        };
+        if let Some(confirm_quit) = self.confirm_quit {
+            let mut node = create_node(confirm_quit);
+            if add_comments {
+                node.set_leading(format!("{}\n", comment_text));
+            }
+            Some(node)
+        } else if add_comments {
+            let mut node = create_node(true);
+            node.set_leading(format!("{}\n// ", comment_text));
+            Some(node)
+        } else {
+            None
+        }
+    }
     fn focus_follows_mouse_to_kdl(&self, add_comments: bool) -> Option<KdlNode> {
         let comment_text = format!(
             "{}\n{}\n{}",
@@ -4934,6 +4965,9 @@ impl Options {
         }
         if let Some(visual_bell) = self.visual_bell_to_kdl(add_comments) {
             nodes.push(visual_bell);
+        }
+        if let Some(confirm_quit) = self.confirm_quit_to_kdl(add_comments) {
+            nodes.push(confirm_quit);
         }
         if let Some(focus_follows_mouse) = self.focus_follows_mouse_to_kdl(add_comments) {
             nodes.push(focus_follows_mouse);
@@ -7767,6 +7801,42 @@ fn scroll_mode_sync_round_trips_through_kdl() {
         deserialized_from_serialized.scroll_mode_sync,
         Some(false),
         "scroll_mode_sync survives a serialize/parse round trip"
+    );
+}
+
+#[test]
+fn confirm_quit_from_kdl() {
+    let fake_config = r##"
+        confirm_quit false
+    "##;
+    let document: KdlDocument = fake_config.parse().unwrap();
+    let deserialized = Options::from_kdl(&document).unwrap();
+    assert_eq!(deserialized.confirm_quit, Some(false));
+
+    let empty_document: KdlDocument = "".parse().unwrap();
+    let deserialized_empty = Options::from_kdl(&empty_document).unwrap();
+    assert_eq!(
+        deserialized_empty.confirm_quit, None,
+        "an unspecified confirm_quit stays None so the default applies"
+    );
+}
+
+#[test]
+fn confirm_quit_round_trips_through_kdl() {
+    let fake_config = r##"
+        confirm_quit false
+    "##;
+    let document: KdlDocument = fake_config.parse().unwrap();
+    let deserialized = Options::from_kdl(&document).unwrap();
+    let mut serialized = Options::to_kdl(&deserialized, false);
+    let mut fake_document = KdlDocument::new();
+    fake_document.nodes_mut().append(&mut serialized);
+    let deserialized_from_serialized =
+        Options::from_kdl(&fake_document.to_string().parse::<KdlDocument>().unwrap()).unwrap();
+    assert_eq!(
+        deserialized_from_serialized.confirm_quit,
+        Some(false),
+        "confirm_quit survives a serialize/parse round trip"
     );
 }
 

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__bare_config_from_default_assets_to_string.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__bare_config_from_default_assets_to_string.snap
@@ -179,11 +179,11 @@ keybinds clear-defaults=true {
     shared_except "locked" "session" {
         bind "Ctrl o" { SwitchToMode "session"; }
     }
-    shared_except "locked" "scroll" "search" "tmux" {
-        bind "Ctrl b" { SwitchToMode "tmux"; }
-    }
     shared_except "locked" "scroll" "search" {
         bind "Ctrl s" { SwitchToMode "scroll"; }
+    }
+    shared_except "locked" "scroll" "search" "tmux" {
+        bind "Ctrl b" { SwitchToMode "tmux"; }
     }
     shared_except "locked" "tab" {
         bind "Ctrl t" { SwitchToMode "tab"; }

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__bare_config_from_default_assets_to_string_with_comments.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__bare_config_from_default_assets_to_string_with_comments.snap
@@ -179,11 +179,11 @@ keybinds clear-defaults=true {
     shared_except "locked" "session" {
         bind "Ctrl o" { SwitchToMode "session"; }
     }
-    shared_except "locked" "scroll" "search" "tmux" {
-        bind "Ctrl b" { SwitchToMode "tmux"; }
-    }
     shared_except "locked" "scroll" "search" {
         bind "Ctrl s" { SwitchToMode "scroll"; }
+    }
+    shared_except "locked" "scroll" "search" "tmux" {
+        bind "Ctrl b" { SwitchToMode "tmux"; }
     }
     shared_except "locked" "tab" {
         bind "Ctrl t" { SwitchToMode "tab"; }
@@ -595,6 +595,11 @@ web_client {
 // Whether to show visual bell indicators (pane/tab frame flash and [!] suffix)
 // default is true
 // visual_bell true
+ 
+// Whether to show a confirmation prompt before quitting (e.g. with Ctrl+q / the Quit action)
+// Quitting exits the current client from the session; the session ends when the last client quits
+// default is true
+// confirm_quit true
  
 // Whether to focus panes on mouse hover
 // default is false

--- a/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__config_options_to_string_with_comments.snap
+++ b/zellij-utils/src/kdl/snapshots/zellij_utils__kdl__config_options_to_string_with_comments.snap
@@ -306,6 +306,11 @@ web_sharing "disabled"
 // default is true
 // visual_bell true
  
+// Whether to show a confirmation prompt before quitting (e.g. with Ctrl+q / the Quit action)
+// Quitting exits the current client from the session; the session ends when the last client quits
+// default is true
+// confirm_quit true
+ 
 // Whether to focus panes on mouse hover
 // default is false
 // focus_follows_mouse false

--- a/zellij-utils/src/plugin_api/input_mode.proto
+++ b/zellij-utils/src/plugin_api/input_mode.proto
@@ -37,4 +37,6 @@ enum InputMode {
     Prompt = 12;
     /// `Tmux` mode allows for basic tmux keybindings functionality
     Tmux = 13;
+    /// `ConfirmQuit` mode is used transiently while the quit confirmation prompt is open
+    ConfirmQuit = 14;
 }

--- a/zellij-utils/src/plugin_api/input_mode.rs
+++ b/zellij-utils/src/plugin_api/input_mode.rs
@@ -23,6 +23,7 @@ impl TryFrom<ProtobufInputMode> for InputMode {
             ProtobufInputMode::Move => Ok(InputMode::Move),
             ProtobufInputMode::Prompt => Ok(InputMode::Prompt),
             ProtobufInputMode::Tmux => Ok(InputMode::Tmux),
+            ProtobufInputMode::ConfirmQuit => Ok(InputMode::ConfirmQuit),
         }
     }
 }
@@ -45,6 +46,7 @@ impl TryFrom<InputMode> for ProtobufInputMode {
             InputMode::Move => ProtobufInputMode::Move,
             InputMode::Prompt => ProtobufInputMode::Prompt,
             InputMode::Tmux => ProtobufInputMode::Tmux,
+            InputMode::ConfirmQuit => ProtobufInputMode::ConfirmQuit,
         })
     }
 }

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_config_options.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 724
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -50,6 +51,7 @@ Options {
     mouse_hover_effects: None,
     mouse_hover_tips: None,
     visual_bell: None,
+    confirm_quit: None,
     focus_follows_mouse: None,
     mouse_click_through: None,
     osc133_command_selection: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__cli_arguments_override_layout_options.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 758
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -50,6 +51,7 @@ Options {
     mouse_hover_effects: None,
     mouse_hover_tips: None,
     visual_bell: None,
+    confirm_quit: None,
     focus_follows_mouse: None,
     mouse_click_through: None,
     osc133_command_selection: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments-3.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 714
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -48,6 +49,7 @@ Options {
     mouse_hover_effects: None,
     mouse_hover_tips: None,
     visual_bell: None,
+    confirm_quit: None,
     focus_follows_mouse: None,
     mouse_click_through: None,
     osc133_command_selection: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__default_config_with_no_cli_arguments.snap
@@ -6093,6 +6093,346 @@ Config {
                 },
             ],
         },
+        ConfirmQuit: {
+            KeyWithModifier {
+                bare_key: Left,
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocusOrTab {
+                    direction: Left,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Down,
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocus {
+                    direction: Down,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Up,
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocus {
+                    direction: Up,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Right,
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocusOrTab {
+                    direction: Right,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    '+',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                Resize {
+                    resize: Increase,
+                    direction: None,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    '-',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                Resize {
+                    resize: Decrease,
+                    direction: None,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    '=',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                Resize {
+                    resize: Increase,
+                    direction: None,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    '[',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                PreviousSwapLayout,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    ']',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                NextSwapLayout,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'b',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Tmux,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'f',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                ToggleFloatingPanes,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'g',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Locked,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'h',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Move,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'h',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocusOrTab {
+                    direction: Left,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'i',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveTab {
+                    direction: Left,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'j',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocus {
+                    direction: Down,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'k',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocus {
+                    direction: Up,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'l',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocusOrTab {
+                    direction: Right,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'n',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Resize,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'n',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                NewPane {
+                    direction: None,
+                    pane_name: None,
+                    start_suppressed: false,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'o',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Session,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'o',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveTab {
+                    direction: Right,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'p',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Pane,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'p',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                TogglePaneInGroup,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'p',
+                ),
+                key_modifiers: {
+                    Alt,
+                    Shift,
+                },
+            }: [
+                ToggleGroupMarking,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'q',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                Quit,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    's',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Scroll,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    't',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Tab,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Esc,
+                key_modifiers: {},
+            }: [
+                SwitchToMode {
+                    input_mode: Normal,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Enter,
+                key_modifiers: {},
+            }: [
+                SwitchToMode {
+                    input_mode: Normal,
+                },
+            ],
+        },
     },
     options: Options {
         simplified_ui: None,
@@ -6140,6 +6480,7 @@ Config {
         mouse_hover_effects: None,
         mouse_hover_tips: None,
         visual_bell: None,
+        confirm_quit: None,
         focus_follows_mouse: None,
         mouse_click_through: None,
         osc133_command_selection: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_env_vars_override_config_env_vars.snap
@@ -6093,6 +6093,346 @@ Config {
                 },
             ],
         },
+        ConfirmQuit: {
+            KeyWithModifier {
+                bare_key: Left,
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocusOrTab {
+                    direction: Left,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Down,
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocus {
+                    direction: Down,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Up,
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocus {
+                    direction: Up,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Right,
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocusOrTab {
+                    direction: Right,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    '+',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                Resize {
+                    resize: Increase,
+                    direction: None,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    '-',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                Resize {
+                    resize: Decrease,
+                    direction: None,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    '=',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                Resize {
+                    resize: Increase,
+                    direction: None,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    '[',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                PreviousSwapLayout,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    ']',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                NextSwapLayout,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'b',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Tmux,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'f',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                ToggleFloatingPanes,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'g',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Locked,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'h',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Move,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'h',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocusOrTab {
+                    direction: Left,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'i',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveTab {
+                    direction: Left,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'j',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocus {
+                    direction: Down,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'k',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocus {
+                    direction: Up,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'l',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocusOrTab {
+                    direction: Right,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'n',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Resize,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'n',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                NewPane {
+                    direction: None,
+                    pane_name: None,
+                    start_suppressed: false,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'o',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Session,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'o',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveTab {
+                    direction: Right,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'p',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Pane,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'p',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                TogglePaneInGroup,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'p',
+                ),
+                key_modifiers: {
+                    Alt,
+                    Shift,
+                },
+            }: [
+                ToggleGroupMarking,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'q',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                Quit,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    's',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Scroll,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    't',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Tab,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Esc,
+                key_modifiers: {},
+            }: [
+                SwitchToMode {
+                    input_mode: Normal,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Enter,
+                key_modifiers: {},
+            }: [
+                SwitchToMode {
+                    input_mode: Normal,
+                },
+            ],
+        },
     },
     options: Options {
         simplified_ui: None,
@@ -6140,6 +6480,7 @@ Config {
         mouse_hover_effects: None,
         mouse_hover_tips: None,
         visual_bell: None,
+        confirm_quit: None,
         focus_follows_mouse: None,
         mouse_click_through: None,
         osc133_command_selection: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_keybinds_override_config_keybinds.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 824
 expression: "format!(\"{:#?}\", config)"
 ---
 Config {
@@ -135,6 +136,7 @@ Config {
         mouse_hover_effects: None,
         mouse_hover_tips: None,
         visual_bell: None,
+        confirm_quit: None,
         focus_follows_mouse: None,
         mouse_click_through: None,
         osc133_command_selection: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_options_override_config_options.snap
@@ -1,5 +1,6 @@
 ---
 source: zellij-utils/src/setup.rs
+assertion_line: 734
 expression: "format!(\"{:#?}\", options)"
 ---
 Options {
@@ -50,6 +51,7 @@ Options {
     mouse_hover_effects: None,
     mouse_hover_tips: None,
     visual_bell: None,
+    confirm_quit: None,
     focus_follows_mouse: None,
     mouse_click_through: None,
     osc133_command_selection: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_themes_override_config_themes.snap
@@ -6093,6 +6093,346 @@ Config {
                 },
             ],
         },
+        ConfirmQuit: {
+            KeyWithModifier {
+                bare_key: Left,
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocusOrTab {
+                    direction: Left,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Down,
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocus {
+                    direction: Down,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Up,
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocus {
+                    direction: Up,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Right,
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocusOrTab {
+                    direction: Right,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    '+',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                Resize {
+                    resize: Increase,
+                    direction: None,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    '-',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                Resize {
+                    resize: Decrease,
+                    direction: None,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    '=',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                Resize {
+                    resize: Increase,
+                    direction: None,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    '[',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                PreviousSwapLayout,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    ']',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                NextSwapLayout,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'b',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Tmux,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'f',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                ToggleFloatingPanes,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'g',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Locked,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'h',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Move,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'h',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocusOrTab {
+                    direction: Left,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'i',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveTab {
+                    direction: Left,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'j',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocus {
+                    direction: Down,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'k',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocus {
+                    direction: Up,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'l',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocusOrTab {
+                    direction: Right,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'n',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Resize,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'n',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                NewPane {
+                    direction: None,
+                    pane_name: None,
+                    start_suppressed: false,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'o',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Session,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'o',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveTab {
+                    direction: Right,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'p',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Pane,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'p',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                TogglePaneInGroup,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'p',
+                ),
+                key_modifiers: {
+                    Alt,
+                    Shift,
+                },
+            }: [
+                ToggleGroupMarking,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'q',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                Quit,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    's',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Scroll,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    't',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Tab,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Esc,
+                key_modifiers: {},
+            }: [
+                SwitchToMode {
+                    input_mode: Normal,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Enter,
+                key_modifiers: {},
+            }: [
+                SwitchToMode {
+                    input_mode: Normal,
+                },
+            ],
+        },
     },
     options: Options {
         simplified_ui: None,
@@ -6140,6 +6480,7 @@ Config {
         mouse_hover_effects: None,
         mouse_hover_tips: None,
         visual_bell: None,
+        confirm_quit: None,
         focus_follows_mouse: None,
         mouse_click_through: None,
         osc133_command_selection: None,

--- a/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
+++ b/zellij-utils/src/snapshots/zellij_utils__setup__setup_test__layout_ui_config_overrides_config_ui_config.snap
@@ -6093,6 +6093,346 @@ Config {
                 },
             ],
         },
+        ConfirmQuit: {
+            KeyWithModifier {
+                bare_key: Left,
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocusOrTab {
+                    direction: Left,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Down,
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocus {
+                    direction: Down,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Up,
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocus {
+                    direction: Up,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Right,
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocusOrTab {
+                    direction: Right,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    '+',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                Resize {
+                    resize: Increase,
+                    direction: None,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    '-',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                Resize {
+                    resize: Decrease,
+                    direction: None,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    '=',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                Resize {
+                    resize: Increase,
+                    direction: None,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    '[',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                PreviousSwapLayout,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    ']',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                NextSwapLayout,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'b',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Tmux,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'f',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                ToggleFloatingPanes,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'g',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Locked,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'h',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Move,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'h',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocusOrTab {
+                    direction: Left,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'i',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveTab {
+                    direction: Left,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'j',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocus {
+                    direction: Down,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'k',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocus {
+                    direction: Up,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'l',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveFocusOrTab {
+                    direction: Right,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'n',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Resize,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'n',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                NewPane {
+                    direction: None,
+                    pane_name: None,
+                    start_suppressed: false,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'o',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Session,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'o',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                MoveTab {
+                    direction: Right,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'p',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Pane,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'p',
+                ),
+                key_modifiers: {
+                    Alt,
+                },
+            }: [
+                TogglePaneInGroup,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'p',
+                ),
+                key_modifiers: {
+                    Alt,
+                    Shift,
+                },
+            }: [
+                ToggleGroupMarking,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    'q',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                Quit,
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    's',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Scroll,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Char(
+                    't',
+                ),
+                key_modifiers: {
+                    Ctrl,
+                },
+            }: [
+                SwitchToMode {
+                    input_mode: Tab,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Esc,
+                key_modifiers: {},
+            }: [
+                SwitchToMode {
+                    input_mode: Normal,
+                },
+            ],
+            KeyWithModifier {
+                bare_key: Enter,
+                key_modifiers: {},
+            }: [
+                SwitchToMode {
+                    input_mode: Normal,
+                },
+            ],
+        },
     },
     options: Options {
         simplified_ui: None,
@@ -6140,6 +6480,7 @@ Config {
         mouse_hover_effects: None,
         mouse_hover_tips: None,
         visual_bell: None,
+        confirm_quit: None,
         focus_follows_mouse: None,
         mouse_click_through: None,
         osc133_command_selection: None,


### PR DESCRIPTION
Adds a "Quit?" prompt when Ctrl-Q is hit, all key strokes in the session are then ignored minus Y/N/Esc.

This prompt can be disabled by setting `confirm_quit = false`.

Closes: #933, #467, #1229, #3147.