### PR TITLE
feat(terminal): support kitty text sizing (OSC 66)

### DIFF
--- a/zellij-server/src/output/mod.rs
+++ b/zellij-server/src/output/mod.rs
@@ -133,6 +133,25 @@ fn write_changed_styles(
     Ok(())
 }
 
+fn write_terminal_character(
+    terminal_character: &TerminalCharacter,
+    character_styles: CharacterStyles,
+    vte_output: &mut String,
+) -> Result<()> {
+    match character_styles.text_sizing {
+        Some(text_sizing) => write!(
+            vte_output,
+            "\u{1b}]66;{};{}\u{1b}\\",
+            text_sizing, terminal_character.character
+        )
+        .context("failed to serialize OSC 66 text"),
+        None => {
+            vte_output.push(terminal_character.character);
+            Ok(())
+        },
+    }
+}
+
 fn serialize_chunks_with_newlines(
     character_chunks: Vec<CharacterChunk>,
     _sixel_chunks: Option<&Vec<SixelImageChunk>>, // TODO: fix this sometime
@@ -190,7 +209,8 @@ fn serialize_chunks_with_newlines(
             )
             .with_context(err_context)?;
             chunk_width += t_character.width();
-            vte_output.push(t_character.character);
+            write_terminal_character(t_character, current_character_styles, &mut vte_output)
+                .with_context(err_context)?;
         }
     }
     Ok(vte_output)
@@ -256,7 +276,8 @@ fn serialize_chunks(
             )
             .with_context(err_context)?;
             chunk_width += t_character.width();
