### PR TITLE
feat(nested-sessions): report a guest's input mode and key bindings to its host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+* feat: report a nested session's input mode and keybindings to its host, so host plugins can show hints for the session the user is actually typing into (https://github.com/zellij-org/zellij/issues/5561)
 
 ## [0.45.1] - 2026-08-28
 * fix: nested-session detection over SSH (https://github.com/zellij-org/zellij/pull/5522)

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -672,7 +672,10 @@ pub async fn run_remote_client_terminal_loop(
                     if reannounce_scheduler.on_tick(std::time::Instant::now()) {
                         let announce = nested_session::NestedSessionMessage::Announce {
                             session_name: session_name.clone(),
-                            capabilities: vec![nested_session::NestedSessionCapability::NestedControl],
+                            capabilities: vec![
+                                nested_session::NestedSessionCapability::NestedControl,
+                                nested_session::NestedSessionCapability::HintReporting,
+                            ],
                         };
                         let mut stdout = os_input.get_stdout_writer();
                         if stdout
@@ -869,7 +872,10 @@ pub fn start_remote_client(
     stdout.write_all(ENABLE_FOCUS_REPORTING.as_bytes()).unwrap();
     let announce = nested_session::NestedSessionMessage::Announce {
         session_name: remote_session_name.clone(),
-        capabilities: vec![nested_session::NestedSessionCapability::NestedControl],
+        capabilities: vec![
+            nested_session::NestedSessionCapability::NestedControl,
+            nested_session::NestedSessionCapability::HintReporting,
+        ],
     };
     stdout
         .write_all(&nested_session::encode_frame(&announce))
@@ -1187,7 +1193,10 @@ pub fn start_client(
     stdout.write_all(ENABLE_FOCUS_REPORTING.as_bytes()).unwrap();
     let announce = nested_session::NestedSessionMessage::Announce {
         session_name: own_session_name.clone(),
-        capabilities: vec![nested_session::NestedSessionCapability::NestedControl],
+        capabilities: vec![
+            nested_session::NestedSessionCapability::NestedControl,
+            nested_session::NestedSessionCapability::HintReporting,
+        ],
     };
     stdout
         .write_all(&nested_session::encode_frame(&announce))

--- a/zellij-client/src/nested_reannounce.rs
+++ b/zellij-client/src/nested_reannounce.rs
@@ -48,7 +48,10 @@ impl NestedReannounce {
                     }
                     let announce = NestedSessionMessage::Announce {
                         session_name: session_name.clone(),
-                        capabilities: vec![NestedSessionCapability::NestedControl],
+                        capabilities: vec![
+                            NestedSessionCapability::NestedControl,
+                            NestedSessionCapability::HintReporting,
+                        ],
                     };
                     let mut stdout = os_input.get_stdout_writer();
                     if stdout

--- a/zellij-integration-tests/tests/nested_hint_reporting.rs
+++ b/zellij-integration-tests/tests/nested_hint_reporting.rs
@@ -66,8 +66,16 @@ fn the_guest_answers_a_keybinding_request_with_its_table_and_current_mode() {
     );
     nested.guest_to_host().wait_for_after(
         since,
-        "the guest to send its current mode alongside the keybinding table",
-        |message| matches!(message, NestedSessionMessage::GuestModeUpdate { .. }),
+        "the guest to send its current mode and base mode alongside the keybinding table",
+        |message| {
+            matches!(
+                message,
+                NestedSessionMessage::GuestModeUpdate {
+                    base_mode: Some(_),
+                    ..
+                }
+            )
+        },
     );
 }
 
@@ -88,7 +96,8 @@ fn the_guest_reports_its_mode_as_the_user_switches_modes_inside_it() {
             matches!(
                 message,
                 NestedSessionMessage::GuestModeUpdate {
-                    mode: InputMode::Pane
+                    mode: InputMode::Pane,
+                    ..
                 }
             )
         },
@@ -103,7 +112,8 @@ fn the_guest_reports_its_mode_as_the_user_switches_modes_inside_it() {
             matches!(
                 message,
                 NestedSessionMessage::GuestModeUpdate {
-                    mode: InputMode::Normal
+                    mode: InputMode::Normal,
+                    ..
                 }
             )
         },

--- a/zellij-integration-tests/tests/nested_hint_reporting.rs
+++ b/zellij-integration-tests/tests/nested_hint_reporting.rs
@@ -40,6 +40,29 @@ fn both_sides_advertise_hint_reporting_during_the_handshake() {
 }
 
 #[test]
+fn the_guest_reports_its_mode_as_soon_as_the_handshake_completes() {
+    let nested = NestedHarness::start(TERMINAL_SIZE);
+    nested.wait_for_guest_to_announce();
+    nested.wait_for_host_to_acknowledge_guest();
+
+    // Nothing has driven the guest yet, so this frame can only be the unprompted report the
+    // guest makes on contact. A host plugin needs it: until one arrives, the host has no way
+    // of knowing which of its panes holds a session it could ask for keybindings.
+    nested.guest_to_host().wait_for(
+        "the guest to report its starting mode without being asked",
+        |message| {
+            matches!(
+                message,
+                NestedSessionMessage::GuestModeUpdate {
+                    mode: InputMode::Normal,
+                    base_mode: Some(_),
+                }
+            )
+        },
+    );
+}
+
+#[test]
 fn the_guest_answers_a_keybinding_request_with_its_table_and_current_mode() {
     let nested = NestedHarness::start(TERMINAL_SIZE);
     nested.wait_for_guest_to_announce();

--- a/zellij-integration-tests/tests/nested_hint_reporting.rs
+++ b/zellij-integration-tests/tests/nested_hint_reporting.rs
@@ -1,0 +1,111 @@
+#![cfg(unix)]
+//! A host session cannot render hints for a guest it knows nothing about. These tests cover
+//! the frames that close that gap: the guest telling its host which input mode it is in, and
+//! the guest answering the host's request for its full keybinding table.
+
+use zellij_integration_tests::keys;
+use zellij_integration_tests::nested::NestedHarness;
+use zellij_utils::data::InputMode;
+use zellij_utils::nested_session::{self, NestedSessionCapability, NestedSessionMessage};
+use zellij_utils::pane_size::Size;
+
+const TERMINAL_SIZE: Size = Size {
+    cols: 121,
+    rows: 30,
+};
+
+#[test]
+fn both_sides_advertise_hint_reporting_during_the_handshake() {
+    let nested = NestedHarness::start(TERMINAL_SIZE);
+    nested.guest_to_host().wait_for(
+        "the guest to advertise that it can report its hints",
+        |message| {
+            matches!(
+                message,
+                NestedSessionMessage::Announce { capabilities, .. }
+                    if capabilities.contains(&NestedSessionCapability::HintReporting)
+            )
+        },
+    );
+    nested.host_to_guest().wait_for(
+        "the host to advertise that it can consume the guest's hints",
+        |message| {
+            matches!(
+                message,
+                NestedSessionMessage::AnnounceAck { capabilities, .. }
+                    if capabilities.contains(&NestedSessionCapability::HintReporting)
+            )
+        },
+    );
+}
+
+#[test]
+fn the_guest_answers_a_keybinding_request_with_its_table_and_current_mode() {
+    let nested = NestedHarness::start(TERMINAL_SIZE);
+    nested.wait_for_guest_to_announce();
+    nested.wait_for_host_to_acknowledge_guest();
+
+    // A plugin in the host would trigger this frame through
+    // PluginCommand::RequestNestedSessionKeybinds; writing it into the guest's stdin puts it
+    // on the same wire the host writes to, without needing a plugin in the test.
+    let since = nested.mark_guest_to_host();
+    nested.guest.send_stdin(&nested_session::encode_frame(
+        &NestedSessionMessage::RequestGuestKeybinds,
+    ));
+
+    nested.guest_to_host().wait_for_after(
+        since,
+        "the guest to answer with a keybinding table that has bindings in it",
+        |message| {
+            matches!(
+                message,
+                NestedSessionMessage::GuestKeybindsUpdate { keybinds }
+                    if keybinds.iter().any(|(_, bindings)| !bindings.is_empty())
+            )
+        },
+    );
+    nested.guest_to_host().wait_for_after(
+        since,
+        "the guest to send its current mode alongside the keybinding table",
+        |message| matches!(message, NestedSessionMessage::GuestModeUpdate { .. }),
+    );
+}
+
+#[test]
+fn the_guest_reports_its_mode_as_the_user_switches_modes_inside_it() {
+    let nested = NestedHarness::start(TERMINAL_SIZE);
+    nested.wait_for_guest_to_announce();
+    nested.wait_for_host_to_acknowledge_guest();
+    nested.descend_into_guest_via_modal();
+    nested.wait_for_host_to_descend_into_guest();
+
+    let since = nested.mark_guest_to_host();
+    nested.host.send_stdin(&keys::ctrl('p'));
+    nested.guest_to_host().wait_for_after(
+        since,
+        "the guest to report that it entered pane mode",
+        |message| {
+            matches!(
+                message,
+                NestedSessionMessage::GuestModeUpdate {
+                    mode: InputMode::Pane
+                }
+            )
+        },
+    );
+
+    let since = nested.mark_guest_to_host();
+    nested.host.send_stdin(&keys::ESC);
+    nested.guest_to_host().wait_for_after(
+        since,
+        "the guest to report that it left pane mode again",
+        |message| {
+            matches!(
+                message,
+                NestedSessionMessage::GuestModeUpdate {
+                    mode: InputMode::Normal
+                }
+            )
+        },
+    );
+}

--- a/zellij-server/src/plugins/wasm_bridge.rs
+++ b/zellij-server/src/plugins/wasm_bridge.rs
@@ -2099,6 +2099,8 @@ fn check_event_permission(
         | Event::SoftKeyboardVisibilityChanged(..)
         | Event::HintText(..)
         | Event::ActivePaneScroll(..)
+        | Event::NestedSessionModeUpdate { .. }
+        | Event::NestedSessionKeybinds { .. }
         | Event::InputReceived => PermissionType::ReadApplicationState,
         Event::WebServerStatus(..) => PermissionType::StartWebServer,
         Event::PaneRenderReport(..) => PermissionType::ReadPaneContents,

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -338,6 +338,9 @@ fn host_run_plugin_command(mut caller: Caller<'_, PluginEnv>) {
                     PluginCommand::ToggleFocusFullscreen => toggle_focus_fullscreen(env),
                     PluginCommand::ToggleFocusNoUiFullscreen => toggle_focus_no_ui_fullscreen(env),
                     PluginCommand::FocusHostSession => focus_host_session(env),
+                    PluginCommand::RequestNestedSessionKeybinds(pane_id) => {
+                        request_nested_session_keybinds(env, pane_id.into())
+                    },
                     PluginCommand::TogglePaneFrames => toggle_pane_frames(env),
                     PluginCommand::SetPaneFrameStyle(pane_frame_style) => {
                         set_pane_frame_style(env, pane_frame_style)
@@ -3161,6 +3164,18 @@ fn focus_host_session(env: &PluginEnv) {
         .non_fatal();
 }
 
+fn request_nested_session_keybinds(env: &PluginEnv, pane_id: PaneId) {
+    env.senders
+        .send_to_screen(ScreenInstruction::RequestNestedSessionKeybinds(pane_id))
+        .with_context(|| {
+            format!(
+                "failed to request nested session keybindings from plugin {}",
+                env.name()
+            )
+        })
+        .non_fatal();
+}
+
 fn toggle_pane_frames(env: &PluginEnv) {
     let error_msg = || format!("failed to toggle full screen in plugin {}", env.name());
     let action = Action::TogglePaneFrames;
@@ -5595,6 +5610,7 @@ fn check_command_permission(
         | PluginCommand::CurrentSessionLastSavedTime
         | PluginCommand::GetPaneInfo(..)
         | PluginCommand::GetTabInfo(..)
+        | PluginCommand::RequestNestedSessionKeybinds(..)
         | PluginCommand::GetSessionList => PermissionType::ReadApplicationState,
         PluginCommand::RebindKeys { .. } | PluginCommand::Reconfigure(..) => {
             PermissionType::Reconfigure

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -2815,6 +2815,14 @@ pub(crate) fn route_thread_main(
                                         retry_queue
                                     );
                                 },
+                                Some(message @ zellij_utils::nested_session::NestedSessionMessage::RequestGuestKeybinds) => {
+                                    let _ = send_to_screen_or_retry_queue!(
+                                        senders,
+                                        ScreenInstruction::NestedSessionMessageFromHost { client_id, message },
+                                        instruction,
+                                        retry_queue
+                                    );
+                                },
                                 Some(message @ zellij_utils::nested_session::NestedSessionMessage::AncestryUpdate { .. }) => {
                                     let _ = send_to_screen_or_retry_queue!(
                                         senders,

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -4105,6 +4105,12 @@ impl Screen {
                 let _ = self.bus.senders.send_to_server(
                     ServerInstruction::EmitNestedSessionFrameToClient(client_id, payload),
                 );
+                // Report the mode we are already in rather than waiting for the first mode
+                // change. Without this the host would have no idea we exist until the user
+                // happened to switch modes inside us, and a host plugin that wants our
+                // keybindings would have nothing to ask about.
+                let (current_mode, base_mode) = self.current_mode_for_client(client_id);
+                self.report_mode_to_host(client_id, current_mode, base_mode);
             },
             NestedSessionMessage::ShortcutUpdate { descend_keys, .. } => {
                 if self.host_descend_keys != descend_keys {
@@ -4123,14 +4129,7 @@ impl Screen {
                 );
                 // The host asked because it is about to render our hints, so send the current
                 // mode too rather than making it wait for the next mode change.
-                let (current_mode, base_mode) = self
-                    .mode_info
-                    .get(&client_id)
-                    .map(|mode_info| (mode_info.mode, mode_info.base_mode))
-                    .unwrap_or((
-                        self.default_mode_info.mode,
-                        self.default_mode_info.base_mode,
-                    ));
+                let (current_mode, base_mode) = self.current_mode_for_client(client_id);
                 self.report_mode_to_host(client_id, current_mode, base_mode);
             },
             NestedSessionMessage::FullscreenState { fullscreen } => {
@@ -6189,6 +6188,18 @@ impl Screen {
         }
         self.report_mode_to_host(client_id, mode_info.mode, mode_info.base_mode);
         Ok(())
+    }
+
+    /// The input mode and base mode a client is in, falling back to the configured defaults
+    /// for a client that has not been given a mode of its own yet.
+    fn current_mode_for_client(&self, client_id: ClientId) -> (InputMode, Option<InputMode>) {
+        self.mode_info
+            .get(&client_id)
+            .map(|mode_info| (mode_info.mode, mode_info.base_mode))
+            .unwrap_or((
+                self.default_mode_info.mode,
+                self.default_mode_info.base_mode,
+            ))
     }
 
     /// While this session runs nested inside a host, tell the host about our input mode.

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -573,6 +573,7 @@ pub enum ScreenInstruction {
         client_id: ClientId,
         message: NestedSessionMessage,
     },
+    RequestNestedSessionKeybinds(PaneId),
     GuestModalChoice {
         client_id: ClientId,
         pane_id: PaneId,
@@ -1114,6 +1115,9 @@ impl From<&ScreenInstruction> for ScreenContext {
             ScreenInstruction::NestedSessionMessageFromHost { .. } => {
                 ScreenContext::NestedSessionMessageFromHost
             },
+            ScreenInstruction::RequestNestedSessionKeybinds(..) => {
+                ScreenContext::RequestNestedSessionKeybinds
+            },
             ScreenInstruction::GuestModalChoice { .. } => ScreenContext::GuestModalChoice,
             ScreenInstruction::ForwardedReplyFromHost { .. } => {
                 ScreenContext::ForwardedReplyFromHost
@@ -1615,6 +1619,9 @@ pub(crate) struct Screen {
     dimmed_clients: HashSet<ClientId>,
     nested_guest_choices: HashMap<(ClientId, PaneId), NestedGuestChoice>,
     guest_ascend_keys: HashMap<PaneId, Vec<KeyWithModifier>>,
+    /// What each nested guest said it can do when it announced itself, so this session
+    /// does not ask a guest for something it cannot answer.
+    guest_capabilities: HashMap<PaneId, Vec<NestedSessionCapability>>,
     host_descend_keys: Vec<KeyWithModifier>,
     host_descended: bool,
     host_terminal_theme_mode: Option<HostTerminalThemeMode>,
@@ -1822,6 +1829,7 @@ impl Screen {
             dimmed_clients: HashSet::new(),
             nested_guest_choices: HashMap::new(),
             guest_ascend_keys: HashMap::new(),
+            guest_capabilities: HashMap::new(),
             host_descend_keys: vec![],
             host_descended: false,
             host_terminal_theme_mode: None,
@@ -3109,8 +3117,11 @@ impl Screen {
         message: NestedSessionMessage,
     ) {
         match message {
-            NestedSessionMessage::Announce { session_name, .. } => {
-                self.handle_nested_guest_announce(pane_id, session_name);
+            NestedSessionMessage::Announce {
+                session_name,
+                capabilities,
+            } => {
+                self.handle_nested_guest_announce(pane_id, session_name, capabilities);
             },
             NestedSessionMessage::Pong => {
                 self.nested_guest_tracker.on_pong(pane_id, Instant::now());
@@ -3180,6 +3191,50 @@ impl Screen {
                 self.guest_ascend_keys.insert(pane_id, ascend_keys);
                 self.refresh_nested_ascend_keys_for_pane(pane_id);
             },
+            NestedSessionMessage::GuestModeUpdate { mode } => {
+                if !self.nested_guest_tracker.is_tracked(pane_id) {
+                    log::debug!(
+                        "ignoring nested mode update from non-live guest pane {:?}",
+                        pane_id
+                    );
+                    return;
+                }
+                let session_name = self.guest_session_name_on_pane(pane_id);
+                let _ = self
+                    .bus
+                    .senders
+                    .send_to_plugin(PluginInstruction::Update(vec![(
+                        None,
+                        None,
+                        Event::NestedSessionModeUpdate {
+                            pane_id: pane_id.into(),
+                            session_name,
+                            mode,
+                        },
+                    )]));
+            },
+            NestedSessionMessage::GuestKeybindsUpdate { keybinds } => {
+                if !self.nested_guest_tracker.is_tracked(pane_id) {
+                    log::debug!(
+                        "ignoring nested keybinding update from non-live guest pane {:?}",
+                        pane_id
+                    );
+                    return;
+                }
+                let session_name = self.guest_session_name_on_pane(pane_id);
+                let _ = self
+                    .bus
+                    .senders
+                    .send_to_plugin(PluginInstruction::Update(vec![(
+                        None,
+                        None,
+                        Event::NestedSessionKeybinds {
+                            pane_id: pane_id.into(),
+                            session_name,
+                            keybinds,
+                        },
+                    )]));
+            },
             NestedSessionMessage::ToggleHostFullscreen { fullscreen } => {
                 if !self.nested_guest_tracker.is_tracked(pane_id) {
                     log::debug!(
@@ -3210,7 +3265,59 @@ impl Screen {
         }
     }
 
-    fn handle_nested_guest_announce(&mut self, pane_id: PaneId, guest_session_name: String) {
+    fn guest_session_name_on_pane(&self, pane_id: PaneId) -> Option<String> {
+        self.tabs
+            .values()
+            .find(|tab| tab.has_pane_with_pid(&pane_id))
+            .and_then(|tab| tab.guest_session_name_on_pane(pane_id))
+    }
+
+    /// Ask the nested guest running in `pane_id` to report its full keybinding table.
+    ///
+    /// The guest answers asynchronously with a `GuestKeybindsUpdate` frame, which arrives back
+    /// here and is forwarded to plugins as `Event::NestedSessionKeybinds`. Guests that did not
+    /// advertise the `HintReporting` capability cannot answer, so we skip them rather than
+    /// writing a frame they would ignore.
+    pub fn request_nested_session_keybinds(&mut self, pane_id: PaneId) {
+        let terminal_id = match pane_id {
+            PaneId::Terminal(terminal_id) => terminal_id,
+            PaneId::Plugin(_) => return,
+        };
+        if !self.nested_guest_tracker.is_tracked(pane_id) {
+            log::debug!(
+                "ignoring keybinding request for non-live guest pane {:?}",
+                pane_id
+            );
+            return;
+        }
+        let guest_supports_hint_reporting = self
+            .guest_capabilities
+            .get(&pane_id)
+            .map(|capabilities| capabilities.contains(&NestedSessionCapability::HintReporting))
+            .unwrap_or(false);
+        if !guest_supports_hint_reporting {
+            log::debug!(
+                "nested guest in pane {:?} does not report hints, dropping keybinding request",
+                pane_id
+            );
+            return;
+        }
+        let _ = self
+            .bus
+            .senders
+            .send_to_pty_writer(PtyWriteInstruction::Write(
+                nested_session::encode_frame(&NestedSessionMessage::RequestGuestKeybinds),
+                terminal_id,
+                None,
+            ));
+    }
+
+    fn handle_nested_guest_announce(
+        &mut self,
+        pane_id: PaneId,
+        guest_session_name: String,
+        guest_capabilities: Vec<NestedSessionCapability>,
+    ) {
         use crate::nested_guest::AnnounceKind;
         let terminal_id = match pane_id {
             PaneId::Terminal(terminal_id) => terminal_id,
@@ -3248,11 +3355,15 @@ impl Screen {
                 return;
             },
         }
+        self.guest_capabilities.insert(pane_id, guest_capabilities);
         let mut ancestry = self.nested_ancestry.clone();
         ancestry.push(self.session_name.clone());
         let announce_ack = NestedSessionMessage::AnnounceAck {
             ancestry,
-            capabilities: vec![NestedSessionCapability::NestedControl],
+            capabilities: vec![
+                NestedSessionCapability::NestedControl,
+                NestedSessionCapability::HintReporting,
+            ],
             descend_keys: self.own_descend_shortcut(),
         };
         let _ = self
@@ -3450,6 +3561,7 @@ impl Screen {
     pub fn clear_nested_guest(&mut self, pane_id: PaneId) {
         self.nested_guest_tracker.remove(pane_id);
         self.guest_ascend_keys.remove(&pane_id);
+        self.guest_capabilities.remove(&pane_id);
         let _ = self
             .bus
             .senders
@@ -3998,6 +4110,24 @@ impl Screen {
                     self.host_descend_keys = descend_keys;
                     self.update_all_clients_nesting_mode_info();
                 }
+            },
+            NestedSessionMessage::RequestGuestKeybinds => {
+                let keybinds = self.default_mode_info.keybinds.clone();
+                let payload =
+                    nested_session::encode_payload(&NestedSessionMessage::GuestKeybindsUpdate {
+                        keybinds,
+                    });
+                let _ = self.bus.senders.send_to_server(
+                    ServerInstruction::EmitNestedSessionFrameToClient(client_id, payload),
+                );
+                // The host asked because it is about to render our hints, so send the current
+                // mode too rather than making it wait for the next mode change.
+                let current_mode = self
+                    .mode_info
+                    .get(&client_id)
+                    .map(|mode_info| mode_info.mode)
+                    .unwrap_or(self.default_mode_info.mode);
+                self.report_mode_to_host(client_id, current_mode);
             },
             NestedSessionMessage::FullscreenState { fullscreen } => {
                 self.host_fullscreen = fullscreen;
@@ -6053,7 +6183,27 @@ impl Screen {
                 .send_to_plugin(PluginInstruction::Update(bg_updates))
                 .context("failed to update background plugins with mode info")?;
         }
+        self.report_mode_to_host(client_id, mode_info.mode);
         Ok(())
+    }
+
+    /// While this session runs nested inside a host, tell the host about our input mode.
+    ///
+    /// Host plugins use this to render the hints of the session the user is actually driving.
+    /// The update is sent on every mode change rather than only while the host is descended
+    /// into us, so the host already knows the right mode the moment focus arrives.
+    fn report_mode_to_host(&mut self, client_id: ClientId, mode: InputMode) {
+        if self.nested_via_client_id != Some(client_id) {
+            return;
+        }
+        let payload =
+            nested_session::encode_payload(&NestedSessionMessage::GuestModeUpdate { mode });
+        let _ = self
+            .bus
+            .senders
+            .send_to_server(ServerInstruction::EmitNestedSessionFrameToClient(
+                client_id, payload,
+            ));
     }
     // Keep the client's mode in sync with the pane it just focused: entering a scrolled
     // pane switches to Scroll so its position is navigable, leaving it returns to the
@@ -10087,6 +10237,9 @@ pub(crate) fn screen_thread_main(
             },
             ScreenInstruction::NestedSessionMessageFromHost { client_id, message } => {
                 screen.handle_nested_session_message_from_host(client_id, message);
+            },
+            ScreenInstruction::RequestNestedSessionKeybinds(pane_id) => {
+                screen.request_nested_session_keybinds(pane_id);
             },
             ScreenInstruction::GuestModalChoice {
                 client_id,

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -41,10 +41,10 @@ use crate::route::NotificationEnd;
 use log::{debug, warn};
 use zellij_utils::data::{
     CommandOrPlugin, Direction, EventType, FloatingPaneCoordinates, GetFocusedPaneInfoResponse,
-    HostTerminalThemeMode, KeyWithModifier, LayoutInfo, LayoutWithError, ListPanesResponse,
-    ListTabsResponse, NewPanePlacement, PaneContents, PaneInfo, PaneListEntry, PaneManifest,
-    PaneRenderReport, PaneScrollbackResponse, PluginPermission, RegexHighlight, Resize,
-    ResizeStrategy, SessionInfo, Styling, TabInfo, ThemeHue, WebSharing,
+    HostTerminalThemeMode, KeyWithModifier, KeybindsVec, LayoutInfo, LayoutWithError,
+    ListPanesResponse, ListTabsResponse, NewPanePlacement, PaneContents, PaneInfo, PaneListEntry,
+    PaneManifest, PaneRenderReport, PaneScrollbackResponse, PluginPermission, RegexHighlight,
+    Resize, ResizeStrategy, SessionInfo, Styling, TabInfo, ThemeHue, WebSharing,
 };
 use zellij_utils::errors::prelude::*;
 use zellij_utils::input::actions::Action;
@@ -4119,14 +4119,7 @@ impl Screen {
                 }
             },
             NestedSessionMessage::RequestGuestKeybinds => {
-                let keybinds = self.default_mode_info.keybinds.clone();
-                let payload =
-                    nested_session::encode_payload(&NestedSessionMessage::GuestKeybindsUpdate {
-                        keybinds,
-                    });
-                let _ = self.bus.senders.send_to_server(
-                    ServerInstruction::EmitNestedSessionFrameToClient(client_id, payload),
-                );
+                self.report_keybinds_to_host(client_id);
                 // The host asked because it is about to render our hints, so send the current
                 // mode too rather than making it wait for the next mode change.
                 let (current_mode, base_mode) = self.current_mode_for_client(client_id);
@@ -6202,6 +6195,38 @@ impl Screen {
             ))
     }
 
+    /// The keybindings a client is typing against, falling back to the configured defaults
+    /// for a client that has not been given a table of its own yet.
+    ///
+    /// A client can carry its own table: `reconfigure` with `write_to_disk` unset rebinds
+    /// only the client that asked for it, leaving the rest of the session on the defaults.
+    fn keybinds_for_client(&self, client_id: ClientId) -> KeybindsVec {
+        self.mode_info
+            .get(&client_id)
+            .map(|mode_info| mode_info.keybinds.clone())
+            .unwrap_or_else(|| self.default_mode_info.keybinds.clone())
+    }
+
+    /// While this session runs nested inside a host, tell the host what we are bound to.
+    ///
+    /// Sent in answer to a host's request, and again whenever a reconfigure rewrites the
+    /// table, since a host that has already been told once has no way of noticing that the
+    /// bindings it is drawing have gone stale.
+    fn report_keybinds_to_host(&mut self, client_id: ClientId) {
+        if self.nested_via_client_id != Some(client_id) {
+            return;
+        }
+        let payload = nested_session::encode_payload(&NestedSessionMessage::GuestKeybindsUpdate {
+            keybinds: self.keybinds_for_client(client_id),
+        });
+        let _ = self
+            .bus
+            .senders
+            .send_to_server(ServerInstruction::EmitNestedSessionFrameToClient(
+                client_id, payload,
+            ));
+    }
+
     /// While this session runs nested inside a host, tell the host about our input mode.
     ///
     /// Host plugins use this to render the hints of the session the user is actually driving.
@@ -7137,6 +7162,12 @@ impl Screen {
             tab.update_input_modes()?;
         }
         self.broadcast_nested_shortcuts();
+        // A reconfigure rewrites the keybindings and the base mode without going through
+        // `change_mode`, so a host that is drawing our hints would otherwise keep drawing
+        // the table we had before the config was reloaded.
+        let (current_mode, base_mode) = self.current_mode_for_client(client_id);
+        self.report_mode_to_host(client_id, current_mode, base_mode);
+        self.report_keybinds_to_host(client_id);
         Ok(())
     }
     pub fn update_host_terminal_theme_mode(&mut self, mode: HostTerminalThemeMode) -> Result<()> {

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -3191,7 +3191,7 @@ impl Screen {
                 self.guest_ascend_keys.insert(pane_id, ascend_keys);
                 self.refresh_nested_ascend_keys_for_pane(pane_id);
             },
-            NestedSessionMessage::GuestModeUpdate { mode } => {
+            NestedSessionMessage::GuestModeUpdate { mode, base_mode } => {
                 if !self.nested_guest_tracker.is_tracked(pane_id) {
                     log::debug!(
                         "ignoring nested mode update from non-live guest pane {:?}",
@@ -3210,6 +3210,7 @@ impl Screen {
                             pane_id: pane_id.into(),
                             session_name,
                             mode,
+                            base_mode,
                         },
                     )]));
             },
@@ -4122,12 +4123,15 @@ impl Screen {
                 );
                 // The host asked because it is about to render our hints, so send the current
                 // mode too rather than making it wait for the next mode change.
-                let current_mode = self
+                let (current_mode, base_mode) = self
                     .mode_info
                     .get(&client_id)
-                    .map(|mode_info| mode_info.mode)
-                    .unwrap_or(self.default_mode_info.mode);
-                self.report_mode_to_host(client_id, current_mode);
+                    .map(|mode_info| (mode_info.mode, mode_info.base_mode))
+                    .unwrap_or((
+                        self.default_mode_info.mode,
+                        self.default_mode_info.base_mode,
+                    ));
+                self.report_mode_to_host(client_id, current_mode, base_mode);
             },
             NestedSessionMessage::FullscreenState { fullscreen } => {
                 self.host_fullscreen = fullscreen;
@@ -6183,7 +6187,7 @@ impl Screen {
                 .send_to_plugin(PluginInstruction::Update(bg_updates))
                 .context("failed to update background plugins with mode info")?;
         }
-        self.report_mode_to_host(client_id, mode_info.mode);
+        self.report_mode_to_host(client_id, mode_info.mode, mode_info.base_mode);
         Ok(())
     }
 
@@ -6192,12 +6196,24 @@ impl Screen {
     /// Host plugins use this to render the hints of the session the user is actually driving.
     /// The update is sent on every mode change rather than only while the host is descended
     /// into us, so the host already knows the right mode the moment focus arrives.
-    fn report_mode_to_host(&mut self, client_id: ClientId, mode: InputMode) {
+    fn report_mode_to_host(
+        &mut self,
+        client_id: ClientId,
+        mode: InputMode,
+        base_mode: Option<InputMode>,
+    ) {
         if self.nested_via_client_id != Some(client_id) {
             return;
         }
-        let payload =
-            nested_session::encode_payload(&NestedSessionMessage::GuestModeUpdate { mode });
+        // A client that has not switched modes yet carries no base mode of its own, so fall
+        // back the way the rest of Screen does: the configured default mode is the base.
+        let base_mode = base_mode
+            .or(self.default_mode_info.base_mode)
+            .unwrap_or(self.default_mode_info.mode);
+        let payload = nested_session::encode_payload(&NestedSessionMessage::GuestModeUpdate {
+            mode,
+            base_mode: Some(base_mode),
+        });
         let _ = self
             .bus
             .senders

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -4086,6 +4086,18 @@ impl Tab {
             pane.set_guest_session_name(session_name);
         }
     }
+    pub fn guest_session_name_on_pane(&self, pane_id: PaneId) -> Option<String> {
+        self.tiled_panes
+            .get_pane(pane_id)
+            .or_else(|| self.floating_panes.get_pane(pane_id))
+            .or_else(|| {
+                self.suppressed_panes
+                    .values()
+                    .find(|s_p| s_p.1.pid() == pane_id)
+                    .map(|s_p| &s_p.1)
+            })
+            .and_then(|pane| pane.guest_session_name())
+    }
     pub fn set_guest_modal_shortcuts_on_pane(
         &mut self,
         pane_id: PaneId,

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -11229,7 +11229,8 @@ pub fn nested_guest_announce_gets_announce_ack_with_ancestry() {
         zellij_utils::nested_session::NestedSessionMessage::AnnounceAck {
             ancestry: vec!["zellij-test".to_owned()],
             capabilities: vec![
-                zellij_utils::nested_session::NestedSessionCapability::NestedControl
+                zellij_utils::nested_session::NestedSessionCapability::NestedControl,
+                zellij_utils::nested_session::NestedSessionCapability::HintReporting
             ],
             descend_keys: vec![],
         }

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -1305,6 +1305,23 @@ pub fn focus_host_session() {
     unsafe { host_run_plugin_command() };
 }
 
+/// Ask the nested session running in `pane_id` for its keybindings.
+///
+/// The answer arrives as an [`Event::NestedSessionKeybinds`], so subscribe to that event
+/// before asking. A nested session running a Zellij too old to report its keybindings
+/// never answers, so treat the bindings as unavailable until the event arrives rather
+/// than waiting on it.
+///
+/// Requires the `ReadApplicationState` permission.
+///
+/// [`Event::NestedSessionKeybinds`]: zellij_utils::data::Event::NestedSessionKeybinds
+pub fn request_nested_session_keybinds(pane_id: PaneId) {
+    let plugin_command = PluginCommand::RequestNestedSessionKeybinds(pane_id);
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
 /// Toggle the UI pane frames on or off
 pub fn toggle_pane_frames() {
     let plugin_command = PluginCommand::TogglePaneFrames;

--- a/zellij-utils/assets/prost/api.event.rs
+++ b/zellij-utils/assets/prost/api.event.rs
@@ -10,7 +10,7 @@ pub struct EventNameList {
 pub struct Event {
     #[prost(enumeration="EventType", tag="1")]
     pub name: i32,
-    #[prost(oneof="event::Payload", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 38, 39, 40, 41, 42, 43")]
+    #[prost(oneof="event::Payload", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 38, 39, 40, 41, 42, 43, 44, 45")]
     pub payload: ::core::option::Option<event::Payload>,
 }
 /// Nested message and enum types in `Event`.
@@ -100,7 +100,31 @@ pub mod event {
         HintTextPayload(super::HintTextPayload),
         #[prost(message, tag="43")]
         ActivePaneScrollPayload(super::ActivePaneScrollPayload),
+        #[prost(message, tag="44")]
+        NestedSessionModeUpdatePayload(super::NestedSessionModeUpdatePayload),
+        #[prost(message, tag="45")]
+        NestedSessionKeybindsPayload(super::NestedSessionKeybindsPayload),
     }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NestedSessionModeUpdatePayload {
+    #[prost(message, optional, tag="1")]
+    pub pane_id: ::core::option::Option<PaneId>,
+    #[prost(string, optional, tag="2")]
+    pub session_name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(enumeration="super::input_mode::InputMode", tag="3")]
+    pub mode: i32,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NestedSessionKeybindsPayload {
+    #[prost(message, optional, tag="1")]
+    pub pane_id: ::core::option::Option<PaneId>,
+    #[prost(string, optional, tag="2")]
+    pub session_name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, repeated, tag="3")]
+    pub keybinds: ::prost::alloc::vec::Vec<InputModeKeybinds>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -896,6 +920,8 @@ pub enum EventType {
     SoftKeyboardVisibilityChanged = 47,
     HintText = 48,
     ActivePaneScroll = 49,
+    NestedSessionModeUpdate = 50,
+    NestedSessionKeybinds = 51,
 }
 impl EventType {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -952,6 +978,8 @@ impl EventType {
             EventType::SoftKeyboardVisibilityChanged => "SoftKeyboardVisibilityChanged",
             EventType::HintText => "HintText",
             EventType::ActivePaneScroll => "ActivePaneScroll",
+            EventType::NestedSessionModeUpdate => "NestedSessionModeUpdate",
+            EventType::NestedSessionKeybinds => "NestedSessionKeybinds",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -1005,6 +1033,8 @@ impl EventType {
             "SoftKeyboardVisibilityChanged" => Some(Self::SoftKeyboardVisibilityChanged),
             "HintText" => Some(Self::HintText),
             "ActivePaneScroll" => Some(Self::ActivePaneScroll),
+            "NestedSessionModeUpdate" => Some(Self::NestedSessionModeUpdate),
+            "NestedSessionKeybinds" => Some(Self::NestedSessionKeybinds),
             _ => None,
         }
     }

--- a/zellij-utils/assets/prost/api.event.rs
+++ b/zellij-utils/assets/prost/api.event.rs
@@ -115,6 +115,8 @@ pub struct NestedSessionModeUpdatePayload {
     pub session_name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(enumeration="super::input_mode::InputMode", tag="3")]
     pub mode: i32,
+    #[prost(enumeration="super::input_mode::InputMode", optional, tag="4")]
+    pub base_mode: ::core::option::Option<i32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/zellij-utils/assets/prost/api.plugin_command.rs
+++ b/zellij-utils/assets/prost/api.plugin_command.rs
@@ -4,7 +4,7 @@
 pub struct PluginCommand {
     #[prost(enumeration="CommandName", tag="1")]
     pub name: i32,
-    #[prost(oneof="plugin_command::Payload", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 168, 169, 170, 171")]
+    #[prost(oneof="plugin_command::Payload", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 168, 169, 170, 171, 172")]
     pub payload: ::core::option::Option<plugin_command::Payload>,
 }
 /// Nested message and enum types in `PluginCommand`.
@@ -320,7 +320,15 @@ pub mod plugin_command {
         SetPaneFrameStylePayload(super::SetPaneFrameStylePayload),
         #[prost(message, tag="171")]
         ToggleFloatingPanesPayload(super::ToggleFloatingPanesPayload),
+        #[prost(message, tag="172")]
+        RequestNestedSessionKeybindsPayload(super::RequestNestedSessionKeybindsPayload),
     }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RequestNestedSessionKeybindsPayload {
+    #[prost(message, optional, tag="1")]
+    pub pane_id: ::core::option::Option<PaneId>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2227,6 +2235,7 @@ pub enum CommandName {
     NewPane = 226,
     ToggleFocusNoUiFullscreen = 227,
     FocusHostSession = 228,
+    RequestNestedSessionKeybinds = 229,
 }
 impl CommandName {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -2438,6 +2447,7 @@ impl CommandName {
             CommandName::NewPane => "NewPane",
             CommandName::ToggleFocusNoUiFullscreen => "ToggleFocusNoUiFullscreen",
             CommandName::FocusHostSession => "FocusHostSession",
+            CommandName::RequestNestedSessionKeybinds => "RequestNestedSessionKeybinds",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -2646,6 +2656,7 @@ impl CommandName {
             "NewPane" => Some(Self::NewPane),
             "ToggleFocusNoUiFullscreen" => Some(Self::ToggleFocusNoUiFullscreen),
             "FocusHostSession" => Some(Self::FocusHostSession),
+            "RequestNestedSessionKeybinds" => Some(Self::RequestNestedSessionKeybinds),
             _ => None,
         }
     }

--- a/zellij-utils/assets/prost_nested_session/nested_session_contract.rs
+++ b/zellij-utils/assets/prost_nested_session/nested_session_contract.rs
@@ -115,12 +115,17 @@ pub struct AncestryUpdate {
 pub struct Ping {
 }
 /// Sent by a guest to its host whenever the guest's input mode changes, so the host
-/// knows which of the guest's keybindings currently apply.
+/// knows which of the guest's keybindings currently apply. `base_mode` is the mode the
+/// guest returns to, empty when the guest does not report one; a host needs it to tell
+/// which of the guest's bindings are inherited from its base mode rather than specific to
+/// the mode it is in now.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GuestModeUpdate {
     #[prost(string, tag="1")]
     pub mode: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub base_mode: ::prost::alloc::string::String,
 }
 /// Sent by a host to ask a guest for its full keybinding table.
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/zellij-utils/assets/prost_nested_session/nested_session_contract.rs
+++ b/zellij-utils/assets/prost_nested_session/nested_session_contract.rs
@@ -2,7 +2,7 @@
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NestedSessionMessage {
-    #[prost(oneof="nested_session_message::Payload", tags="1, 2, 3, 4, 5, 8, 9, 10, 11, 12, 13, 14")]
+    #[prost(oneof="nested_session_message::Payload", tags="1, 2, 3, 4, 5, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17")]
     pub payload: ::core::option::Option<nested_session_message::Payload>,
 }
 /// Nested message and enum types in `NestedSessionMessage`.
@@ -34,6 +34,12 @@ pub mod nested_session_message {
         Ping(super::Ping),
         #[prost(message, tag="14")]
         ShortcutUpdate(super::ShortcutUpdate),
+        #[prost(message, tag="15")]
+        GuestModeUpdate(super::GuestModeUpdate),
+        #[prost(message, tag="16")]
+        RequestGuestKeybinds(super::RequestGuestKeybinds),
+        #[prost(message, tag="17")]
+        GuestKeybindsUpdate(super::GuestKeybindsUpdate),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -108,11 +114,39 @@ pub struct AncestryUpdate {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Ping {
 }
+/// Sent by a guest to its host whenever the guest's input mode changes, so the host
+/// knows which of the guest's keybindings currently apply.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GuestModeUpdate {
+    #[prost(string, tag="1")]
+    pub mode: ::prost::alloc::string::String,
+}
+/// Sent by a host to ask a guest for its full keybinding table.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RequestGuestKeybinds {
+}
+/// A guest's answer to RequestGuestKeybinds.
+///
+/// The table is carried as an encoded plugin-API `InitialKeybindsPayload` rather than
+/// being redescribed here, because describing keybindings natively would mean pulling the
+/// whole `Action` schema into this contract. Protobuf's unknown-field and unknown-enum
+/// handling means a host and a guest built from different Zellij versions still exchange
+/// everything they both understand.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GuestKeybindsUpdate {
+    #[prost(bytes="vec", tag="1")]
+    pub keybinds_payload: ::prost::alloc::vec::Vec<u8>,
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum NestedCapability {
     Unspecified = 0,
     NestedControl = 1,
+    /// The peer can report its input mode and keybindings to its host.
+    HintReporting = 2,
 }
 impl NestedCapability {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -123,6 +157,7 @@ impl NestedCapability {
         match self {
             NestedCapability::Unspecified => "NESTED_CAPABILITY_UNSPECIFIED",
             NestedCapability::NestedControl => "NESTED_CAPABILITY_NESTED_CONTROL",
+            NestedCapability::HintReporting => "NESTED_CAPABILITY_HINT_REPORTING",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -130,6 +165,7 @@ impl NestedCapability {
         match value {
             "NESTED_CAPABILITY_UNSPECIFIED" => Some(Self::Unspecified),
             "NESTED_CAPABILITY_NESTED_CONTROL" => Some(Self::NestedControl),
+            "NESTED_CAPABILITY_HINT_REPORTING" => Some(Self::HintReporting),
             _ => None,
         }
     }

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -1040,6 +1040,27 @@ pub enum Event {
     SoftKeyboardVisibilityChanged(bool),
     HintText(BTreeMap<usize, StyledText>),
     ActivePaneScroll(Option<(usize, usize)>),
+    /// The current input mode of a nested session running inside one of this session's
+    /// panes, sent whenever that mode changes.
+    ///
+    /// `pane_id` is the pane hosting the nested session, and `session_name` is that
+    /// session's own name when it has announced one. Together they let a plugin tell
+    /// several nested sessions apart.
+    NestedSessionModeUpdate {
+        pane_id: PaneId,
+        session_name: Option<String>,
+        mode: InputMode,
+    },
+    /// The keybindings of a nested session running inside one of this session's panes,
+    /// sent in answer to [`PluginCommand::RequestNestedSessionKeybinds`].
+    ///
+    /// Bindings that this session's build cannot represent are omitted, so a nested
+    /// session running a different Zellij version reports what both sides understand.
+    NestedSessionKeybinds {
+        pane_id: PaneId,
+        session_name: Option<String>,
+        keybinds: KeybindsVec,
+    },
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -3690,6 +3711,12 @@ pub enum PluginCommand {
     DeleteAllDeadSessionsAndReply,     // no payload; sends a response back
     SetSoftKeyboard(bool),
     FocusHostSession,
+    /// Ask the nested session running in the given pane for its keybindings.
+    ///
+    /// The answer arrives as an [`Event::NestedSessionKeybinds`]. A nested session running
+    /// a Zellij too old to report them does not answer, so a plugin should treat the
+    /// bindings as unavailable until the event arrives rather than waiting on it.
+    RequestNestedSessionKeybinds(PaneId),
 }
 
 // Response type for plugin API methods that open a pane in a new tab

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -1050,6 +1050,10 @@ pub enum Event {
         pane_id: PaneId,
         session_name: Option<String>,
         mode: InputMode,
+        /// The mode the nested session returns to, when it reports one. A plugin needs it
+        /// to tell which of that session's bindings are inherited from its base mode
+        /// rather than specific to the mode it is in now.
+        base_mode: Option<InputMode>,
     },
     /// The keybindings of a nested session running inside one of this session's panes,
     /// sent in answer to [`PluginCommand::RequestNestedSessionKeybinds`].

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -324,6 +324,7 @@ pub enum ScreenContext {
     NestedSessionMessageFromPane,
     NestedGuestPingTick,
     NestedSessionMessageFromHost,
+    RequestNestedSessionKeybinds,
     GuestModalChoice,
     ForwardedReplyFromHost,
     ResumePaneAfterForward,

--- a/zellij-utils/src/nested_session.rs
+++ b/zellij-utils/src/nested_session.rs
@@ -1,4 +1,4 @@
-use crate::data::{Direction, InputMode, KeyWithModifier, KeybindsVec};
+use crate::data::{BareKey, Direction, InputMode, KeyWithModifier, KeybindsVec};
 use crate::nested_session_contract::nested_session_contract as proto;
 use crate::plugin_api::event::{keybinds_from_protobuf, keybinds_to_protobuf};
 use crate::plugin_api::generated_api::api::event::InitialKeybindsPayload as ProtobufInitialKeybindsPayload;
@@ -220,7 +220,24 @@ fn keybinds_to_proto(keybinds: KeybindsVec) -> Vec<u8> {
 
 fn keybinds_from_proto(payload_bytes: &[u8]) -> Option<KeybindsVec> {
     let payload = ProtobufInitialKeybindsPayload::decode(payload_bytes).ok()?;
-    Some(keybinds_from_protobuf(payload.keybinds))
+    let mut keybinds = keybinds_from_protobuf(payload.keybinds);
+    for (_mode, bindings) in keybinds.iter_mut() {
+        bindings.retain(|(key, _actions)| !binds_a_control_character(key));
+    }
+    Some(keybinds)
+}
+
+/// Whether a binding is on a raw control character.
+///
+/// Nothing this side can read is authenticated: a guest's frames travel in the terminal
+/// stream of the pane it runs in, so any program with that pane can write them. A host that
+/// draws these bindings puts their keys on its own screen, and a control character there is
+/// a terminal escape in the host's output rather than a key anyone could press. Zellij
+/// spells the control keys that do exist as their own [`BareKey`] variants ([`BareKey::Esc`],
+/// [`BareKey::Tab`], [`BareKey::Enter`], [`BareKey::Backspace`]), so a `Char` holding one
+/// describes no real binding and is dropped.
+fn binds_a_control_character(key: &KeyWithModifier) -> bool {
+    matches!(key.bare_key, BareKey::Char(character) if character.is_control())
 }
 
 fn direction_to_proto(direction: Option<Direction>) -> i32 {
@@ -761,6 +778,32 @@ mod tests {
     fn empty_keybinds_survive_the_roundtrip() {
         let message = NestedSessionMessage::GuestKeybindsUpdate { keybinds: vec![] };
         assert_eq!(decode_payload(&encode_payload(&message)), Some(message));
+    }
+
+    #[test]
+    fn a_binding_on_a_control_character_is_dropped_without_losing_the_rest() {
+        let mut keybinds = sample_keybinds();
+        // A key nobody can press, and an escape in the output of any host that draws it.
+        keybinds[0].1.push((
+            KeyWithModifier::new(BareKey::Char('\u{1b}')),
+            vec![Action::Quit],
+        ));
+        let bindings_in_normal_mode = keybinds[0].1.len();
+
+        let decoded = decode_payload(&encode_payload(
+            &NestedSessionMessage::GuestKeybindsUpdate { keybinds },
+        ));
+        let Some(NestedSessionMessage::GuestKeybindsUpdate { keybinds: decoded }) = decoded else {
+            panic!("expected a keybinding table, got {:?}", decoded);
+        };
+
+        assert_eq!(decoded[0].1.len(), bindings_in_normal_mode - 1);
+        assert!(!decoded.iter().flat_map(|(_mode, bindings)| bindings).any(
+            |(key, _actions)| matches!(key.bare_key, BareKey::Char(character)
+                if character.is_control())
+        ));
+        // The mode it shared a table with is otherwise untouched.
+        assert_eq!(decoded[1], sample_keybinds()[1]);
     }
 
     #[test]

--- a/zellij-utils/src/nested_session.rs
+++ b/zellij-utils/src/nested_session.rs
@@ -213,7 +213,7 @@ fn mode_from_proto(mode: &str) -> Option<InputMode> {
 /// have in common.
 fn keybinds_to_proto(keybinds: KeybindsVec) -> Vec<u8> {
     let payload = ProtobufInitialKeybindsPayload {
-        keybinds: keybinds_to_protobuf(keybinds).unwrap_or_default(),
+        keybinds: keybinds_to_protobuf(keybinds),
     };
     payload.encode_to_vec()
 }

--- a/zellij-utils/src/nested_session.rs
+++ b/zellij-utils/src/nested_session.rs
@@ -1,5 +1,7 @@
-use crate::data::{Direction, KeyWithModifier};
+use crate::data::{Direction, InputMode, KeyWithModifier, KeybindsVec};
 use crate::nested_session_contract::nested_session_contract as proto;
+use crate::plugin_api::event::{keybinds_from_protobuf, keybinds_to_protobuf};
+use crate::plugin_api::generated_api::api::event::InitialKeybindsPayload as ProtobufInitialKeybindsPayload;
 use base64::alphabet::STANDARD as BASE64_STANDARD_ALPHABET;
 use base64::engine::general_purpose::{
     GeneralPurpose, GeneralPurposeConfig, STANDARD as BASE64_STANDARD,
@@ -97,6 +99,10 @@ impl ReannounceScheduler {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NestedSessionCapability {
     NestedControl,
+    /// The peer can report its input mode and keybindings to its host, through
+    /// [`NestedSessionMessage::GuestModeUpdate`] and
+    /// [`NestedSessionMessage::GuestKeybindsUpdate`].
+    HintReporting,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -133,6 +139,16 @@ pub enum NestedSessionMessage {
         ascend_keys: Vec<KeyWithModifier>,
         descend_keys: Vec<KeyWithModifier>,
     },
+    /// Sent by a guest to its host whenever the guest's input mode changes.
+    GuestModeUpdate {
+        mode: InputMode,
+    },
+    /// Sent by a host to ask a guest for its full keybinding table.
+    RequestGuestKeybinds,
+    /// A guest's answer to [`NestedSessionMessage::RequestGuestKeybinds`].
+    GuestKeybindsUpdate {
+        keybinds: KeybindsVec,
+    },
 }
 
 fn keys_to_proto(keys: &[KeyWithModifier]) -> Vec<String> {
@@ -156,6 +172,7 @@ fn capabilities_to_proto(capabilities: &[NestedSessionCapability]) -> Vec<i32> {
         .iter()
         .map(|capability| match capability {
             NestedSessionCapability::NestedControl => proto::NestedCapability::NestedControl as i32,
+            NestedSessionCapability::HintReporting => proto::NestedCapability::HintReporting as i32,
         })
         .collect()
 }
@@ -168,10 +185,41 @@ fn capabilities_from_proto(capabilities: &[i32]) -> Vec<NestedSessionCapability>
                 Some(proto::NestedCapability::NestedControl) => {
                     Some(NestedSessionCapability::NestedControl)
                 },
+                Some(proto::NestedCapability::HintReporting) => {
+                    Some(NestedSessionCapability::HintReporting)
+                },
                 _ => None,
             },
         )
         .collect()
+}
+
+/// An [`InputMode`] is written to the wire under the name [`InputMode::from_str`] reads,
+/// so that a mode one side does not know about is rejected rather than misread, and so
+/// that adding a mode needs no change to this contract.
+fn mode_to_proto(mode: InputMode) -> String {
+    format!("{:?}", mode)
+}
+
+fn mode_from_proto(mode: &str) -> Option<InputMode> {
+    InputMode::from_str(mode).ok()
+}
+
+/// Keybindings travel as an encoded plugin-API payload rather than as part of this
+/// contract, so that describing them here does not mean restating the whole `Action`
+/// schema. Anything the reading side cannot understand is dropped, which is what lets a
+/// host and a guest built from different Zellij versions still exchange the bindings they
+/// have in common.
+fn keybinds_to_proto(keybinds: KeybindsVec) -> Vec<u8> {
+    let payload = ProtobufInitialKeybindsPayload {
+        keybinds: keybinds_to_protobuf(keybinds).unwrap_or_default(),
+    };
+    payload.encode_to_vec()
+}
+
+fn keybinds_from_proto(payload_bytes: &[u8]) -> Option<KeybindsVec> {
+    let payload = ProtobufInitialKeybindsPayload::decode(payload_bytes).ok()?;
+    Some(keybinds_from_protobuf(payload.keybinds))
 }
 
 fn direction_to_proto(direction: Option<Direction>) -> i32 {
@@ -242,6 +290,19 @@ impl From<NestedSessionMessage> for proto::NestedSessionMessage {
                 ascend_keys: keys_to_proto(&ascend_keys),
                 descend_keys: keys_to_proto(&descend_keys),
             }),
+            NestedSessionMessage::GuestModeUpdate { mode } => {
+                Payload::GuestModeUpdate(proto::GuestModeUpdate {
+                    mode: mode_to_proto(mode),
+                })
+            },
+            NestedSessionMessage::RequestGuestKeybinds => {
+                Payload::RequestGuestKeybinds(proto::RequestGuestKeybinds {})
+            },
+            NestedSessionMessage::GuestKeybindsUpdate { keybinds } => {
+                Payload::GuestKeybindsUpdate(proto::GuestKeybindsUpdate {
+                    keybinds_payload: keybinds_to_proto(keybinds),
+                })
+            },
         };
         proto::NestedSessionMessage {
             payload: Some(payload),
@@ -293,6 +354,18 @@ impl TryFrom<proto::NestedSessionMessage> for NestedSessionMessage {
                     ascend_keys: keys_from_proto(&shortcut_update.ascend_keys),
                     descend_keys: keys_from_proto(&shortcut_update.descend_keys),
                 })
+            },
+            Some(Payload::GuestModeUpdate(guest_mode_update)) => {
+                let mode = mode_from_proto(&guest_mode_update.mode).ok_or(())?;
+                Ok(NestedSessionMessage::GuestModeUpdate { mode })
+            },
+            Some(Payload::RequestGuestKeybinds(_)) => {
+                Ok(NestedSessionMessage::RequestGuestKeybinds)
+            },
+            Some(Payload::GuestKeybindsUpdate(guest_keybinds_update)) => {
+                let keybinds =
+                    keybinds_from_proto(&guest_keybinds_update.keybinds_payload).ok_or(())?;
+                Ok(NestedSessionMessage::GuestKeybindsUpdate { keybinds })
             },
             None => Err(()),
         }

--- a/zellij-utils/src/nested_session.rs
+++ b/zellij-utils/src/nested_session.rs
@@ -142,6 +142,7 @@ pub enum NestedSessionMessage {
     /// Sent by a guest to its host whenever the guest's input mode changes.
     GuestModeUpdate {
         mode: InputMode,
+        base_mode: Option<InputMode>,
     },
     /// Sent by a host to ask a guest for its full keybinding table.
     RequestGuestKeybinds,
@@ -290,9 +291,10 @@ impl From<NestedSessionMessage> for proto::NestedSessionMessage {
                 ascend_keys: keys_to_proto(&ascend_keys),
                 descend_keys: keys_to_proto(&descend_keys),
             }),
-            NestedSessionMessage::GuestModeUpdate { mode } => {
+            NestedSessionMessage::GuestModeUpdate { mode, base_mode } => {
                 Payload::GuestModeUpdate(proto::GuestModeUpdate {
                     mode: mode_to_proto(mode),
+                    base_mode: base_mode.map(mode_to_proto).unwrap_or_default(),
                 })
             },
             NestedSessionMessage::RequestGuestKeybinds => {
@@ -357,7 +359,15 @@ impl TryFrom<proto::NestedSessionMessage> for NestedSessionMessage {
             },
             Some(Payload::GuestModeUpdate(guest_mode_update)) => {
                 let mode = mode_from_proto(&guest_mode_update.mode).ok_or(())?;
-                Ok(NestedSessionMessage::GuestModeUpdate { mode })
+                // An empty base mode means the guest did not report one. A name this side
+                // does not recognize is treated the same way, so an unknown base mode
+                // costs the inherited-binding distinction rather than the whole message.
+                let base_mode = if guest_mode_update.base_mode.is_empty() {
+                    None
+                } else {
+                    mode_from_proto(&guest_mode_update.base_mode)
+                };
+                Ok(NestedSessionMessage::GuestModeUpdate { mode, base_mode })
             },
             Some(Payload::RequestGuestKeybinds(_)) => {
                 Ok(NestedSessionMessage::RequestGuestKeybinds)
@@ -545,6 +555,7 @@ mod tests {
             },
             NestedSessionMessage::GuestModeUpdate {
                 mode: InputMode::Locked,
+                base_mode: Some(InputMode::Normal),
             },
             NestedSessionMessage::RequestGuestKeybinds,
             NestedSessionMessage::GuestKeybindsUpdate {
@@ -680,7 +691,10 @@ mod tests {
     #[test]
     fn guest_mode_update_roundtrip_preserves_every_input_mode() {
         for mode in InputMode::iter() {
-            let message = NestedSessionMessage::GuestModeUpdate { mode };
+            let message = NestedSessionMessage::GuestModeUpdate {
+                mode,
+                base_mode: Some(mode),
+            };
             assert_eq!(
                 decode_payload(&encode_payload(&message)),
                 Some(message),
@@ -691,11 +705,43 @@ mod tests {
     }
 
     #[test]
+    fn a_guest_that_reports_no_base_mode_round_trips_as_none() {
+        let message = NestedSessionMessage::GuestModeUpdate {
+            mode: InputMode::Normal,
+            base_mode: None,
+        };
+        assert_eq!(decode_payload(&encode_payload(&message)), Some(message));
+    }
+
+    #[test]
+    fn an_unknown_base_mode_name_costs_only_the_base_mode() {
+        // The mode itself still has to be readable, but a base mode this side does not
+        // recognize must not take the whole message down with it.
+        let payload = proto::NestedSessionMessage {
+            payload: Some(proto::nested_session_message::Payload::GuestModeUpdate(
+                proto::GuestModeUpdate {
+                    mode: "Normal".to_owned(),
+                    base_mode: "ModeFromAFutureZellij".to_owned(),
+                },
+            )),
+        }
+        .encode_to_vec();
+        assert_eq!(
+            decode_payload(&payload),
+            Some(NestedSessionMessage::GuestModeUpdate {
+                mode: InputMode::Normal,
+                base_mode: None,
+            })
+        );
+    }
+
+    #[test]
     fn unknown_input_mode_name_is_rejected() {
         let payload = proto::NestedSessionMessage {
             payload: Some(proto::nested_session_message::Payload::GuestModeUpdate(
                 proto::GuestModeUpdate {
                     mode: "ModeFromAFutureZellij".to_owned(),
+                    base_mode: String::new(),
                 },
             )),
         }

--- a/zellij-utils/src/nested_session.rs
+++ b/zellij-utils/src/nested_session.rs
@@ -497,12 +497,17 @@ impl NestedFrameExtractor {
 mod tests {
     use super::*;
     use crate::data::BareKey;
+    use crate::input::actions::Action;
+    use strum::IntoEnumIterator;
 
     fn all_message_arms() -> Vec<NestedSessionMessage> {
         vec![
             NestedSessionMessage::Announce {
                 session_name: "guest".to_owned(),
-                capabilities: vec![NestedSessionCapability::NestedControl],
+                capabilities: vec![
+                    NestedSessionCapability::NestedControl,
+                    NestedSessionCapability::HintReporting,
+                ],
             },
             NestedSessionMessage::FocusHost {
                 direction: Some(Direction::Left),
@@ -513,7 +518,10 @@ mod tests {
             NestedSessionMessage::Bye,
             NestedSessionMessage::AnnounceAck {
                 ancestry: vec!["outer".to_owned(), "middle".to_owned()],
-                capabilities: vec![NestedSessionCapability::NestedControl],
+                capabilities: vec![
+                    NestedSessionCapability::NestedControl,
+                    NestedSessionCapability::HintReporting,
+                ],
                 descend_keys: vec![
                     KeyWithModifier::new(BareKey::Char('o')).with_ctrl_modifier(),
                     KeyWithModifier::new(BareKey::Down),
@@ -535,6 +543,46 @@ mod tests {
                 ],
                 descend_keys: vec![],
             },
+            NestedSessionMessage::GuestModeUpdate {
+                mode: InputMode::Locked,
+            },
+            NestedSessionMessage::RequestGuestKeybinds,
+            NestedSessionMessage::GuestKeybindsUpdate {
+                keybinds: sample_keybinds(),
+            },
+        ]
+    }
+
+    fn sample_keybinds() -> KeybindsVec {
+        vec![
+            (
+                InputMode::Normal,
+                vec![(
+                    KeyWithModifier::new(BareKey::Char('p')).with_ctrl_modifier(),
+                    vec![Action::SwitchToMode {
+                        input_mode: InputMode::Pane,
+                    }],
+                )],
+            ),
+            (
+                InputMode::Pane,
+                vec![
+                    (
+                        KeyWithModifier::new(BareKey::Char('n')),
+                        vec![Action::NewPane {
+                            direction: None,
+                            pane_name: None,
+                            start_suppressed: false,
+                        }],
+                    ),
+                    (
+                        KeyWithModifier::new(BareKey::Esc),
+                        vec![Action::SwitchToMode {
+                            input_mode: InputMode::Normal,
+                        }],
+                    ),
+                ],
+            ),
         ]
     }
 
@@ -609,6 +657,59 @@ mod tests {
     #[test]
     fn empty_payload_is_rejected() {
         assert_eq!(decode_payload(&[]), None);
+    }
+
+    #[test]
+    fn guest_mode_update_roundtrip_preserves_every_input_mode() {
+        for mode in InputMode::iter() {
+            let message = NestedSessionMessage::GuestModeUpdate { mode };
+            assert_eq!(
+                decode_payload(&encode_payload(&message)),
+                Some(message),
+                "input mode {:?} did not survive the round trip",
+                mode
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_input_mode_name_is_rejected() {
+        let payload = proto::NestedSessionMessage {
+            payload: Some(proto::nested_session_message::Payload::GuestModeUpdate(
+                proto::GuestModeUpdate {
+                    mode: "ModeFromAFutureZellij".to_owned(),
+                },
+            )),
+        }
+        .encode_to_vec();
+        assert_eq!(decode_payload(&payload), None);
+    }
+
+    #[test]
+    fn guest_keybinds_update_preserves_modes_keys_and_actions() {
+        let message = NestedSessionMessage::GuestKeybindsUpdate {
+            keybinds: sample_keybinds(),
+        };
+        assert_eq!(decode_payload(&encode_payload(&message)), Some(message));
+    }
+
+    #[test]
+    fn empty_keybinds_survive_the_roundtrip() {
+        let message = NestedSessionMessage::GuestKeybindsUpdate { keybinds: vec![] };
+        assert_eq!(decode_payload(&encode_payload(&message)), Some(message));
+    }
+
+    #[test]
+    fn undecodable_keybinds_payload_is_rejected() {
+        let payload = proto::NestedSessionMessage {
+            payload: Some(proto::nested_session_message::Payload::GuestKeybindsUpdate(
+                proto::GuestKeybindsUpdate {
+                    keybinds_payload: vec![0xff, 0xff, 0xff, 0xff],
+                },
+            )),
+        }
+        .encode_to_vec();
+        assert_eq!(decode_payload(&payload), None);
     }
 
     fn test_scheduler(now: Instant) -> ReannounceScheduler {

--- a/zellij-utils/src/nested_session.rs
+++ b/zellij-utils/src/nested_session.rs
@@ -660,6 +660,24 @@ mod tests {
     }
 
     #[test]
+    fn a_capability_the_reading_side_does_not_know_is_dropped() {
+        // A peer built from a newer Zellij may advertise capabilities this side has never
+        // heard of. Those must be ignored without taking the known ones down with them.
+        let capabilities = capabilities_from_proto(&[
+            proto::NestedCapability::HintReporting as i32,
+            9999,
+            proto::NestedCapability::NestedControl as i32,
+        ]);
+        assert_eq!(
+            capabilities,
+            vec![
+                NestedSessionCapability::HintReporting,
+                NestedSessionCapability::NestedControl,
+            ]
+        );
+    }
+
+    #[test]
     fn guest_mode_update_roundtrip_preserves_every_input_mode() {
         for mode in InputMode::iter() {
             let message = NestedSessionMessage::GuestModeUpdate { mode };

--- a/zellij-utils/src/nested_session_contract/nested_session_message.proto
+++ b/zellij-utils/src/nested_session_contract/nested_session_message.proto
@@ -85,9 +85,13 @@ message Ping {
 }
 
 // Sent by a guest to its host whenever the guest's input mode changes, so the host
-// knows which of the guest's keybindings currently apply.
+// knows which of the guest's keybindings currently apply. `base_mode` is the mode the
+// guest returns to, empty when the guest does not report one; a host needs it to tell
+// which of the guest's bindings are inherited from its base mode rather than specific to
+// the mode it is in now.
 message GuestModeUpdate {
   string mode = 1;
+  string base_mode = 2;
 }
 
 // Sent by a host to ask a guest for its full keybinding table.

--- a/zellij-utils/src/nested_session_contract/nested_session_message.proto
+++ b/zellij-utils/src/nested_session_contract/nested_session_message.proto
@@ -15,12 +15,17 @@ message NestedSessionMessage {
     AncestryUpdate ancestry_update = 12;
     Ping ping = 13;
     ShortcutUpdate shortcut_update = 14;
+    GuestModeUpdate guest_mode_update = 15;
+    RequestGuestKeybinds request_guest_keybinds = 16;
+    GuestKeybindsUpdate guest_keybinds_update = 17;
   }
 }
 
 enum NestedCapability {
   NESTED_CAPABILITY_UNSPECIFIED = 0;
   NESTED_CAPABILITY_NESTED_CONTROL = 1;
+  // The peer can report its input mode and keybindings to its host.
+  NESTED_CAPABILITY_HINT_REPORTING = 2;
 }
 
 enum NestedDirection {
@@ -77,4 +82,25 @@ message AncestryUpdate {
 }
 
 message Ping {
+}
+
+// Sent by a guest to its host whenever the guest's input mode changes, so the host
+// knows which of the guest's keybindings currently apply.
+message GuestModeUpdate {
+  string mode = 1;
+}
+
+// Sent by a host to ask a guest for its full keybinding table.
+message RequestGuestKeybinds {
+}
+
+// A guest's answer to RequestGuestKeybinds.
+//
+// The table is carried as an encoded plugin-API `InitialKeybindsPayload` rather than
+// being redescribed here, because describing keybindings natively would mean pulling the
+// whole `Action` schema into this contract. Protobuf's unknown-field and unknown-enum
+// handling means a host and a guest built from different Zellij versions still exchange
+// everything they both understand.
+message GuestKeybindsUpdate {
+  bytes keybinds_payload = 1;
 }

--- a/zellij-utils/src/plugin_api/event.proto
+++ b/zellij-utils/src/plugin_api/event.proto
@@ -72,6 +72,8 @@ enum EventType {
     SoftKeyboardVisibilityChanged = 47;
     HintText = 48;
     ActivePaneScroll = 49;
+    NestedSessionModeUpdate = 50;
+    NestedSessionKeybinds = 51;
 }
 
 message EventNameList {
@@ -123,7 +125,21 @@ message Event {
     SoftKeyboardVisibilityChangedPayload soft_keyboard_visibility_changed_payload = 41;
     HintTextPayload hint_text_payload = 42;
     ActivePaneScrollPayload active_pane_scroll_payload = 43;
+    NestedSessionModeUpdatePayload nested_session_mode_update_payload = 44;
+    NestedSessionKeybindsPayload nested_session_keybinds_payload = 45;
   }
+}
+
+message NestedSessionModeUpdatePayload {
+  PaneId pane_id = 1;
+  optional string session_name = 2;
+  input_mode.InputMode mode = 3;
+}
+
+message NestedSessionKeybindsPayload {
+  PaneId pane_id = 1;
+  optional string session_name = 2;
+  repeated InputModeKeybinds keybinds = 3;
 }
 
 message HintTextPayload {

--- a/zellij-utils/src/plugin_api/event.proto
+++ b/zellij-utils/src/plugin_api/event.proto
@@ -134,6 +134,7 @@ message NestedSessionModeUpdatePayload {
   PaneId pane_id = 1;
   optional string session_name = 2;
   input_mode.InputMode mode = 3;
+  optional input_mode.InputMode base_mode = 4;
 }
 
 message NestedSessionKeybindsPayload {

--- a/zellij-utils/src/plugin_api/event.rs
+++ b/zellij-utils/src/plugin_api/event.rs
@@ -622,10 +622,15 @@ impl TryFrom<ProtobufEvent> for Event {
                     let mode: InputMode = ProtobufInputMode::try_from(payload.mode)
                         .map_err(|_| "Malformed InputMode in the NestedSessionModeUpdate Event")?
                         .try_into()?;
+                    let base_mode = payload
+                        .base_mode
+                        .and_then(|base_mode| ProtobufInputMode::try_from(base_mode).ok())
+                        .and_then(|base_mode| InputMode::try_from(base_mode).ok());
                     Ok(Event::NestedSessionModeUpdate {
                         pane_id: PaneId::try_from(pane_id)?,
                         session_name: payload.session_name,
                         mode,
+                        base_mode,
                     })
                 },
                 _ => Err("Malformed payload for the NestedSessionModeUpdate Event"),
@@ -1265,8 +1270,13 @@ impl TryFrom<Event> for ProtobufEvent {
                 pane_id,
                 session_name,
                 mode,
+                base_mode,
             } => {
                 let protobuf_mode: ProtobufInputMode = mode.try_into()?;
+                let protobuf_base_mode = base_mode
+                    .map(ProtobufInputMode::try_from)
+                    .transpose()?
+                    .map(|base_mode| base_mode as i32);
                 Ok(ProtobufEvent {
                     name: ProtobufEventType::NestedSessionModeUpdate as i32,
                     payload: Some(event::Payload::NestedSessionModeUpdatePayload(
@@ -1274,6 +1284,7 @@ impl TryFrom<Event> for ProtobufEvent {
                             pane_id: Some(pane_id.try_into()?),
                             session_name,
                             mode: protobuf_mode as i32,
+                            base_mode: protobuf_base_mode,
                         },
                     )),
                 })

--- a/zellij-utils/src/plugin_api/event.rs
+++ b/zellij-utils/src/plugin_api/event.rs
@@ -62,17 +62,23 @@ use std::time::Duration;
 /// Converts a keybinding table into the protobuf form used wherever keybindings cross the
 /// plugin boundary.
 ///
-/// An individual action that has no protobuf representation is dropped, so that one
-/// unrepresentable action does not cost the caller the whole binding.
-pub fn keybinds_to_protobuf(
-    keybinds: KeybindsVec,
-) -> Result<Vec<ProtobufInputModeKeybinds>, &'static str> {
+/// Anything that has no protobuf representation is dropped rather than failing the whole
+/// table: an unrepresentable action costs only that action, an unrepresentable key only
+/// that binding, and an unrepresentable mode only that mode. The reader
+/// ([`keybinds_from_protobuf`]) drops on the same terms, so a table survives the trip
+/// between builds that do not share every mode, key and action, minus whatever they do not
+/// have in common.
+pub fn keybinds_to_protobuf(keybinds: KeybindsVec) -> Vec<ProtobufInputModeKeybinds> {
     let mut protobuf_keybinds: Vec<ProtobufInputModeKeybinds> = vec![];
     for (input_mode, input_mode_keybinds) in keybinds {
-        let mode: ProtobufInputMode = input_mode.try_into()?;
+        let Ok(mode) = ProtobufInputMode::try_from(input_mode) else {
+            continue;
+        };
         let mut key_binds: Vec<ProtobufKeyBind> = vec![];
         for (key, actions) in input_mode_keybinds {
-            let protobuf_key: ProtobufKey = key.try_into()?;
+            let Ok(protobuf_key) = ProtobufKey::try_from(key) else {
+                continue;
+            };
             let mut protobuf_actions: Vec<ProtobufAction> = vec![];
             for action in actions {
                 if let Ok(protobuf_action) = action.try_into() {
@@ -89,7 +95,7 @@ pub fn keybinds_to_protobuf(
             key_bind: key_binds,
         });
     }
-    Ok(protobuf_keybinds)
+    protobuf_keybinds
 }
 
 /// Converts a keybinding table back out of its protobuf form.
@@ -1299,12 +1305,12 @@ impl TryFrom<Event> for ProtobufEvent {
                     NestedSessionKeybindsPayload {
                         pane_id: Some(pane_id.try_into()?),
                         session_name,
-                        keybinds: keybinds_to_protobuf(keybinds)?,
+                        keybinds: keybinds_to_protobuf(keybinds),
                     },
                 )),
             }),
             Event::InitialKeybinds(keybinds) => {
-                let protobuf_keybinds = keybinds_to_protobuf(keybinds)?;
+                let protobuf_keybinds = keybinds_to_protobuf(keybinds);
                 Ok(ProtobufEvent {
                     name: ProtobufEventType::InitialKeybinds as i32,
                     payload: Some(event::Payload::InitialKeybindsPayload(
@@ -2164,7 +2170,7 @@ impl TryFrom<ModeInfo> for ProtobufModeUpdatePayload {
             .iter()
             .map(|key| key.to_kdl())
             .collect();
-        let protobuf_input_mode_keybinds = keybinds_to_protobuf(mode_info.keybinds)?;
+        let protobuf_input_mode_keybinds = keybinds_to_protobuf(mode_info.keybinds);
         Ok(ProtobufModeUpdatePayload {
             current_mode: current_mode as i32,
             style: Some(style),
@@ -3396,4 +3402,87 @@ impl TryFrom<SelectedText> for ProtobufSelectedText {
             end: Some(selected_text.end.try_into()?),
         })
     }
+}
+
+#[test]
+fn serialize_nested_session_mode_update_event() {
+    use prost::Message;
+    let nested_session_mode_update_event = Event::NestedSessionModeUpdate {
+        pane_id: PaneId::Terminal(3),
+        session_name: Some("guest session".to_owned()),
+        mode: InputMode::Pane,
+        base_mode: Some(InputMode::Locked),
+    };
+    let protobuf_event: ProtobufEvent =
+        nested_session_mode_update_event.clone().try_into().unwrap();
+    let serialized_protobuf_event = protobuf_event.encode_to_vec();
+    let deserialized_protobuf_event: ProtobufEvent =
+        Message::decode(serialized_protobuf_event.as_slice()).unwrap();
+    let deserialized_event: Event = deserialized_protobuf_event.try_into().unwrap();
+    assert_eq!(
+        nested_session_mode_update_event, deserialized_event,
+        "Event properly serialized/deserialized without change"
+    );
+}
+
+#[test]
+fn serialize_nested_session_keybinds_event() {
+    use crate::data::BareKey;
+    use prost::Message;
+    let nested_session_keybinds_event = Event::NestedSessionKeybinds {
+        pane_id: PaneId::Terminal(3),
+        session_name: Some("guest session".to_owned()),
+        keybinds: vec![
+            (
+                InputMode::Normal,
+                vec![(
+                    KeyWithModifier::new(BareKey::Char('g')).with_ctrl_modifier(),
+                    vec![Action::SwitchToMode {
+                        input_mode: InputMode::Pane,
+                    }],
+                )],
+            ),
+            (
+                InputMode::Pane,
+                vec![(
+                    KeyWithModifier::new(BareKey::Char('x')),
+                    vec![Action::CloseFocus],
+                )],
+            ),
+        ],
+    };
+    let protobuf_event: ProtobufEvent = nested_session_keybinds_event.clone().try_into().unwrap();
+    let serialized_protobuf_event = protobuf_event.encode_to_vec();
+    let deserialized_protobuf_event: ProtobufEvent =
+        Message::decode(serialized_protobuf_event.as_slice()).unwrap();
+    let deserialized_event: Event = deserialized_protobuf_event.try_into().unwrap();
+    assert_eq!(
+        nested_session_keybinds_event, deserialized_event,
+        "Event properly serialized/deserialized without change"
+    );
+}
+
+#[test]
+fn a_key_with_no_protobuf_form_costs_only_its_own_binding() {
+    use crate::data::BareKey;
+    // Only f1 through f12 have a protobuf representation.
+    let unrepresentable_key = KeyWithModifier::new(BareKey::F(20));
+    let representable_key = KeyWithModifier::new(BareKey::Char('x'));
+    let keybinds = vec![(
+        InputMode::Normal,
+        vec![
+            (unrepresentable_key, vec![Action::CloseFocus]),
+            (representable_key.clone(), vec![Action::CloseFocus]),
+        ],
+    )];
+
+    let converted = keybinds_from_protobuf(keybinds_to_protobuf(keybinds));
+
+    assert_eq!(
+        converted,
+        vec![(
+            InputMode::Normal,
+            vec![(representable_key, vec![Action::CloseFocus])]
+        )]
+    );
 }

--- a/zellij-utils/src/plugin_api/event.rs
+++ b/zellij-utils/src/plugin_api/event.rs
@@ -43,10 +43,10 @@ pub use super::generated_api::api::{
 #[allow(hidden_glob_reexports)]
 use crate::data::{
     ClientId, ClientInfo, CopyDestination, Event, EventType, FileMetadata, HostTerminalThemeMode,
-    InputMode, KeyWithModifier, LayoutInfo, LayoutMetadata, ModeInfo, Mouse, PaneContents, PaneId,
-    PaneInfo, PaneManifest, PaneMetadata, PaneScrollbackResponse, PermissionStatus,
-    PluginCapabilities, PluginInfo, SelectedText, SessionInfo, Style, StyledText, TabInfo,
-    TabMetadata, WebServerStatus, WebSharing,
+    InputMode, KeyWithModifier, KeybindsVec, LayoutInfo, LayoutMetadata, ModeInfo, Mouse,
+    PaneContents, PaneId, PaneInfo, PaneManifest, PaneMetadata, PaneScrollbackResponse,
+    PermissionStatus, PluginCapabilities, PluginInfo, SelectedText, SessionInfo, Style, StyledText,
+    TabInfo, TabMetadata, WebServerStatus, WebSharing,
 };
 
 use crate::errors::prelude::*;
@@ -58,6 +58,70 @@ use std::net::IpAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
+
+/// Converts a keybinding table into the protobuf form used wherever keybindings cross the
+/// plugin boundary.
+///
+/// An individual action that has no protobuf representation is dropped, so that one
+/// unrepresentable action does not cost the caller the whole binding.
+pub fn keybinds_to_protobuf(
+    keybinds: KeybindsVec,
+) -> Result<Vec<ProtobufInputModeKeybinds>, &'static str> {
+    let mut protobuf_keybinds: Vec<ProtobufInputModeKeybinds> = vec![];
+    for (input_mode, input_mode_keybinds) in keybinds {
+        let mode: ProtobufInputMode = input_mode.try_into()?;
+        let mut key_binds: Vec<ProtobufKeyBind> = vec![];
+        for (key, actions) in input_mode_keybinds {
+            let protobuf_key: ProtobufKey = key.try_into()?;
+            let mut protobuf_actions: Vec<ProtobufAction> = vec![];
+            for action in actions {
+                if let Ok(protobuf_action) = action.try_into() {
+                    protobuf_actions.push(protobuf_action);
+                }
+            }
+            key_binds.push(ProtobufKeyBind {
+                key: Some(protobuf_key),
+                action: protobuf_actions,
+            });
+        }
+        protobuf_keybinds.push(ProtobufInputModeKeybinds {
+            mode: mode as i32,
+            key_bind: key_binds,
+        });
+    }
+    Ok(protobuf_keybinds)
+}
+
+/// Converts a keybinding table back out of its protobuf form.
+///
+/// Anything that cannot be understood is dropped rather than failing the whole table: a
+/// mode, key, or action a given build does not know about simply does not appear. This
+/// keeps a table readable across builds that do not share every mode and action.
+pub fn keybinds_from_protobuf(protobuf_keybinds: Vec<ProtobufInputModeKeybinds>) -> KeybindsVec {
+    protobuf_keybinds
+        .into_iter()
+        .filter_map(|input_mode_keybinds| {
+            let input_mode: InputMode = ProtobufInputMode::try_from(input_mode_keybinds.mode)
+                .ok()?
+                .try_into()
+                .ok()?;
+            let key_binds = input_mode_keybinds
+                .key_bind
+                .into_iter()
+                .filter_map(|key_bind| {
+                    let key: KeyWithModifier = key_bind.key?.try_into().ok()?;
+                    let actions: Vec<Action> = key_bind
+                        .action
+                        .into_iter()
+                        .filter_map(|action| action.try_into().ok())
+                        .collect();
+                    Some((key, actions))
+                })
+                .collect();
+            Some((input_mode, key_binds))
+        })
+        .collect()
+}
 
 impl TryFrom<ProtobufEvent> for Event {
     type Error = &'static str;
@@ -552,31 +616,7 @@ impl TryFrom<ProtobufEvent> for Event {
             },
             Some(ProtobufEventType::InitialKeybinds) => match protobuf_event.payload {
                 Some(ProtobufEventPayload::InitialKeybindsPayload(p)) => {
-                    let keybinds = p
-                        .keybinds
-                        .into_iter()
-                        .filter_map(|imk| {
-                            let mode: InputMode = ProtobufInputMode::try_from(imk.mode)
-                                .ok()?
-                                .try_into()
-                                .ok()?;
-                            let key_binds: Vec<(KeyWithModifier, Vec<Action>)> = imk
-                                .key_bind
-                                .into_iter()
-                                .filter_map(|kb| {
-                                    let key: KeyWithModifier = kb.key?.try_into().ok()?;
-                                    let actions: Vec<Action> = kb
-                                        .action
-                                        .into_iter()
-                                        .filter_map(|a| a.try_into().ok())
-                                        .collect();
-                                    Some((key, actions))
-                                })
-                                .collect();
-                            Some((mode, key_binds))
-                        })
-                        .collect();
-                    Ok(Event::InitialKeybinds(keybinds))
+                    Ok(Event::InitialKeybinds(keybinds_from_protobuf(p.keybinds)))
                 },
                 _ => Err("Malformed payload for InitialKeybinds Event"),
             },
@@ -1193,28 +1233,7 @@ impl TryFrom<Event> for ProtobufEvent {
                 })
             },
             Event::InitialKeybinds(keybinds) => {
-                let mut protobuf_keybinds: Vec<ProtobufInputModeKeybinds> = vec![];
-                for (input_mode, input_mode_keybinds) in keybinds {
-                    let mode: ProtobufInputMode = input_mode.try_into()?;
-                    let mut key_binds: Vec<ProtobufKeyBind> = vec![];
-                    for (key, actions) in input_mode_keybinds {
-                        let protobuf_key: ProtobufKey = key.try_into()?;
-                        let mut protobuf_actions: Vec<ProtobufAction> = vec![];
-                        for action in actions {
-                            if let Ok(protobuf_action) = action.try_into() {
-                                protobuf_actions.push(protobuf_action);
-                            }
-                        }
-                        key_binds.push(ProtobufKeyBind {
-                            key: Some(protobuf_key),
-                            action: protobuf_actions,
-                        });
-                    }
-                    protobuf_keybinds.push(ProtobufInputModeKeybinds {
-                        mode: mode as i32,
-                        key_bind: key_binds,
-                    });
-                }
+                let protobuf_keybinds = keybinds_to_protobuf(keybinds)?;
                 Ok(ProtobufEvent {
                     name: ProtobufEventType::InitialKeybinds as i32,
                     payload: Some(event::Payload::InitialKeybindsPayload(
@@ -1950,31 +1969,8 @@ impl TryFrom<ProtobufModeUpdatePayload> for ModeInfo {
         let base_mode: Option<InputMode> = protobuf_mode_update_payload
             .base_mode
             .and_then(|b_m| ProtobufInputMode::try_from(b_m).ok()?.try_into().ok());
-        let keybinds: Vec<(InputMode, Vec<(KeyWithModifier, Vec<Action>)>)> =
-            protobuf_mode_update_payload
-                .keybinds
-                .iter_mut()
-                .filter_map(|k| {
-                    let input_mode: InputMode = ProtobufInputMode::try_from(k.mode)
-                        .ok()
-                        .ok_or("Malformed InputMode in the ModeUpdate Event")
-                        .ok()?
-                        .try_into()
-                        .ok()?;
-                    let mut keybinds: Vec<(KeyWithModifier, Vec<Action>)> = vec![];
-                    for mut protobuf_keybind in k.key_bind.drain(..) {
-                        let key: KeyWithModifier = protobuf_keybind.key.unwrap().try_into().ok()?;
-                        let mut actions: Vec<Action> = vec![];
-                        for action in protobuf_keybind.action.drain(..) {
-                            if let Ok(action) = action.try_into() {
-                                actions.push(action);
-                            }
-                        }
-                        keybinds.push((key, actions));
-                    }
-                    Some((input_mode, keybinds))
-                })
-                .collect();
+        let keybinds: KeybindsVec =
+            keybinds_from_protobuf(std::mem::take(&mut protobuf_mode_update_payload.keybinds));
         let style: Style = protobuf_mode_update_payload
             .style
             .and_then(|m| m.try_into().ok())
@@ -2097,30 +2093,7 @@ impl TryFrom<ModeInfo> for ProtobufModeUpdatePayload {
             .iter()
             .map(|key| key.to_kdl())
             .collect();
-        let mut protobuf_input_mode_keybinds: Vec<ProtobufInputModeKeybinds> = vec![];
-        for (input_mode, input_mode_keybinds) in mode_info.keybinds {
-            let mode: ProtobufInputMode = input_mode.try_into()?;
-            let mut keybinds: Vec<ProtobufKeyBind> = vec![];
-            for (key, actions) in input_mode_keybinds {
-                let protobuf_key: ProtobufKey = key.try_into()?;
-                let mut protobuf_actions: Vec<ProtobufAction> = vec![];
-                for action in actions {
-                    if let Ok(protobuf_action) = action.try_into() {
-                        protobuf_actions.push(protobuf_action);
-                    }
-                }
-                let key_bind = ProtobufKeyBind {
-                    key: Some(protobuf_key),
-                    action: protobuf_actions,
-                };
-                keybinds.push(key_bind);
-            }
-            let input_mode_keybind = ProtobufInputModeKeybinds {
-                mode: mode as i32,
-                key_bind: keybinds,
-            };
-            protobuf_input_mode_keybinds.push(input_mode_keybind);
-        }
+        let protobuf_input_mode_keybinds = keybinds_to_protobuf(mode_info.keybinds)?;
         Ok(ProtobufModeUpdatePayload {
             current_mode: current_mode as i32,
             style: Some(style),

--- a/zellij-utils/src/plugin_api/event.rs
+++ b/zellij-utils/src/plugin_api/event.rs
@@ -614,6 +614,35 @@ impl TryFrom<ProtobufEvent> for Event {
                 },
                 _ => Err("Malformed payload for HighlightClicked Event"),
             },
+            Some(ProtobufEventType::NestedSessionModeUpdate) => match protobuf_event.payload {
+                Some(ProtobufEventPayload::NestedSessionModeUpdatePayload(payload)) => {
+                    let pane_id = payload
+                        .pane_id
+                        .ok_or("Malformed payload for the NestedSessionModeUpdate Event")?;
+                    let mode: InputMode = ProtobufInputMode::try_from(payload.mode)
+                        .map_err(|_| "Malformed InputMode in the NestedSessionModeUpdate Event")?
+                        .try_into()?;
+                    Ok(Event::NestedSessionModeUpdate {
+                        pane_id: PaneId::try_from(pane_id)?,
+                        session_name: payload.session_name,
+                        mode,
+                    })
+                },
+                _ => Err("Malformed payload for the NestedSessionModeUpdate Event"),
+            },
+            Some(ProtobufEventType::NestedSessionKeybinds) => match protobuf_event.payload {
+                Some(ProtobufEventPayload::NestedSessionKeybindsPayload(payload)) => {
+                    let pane_id = payload
+                        .pane_id
+                        .ok_or("Malformed payload for the NestedSessionKeybinds Event")?;
+                    Ok(Event::NestedSessionKeybinds {
+                        pane_id: PaneId::try_from(pane_id)?,
+                        session_name: payload.session_name,
+                        keybinds: keybinds_from_protobuf(payload.keybinds),
+                    })
+                },
+                _ => Err("Malformed payload for the NestedSessionKeybinds Event"),
+            },
             Some(ProtobufEventType::InitialKeybinds) => match protobuf_event.payload {
                 Some(ProtobufEventPayload::InitialKeybindsPayload(p)) => {
                     Ok(Event::InitialKeybinds(keybinds_from_protobuf(p.keybinds)))
@@ -1232,6 +1261,37 @@ impl TryFrom<Event> for ProtobufEvent {
                     payload: Some(event::Payload::ActivePaneScrollPayload(payload)),
                 })
             },
+            Event::NestedSessionModeUpdate {
+                pane_id,
+                session_name,
+                mode,
+            } => {
+                let protobuf_mode: ProtobufInputMode = mode.try_into()?;
+                Ok(ProtobufEvent {
+                    name: ProtobufEventType::NestedSessionModeUpdate as i32,
+                    payload: Some(event::Payload::NestedSessionModeUpdatePayload(
+                        NestedSessionModeUpdatePayload {
+                            pane_id: Some(pane_id.try_into()?),
+                            session_name,
+                            mode: protobuf_mode as i32,
+                        },
+                    )),
+                })
+            },
+            Event::NestedSessionKeybinds {
+                pane_id,
+                session_name,
+                keybinds,
+            } => Ok(ProtobufEvent {
+                name: ProtobufEventType::NestedSessionKeybinds as i32,
+                payload: Some(event::Payload::NestedSessionKeybindsPayload(
+                    NestedSessionKeybindsPayload {
+                        pane_id: Some(pane_id.try_into()?),
+                        session_name,
+                        keybinds: keybinds_to_protobuf(keybinds)?,
+                    },
+                )),
+            }),
             Event::InitialKeybinds(keybinds) => {
                 let protobuf_keybinds = keybinds_to_protobuf(keybinds)?;
                 Ok(ProtobufEvent {
@@ -2205,6 +2265,8 @@ impl TryFrom<ProtobufEventType> for EventType {
             },
             ProtobufEventType::HintText => EventType::HintText,
             ProtobufEventType::ActivePaneScroll => EventType::ActivePaneScroll,
+            ProtobufEventType::NestedSessionModeUpdate => EventType::NestedSessionModeUpdate,
+            ProtobufEventType::NestedSessionKeybinds => EventType::NestedSessionKeybinds,
         })
     }
 }
@@ -2263,6 +2325,8 @@ impl TryFrom<EventType> for ProtobufEventType {
             },
             EventType::HintText => ProtobufEventType::HintText,
             EventType::ActivePaneScroll => ProtobufEventType::ActivePaneScroll,
+            EventType::NestedSessionModeUpdate => ProtobufEventType::NestedSessionModeUpdate,
+            EventType::NestedSessionKeybinds => ProtobufEventType::NestedSessionKeybinds,
         })
     }
 }

--- a/zellij-utils/src/plugin_api/plugin_command.proto
+++ b/zellij-utils/src/plugin_api/plugin_command.proto
@@ -218,6 +218,7 @@ enum CommandName {
   NewPane = 226;
   ToggleFocusNoUiFullscreen = 227;
   FocusHostSession = 228;
+  RequestNestedSessionKeybinds = 229;
 }
 
 message PluginCommand {
@@ -378,7 +379,12 @@ message PluginCommand {
     NewTiledPaneInTabPayload new_tiled_pane_in_tab_payload = 169;
     SetPaneFrameStylePayload set_pane_frame_style_payload = 170;
     ToggleFloatingPanesPayload toggle_floating_panes_payload = 171;
+    RequestNestedSessionKeybindsPayload request_nested_session_keybinds_payload = 172;
   }
+}
+
+message RequestNestedSessionKeybindsPayload {
+  PaneId pane_id = 1;
 }
 
 message SetPaneFrameStylePayload {

--- a/zellij-utils/src/plugin_api/plugin_command.rs
+++ b/zellij-utils/src/plugin_api/plugin_command.rs
@@ -114,8 +114,9 @@ pub use super::generated_api::api::{
         RegexHighlight as ProtobufRegexHighlight, ReloadPluginPayload, RenameLayoutPayload,
         RenameLayoutResponse as ProtobufRenameLayoutResponse, RenameTabWithIdPayload,
         RenameWebLoginTokenPayload, RenameWebTokenResponse, ReplacePaneWithExistingPanePayload,
-        RequestPluginPermissionPayload, RerunCommandPanePayload, ResizePaneIdWithDirectionPayload,
-        ResizePayload, RevokeAllWebTokensResponse, RevokeTokenResponse, RevokeWebLoginTokenPayload,
+        RequestNestedSessionKeybindsPayload, RequestPluginPermissionPayload,
+        RerunCommandPanePayload, ResizePaneIdWithDirectionPayload, ResizePayload,
+        RevokeAllWebTokensResponse, RevokeTokenResponse, RevokeWebLoginTokenPayload,
         RunActionPayload, RunCommandPayload, RunningCommand as ProtobufRunningCommand,
         SaveLayoutPayload, SaveLayoutResponse as ProtobufSaveLayoutResponse, SaveSessionPayload,
         SaveSessionResponse as ProtobufSaveSessionResponse, ScrollDownInPaneIdPayload,
@@ -2493,6 +2494,18 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
             Some(CommandName::CurrentSessionLastSavedTime) => {
                 Ok(PluginCommand::CurrentSessionLastSavedTime)
             },
+            Some(CommandName::RequestNestedSessionKeybinds) => {
+                match protobuf_plugin_command.payload {
+                    Some(Payload::RequestNestedSessionKeybindsPayload(payload)) => {
+                        let pane_id = payload
+                            .pane_id
+                            .ok_or("Malformed pane_id for RequestNestedSessionKeybinds")
+                            .and_then(|pane_id| pane_id.try_into())?;
+                        Ok(PluginCommand::RequestNestedSessionKeybinds(pane_id))
+                    },
+                    _ => Err("Malformed payload for RequestNestedSessionKeybinds"),
+                }
+            },
             Some(CommandName::GetPaneInfo) => match protobuf_plugin_command.payload {
                 Some(Payload::GetPaneInfoPayload(get_pane_info_payload)) => {
                     let pane_id = get_pane_info_payload
@@ -4278,6 +4291,17 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
                     CurrentSessionLastSavedTimePayload {},
                 )),
             }),
+            PluginCommand::RequestNestedSessionKeybinds(pane_id) => {
+                let protobuf_pane_id: ProtobufPaneId = pane_id.try_into()?;
+                Ok(ProtobufPluginCommand {
+                    name: CommandName::RequestNestedSessionKeybinds as i32,
+                    payload: Some(Payload::RequestNestedSessionKeybindsPayload(
+                        RequestNestedSessionKeybindsPayload {
+                            pane_id: Some(protobuf_pane_id),
+                        },
+                    )),
+                })
+            },
             PluginCommand::GetPaneInfo(pane_id) => {
                 let protobuf_pane_id: ProtobufPaneId = pane_id.try_into()?;
                 Ok(ProtobufPluginCommand {


### PR DESCRIPTION
Closes #5561.

When focus descends into a nested session, the host's `ModeInfo` still describes the
host, and Zellij exposes nothing else about the guest. A host status bar therefore
cannot say anything about the session the user is actually typing into. This adds the
missing reports. No default plugin is modified, so the diff is API surface plus the
plumbing to fill it.

### Wire protocol

Three arms on `NestedSessionMessage`, in the self-contained `nested_session_contract`
protobuf, plus a `HintReporting` capability advertised in the existing handshake:

- `GuestModeUpdate { mode, base_mode }`, guest to host
- `RequestGuestKeybinds`, host to guest
- `GuestKeybindsUpdate { keybinds }`, guest to host

Keybindings cross as an opaque `bytes keybinds_payload` holding a plugin-API
`InitialKeybindsPayload`, so the contract does not restate the `Action` schema. Modes
cross under the name `InputMode::from_str` reads, so a new mode needs no contract
change.

Everything is appended and no existing arm changed, so an older build decodes an
unknown arm as `Err` and drops the frame. An unknown capability is dropped without
losing the known ones.

### Plugin API

- `Event::NestedSessionModeUpdate { pane_id, session_name, mode, base_mode }`
- `Event::NestedSessionKeybinds { pane_id, session_name, keybinds }`
- `PluginCommand::RequestNestedSessionKeybinds(PaneId)`, with a `zellij-tile` shim

All under `PermissionType::ReadApplicationState`, matching `ModeUpdate` and
`GetPaneInfo`, delivered through the existing `EventType` subscription.

### Server and client

A guest reports its mode when the handshake completes, on every mode change, when
answering a keybinding request, and when a reconfigure rewrites its bindings.
`report_mode_to_host` returns immediately unless the session really is nested, so a
standalone session stays silent.

The unprompted report on handshake matters: without it a host does not know a guest
exists until the user happens to change mode inside it, so a host plugin has nothing
to ask key bindings about.


### Tests

- `nested_session.rs`: 21 unit tests. Every arm and every `InputMode` round-trips,
  unknown mode names reject the frame, tables keep their modes/keys/actions, empty
  tables survive, undecodable payloads are rejected, unknown capabilities are dropped
  without losing known ones, control-character bindings are dropped without losing the
  rest.
- `plugin_api/event.rs`: protobuf round trips for both events, plus one covering that
  an unrepresentable key costs only its own binding.
- `zellij-integration-tests/tests/nested_hint_reporting.rs`: 4 tests on the existing
  `NestedHarness` pattern, covering the handshake, the unprompted report, the request
  and answer, and mode changes flowing up while descended.

```
cargo test -p zellij-utils --lib                                    462 pass
cargo test -p zellij-server --lib                                  1576 pass
cargo test -p zellij-integration-tests --test nested_hint_reporting   4 pass
cargo fmt --all --check                                            clean
cargo xtask build                                                  succeeds
```

### Actual Use

I've already have a working update to my zjstatus-hints to use this API.
https://github.com/myah-mitchell/zjstatus-hints/tree/feat/nested-session-hint-events