### PR TITLE
fix(kitty-graphics): honour the x=/y= source origin for unscaled placements

### DIFF
--- a/zellij-server/src/panes/kitty_graphics/grid_state.rs
+++ b/zellij-server/src/panes/kitty_graphics/grid_state.rs
@@ -392,8 +392,13 @@ impl KittyGrid {
                 width: source_w,
                 height: source_h,
             },
-            emit_x: 0,
-            emit_y: 0,
+            // emit_{x,y} is the offset into the raster that will be transmitted to the
+            // host terminal. A scaled placement transmits a variant that crop_rgba has
+            // already cut to the source rectangle, so it starts at the origin; an
+            // unscaled one transmits the whole image, so the source rectangle has to be
+            // forwarded for the host to apply it.
+            emit_x: if is_scaled { 0 } else { source_x },
+            emit_y: if is_scaled { 0 } else { source_y },
             scaled_px: if is_scaled {
                 Some((dst_w, dst_h))
             } else {


### PR DESCRIPTION
Fixes #5567.

On a kitty display command, `x`, `y`, `w` and `h` are the source rectangle, meaning which pixels of the stored image to show, with `x`/`y` as its top-left corner. `c` and `r` give the destination size in cells. A placement that sends only a source rectangle falls into the `(0, 0)` columns/rows arm, where `is_scaled` is false. `crop_rgba` doesn't run there, and `emit_x`/`emit_y` are left at 0, so the `x`/`y` the application asked for is lost on both paths and the image always draws from its top-left corner.

The two branches need different starting values. A scaled placement sends a variant that has already been cropped to the source rectangle, so 0 is right for it. An unscaled one sends the whole image, so the offset has to travel with it. `output/mod.rs` writes `x={},y={}` from these same fields, it just never had anything to write.

Scroll trim still adds to `emit_y` on top of this, and the reset in the cell-size regeneration path only touches scaled placements, so both keep working as before.

Checked with the script in #5567: three source rectangles over a 3x3 grid of tiles render A, E, I after the change, A, A, A before it. `cargo test -p zellij-server kitty` stays at 140 passing, `cargo fmt --check` is clean.
