### PR TITLE
fix(cli): allow --token-name alongside --create-token / --create-read-only-token

### DIFF
--- a/zellij-utils/src/cli.rs
+++ b/zellij-utils/src/cli.rs
@@ -226,13 +226,23 @@ pub struct WebCli {
     pub server_startup_timeout: Option<u64>,
     /// Create a login token for the web interface, will only be displayed once and cannot later be
     /// retrieved. Returns the token name and the token.
-    #[clap(long, value_parser, exclusive(true), display_order = 7)]
+    #[clap(
+        long,
+        value_parser,
+        conflicts_with_all(&["stop", "status", "daemonize", "create_read_only_token", "revoke_token", "revoke_all_tokens", "list_tokens"]),
+        display_order = 7
+    )]
     pub create_token: bool,
-    /// Optional name for the token
+    /// Optional name for the token, used together with --create-token or --create-read-only-token
     #[clap(long, value_parser, value_name = "TOKEN_NAME", display_order = 8)]
     pub token_name: Option<String>,
     /// Create a read-only login token (can only attach to existing sessions as watcher)
-    #[clap(long, value_parser, exclusive(true), display_order = 9)]
+    #[clap(
+        long,
+        value_parser,
+        conflicts_with_all(&["stop", "status", "daemonize", "create_token", "revoke_token", "revoke_all_tokens", "list_tokens"]),
+        display_order = 9
+    )]
     pub create_read_only_token: bool,
     /// Revoke a login token by its name
     #[clap(


### PR DESCRIPTION
## Description

Fixes #5491.

`--create-token` and `--create-read-only-token` were declared with `exclusive(true)` in clap, which means they reject **any** other CLI flag being present at the same time — including `--token-name`, which is documented as the way to name a created token. In practice this makes `--token-name` unusable together with either token-creation flag.

## Fix

Replaced `exclusive(true)` on both flags with an explicit `conflicts_with_all(&[...])` listing only the flags that are genuinely mutually exclusive with token creation (`stop`, `status`, `daemonize`, and the other token-management flags). This preserves the original intent (you can't mix token creation with server lifecycle/other token commands) while allowing `--token-name` to combine with either `--create-token` or `--create-read-only-token`, matching the existing documentation and the parameter accepted by `create_auth_token()`.

## Testing

- `cargo build -p zellij-utils` succeeds.
- Manually verified `zellij web --create-token --token-name foo` and `zellij web --create-read-only-token --token-name foo` no longer error with a clap "cannot be used with" conflict, while `zellij web --create-token --stop` still correctly errors as conflicting.