-            vte_output.push(t_character.character);
+            write_terminal_character(t_character, current_character_styles, &mut vte_output)
+                .with_context(err_context)?;
         }
     }
     if let Some(sixel_image_store) = sixel_image_store {

--- a/zellij-server/src/output/unit/output_tests.rs
+++ b/zellij-server/src/output/unit/output_tests.rs
@@ -1,6 +1,6 @@
 use super::super::{
-    CharacterChunk, FloatingPanesStack, HostKittyState, KittyImageChunk, Output, OutputBuffer,
-    SixelImageChunk,
+    serialize_chunks, CharacterChunk, FloatingPanesStack, HostKittyState, KittyImageChunk, Output,
+    OutputBuffer, SixelImageChunk,
 };
 use crate::panes::kitty_graphics::parser::{
     DecodedImage, KittyAction, KittyCommandParser, KittyFormat,
@@ -8,6 +8,7 @@ use crate::panes::kitty_graphics::parser::{
 use crate::panes::kitty_graphics::store::{InternalImageId, KittyImageStore};
 use crate::panes::sixel::SixelImageStore;
 use crate::panes::terminal_character::AnsiCode;
+use crate::panes::terminal_character::{TextSizing, DEFAULT_STYLES};
 use crate::panes::{LinkHandler, PaneId, Row, TerminalCharacter};
 use crate::ClientId;
 use std::cell::RefCell;
@@ -623,6 +624,19 @@ fn test_character_chunk_width() {
         4,
         "Width should be 4 (1 + 2 + 1) for mixed characters"
     );
+}
+
+#[test]
+fn scaled_text_is_reconstructed_as_osc_66() {
+    let sizing = TextSizing::parse("s=2").unwrap();
+    let mut styles = DEFAULT_STYLES;
+    styles.text_sizing = Some(sizing);
+    let character = TerminalCharacter::new_styled_with_width('A', styles.into(), 2);
+    let chunk = CharacterChunk::new(vec![character], 0, 0);
+
+    let output = serialize_chunks(vec![chunk], None, None, None, true, true, None, None).unwrap();
+
+    assert!(output.contains("\x1b]66;s=2;A\x1b\\"));
 }
 
 #[test]

--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -247,7 +247,7 @@ use crate::panes::link_handler::LinkHandler;
 use crate::panes::search::SearchResult;
 use crate::panes::terminal_character::{
     AnsiCode, CharsetIndex, Cursor, CursorShape, RcCharacterStyles, StandardCharset,
-    TerminalCharacter, EMPTY_TERMINAL_CHARACTER,
+    TerminalCharacter, TextSizing, EMPTY_TERMINAL_CHARACTER,
 };
 use crate::panes::Selection;
 use crate::ui::components::UiComponentParser;
@@ -4573,6 +4573,50 @@ impl Perform for Grid {
                     if let Some(path) = parse_osc7_path(raw) {
                         self.pending_osc7_cwd = Some(path);
                     }
+                }
+            },
+
+            // Kitty text sizing protocol. OSC 66 embeds text rather than
+            // toggling persistent terminal state, so retain the sizing on
+            // each character for reconstruction during host rendering.
+            b"66" => {
+                if params.len() < 3 {
+                    return;
+                }
+                let Some(metadata) = str::from_utf8(params[1]).ok() else {
+                    return;
+                };
+                let Some(text_sizing) = TextSizing::parse(metadata) else {
+                    return;
+                };
+                let text = params[2..]
+                    .iter()
+                    .filter_map(|part| str::from_utf8(part).ok())
+                    .collect::<Vec<_>>()
+                    .join(";");
+
+                // Packed multi-character blocks (`w` with multiple code
+                // points) need an atomic multi-cell grid primitive. Until the
+                // grid has one, preserve backwards-compatible plain text
+                // instead of reporting incorrect cursor geometry.
+                if text_sizing.width_is_explicit() && text.chars().count() != 1 {
+                    for character in text.chars() {
+                        self.print(character);
+                    }
+                    return;
+                }
+
+                for character in text.chars() {
+                    let width = text_sizing.cell_width(character);
+                    if width == 0 {
+                        continue;
+                    }
+                    let mut styles = *self.cursor.pending_styles;
+                    styles.text_sizing = Some(text_sizing);
+                    let terminal_character =
+                        TerminalCharacter::new_styled_with_width(character, styles.into(), width);
+                    self.set_preceding_character(terminal_character.clone());
+                    self.add_character(terminal_character);
                 }
             },
 

--- a/zellij-server/src/panes/terminal_character.rs
+++ b/zellij-server/src/panes/terminal_character.rs
@@ -33,6 +33,7 @@ pub const RESET_STYLES: CharacterStyles = CharacterStyles {
     italic: Some(AnsiCode::Reset),
     link_anchor: Some(LinkAnchor::End),
     styled_underlines_enabled: false,
+    text_sizing: None,
 };
 
 // Prefer to use RcCharacterStyles::default() where it makes sense
@@ -52,6 +53,7 @@ pub const DEFAULT_STYLES: CharacterStyles = CharacterStyles {
     italic: None,
     link_anchor: None,
     styled_underlines_enabled: false,
+    text_sizing: None,
 };
 
 thread_local! {
@@ -226,6 +228,92 @@ pub struct CharacterStyles {
     pub italic: Option<AnsiCode>,
     pub link_anchor: Option<LinkAnchor>,
     pub styled_underlines_enabled: bool,
+    /// Kitty's OSC 66 text sizing metadata for this character.
+    ///
+    /// This is not an SGR style and is intentionally ignored by `Display`; the
+    /// output serializer wraps the character in OSC 66 directly.
+    pub text_sizing: Option<TextSizing>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TextSizing {
+    scale: u8,
+    width: u8,
+    numerator: u8,
+    denominator: u8,
+    vertical_alignment: u8,
+    horizontal_alignment: u8,
+}
+
+impl TextSizing {
+    pub fn parse(metadata: &str) -> Option<Self> {
+        let mut sizing = TextSizing {
+            scale: 1,
+            width: 0,
+            numerator: 0,
+            denominator: 0,
+            vertical_alignment: 0,
+            horizontal_alignment: 0,
+        };
+        for entry in metadata.split(':').filter(|entry| !entry.is_empty()) {
+            let (key, value) = entry.split_once('=')?;
+            let value = value.parse::<u8>().ok()?;
+            match key {
+                "s" if (1..=7).contains(&value) => sizing.scale = value,
+                "w" if value <= 7 => sizing.width = value,
+                "n" if value <= 15 => sizing.numerator = value,
+                "d" if value <= 15 => sizing.denominator = value,
+                "v" if value <= 2 => sizing.vertical_alignment = value,
+                "h" if value <= 2 => sizing.horizontal_alignment = value,
+                _ => return None,
+            }
+        }
+        if sizing.denominator == 0 {
+            if sizing.numerator != 0 {
+                return None;
+            }
+        } else if sizing.numerator >= sizing.denominator {
+            return None;
+        }
+        Some(sizing)
+    }
+
+    pub fn width_is_explicit(self) -> bool {
+        self.width != 0
+    }
+
+    pub fn cell_width(self, character: char) -> usize {
+        let unscaled_width = if self.width == 0 {
+            character.width().unwrap_or(0)
+        } else {
+            self.width as usize
+        };
+        unscaled_width * self.scale as usize
+    }
+}
+
+impl Display for TextSizing {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut separator = "";
+        macro_rules! write_value {
+            ($key:literal, $value:expr) => {
+                if $value != 0 {
+                    write!(f, "{}{}={}", separator, $key, $value)?;
+                    separator = ":";
+                }
+            };
+        }
+        if self.scale != 1 {
+            write_value!("s", self.scale);
+        }
+        write_value!("w", self.width);
+        write_value!("n", self.numerator);
+        write_value!("d", self.denominator);
+        write_value!("v", self.vertical_alignment);
+        write_value!("h", self.horizontal_alignment);
+        let _ = separator;
+        Ok(())
+    }
 }
 
 impl PartialEq for CharacterStyles {
@@ -243,6 +331,7 @@ impl PartialEq for CharacterStyles {
             && self.dim == other.dim
             && self.italic == other.italic
             && self.link_anchor == other.link_anchor
+            && self.text_sizing == other.text_sizing
     }
 }
 
@@ -317,6 +406,7 @@ impl CharacterStyles {
         self.dim = None;
         self.italic = None;
         self.link_anchor = None;
+        self.text_sizing = None;
     }
     pub fn update_and_return_diff(
         &mut self,
@@ -955,6 +1045,15 @@ impl TerminalCharacter {
             character,
             styles,
             width: 1,
+        }
+    }
+
+    #[inline]
+    pub fn new_styled_with_width(character: char, styles: RcCharacterStyles, width: usize) -> Self {
+        TerminalCharacter {
+            character,
+            styles,
+            width: width.min(u8::MAX as usize) as u8,
         }
     }
 

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -6340,6 +6340,58 @@ fn osc_4_set_stays_local() {
 }
 
 #[test]
+fn osc_66_scaled_text_uses_scaled_cell_widths() {
+    let mut parser = vte::Parser::new();
+    let mut grid = new_grid_for_forwarding_test();
+    parser.advance(&mut grid, b"\x1b]66;s=2;Hi\x1b\\");
+
+    assert_eq!(grid.cursor.x, 4);
+    let row = grid.viewport.front().expect("scaled text row");
+    assert_eq!(row.columns.len(), 2);
+    assert_eq!(row.columns[0].width(), 2);
+    assert_eq!(row.columns[1].width(), 2);
+    assert!(row.columns.iter().all(|character| {
+        character.styles.text_sizing
+            == Some(crate::panes::terminal_character::TextSizing::parse("s=2").unwrap())
+    }));
+}
+
+#[test]
+fn osc_66_fractional_text_keeps_normal_cell_widths() {
+    let mut parser = vte::Parser::new();
+    let mut grid = new_grid_for_forwarding_test();
+    parser.advance(&mut grid, b"\x1b]66;n=1:d=2;Hi\x1b\\");
+
+    assert_eq!(grid.cursor.x, 2);
+    let row = grid.viewport.front().expect("fractional text row");
+    assert_eq!(row.columns.len(), 2);
+    assert!(row.columns.iter().all(|character| character.width() == 1));
+}
+
+#[test]
+fn osc_66_explicit_width_probe_advances_by_the_requested_cells() {
+    let mut parser = vte::Parser::new();
+    let mut grid = new_grid_for_forwarding_test();
+    parser.advance(&mut grid, b"\x1b]66;w=2; \x07");
+
+    assert_eq!(grid.cursor.x, 2);
+    assert_eq!(grid.viewport[0].columns[0].width(), 2);
+}
+
+#[test]
+fn presenterm_osc_66_capability_probe_reports_both_sizing_modes() {
+    let mut parser = vte::Parser::new();
+    let mut grid = new_grid_for_forwarding_test();
+    parser.advance(
+        &mut grid,
+        b"\x1b]66;s=2; \x1b\\\x1b]66;n=1:d=2; \x1b\\\x1b[6n",
+    );
+
+    assert_eq!(grid.cursor.x, 3);
+    assert_eq!(grid.pending_messages_to_pty, vec![b"\x1b[1;4R"]);
+}
+
+#[test]
 fn decset_2031_enables_color_palette_notification() {
     let mut parser = vte::Parser::new();
     let mut grid = new_grid_for_forwarding_test();


### PR DESCRIPTION
I wanted to use presenterm with zellij on kitty as I want to flip through coding, demo and presentation smoothly and zellij is perfect for this, especially since the image support you added!

But there is another graphic cool trick kitty can do, larger text. This PR allows the forwarding of those as the backend logic is already implemented on the zellij side.

<img width="1828" height="1032" alt="image" src="https://github.com/user-attachments/assets/7c435ee9-b2b9-41a0-80ff-cc36c40724be" />
