### PR TITLE
fix(sessions): don't delete a live session's socket when a connection is refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+* fix: don't delete a live session's socket when a connection is refused (https://github.com/zellij-org/zellij/pull/5583)
 
 ## [0.45.1] - 2026-08-28
 * fix: nested-session detection over SSH (https://github.com/zellij-org/zellij/pull/5522)

--- a/zellij-utils/src/sessions.rs
+++ b/zellij-utils/src/sessions.rs
@@ -13,7 +13,7 @@ use humantime::format_duration;
 use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 use std::time::{Duration, SystemTime};
-use std::{fs, io, process};
+use std::{fs, io, process, thread};
 use suggest::Suggest;
 
 pub fn get_sessions() -> Result<Vec<(String, Duration)>, io::ErrorKind> {
@@ -140,31 +140,75 @@ pub fn get_sessions_sorted_by_mtime() -> anyhow::Result<Vec<String>> {
     }
 }
 
+/// How many times a refused connection is retried before the socket it points at
+/// is treated as stale. See [`assert_socket_at`].
+#[cfg(unix)]
+const REFUSED_CONNECTION_RETRIES: usize = 3;
+
+/// How long to wait between the retries above.
+#[cfg(unix)]
+const REFUSED_CONNECTION_RETRY_DELAY: Duration = Duration::from_millis(100);
+
 /// Probe a session socket to check if a server is alive.
 ///
 /// On Unix, connects and sends a `ConnStatus` message to verify the server responds.
 /// On Windows, reads the server PID from the marker file and checks process liveness.
 #[cfg(unix)]
 fn assert_socket(name: &str) -> bool {
+    assert_socket_at(&ZELLIJ_SOCK_DIR.join(name))
+}
+
+/// Probe the session socket at `path`, removing it if it turns out to be stale.
+///
+/// A refused connection is not on its own proof that the session is gone.
+/// `ECONNREFUSED` on a unix socket means either that nothing is listening on it -
+/// a stale file left behind by a server that did not shut down cleanly - or that
+/// a server *is* listening but cannot accept right now. On macOS and the BSDs the
+/// kernel refuses connections once a listener's accept backlog is full, which a
+/// busy but perfectly healthy server can hit.
+///
+/// Getting this wrong is not symmetrical. Keeping a stale socket around costs
+/// almost nothing, since the next server to take that name unlinks it before
+/// binding anyway. Removing the socket of a *live* server destroys that session
+/// permanently: a unix socket is bound to its inode rather than to its path, so
+/// once the path is unlinked the running server can never be reached again, and
+/// `zellij attach --create` will quietly start a second server under the same
+/// name while the first keeps running with all of the user's panes in it.
+///
+/// So retry a refused connection before concluding anything, and only remove the
+/// socket once it stays refused.
+#[cfg(unix)]
+fn assert_socket_at(path: &Path) -> bool {
     use crate::consts::ipc_connect;
-    let path = &*ZELLIJ_SOCK_DIR.join(name);
-    match ipc_connect(path) {
-        Ok(stream) => {
-            let mut sender: IpcSenderWithContext<ClientToServerMsg> =
-                IpcSenderWithContext::new(stream);
-            let _ = sender.send_client_msg(ClientToServerMsg::ConnStatus);
-            let mut receiver: IpcReceiverWithContext<ServerToClientMsg> = sender.get_receiver();
-            match receiver.recv_server_msg() {
-                Some((ServerToClientMsg::Connected, _)) => true,
-                None | Some((_, _)) => false,
-            }
-        },
-        Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => {
-            drop(fs::remove_file(path));
-            false
-        },
-        Err(_) => false,
+
+    let mut retries_left = REFUSED_CONNECTION_RETRIES;
+    loop {
+        match ipc_connect(path) {
+            Ok(stream) => return server_answers_conn_status(stream),
+            Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => {
+                if retries_left == 0 {
+                    drop(fs::remove_file(path));
+                    return false;
+                }
+                retries_left -= 1;
+                thread::sleep(REFUSED_CONNECTION_RETRY_DELAY);
+            },
+            Err(_) => return false,
+        }
     }
+}
+
+/// Ask the server on the other end of `stream` whether it is up, and wait for its
+/// answer.
+#[cfg(unix)]
+fn server_answers_conn_status(stream: interprocess::local_socket::Stream) -> bool {
+    let mut sender: IpcSenderWithContext<ClientToServerMsg> = IpcSenderWithContext::new(stream);
+    let _ = sender.send_client_msg(ClientToServerMsg::ConnStatus);
+    let mut receiver: IpcReceiverWithContext<ServerToClientMsg> = sender.get_receiver();
+    matches!(
+        receiver.recv_server_msg(),
+        Some((ServerToClientMsg::Connected, _))
+    )
 }
 
 /// On Windows, reads the server PID from the marker file and checks whether
@@ -802,3 +846,77 @@ const NOUNS: &[&'static str] = &[
     "yak",
     "zebra",
 ];
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::net::UnixListener;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::Instant;
+
+    /// A socket file with nothing bound to it any more, the way a server that was
+    /// killed rather than shut down cleanly leaves one behind.
+    fn stale_socket(dir: &tempfile::TempDir) -> std::path::PathBuf {
+        let path = dir.path().join("session.sock");
+        drop(UnixListener::bind(&path).expect("failed to bind test socket"));
+        assert!(
+            path.exists(),
+            "dropping the listener should leave the socket file behind"
+        );
+        path
+    }
+
+    #[test]
+    fn removes_a_socket_nothing_is_listening_on() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = stale_socket(&dir);
+
+        assert!(!assert_socket_at(&path));
+        assert!(
+            !path.exists(),
+            "a socket that stays refused should be cleaned up"
+        );
+    }
+
+    #[test]
+    fn keeps_a_socket_that_only_refuses_the_first_connection() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = stale_socket(&dir);
+
+        // A server that cannot accept at first but catches up well within the
+        // retry window, the way one with a momentarily full accept backlog does.
+        let server_path = path.clone();
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_accepting = Arc::clone(&stop);
+        let server = thread::spawn(move || {
+            thread::sleep(REFUSED_CONNECTION_RETRY_DELAY / 2);
+            fs::remove_file(&server_path).unwrap();
+            let listener = UnixListener::bind(&server_path).unwrap();
+            listener.set_nonblocking(true).unwrap();
+
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while !stop_accepting.load(Ordering::Relaxed) && Instant::now() < deadline {
+                match listener.accept() {
+                    // Dropping the stream right away hands the probe an EOF
+                    // instead of a `Connected`. That is fine: what this test cares
+                    // about is that the socket file survives.
+                    Ok(_) => {},
+                    Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(5))
+                    },
+                    Err(_) => break,
+                }
+            }
+        });
+
+        assert_socket_at(&path);
+        stop.store(true, Ordering::Relaxed);
+        server.join().unwrap();
+
+        assert!(
+            path.exists(),
+            "a socket that stopped refusing connections must not be removed"
+        );
+    }
+}


