### PR TITLE
fix(input): prevent invalid UTF-8 paste buffer overrun

### DIFF
--- a/zellij-utils/src/vendored/termwiz/input.rs
+++ b/zellij-utils/src/vendored/termwiz/input.rs
@@ -1689,9 +1689,10 @@ impl InputParser {
                 InputState::Pasting(offset) => {
                     let end_paste = b"\x1b[201~";
                     if let Some(idx) = self.buf.find_subsequence(offset, end_paste) {
+                        let consumed = idx + end_paste.len();
                         let pasted =
                             String::from_utf8_lossy(&self.buf.as_slice()[0..idx]).to_string();
-                        self.buf.advance(pasted.len() + end_paste.len());
+                        self.buf.advance(consumed);
                         callback(InputEvent::Paste(pasted), self.buf.len());
                         self.state = InputState::Normal;
                     } else {
@@ -2549,6 +2550,28 @@ mod test {
         p.parse(input2, |e| inputs.push(e), false);
 
         assert_eq!(vec![InputEvent::Paste("12345678".to_owned())], inputs)
+    }
+
+    #[test]
+    fn bracketed_paste_with_invalid_utf8_preserves_following_input() {
+        let mut p = InputParser::new();
+
+        let input = b"\x1b[200~before\xa0after\x1b[201~x";
+
+        let mut inputs = vec![];
+
+        p.parse(input, |event| inputs.push(event), false);
+
+        assert_eq!(
+            vec![
+                InputEvent::Paste("before\u{fffd}after".to_owned()),
+                InputEvent::Key(KeyEvent {
+                    key: KeyCode::Char('x'),
+                    modifiers: Modifiers::NONE,
+                }),
+            ],
+            inputs
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

When a bracketed-paste payload contains invalid UTF-8,`String::from_utf8_lossy()` may expand an invalid byte into the multi-byte replacement character (`U+FFFD`).

The parser used the length of this decoded string to advance the raw input buffer. This could make it consume more bytes than the buffer contains and panic in `ReadBuffer::advance()`.

This matches the `stdin_handler` panic path reported in #4163.

## Change

Advance the input buffer using the raw byte offset of the bracketed-paste end marker instead of the length of the decoded string.

This keeps raw buffer accounting independent of lossy UTF-8 decoding.
A regression test verifies that invalid UTF-8 in a bracketed paste:

- is decoded using the existing replacement-character behavior;
- does not panic;
- does not consume input following the paste.

 ## Verification
- The regression test fails before the change and passes after it.
- `cargo test -p zellij-utils --lib` — 451 passed, 2 ignored.
-  `cargo test -p zellij-client --lib` — 109 passed.
- `cargo fmt --all -- --check` — passed.

Addresses #4163.