### PR TITLE
fix(grid): keep wide characters before the cursor when erasing to end of screen

### DIFF
--- a/zellij-server/src/panes/grid.rs
+++ b/zellij-server/src/panes/grid.rs
@@ -5994,8 +5994,10 @@ impl Row {
         self.width = None;
     }
     pub fn truncate(&mut self, x: usize) {
-        let width_offset = self.excess_width_until(x);
-        let truncate_position = x.saturating_sub(width_offset);
+        // `x` is a display column; `columns` is indexed by character. `excess_width_until` counts
+        // the excess of the first `x` *characters*, which over-counts once more than one wide
+        // character precedes the column, so convert the same way the rest of `Row` does.
+        let truncate_position = self.position_accounting_for_widechars(x);
         if truncate_position < self.columns.len() {
             self.columns.truncate(truncate_position);
         }

--- a/zellij-server/src/panes/unit/grid_tests.rs
+++ b/zellij-server/src/panes/unit/grid_tests.rs
@@ -9354,3 +9354,44 @@ fn a_character_wider_than_two_columns_advances_the_cursor_by_its_full_width() {
     assert_eq!(row.width(), 4);
     assert_eq!(cursor_position(&grid), Some((4, 0)));
 }
+
+#[test]
+fn clear_to_end_of_screen_keeps_wide_characters_before_the_cursor() {
+    // Park the cursor on the second half of the row and erase from there to the end of the
+    // screen. Only what is at or after the cursor may go.
+    let first_row_after = |bytes: &str| {
+        let mut grid = Grid::new(
+            3,
+            20,
+            Rc::new(RefCell::new(Palette::default())),
+            Rc::new(RefCell::new(HashMap::new())),
+            Rc::new(RefCell::new(LinkHandler::new())),
+            Rc::new(RefCell::new(None)),
+            Rc::new(RefCell::new(SixelImageStore::default())),
+            Rc::new(RefCell::new(KittyImageStore::default())),
+            Style::default(),
+            false,
+            true,
+            true,
+            true,
+            false,
+        );
+        let mut vte_parser = vte::Parser::new();
+        vte_parser.advance(&mut grid, bytes.as_bytes());
+        let rendered = format!("{:?}", grid);
+        rendered.lines().next().unwrap().trim_end().to_owned()
+    };
+
+    // Two wide characters, cursor to display column 2, erase to end of screen.
+    assert_eq!(
+        first_row_after("\u{65e5}\u{672c}\u{1b}[3G\u{1b}[0J"),
+        "00 (C): \u{65e5}"
+    );
+    // A narrow character followed by two wide ones, cursor to display column 3.
+    assert_eq!(
+        first_row_after("a\u{65e5}\u{672c}\u{1b}[4G\u{1b}[0J"),
+        "00 (C): a\u{65e5}"
+    );
+    // Narrow characters only: unchanged by this fix.
+    assert_eq!(first_row_after("ab\u{1b}[3G\u{1b}[0J"), "00 (C): ab");
+}


### PR DESCRIPTION
`Row::truncate` takes a display column, but converted it to a character index with
`x - excess_width_until(x)`. `excess_width_until` counts the excess of the first `x`
*characters* (`columns.iter().take(x)`), so as soon as more than one wide character precedes the
column it over-counts and the row is cut shorter than asked. `position_accounting_for_widechars`,
twenty lines below in the same `impl`, is the converter that gets this right, and
`replace_and_pad_end` already uses it.

The visible effect is through `clear_all_after_cursor` (CSI 0 J, which shells emit constantly):
with the cursor anywhere past a second wide character, text *before* the cursor is deleted.
Measured on `main` (af38660c), first row after the sequence, 20-column grid:

| input | expected | on main |
|---|---|---|
| `日本` then CUP col 3, `ESC[0J` | `日` | *(empty)* |
| `a日本` then CUP col 4, `ESC[0J` | `a日` | `a` |
| `ab` then CUP col 3, `ESC[0J` | `ab` | `ab` |

Narrow-only rows are unaffected, which is why this has stayed invisible.

Nothing in the suite could see it: every wide-character test in `grid_tests.rs`
(`wide_characters`, `wide_characters_line_wrap`, `bash_delete_wide_characters`,
`fish_wide_characters_override_clock`) is an `assert_snapshot!` of a fixture replay, and the
hand-written ED tests are all ASCII. `truncate`'s formula and those fixtures landed in the same
commit, `44d67de1` (#535, 2021-05-26). Reverting only `grid.rs` to `main` fails the one new test
and nothing else; all 1577 lib tests pass with the fix and no snapshot needed regenerating.

Worth saying: the naive version — `truncate_position = x`, ignoring wide characters — also passes
the new test. It fails five existing ones (`delete_char_in_middle_of_line_with_widechar`,
`insert_character_in_line_with_wide_character`, and three `search_tests`), so the suite pins
over-truncation while being blind to under-truncation. `position_accounting_for_widechars` is what
satisfies both directions.

Out of scope: the other `excess_width_until(x)` call, in `add_character_at`'s `Ordering::Less` arm,
is not affected — there `x` is at or past the row's display width, so the two readings coincide.
#5240 touches `replace_and_pad_end`, not `truncate`; no overlap.

`cargo test -p zellij-server --lib` (1577 passed), `cargo fmt --all --check` clean. `cargo clippy`
at the pinned 1.95.0 already fails on `main` in `output/mod.rs` and `plugins/unit/plugin_tests.rs`;
nothing in the changed files is new.

Found by reading `Row`'s three display-column/character-index converters against each other, not
from normal use. Written with AI assistance (Claude Opus 5, `claude-opus-5`); every number above
came from running the built test binary.