### PR DESCRIPTION
## What

`assert_socket()` removes a session's socket file whenever `connect()` returns `ECONNREFUSED`. That is correct for a socket nothing is listening on, but on macOS and the BSDs the kernel also returns `ECONNREFUSED` when a listener *is* there and its accept backlog is full — something a busy but perfectly healthy zellij server can hit.

When that happens the session is destroyed permanently. A unix socket is bound to its inode rather than to its path, so once the path is unlinked the still-running server can never be reached again: `zellij list-sessions` reports nothing, and the next `zellij attach --create <name>` quietly starts a *second* server under the same name while the first keeps running with all of the user's panes in it. There is no recovery — you cannot re-publish a unix socket by recreating the path.

This retries a refused connection a few times before concluding the session is gone, and only removes the socket once it stays refused.

## How I ran into it

A session had been alive about 9 hours with a long-running coding agent in one pane. Reattaching from another machine produced a brand new empty session. The old server was still running and completely healthy — `sample` showed its `server_listener` thread sitting in `accept()`, the main thread idle on its instruction channel, every pane process alive — but its socket file was gone, replaced by the new server's. Nothing in `zellij.log`, because the delete happens client-side.

## Reproduction

zellij 0.45.1, macOS 24.6 (arm64), in an isolated `ZELLIJ_SOCKET_DIR`:

1. `zellij attach --create-background probe`
2. `SIGSTOP` the server — standing in for an accept loop that is momentarily busy
3. open connections until one is refused (the 130th, i.e. a backlog of 128)
4. run a single `zellij list-sessions` while the backlog is still full
5. `SIGCONT` the server

```
backlog full after 129 pending conns; next connect -> ECONNREFUSED
socket file before asking zellij: PRESENT
zellij list-sessions -> No active zellij sessions found.
socket file AFTER  asking zellij: *** DELETED BY ZELLIJ ***
server after CONT: ALIVE (pid 31398)
socket file: *** STILL GONE -> session unreachable forever ***
```

The server survives the whole sequence. Only its socket is gone.

## Why one unlucky probe was enough

Every `zellij action` invocation opens two connections to the socket: the liveness probe from `get_sessions()` (via `get_active_session()`), plus the real one. I had a shell watcher polling `zellij action list-tabs` + `list-panes` every 0.2s to auto-switch locked mode, which works out to ~18 connections per second per session — roughly 600k over that session's lifetime. That watcher was my own foot-gun and I have since replaced it with a plugin, but any tooling that drives `zellij action` in a loop has the same exposure, and it only takes one probe landing on a full backlog.

## Notes

- Retrying is a mitigation rather than a proof: a backlog that stays full for the entire retry window still ends in a delete. A deterministic fix would be for the unix path to do what the Windows branch of `assert_socket` already does and consult a server PID marker instead of inferring liveness from `connect()`. I'm happy to do that instead if you'd prefer — it is a larger change, since the server would have to write and clean up the marker.
- The retries cost nothing unless a connection is actually refused, and a genuinely stale socket is still removed by the first probe that reaches it, so the added latency is paid once and only in the abnormal case.
- The trade is deliberately asymmetric: keeping a stale socket a little longer is harmless, since the next server to take that name unlinks it before binding anyway, while removing a live one is unrecoverable.

## Tests

Two unit tests in `zellij-utils/src/sessions.rs`. Both are deterministic and portable — they do not depend on any platform's backlog semantics, and are `#[cfg(all(test, unix))]` so the Windows job skips them:

- `removes_a_socket_nothing_is_listening_on` — the existing cleanup behaviour still works
- `keeps_a_socket_that_only_refuses_the_first_connection` — a socket that refuses the first connection but becomes connectable within the retry window is kept

`cargo test -p zellij-utils` passes (452 tests), `cargo fmt --all --check` is clean, and `cargo clippy -p zellij-utils` reports nothing new for the touched code.
