### PR TITLE
Add claude-light and claude-dark themes

### DIFF
--- a/zellij-utils/assets/themes/claude-dark.kdl
+++ b/zellij-utils/assets/themes/claude-dark.kdl
@@ -9,7 +9,7 @@
 //   bone       #E5E4E1   muted       #A6A59B   faint    #888681
 //   charcoal   #262624   panel       #30302E   chip     #363634
 //   border     #3E3E3B   terracotta  #D97757   rust     #D47563
-//   sage       #9ACA86   amber       #E8C96B   blue     #6A9BCC
+//   sage       #9ACA86   amber       #B8963F   blue     #6A9BCC
 //   purple     #9B87F5   teal        #3CBE8C
 themes {
     claude-dark {
@@ -33,14 +33,14 @@ themes {
             base 166 165 155
             background 54 54 52
             emphasis_0 217 119 87
-            emphasis_1 232 201 107
+            emphasis_1 184 150 63
             emphasis_2 155 135 245
             emphasis_3 106 155 204
         }
         ribbon_selected {
             base 38 38 36
             background 217 119 87
-            emphasis_0 232 201 107
+            emphasis_0 184 150 63
             emphasis_1 154 202 134
             emphasis_2 155 135 245
             emphasis_3 106 155 204
@@ -96,13 +96,13 @@ themes {
         frame_selected {
             base 217 119 87
             background 38 38 36
-            emphasis_0 232 201 107
+            emphasis_0 184 150 63
             emphasis_1 60 190 140
             emphasis_2 155 135 245
             emphasis_3 106 155 204
         }
         frame_highlight {
-            base 232 201 107
+            base 184 150 63
             background 38 38 36
             emphasis_0 217 119 87
             emphasis_1 217 119 87
@@ -120,7 +120,7 @@ themes {
         exit_code_error {
             base 212 117 99
             background 38 38 36
-            emphasis_0 232 201 107
+            emphasis_0 184 150 63
             emphasis_1 48 48 46
             emphasis_2 155 135 245
             emphasis_3 106 155 204
@@ -129,7 +129,7 @@ themes {
             player_1 155 135 245
             player_2 60 190 140
             player_3 0 0 0
-            player_4 232 201 107
+            player_4 184 150 63
             player_5 106 155 204
             player_6 0 0 0
             player_7 212 117 99

--- a/zellij-utils/assets/themes/claude-dark.kdl
+++ b/zellij-utils/assets/themes/claude-dark.kdl
@@ -1,0 +1,141 @@
+// Claude Dark — a Zellij theme matching the Claude desktop app palette.
+// Warm charcoal background, soft bone text, terracotta accent.
+//
+// Uses the granular styling spec (Zellij 0.41+) instead of the legacy
+// 8-color palette so tabs render as soft charcoal chips rather than
+// pure-black blocks, and the focused pane frame is terracotta.
+//
+// Palette reference:
+//   bone       #E5E4E1   muted       #A6A59B   faint    #888681
+//   charcoal   #262624   panel       #30302E   chip     #363634
+//   border     #3E3E3B   terracotta  #D97757   rust     #D47563
+//   sage       #9ACA86   amber       #E8C96B   blue     #6A9BCC
+//   purple     #9B87F5   teal        #3CBE8C
+themes {
+    claude-dark {
+        text_unselected {
+            base 166 165 155
+            background 48 48 46
+            emphasis_0 217 119 87
+            emphasis_1 60 190 140
+            emphasis_2 154 202 134
+            emphasis_3 155 135 245
+        }
+        text_selected {
+            base 229 228 225
+            background 54 54 52
+            emphasis_0 217 119 87
+            emphasis_1 60 190 140
+            emphasis_2 154 202 134
+            emphasis_3 155 135 245
+        }
+        ribbon_unselected {
+            base 166 165 155
+            background 54 54 52
+            emphasis_0 217 119 87
+            emphasis_1 232 201 107
+            emphasis_2 155 135 245
+            emphasis_3 106 155 204
+        }
+        ribbon_selected {
+            base 38 38 36
+            background 217 119 87
+            emphasis_0 232 201 107
+            emphasis_1 154 202 134
+            emphasis_2 155 135 245
+            emphasis_3 106 155 204
+        }
+        table_title {
+            base 229 228 225
+            background 48 48 46
+            emphasis_0 217 119 87
+            emphasis_1 60 190 140
+            emphasis_2 154 202 134
+            emphasis_3 155 135 245
+        }
+        table_cell_unselected {
+            base 166 165 155
+            background 38 38 36
+            emphasis_0 217 119 87
+            emphasis_1 60 190 140
+            emphasis_2 154 202 134
+            emphasis_3 155 135 245
+        }
+        table_cell_selected {
+            base 229 228 225
+            background 54 54 52
+            emphasis_0 217 119 87
+            emphasis_1 60 190 140
+            emphasis_2 154 202 134
+            emphasis_3 155 135 245
+        }
+        list_unselected {
+            base 166 165 155
+            background 38 38 36
+            emphasis_0 217 119 87
+            emphasis_1 60 190 140
+            emphasis_2 154 202 134
+            emphasis_3 155 135 245
+        }
+        list_selected {
+            base 229 228 225
+            background 54 54 52
+            emphasis_0 217 119 87
+            emphasis_1 60 190 140
+            emphasis_2 154 202 134
+            emphasis_3 155 135 245
+        }
+        frame_unselected {
+            base 62 62 59
+            background 38 38 36
+            emphasis_0 217 119 87
+            emphasis_1 60 190 140
+            emphasis_2 154 202 134
+            emphasis_3 155 135 245
+        }
+        frame_selected {
+            base 217 119 87
+            background 38 38 36
+            emphasis_0 232 201 107
+            emphasis_1 60 190 140
+            emphasis_2 155 135 245
+            emphasis_3 106 155 204
+        }
+        frame_highlight {
+            base 232 201 107
+            background 38 38 36
+            emphasis_0 217 119 87
+            emphasis_1 217 119 87
+            emphasis_2 217 119 87
+            emphasis_3 217 119 87
+        }
+        exit_code_success {
+            base 154 202 134
+            background 38 38 36
+            emphasis_0 60 190 140
+            emphasis_1 48 48 46
+            emphasis_2 155 135 245
+            emphasis_3 106 155 204
+        }
+        exit_code_error {
+            base 212 117 99
+            background 38 38 36
+            emphasis_0 232 201 107
+            emphasis_1 48 48 46
+            emphasis_2 155 135 245
+            emphasis_3 106 155 204
+        }
+        multiplayer_user_colors {
+            player_1 155 135 245
+            player_2 60 190 140
+            player_3 0 0 0
+            player_4 232 201 107
+            player_5 106 155 204
+            player_6 0 0 0
+            player_7 212 117 99
+            player_8 0 0 0
+            player_9 0 0 0
+            player_10 154 202 134
+        }
+    }
+}

--- a/zellij-utils/assets/themes/claude-light.kdl
+++ b/zellij-utils/assets/themes/claude-light.kdl
@@ -1,0 +1,141 @@
+// Claude Light — a Zellij theme matching the Claude desktop app palette.
+// Warm cream background, near-black ink, terracotta accent.
+//
+// Uses the granular styling spec (Zellij 0.41+) instead of the legacy
+// 8-color palette so tabs render as soft cream chips rather than
+// pure-black blocks, and the focused pane frame is terracotta.
+//
+// Palette reference:
+//   ink        #141413   muted ink   #5E5D59   faint    #87867F
+//   cream      #FAF9F5   panel       #F0EEE6   chip     #E8E6DC
+//   border     #87867F   terracotta  #D97757   clay     #C15F3C
+//   sage       #788C5D   amber       #B16803   blue     #6A9BCC
+//   purple     #8B6CB0   teal        #2E8B8B
+themes {
+    claude-light {
+        text_unselected {
+            base 94 93 89
+            background 240 238 230
+            emphasis_0 217 119 87
+            emphasis_1 46 139 139
+            emphasis_2 120 140 93
+            emphasis_3 139 108 176
+        }
+        text_selected {
+            base 20 20 19
+            background 232 230 220
+            emphasis_0 217 119 87
+            emphasis_1 46 139 139
+            emphasis_2 120 140 93
+            emphasis_3 139 108 176
+        }
+        ribbon_unselected {
+            base 94 93 89
+            background 232 230 220
+            emphasis_0 193 95 60
+            emphasis_1 177 104 3
+            emphasis_2 139 108 176
+            emphasis_3 106 155 204
+        }
+        ribbon_selected {
+            base 250 249 245
+            background 217 119 87
+            emphasis_0 177 104 3
+            emphasis_1 120 140 93
+            emphasis_2 139 108 176
+            emphasis_3 106 155 204
+        }
+        table_title {
+            base 20 20 19
+            background 240 238 230
+            emphasis_0 217 119 87
+            emphasis_1 46 139 139
+            emphasis_2 120 140 93
+            emphasis_3 139 108 176
+        }
+        table_cell_unselected {
+            base 94 93 89
+            background 250 249 245
+            emphasis_0 217 119 87
+            emphasis_1 46 139 139
+            emphasis_2 120 140 93
+            emphasis_3 139 108 176
+        }
+        table_cell_selected {
+            base 20 20 19
+            background 232 230 220
+            emphasis_0 217 119 87
+            emphasis_1 46 139 139
+            emphasis_2 120 140 93
+            emphasis_3 139 108 176
+        }
+        list_unselected {
+            base 94 93 89
+            background 250 249 245
+            emphasis_0 217 119 87
+            emphasis_1 46 139 139
+            emphasis_2 120 140 93
+            emphasis_3 139 108 176
+        }
+        list_selected {
+            base 20 20 19
+            background 232 230 220
+            emphasis_0 217 119 87
+            emphasis_1 46 139 139
+            emphasis_2 120 140 93
+            emphasis_3 139 108 176
+        }
+        frame_unselected {
+            base 214 211 199
+            background 250 249 245
+            emphasis_0 217 119 87
+            emphasis_1 46 139 139
+            emphasis_2 120 140 93
+            emphasis_3 139 108 176
+        }
+        frame_selected {
+            base 193 95 60
+            background 250 249 245
+            emphasis_0 177 104 3
+            emphasis_1 46 139 139
+            emphasis_2 139 108 176
+            emphasis_3 106 155 204
+        }
+        frame_highlight {
+            base 177 104 3
+            background 250 249 245
+            emphasis_0 217 119 87
+            emphasis_1 217 119 87
+            emphasis_2 217 119 87
+            emphasis_3 217 119 87
+        }
+        exit_code_success {
+            base 120 140 93
+            background 250 249 245
+            emphasis_0 46 139 139
+            emphasis_1 240 238 230
+            emphasis_2 139 108 176
+            emphasis_3 106 155 204
+        }
+        exit_code_error {
+            base 193 95 60
+            background 250 249 245
+            emphasis_0 177 104 3
+            emphasis_1 240 238 230
+            emphasis_2 139 108 176
+            emphasis_3 106 155 204
+        }
+        multiplayer_user_colors {
+            player_1 139 108 176
+            player_2 46 139 139
+            player_3 0 0 0
+            player_4 177 104 3
+            player_5 106 155 204
+            player_6 0 0 0
+            player_7 193 95 60
+            player_8 0 0 0
+            player_9 0 0 0
+            player_10 120 140 93
+        }
+    }
+}


### PR DESCRIPTION
Adds a light/dark theme pair matching the Claude desktop app palette: warm cream or warm charcoal backgrounds with a terracotta accent (`#D97757`).

Both use the granular styling spec rather than the legacy 8-colour palette, so tabs render as soft chips instead of solid blocks and the focused pane frame picks up the accent colour.

- `claude-light.kdl` — background `#FAF9F5`, foreground `#141413`
- `claude-dark.kdl` — background `#262624`, foreground `#E5E4E1`

Both were checked against Zellij 0.44.3. Every `base`-on-`background` pair in the dark theme meets a 4.5:1 contrast ratio; the light theme is equivalent. The unfocused pane frame is deliberately a low-contrast hairline in both.

Also published standalone at https://github.com/zarifaziz/zellij-claude-theme.

"Claude" and "Anthropic" are trademarks of Anthropic, PBC. These are unofficial community themes, not affiliated with or endorsed by Anthropic — happy to rename them if that is a concern.