### PR TITLE
Fix typos in code comments

### DIFF
--- a/default-plugins/configuration/src/rebind_leaders_screen.rs
+++ b/default-plugins/configuration/src/rebind_leaders_screen.rs
@@ -48,7 +48,7 @@ impl Default for RebindLeadersScreen {
 
 impl RebindLeadersScreen {
     // temporarily commented out for the time being because the extra leaders screen was deemed a bit
-    // confusing, see commend in <l> key
+    // confusing, see comment in <l> key
     //     pub fn with_rebinding_for_presets(mut self) -> Self {
     //         self.is_rebinding_for_presets = true;
     //         self

--- a/default-plugins/layout-manager/src/ui/layout_detail_view.rs
+++ b/default-plugins/layout-manager/src/ui/layout_detail_view.rs
@@ -120,7 +120,7 @@ impl<'a> LayoutDetail<'a> {
         let wrapped_lines = wrap_text_to_width(error_message, max_cols);
         let available_rows = max_rows.saturating_sub(3);
 
-        let mut current_y = y + 1; // + 1 (and saturating_sub(3) above) to be aligned witht he
+        let mut current_y = y + 1; // + 1 (and saturating_sub(3) above) to be aligned with the
                                    // table on the left
         for line in wrapped_lines.iter().take(available_rows) {
             let text = Text::new(line).error_color_all();

--- a/default-plugins/status-bar/src/first_line.rs
+++ b/default-plugins/status-bar/src/first_line.rs
@@ -133,7 +133,7 @@ impl KeyShortcut {
 /// - `shared_super`: If set to true, all mode shortcut keybindings share a common modifier (see
 ///   [`get_common_modifier`]) and the modifier belonging to the keybinding is **not** printed in
 ///   the shortcut tile.
-/// - `first_tile`: If set to true, the leading separator for this tile will be ommited so no gap
+/// - `first_tile`: If set to true, the leading separator for this tile will be omitted so no gap
 ///   appears on the screen.
 fn long_mode_shortcut(
     key: &KeyShortcut,
@@ -255,7 +255,7 @@ fn shortened_modifier_shortcut(
 /// - `shared_super`: If set to true, all mode shortcut keybindings share a common modifier (see
 ///   [`get_common_modifier`]) and the modifier belonging to the keybinding is **not** printed in
 ///   the shortcut tile.
-/// - `first_tile`: If set to true, the leading separator for this tile will be ommited so no gap
+/// - `first_tile`: If set to true, the leading separator for this tile will be omitted so no gap
 ///   appears on the screen.
 fn short_mode_shortcut(
     key: &KeyShortcut,


### PR DESCRIPTION
Comment-only spelling fixes, no behaviour change:

- `commend` -> `comment` in `rebind_leaders_screen.rs`
- `aligned witht he` -> `aligned with the` in `layout_detail_view.rs`
- `ommited` -> `omitted` in two `first_tile` doc comments in `first_line.rs`