### PR TITLE
fix(client): handle stdout render errors

### DIFF
--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -29,7 +29,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::thread;
-use zellij_utils::errors::FatalError;
+use zellij_utils::errors::prelude::*;
 use zellij_utils::shared::web_server_base_url;
 
 #[cfg(feature = "web_server_capability")]
@@ -172,6 +172,21 @@ use zellij_utils::{
     pane_size::Size,
     vendored::termwiz::input::InputEvent,
 };
+
+fn write_render_output(
+    stdout: &mut dyn Write,
+    output: &[u8],
+    synchronised_output: Option<SyncOutput>,
+) -> io::Result<()> {
+    if let Some(sync) = synchronised_output {
+        stdout.write_all(sync.start_seq())?;
+    }
+    stdout.write_all(output)?;
+    if let Some(sync) = synchronised_output {
+        stdout.write_all(sync.end_seq())?;
+    }
+    stdout.flush()
+}
 
 /// Instructions related to the client-side application
 #[derive(Debug, Clone)]
@@ -706,37 +721,19 @@ pub async fn run_remote_client_terminal_loop(
                 match terminal_msg {
                     Some(Ok(Message::Text(text))) => {
                         let mut stdout = os_input.get_stdout_writer();
-                        if let Some(sync) = synchronised_output {
-                            stdout
-                                .write_all(sync.start_seq())
-                                .expect("cannot write to stdout");
-                        }
-                        stdout
-                            .write_all(text.as_bytes())
-                            .expect("cannot write to stdout");
-                        if let Some(sync) = synchronised_output {
-                            stdout
-                                .write_all(sync.end_seq())
-                                .expect("cannot write to stdout");
-                        }
-                        stdout.flush().expect("could not flush");
+                        write_render_output(
+                            stdout.as_mut(),
+                            text.as_bytes(),
+                            synchronised_output,
+                        )
+                        .context("failed to render remote client output")
+                        .non_fatal();
                     }
                     Some(Ok(Message::Binary(data))) => {
                         let mut stdout = os_input.get_stdout_writer();
-                        if let Some(sync) = synchronised_output {
-                            stdout
-                                .write_all(sync.start_seq())
-                                .expect("cannot write to stdout");
-                        }
-                        stdout
-                            .write_all(&data)
-                            .expect("cannot write to stdout");
-                        if let Some(sync) = synchronised_output {
-                            stdout
-                                .write_all(sync.end_seq())
-                                .expect("cannot write to stdout");
-                        }
-                        stdout.flush().expect("could not flush");
+                        write_render_output(stdout.as_mut(), &data, synchronised_output)
+                            .context("failed to render remote client output")
+                            .non_fatal();
                     }
                     Some(Ok(Message::Close(_))) => {
                         break;
@@ -1417,20 +1414,9 @@ pub fn start_client(
             },
             ClientInstruction::Render(output) => {
                 let mut stdout = os_input.get_stdout_writer();
-                if let Some(sync) = synchronised_output {
-                    stdout
-                        .write_all(sync.start_seq())
-                        .expect("cannot write to stdout");
-                }
-                stdout
-                    .write_all(output.as_bytes())
-                    .expect("cannot write to stdout");
-                if let Some(sync) = synchronised_output {
-                    stdout
-                        .write_all(sync.end_seq())
-                        .expect("cannot write to stdout");
-                }
-                stdout.flush().expect("could not flush");
+                write_render_output(stdout.as_mut(), output.as_bytes(), synchronised_output)
+                    .context("failed to render client output")
+                    .non_fatal();
             },
             ClientInstruction::UnblockInputThread => {
                 command_is_executing.unblock_input_thread();

--- a/zellij-client/src/unit/mod.rs
+++ b/zellij-client/src/unit/mod.rs
@@ -3,4 +3,7 @@
 mod terminal_loop_tests;
 
 #[cfg(test)]
+mod render_output_tests;
+
+#[cfg(test)]
 mod teardown_tests;

--- a/zellij-client/src/unit/render_output_tests.rs
+++ b/zellij-client/src/unit/render_output_tests.rs
@@ -1,0 +1,50 @@
+use crate::stdin_ansi_parser::SyncOutput;
+use crate::write_render_output;
+use std::io::{self, Write};
+
+#[derive(Default)]
+struct TestWriter {
+    output: Vec<u8>,
+    flush_error: bool,
+}
+
+impl Write for TestWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.output.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if self.flush_error {
+            Err(io::Error::other(
+                "insufficient system resources to flush stdout",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[test]
+fn render_output_wraps_content_in_synchronised_output_sequences() {
+    let mut writer = TestWriter::default();
+
+    write_render_output(&mut writer, b"rendered content", Some(SyncOutput::CSI)).unwrap();
+
+    let mut expected = SyncOutput::CSI.start_seq().to_vec();
+    expected.extend_from_slice(b"rendered content");
+    expected.extend_from_slice(SyncOutput::CSI.end_seq());
+    assert_eq!(writer.output, expected);
+}
+
+#[test]
+fn render_output_returns_stdout_flush_errors() {
+    let mut writer = TestWriter {
+        flush_error: true,
+        ..Default::default()
+    };
+
+    let error = write_render_output(&mut writer, b"rendered content", None).unwrap_err();
+
+    assert_eq!(error.kind(), io::ErrorKind::Other);
+}


### PR DESCRIPTION
Hi, I got what's likely the same resource exhaustion issue as in #5007, working on a fix. The bot filed this on my behalf in its infinite wisdom, redacting until I properly review/fix/reproduce myself.