### PR TITLE
feat(plugin-api): let a plugin give its layout space back while empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+* feat: let a plugin give its layout space back while it has nothing to draw, so a bar plugin does not hold an empty row (https://github.com/zellij-org/zellij/issues/5588)
 
 ## [0.45.1] - 2026-08-28
 * fix: nested-session detection over SSH (https://github.com/zellij-org/zellij/pull/5522)

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -3043,11 +3043,11 @@ impl TiledPanes {
     /// anything.
     ///
     /// A collapsed pane drops out of the constraint solve, so its neighbors grow over the
-    /// space it held. It keeps its geometry untouched while it is out, since the solver only
-    /// ever writes to the panes it can see, which is what lets expanding restore exactly the
-    /// size the layout asked for rather than an approximation of it.
+    /// space it held. It keeps its size constraint the whole time, so expanding gives back
+    /// exactly the row or column the layout asked for rather than an approximation of it.
     ///
-    /// The caller relays out the tab afterwards.
+    /// The caller relays out the tab afterwards, which is also where the pane's geometry is
+    /// kept current: see `take_collapsed_panes`.
     pub fn set_pane_collapsed(&mut self, pane_id: PaneId, collapsed: bool) -> bool {
         let changed = if collapsed {
             self.collapsed_panes.insert(pane_id)
@@ -3081,6 +3081,44 @@ impl TiledPanes {
     }
     pub fn pane_is_collapsed(&self, pane_id: &PaneId) -> bool {
         self.collapsed_panes.contains(pane_id)
+    }
+    /// Let the collapsed panes take part in the next solve, and hand them back so the caller
+    /// can collapse them again over the result.
+    ///
+    /// Being filtered out of the solve is what stops a collapsed pane from holding space, but
+    /// it also means nothing writes geometry to it, so across a resize or a relayout it would
+    /// be left describing a display area that no longer exists. That is worse than merely
+    /// stale: the solver reconstructs the layout tree from where the panes currently sit, so
+    /// one pane in the wrong place gives the next solve a tree that does not match the screen.
+    /// Solving with them and then collapsing again over the answer keeps their geometry
+    /// current for the moment they are expanded.
+    ///
+    /// Paired with `restore_collapsed_panes`. Nesting is safe: the inner call finds nothing
+    /// left to take and restores nothing.
+    pub fn take_collapsed_panes(&mut self) -> HashSet<PaneId> {
+        let collapsed = std::mem::take(&mut self.collapsed_panes);
+        if !collapsed.is_empty() {
+            self.refresh_panes_to_hide();
+        }
+        collapsed
+    }
+    /// Put back what `take_collapsed_panes` took, and say whether there was anything to put
+    /// back. The caller solves again when there was, so the neighbors reclaim the space.
+    ///
+    /// A pane that closed while the set was out of the struct never reached
+    /// `forget_collapsed_pane`, so anything that is no longer here is dropped on the way in.
+    pub fn restore_collapsed_panes(&mut self, collapsed: HashSet<PaneId>) -> bool {
+        let panes = &self.panes;
+        let still_here: HashSet<PaneId> = collapsed
+            .into_iter()
+            .filter(|pane_id| panes.contains_key(pane_id))
+            .collect();
+        if still_here.is_empty() {
+            return false;
+        }
+        self.collapsed_panes = still_here;
+        self.refresh_panes_to_hide();
+        true
     }
     pub fn add_to_hidden_panels(&mut self, pid: PaneId) {
         self.panes_to_hide.insert(pid);

--- a/zellij-server/src/panes/tiled_panes/mod.rs
+++ b/zellij-server/src/panes/tiled_panes/mod.rs
@@ -80,6 +80,12 @@ pub struct TiledPanes {
     active_panes: ActivePanes,
     pane_frame_style: PaneFrameStyle,
     panes_to_hide: HashSet<PaneId>,
+    /// Panes that have given their space back to their neighbors until they ask for it again.
+    ///
+    /// Kept apart from `panes_to_hide`, which fullscreen overwrites wholesale: a collapsed pane
+    /// has to stay collapsed across entering and leaving fullscreen, and `panes_to_hide` is
+    /// rebuilt from both sources whenever either changes.
+    collapsed_panes: HashSet<PaneId>,
     fullscreen_is_active: Option<PaneId>,
     fullscreen_covers_ui: Rc<RefCell<bool>>,
     senders: ThreadSenders,
@@ -125,6 +131,7 @@ impl TiledPanes {
             active_panes: ActivePanes::new(&os_api),
             pane_frame_style,
             panes_to_hide: HashSet::new(),
+            collapsed_panes: HashSet::new(),
             fullscreen_is_active: None,
             fullscreen_covers_ui,
             senders,
@@ -544,6 +551,11 @@ impl TiledPanes {
                 // for the other panes in this tab
                 let is_ui_pane =
                     !p.selectable() || (p.borderless() && matches!(p.pid(), PaneId::Plugin(_)));
+                // a collapsed pane holds no space, so it must not shrink the viewport either,
+                // or the panes that grew over it would be sized as if it were still there
+                if self.collapsed_panes.contains(&p.pid()) {
+                    return None;
+                }
                 if is_ui_pane && is_inside_viewport(&self.viewport.borrow(), p) {
                     Some(geom.into())
                 } else {
@@ -2735,9 +2747,18 @@ impl TiledPanes {
     }
     pub fn extract_pane(&mut self, pane_id: PaneId) -> Option<Box<dyn Pane>> {
         self.reset_boundaries();
+        self.forget_collapsed_pane(&pane_id);
         self.panes.remove(&pane_id)
     }
+    /// Drop a pane's collapsed state as it leaves, so that a pane id Zellij hands out again does
+    /// not arrive already invisible.
+    fn forget_collapsed_pane(&mut self, pane_id: &PaneId) {
+        if self.collapsed_panes.remove(pane_id) {
+            self.panes_to_hide.remove(pane_id);
+        }
+    }
     pub fn remove_pane(&mut self, pane_id: PaneId) -> Option<Box<dyn Pane>> {
+        self.forget_collapsed_pane(&pane_id);
         let mut pane_grid = TiledPaneGrid::new(
             &mut self.panes,
             &self.panes_to_hide,
@@ -2808,7 +2829,7 @@ impl TiledPanes {
                 let viewport_pane = self.get_pane_mut(pid).unwrap();
                 viewport_pane.reset_size_and_position_override();
             }
-            self.panes_to_hide.clear();
+            self.panes_to_hide = self.collapsed_panes.clone();
             if let Some(fullscreen_pane) = self.get_pane_mut(fullscreen_pane_id) {
                 fullscreen_pane.reset_size_and_position_override();
             }
@@ -2854,10 +2875,19 @@ impl TiledPanes {
     }
 
     fn set_fullscreen(&mut self, pane_id: PaneId, covers_ui: bool) {
-        self.panes_to_hide = self.panes_covered_by_fullscreen(pane_id, covers_ui);
-        if self.panes_to_hide.is_empty() && !covers_ui {
+        let covered = self.panes_covered_by_fullscreen(pane_id, covers_ui);
+        if covered.is_empty() && !covers_ui {
             return;
         }
+        self.panes_to_hide = covered;
+        // a collapsed pane is hidden for its own reasons and stays that way underneath a
+        // fullscreen, so that leaving fullscreen does not hand it back space it has given up
+        self.panes_to_hide.extend(
+            self.collapsed_panes
+                .iter()
+                .copied()
+                .filter(|p| *p != pane_id),
+        );
         if covers_ui {
             self.expand_pane_over_whole_display(pane_id);
         } else {
@@ -3008,6 +3038,49 @@ impl TiledPanes {
     }
     pub fn visible_panes_count(&self) -> usize {
         self.panes.len().saturating_sub(self.panes_to_hide.len())
+    }
+    /// Take a pane out of the layout's space, or put it back, and say whether that changed
+    /// anything.
+    ///
+    /// A collapsed pane drops out of the constraint solve, so its neighbors grow over the
+    /// space it held. It keeps its geometry untouched while it is out, since the solver only
+    /// ever writes to the panes it can see, which is what lets expanding restore exactly the
+    /// size the layout asked for rather than an approximation of it.
+    ///
+    /// The caller relays out the tab afterwards.
+    pub fn set_pane_collapsed(&mut self, pane_id: PaneId, collapsed: bool) -> bool {
+        let changed = if collapsed {
+            self.collapsed_panes.insert(pane_id)
+        } else {
+            self.collapsed_panes.remove(&pane_id)
+        };
+        if changed {
+            self.refresh_panes_to_hide();
+        }
+        changed
+    }
+    /// Rebuild the hidden set from the two things that feed it: whatever a fullscreen is
+    /// covering, and whatever has collapsed itself.
+    fn refresh_panes_to_hide(&mut self) {
+        let mut hidden = match self.fullscreen_is_active {
+            Some(fullscreen_pane_id) => {
+                let covers_ui = *self.fullscreen_covers_ui.borrow();
+                let mut covered = self.panes_covered_by_fullscreen(fullscreen_pane_id, covers_ui);
+                covered.extend(
+                    self.collapsed_panes
+                        .iter()
+                        .copied()
+                        .filter(|p| *p != fullscreen_pane_id),
+                );
+                covered
+            },
+            None => self.collapsed_panes.clone(),
+        };
+        hidden.retain(|pane_id| self.panes.contains_key(pane_id));
+        self.panes_to_hide = hidden;
+    }
+    pub fn pane_is_collapsed(&self, pane_id: &PaneId) -> bool {
+        self.collapsed_panes.contains(pane_id)
     }
     pub fn add_to_hidden_panels(&mut self, pid: PaneId) {
         self.panes_to_hide.insert(pid);

--- a/zellij-server/src/plugins/zellij_exports.rs
+++ b/zellij-server/src/plugins/zellij_exports.rs
@@ -686,6 +686,9 @@ fn host_run_plugin_command(mut caller: Caller<'_, PluginEnv>) {
                     PluginCommand::SetSelfMouseSelectionSupport(selection_support) => {
                         set_self_mouse_selection_support(env, selection_support);
                     },
+                    PluginCommand::SetSelfCollapsed(collapsed) => {
+                        set_self_collapsed(env, collapsed);
+                    },
                     PluginCommand::GenerateWebLoginToken(token_label, read_only) => {
                         generate_web_login_token(env, token_label, read_only);
                     },
@@ -5279,6 +5282,22 @@ fn set_self_mouse_selection_support(env: &PluginEnv, selection_support: bool) {
             format!(
                 "failed to set plugin {} selectable from plugin {}",
                 selection_support,
+                env.name()
+            )
+        })
+        .non_fatal();
+}
+
+fn set_self_collapsed(env: &PluginEnv, collapsed: bool) {
+    env.senders
+        .send_to_screen(ScreenInstruction::SetPaneCollapsed(
+            PaneId::Plugin(env.plugin_id),
+            collapsed,
+        ))
+        .with_context(|| {
+            format!(
+                "failed to set collapsed {} from plugin {}",
+                collapsed,
                 env.name()
             )
         })

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -9585,7 +9585,13 @@ pub(crate) fn screen_thread_main(
                     }
                 }
                 if !found_pane {
-                    // a plugin can ask for this before its pane has been placed in a tab
+                    // a plugin can ask for this before its pane has been placed in a tab. Unlike
+                    // the other deferred instructions this one is sent whenever the plugin's
+                    // content comes and goes, so only the last word on a given pane is worth
+                    // keeping and the queue stays one entry deep per pane
+                    pending_events_waiting_for_tab.retain(|event| {
+                        !matches!(event, ScreenInstruction::SetPaneCollapsed(pending_pid, _) if *pending_pid == pid)
+                    });
                     pending_events_waiting_for_tab
                         .push(ScreenInstruction::SetPaneCollapsed(pid, collapsed));
                 }

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -900,6 +900,7 @@ pub enum ScreenInstruction {
     ToggleGroupMarking(ClientId, Option<NotificationEnd>),
     SessionSharingStatusChange(bool),
     SetMouseSelectionSupport(PaneId, bool),
+    SetPaneCollapsed(PaneId, bool),
     InterceptKeyPresses(PluginId, ClientId),
     ClearKeyPressesIntercepts(ClientId),
     ReplacePaneWithExistingPane(PaneId, PaneId, bool, Option<NotificationEnd>), // bool -> suppress_replaced_pane
@@ -1272,6 +1273,7 @@ impl From<&ScreenInstruction> for ScreenContext {
             ScreenInstruction::SetMouseSelectionSupport(..) => {
                 ScreenContext::SetMouseSelectionSupport
             },
+            ScreenInstruction::SetPaneCollapsed(..) => ScreenContext::SetPaneCollapsed,
             ScreenInstruction::InterceptKeyPresses(..) => ScreenContext::InterceptKeyPresses,
             ScreenInstruction::ClearKeyPressesIntercepts(..) => {
                 ScreenContext::ClearKeyPressesIntercepts
@@ -9568,6 +9570,24 @@ pub(crate) fn screen_thread_main(
                     pending_events_waiting_for_tab.push(
                         ScreenInstruction::SetMouseSelectionSupport(pid, selection_support),
                     );
+                }
+                screen.render(None)?;
+                screen.log_and_report_session_state()?;
+            },
+            ScreenInstruction::SetPaneCollapsed(pid, collapsed) => {
+                let all_tabs = screen.get_tabs_mut();
+                let mut found_pane = false;
+                for tab in all_tabs.values_mut() {
+                    if tab.has_pane_with_pid(&pid) {
+                        tab.set_pane_collapsed(pid, collapsed);
+                        found_pane = true;
+                        break;
+                    }
+                }
+                if !found_pane {
+                    // a plugin can ask for this before its pane has been placed in a tab
+                    pending_events_waiting_for_tab
+                        .push(ScreenInstruction::SetPaneCollapsed(pid, collapsed));
                 }
                 screen.render(None)?;
                 screen.log_and_report_session_state()?;

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -5655,6 +5655,24 @@ impl Tab {
     pub fn set_mouse_selection_support(&mut self, pane_id: PaneId, selection_support: bool) {
         MouseHandler::set_mouse_selection_support(self, pane_id, selection_support);
     }
+    /// Hand a tiled pane's space to its neighbors, or take it back.
+    ///
+    /// A pane that has nothing to show, such as a status bar whose content is empty, would
+    /// otherwise keep the row a layout reserved for it and draw it blank. Collapsing takes it
+    /// out of the layout's arithmetic without taking it out of the layout, so expanding puts it
+    /// back at the size the layout asked for.
+    ///
+    /// Floating panes take no space from their neighbors, so there is nothing to give back.
+    pub fn set_pane_collapsed(&mut self, pane_id: PaneId, collapsed: bool) {
+        if !self.tiled_panes.panes_contain(&pane_id) {
+            return;
+        }
+        if !self.tiled_panes.set_pane_collapsed(pane_id, collapsed) {
+            return;
+        }
+        let size = self.size;
+        self.resize_whole_tab(size).non_fatal();
+    }
     pub fn close_pane(
         &mut self,
         id: PaneId,

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -1945,6 +1945,9 @@ impl Tab {
         if self.tiled_panes.fullscreen_is_active() {
             self.tiled_panes.unset_fullscreen();
         }
+        // a new layout places every pane, so the collapsed ones take part and are collapsed
+        // again over the result. See TiledPanes::take_collapsed_panes.
+        let collapsed_panes_to_restore = self.tiled_panes.take_collapsed_panes();
         self.dissolve_stack_lists_for_classic_mutation();
         if let Some(layout_candidate) = self
             .swap_layouts
@@ -1986,6 +1989,12 @@ impl Tab {
         let display_area = *self.display_area.borrow();
         // we do this so that the new swap layout has a chance to pass through the constraint system
         self.tiled_panes.resize(display_area);
+        if self
+            .tiled_panes
+            .restore_collapsed_panes(collapsed_panes_to_restore)
+        {
+            self.tiled_panes.resize(display_area);
+        }
         self.set_should_clear_display_before_rendering();
         self.senders
             .send_to_pty_writer(PtyWriteInstruction::ApplyCachedResizes)
@@ -5097,6 +5106,9 @@ impl Tab {
         // resize so the user-visible state is preserved. Without this, hidden
         // panes retain stale geometry from before the resize and the layout
         // solver fails when fullscreen is later toggled off.
+        // Collapsed panes come along for the same reason, and are collapsed again below once
+        // the new geometry is theirs. See TiledPanes::take_collapsed_panes.
+        let collapsed_panes_to_restore = self.tiled_panes.take_collapsed_panes();
         let fullscreen_pane_to_restore = self.tiled_panes.fullscreen_pane_id();
         let fullscreen_covered_ui = self.tiled_panes.fullscreen_covers_ui();
         if fullscreen_pane_to_restore.is_some() {
@@ -5125,6 +5137,13 @@ impl Tab {
         {
             self.swap_layouts.set_is_tiled_damaged();
             let _ = self.relayout_tiled_panes(false);
+        }
+        if self
+            .tiled_panes
+            .restore_collapsed_panes(collapsed_panes_to_restore)
+        {
+            // solve once more, now without them, so their neighbors take the space back
+            self.tiled_panes.resize(new_screen_size);
         }
         self.set_should_clear_display_before_rendering();
         self.senders

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -17981,7 +17981,8 @@ fn a_collapsed_pane_keeps_the_geometry_it_will_come_back_to() {
     assert_eq!(
         geom_of(&tab, PaneId::Terminal(2)),
         before,
-        "a collapsed pane is out of the solve, so nothing should be writing geometry to it"
+        "a collapsed pane holds no space, but it still describes where it will come back, \
+         so collapsing on its own must not move it"
     );
 }
 
@@ -18047,4 +18048,68 @@ fn collapsing_a_pane_that_is_not_in_the_tab_does_nothing() {
         ),
         before
     );
+}
+
+/// The shape a bar plugin actually has: a full-width pane with a one-row pane pinned
+/// under it, the way `pane size=1 borderless` in a layout arrives.
+fn tab_with_a_one_row_bar_under_a_pane(size: Size) -> Tab {
+    let mut layout = TiledPaneLayout::default();
+    layout.children_split_direction = SplitDirection::Horizontal;
+    let mut bar = TiledPaneLayout::default();
+    bar.split_size = Some(SplitSize::Fixed(1));
+    layout.children = vec![TiledPaneLayout::default(), bar];
+    create_new_tab_with_layout(size, layout)
+}
+
+#[test]
+fn a_collapsed_pane_follows_the_tab_when_it_is_resized() {
+    let mut tab = tab_with_a_one_row_bar_under_a_pane(Size {
+        cols: 121,
+        rows: 20,
+    });
+    let main_pane = PaneId::Terminal(0);
+    let bar = PaneId::Terminal(1);
+    tab.set_pane_collapsed(bar, true);
+
+    // the tab changes shape, the way a nested session's does when its host expands it
+    // over the whole display and takes its own bars off the screen with it
+    tab.resize_whole_tab(Size {
+        cols: 118,
+        rows: 23,
+    })
+    .unwrap();
+
+    // being left out of the solve is what keeps a collapsed pane from holding space, but
+    // it must not leave the pane describing a tab that no longer exists: the solver reads
+    // the layout tree back off pane geometry, so a stale one breaks the next solve
+    assert_eq!(
+        geom_of(&tab, bar).y,
+        22,
+        "the collapsed bar should still be tracking the bottom of the tab"
+    );
+    assert_eq!(
+        geom_of(&tab, bar).cols.as_usize(),
+        118,
+        "the collapsed bar should still be tracking the width of the tab"
+    );
+    assert_eq!(
+        geom_of(&tab, main_pane).rows.as_usize(),
+        23,
+        "the pane that stayed should hold every row of the resized tab"
+    );
+
+    tab.set_pane_collapsed(bar, false);
+
+    assert_eq!(
+        geom_of(&tab, main_pane).rows.as_usize(),
+        22,
+        "the pane that stayed should give the row back"
+    );
+    assert_eq!(
+        geom_of(&tab, bar).y,
+        22,
+        "the bar should come back on the bottom row, not partway up the pane above it"
+    );
+    assert_eq!(geom_of(&tab, bar).rows.as_usize(), 1);
+    assert_eq!(geom_of(&tab, bar).cols.as_usize(), 118);
 }

--- a/zellij-server/src/tab/unit/tab_tests.rs
+++ b/zellij-server/src/tab/unit/tab_tests.rs
@@ -17911,3 +17911,140 @@ fn floating_plugin_panes_are_not_shown_again_when_their_tab_returns_with_the_sur
         "a plugin whose floating surface is hidden should not be told it is visible when its tab returns"
     );
 }
+
+fn tab_with_a_pane_above_a_pane() -> Tab {
+    let size = Size {
+        cols: 121,
+        rows: 20,
+    };
+    let mut tab = create_new_tab(size, true);
+    tab.horizontal_split(PaneId::Terminal(2), None, 1, None, None)
+        .unwrap();
+    tab
+}
+
+fn geom_of(tab: &Tab, pane_id: PaneId) -> PaneGeom {
+    tab.tiled_panes
+        .panes
+        .get(&pane_id)
+        .unwrap()
+        .position_and_size()
+}
+
+#[test]
+fn collapsing_a_pane_gives_its_rows_to_its_neighbor() {
+    let mut tab = tab_with_a_pane_above_a_pane();
+    let rows_before = geom_of(&tab, PaneId::Terminal(1)).rows.as_usize();
+
+    tab.set_pane_collapsed(PaneId::Terminal(2), true);
+
+    assert_eq!(
+        geom_of(&tab, PaneId::Terminal(1)).rows.as_usize(),
+        20,
+        "the pane that stayed should hold every row the tab has"
+    );
+    assert!(
+        rows_before < 20,
+        "the two panes should have been sharing the rows to begin with"
+    );
+}
+
+#[test]
+fn expanding_a_pane_restores_the_geometry_it_had() {
+    let mut tab = tab_with_a_pane_above_a_pane();
+    let before = (
+        geom_of(&tab, PaneId::Terminal(1)),
+        geom_of(&tab, PaneId::Terminal(2)),
+    );
+
+    tab.set_pane_collapsed(PaneId::Terminal(2), true);
+    tab.set_pane_collapsed(PaneId::Terminal(2), false);
+
+    // exact equality rather than a row count: the point of collapsing instead of suppressing
+    // is that the layout comes back as it was, position and constraint included
+    assert_eq!(
+        (
+            geom_of(&tab, PaneId::Terminal(1)),
+            geom_of(&tab, PaneId::Terminal(2))
+        ),
+        before
+    );
+}
+
+#[test]
+fn a_collapsed_pane_keeps_the_geometry_it_will_come_back_to() {
+    let mut tab = tab_with_a_pane_above_a_pane();
+    let before = geom_of(&tab, PaneId::Terminal(2));
+
+    tab.set_pane_collapsed(PaneId::Terminal(2), true);
+
+    assert_eq!(
+        geom_of(&tab, PaneId::Terminal(2)),
+        before,
+        "a collapsed pane is out of the solve, so nothing should be writing geometry to it"
+    );
+}
+
+#[test]
+fn collapsing_a_pane_that_is_already_collapsed_does_nothing() {
+    let mut tab = tab_with_a_pane_above_a_pane();
+    tab.set_pane_collapsed(PaneId::Terminal(2), true);
+    let after_first = geom_of(&tab, PaneId::Terminal(1));
+
+    tab.set_pane_collapsed(PaneId::Terminal(2), true);
+
+    assert_eq!(geom_of(&tab, PaneId::Terminal(1)), after_first);
+}
+
+#[test]
+fn a_collapsed_pane_is_still_collapsed_after_a_fullscreen_comes_and_goes() {
+    let mut tab = tab_with_a_pane_above_a_pane();
+    tab.set_pane_collapsed(PaneId::Terminal(2), true);
+    tab.focus_pane_with_id(PaneId::Terminal(1), false, false, 1)
+        .unwrap();
+
+    // fullscreen rebuilds the hidden set from scratch, so a collapse that lived only there
+    // would be handed its rows back on the way out
+    tab.toggle_active_pane_fullscreen(1);
+    tab.toggle_active_pane_fullscreen(1);
+
+    assert!(tab.tiled_panes.pane_is_collapsed(&PaneId::Terminal(2)));
+    assert_eq!(
+        geom_of(&tab, PaneId::Terminal(1)).rows.as_usize(),
+        20,
+        "the pane that stayed should still hold every row"
+    );
+}
+
+#[test]
+fn closing_a_collapsed_pane_forgets_that_it_was_collapsed() {
+    let mut tab = tab_with_a_pane_above_a_pane();
+    tab.set_pane_collapsed(PaneId::Terminal(2), true);
+
+    tab.close_pane(PaneId::Terminal(2), false, None);
+
+    assert!(
+        !tab.tiled_panes.pane_is_collapsed(&PaneId::Terminal(2)),
+        "a pane id Zellij hands out again must not arrive already invisible"
+    );
+}
+
+#[test]
+fn collapsing_a_pane_that_is_not_in_the_tab_does_nothing() {
+    let mut tab = tab_with_a_pane_above_a_pane();
+    let before = (
+        geom_of(&tab, PaneId::Terminal(1)),
+        geom_of(&tab, PaneId::Terminal(2)),
+    );
+
+    tab.set_pane_collapsed(PaneId::Terminal(99), true);
+
+    assert!(!tab.tiled_panes.pane_is_collapsed(&PaneId::Terminal(99)));
+    assert_eq!(
+        (
+            geom_of(&tab, PaneId::Terminal(1)),
+            geom_of(&tab, PaneId::Terminal(2))
+        ),
+        before
+    );
+}

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -2687,6 +2687,23 @@ pub fn set_self_mouse_selection_support(selection_support: bool) {
     unsafe { host_run_plugin_command() };
 }
 
+/// Give this plugin's pane back to its neighbors while it has nothing to draw, or take it
+/// again when it does.
+///
+/// Intended for a plugin mounted in a layout as a bar, whose content is sometimes empty: the
+/// row a layout reserves for it stays reserved otherwise, and shows as a blank line. While
+/// collapsed the pane keeps its place in the layout and simply takes no space, so expanding
+/// restores the exact geometry the layout asked for. Calling it with the size the pane is
+/// already at does nothing.
+///
+/// Has no effect on a floating pane, which takes no space from its neighbors to begin with.
+pub fn set_self_collapsed(collapsed: bool) {
+    let plugin_command = PluginCommand::SetSelfCollapsed(collapsed);
+    let protobuf_plugin_command: ProtobufPluginCommand = plugin_command.try_into().unwrap();
+    object_to_stdout(&protobuf_plugin_command.encode_to_vec());
+    unsafe { host_run_plugin_command() };
+}
+
 pub fn generate_web_login_token(
     token_label: Option<String>,
     read_only: bool,

--- a/zellij-utils/assets/prost/api.plugin_command.rs
+++ b/zellij-utils/assets/prost/api.plugin_command.rs
@@ -4,7 +4,7 @@
 pub struct PluginCommand {
     #[prost(enumeration="CommandName", tag="1")]
     pub name: i32,
-    #[prost(oneof="plugin_command::Payload", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 168, 169, 170, 171")]
+    #[prost(oneof="plugin_command::Payload", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 168, 169, 170, 171, 172")]
     pub payload: ::core::option::Option<plugin_command::Payload>,
 }
 /// Nested message and enum types in `PluginCommand`.
@@ -320,7 +320,15 @@ pub mod plugin_command {
         SetPaneFrameStylePayload(super::SetPaneFrameStylePayload),
         #[prost(message, tag="171")]
         ToggleFloatingPanesPayload(super::ToggleFloatingPanesPayload),
+        #[prost(message, tag="172")]
+        SetSelfCollapsedPayload(super::SetSelfCollapsedPayload),
     }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SetSelfCollapsedPayload {
+    #[prost(bool, tag="1")]
+    pub collapsed: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2227,6 +2235,7 @@ pub enum CommandName {
     NewPane = 226,
     ToggleFocusNoUiFullscreen = 227,
     FocusHostSession = 228,
+    SetSelfCollapsed = 229,
 }
 impl CommandName {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -2438,6 +2447,7 @@ impl CommandName {
             CommandName::NewPane => "NewPane",
             CommandName::ToggleFocusNoUiFullscreen => "ToggleFocusNoUiFullscreen",
             CommandName::FocusHostSession => "FocusHostSession",
+            CommandName::SetSelfCollapsed => "SetSelfCollapsed",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -2646,6 +2656,7 @@ impl CommandName {
             "NewPane" => Some(Self::NewPane),
             "ToggleFocusNoUiFullscreen" => Some(Self::ToggleFocusNoUiFullscreen),
             "FocusHostSession" => Some(Self::FocusHostSession),
+            "SetSelfCollapsed" => Some(Self::SetSelfCollapsed),
             _ => None,
         }
     }

--- a/zellij-utils/src/data.rs
+++ b/zellij-utils/src/data.rs
@@ -3614,6 +3614,10 @@ pub enum PluginCommand {
     EmbedMultiplePanes(Vec<PaneId>),
     QueryWebServerStatus,
     SetSelfMouseSelectionSupport(bool),
+    /// Give this plugin's own row or column in the layout back to its neighbors while it has
+    /// nothing to draw, and take it again when it does. The pane keeps its place in the layout
+    /// the whole time, so expanding restores exactly the size the layout asked for.
+    SetSelfCollapsed(bool),
     GenerateWebLoginToken(Option<String>, bool), // (token_label, read_only)
     RevokeWebLoginToken(String), // String -> token id (provided name or generated id)
     ListWebLoginTokens,

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -436,6 +436,7 @@ pub enum ScreenContext {
     ToggleGroupMarking,
     SessionSharingStatusChange,
     SetMouseSelectionSupport,
+    SetPaneCollapsed,
     InterceptKeyPresses,
     ClearKeyPressesIntercepts,
     ReplacePaneWithExistingPane,

--- a/zellij-utils/src/plugin_api/plugin_command.proto
+++ b/zellij-utils/src/plugin_api/plugin_command.proto
@@ -218,6 +218,7 @@ enum CommandName {
   NewPane = 226;
   ToggleFocusNoUiFullscreen = 227;
   FocusHostSession = 228;
+  SetSelfCollapsed = 229;
 }
 
 message PluginCommand {
@@ -378,7 +379,12 @@ message PluginCommand {
     NewTiledPaneInTabPayload new_tiled_pane_in_tab_payload = 169;
     SetPaneFrameStylePayload set_pane_frame_style_payload = 170;
     ToggleFloatingPanesPayload toggle_floating_panes_payload = 171;
+    SetSelfCollapsedPayload set_self_collapsed_payload = 172;
   }
+}
+
+message SetSelfCollapsedPayload {
+  bool collapsed = 1;
 }
 
 message SetPaneFrameStylePayload {

--- a/zellij-utils/src/plugin_api/plugin_command.rs
+++ b/zellij-utils/src/plugin_api/plugin_command.rs
@@ -123,7 +123,8 @@ pub use super::generated_api::api::{
         SessionListSnapshot as ProtobufSessionListSnapshot, SetFloatingPanePinnedPayload,
         SetPaneBorderlessPayload, SetPaneColorPayload,
         SetPaneFrameStylePayload as ProtobufSetPaneFrameStylePayload,
-        SetPaneRegexHighlightsPayload, SetSelfMouseSelectionSupportPayload,
+        SetPaneRegexHighlightsPayload, SetSelfCollapsedPayload,
+        SetSelfMouseSelectionSupportPayload,
         SetSoftKeyboardPayload as ProtobufSetSoftKeyboardPayload, SetTimeoutPayload,
         ShowCursorPayload, ShowFloatingPanesPayload as ProtobufShowFloatingPanesPayload,
         ShowFloatingPanesResponse as ProtobufShowFloatingPanesResponse, ShowPaneWithIdPayload,
@@ -2386,6 +2387,12 @@ impl TryFrom<ProtobufPluginCommand> for PluginCommand {
                     _ => Err("SetSelfMouseSelectionSupport requires a payload"),
                 }
             },
+            Some(CommandName::SetSelfCollapsed) => match protobuf_plugin_command.payload {
+                Some(Payload::SetSelfCollapsedPayload(set_self_collapsed_payload)) => Ok(
+                    PluginCommand::SetSelfCollapsed(set_self_collapsed_payload.collapsed),
+                ),
+                _ => Err("SetSelfCollapsed requires a payload"),
+            },
             Some(CommandName::GenerateWebLoginToken) => match protobuf_plugin_command.payload {
                 Some(Payload::GenerateWebLoginTokenPayload(generate_web_login_token_payload)) => {
                     Ok(PluginCommand::GenerateWebLoginToken(
@@ -4164,6 +4171,12 @@ impl TryFrom<PluginCommand> for ProtobufPluginCommand {
                     )),
                 })
             },
+            PluginCommand::SetSelfCollapsed(collapsed) => Ok(ProtobufPluginCommand {
+                name: CommandName::SetSelfCollapsed as i32,
+                payload: Some(Payload::SetSelfCollapsedPayload(SetSelfCollapsedPayload {
+                    collapsed,
+                })),
+            }),
             PluginCommand::GenerateWebLoginToken(token_label, read_only) => {
                 Ok(ProtobufPluginCommand {
                     name: CommandName::GenerateWebLoginToken as i32,


### PR DESCRIPTION
Closes #5588.

A plugin mounted as a bar holds its layout row whether or not it draws anything, so an
empty bar shows as a blank line. Nothing in the API covers giving that row up and
getting it back: `hide_self()` returns through `add_tiled_pane`, which splits a
neighbor rather than restoring the layout node, so a `size=1 borderless` bar does not
come back as one; `close_self()` does not come back at all; and `Fixed(0)` cannot exist
because `discretize_spans` errors on any span below 1.

This adds `PluginCommand::SetSelfCollapsed(bool)` through the usual chain, with a
`zellij-tile` shim `set_self_collapsed`. Ungated, matching `HideSelf`, `CloseSelf` and
`SetSelfMouseSelectionSupport`: it names no pane but the caller's own.

### How it works

The pane leaves the constraint solve, not the layout. `TiledPaneGrid::new` already
filters `panes_to_hide` and `constrain_spans` already forces the surviving spans to
fill the space, so the neighbors absorb the row on their own. The pane keeps its size
constraint while it is out, so a `Fixed(1)` bar is still `Fixed(1)` when it rejoins and
expanding restores the layout exactly.

Three things that are not obvious from the diff:

- Collapsed state lives in its own set rather than in `panes_to_hide`, because
  `set_fullscreen` overwrites that wholesale and `unset_fullscreen` clears it.
  `refresh_panes_to_hide` composes the two.
- `non_selectable_pane_geoms_inside_viewport` skips collapsed panes, otherwise
  `offset_viewport` still shrinks the viewport by a row nobody holds.
- Nothing writes geometry to a pane the solver cannot see, so `resize_whole_tab` and
  `relayout_tiled_panes` let collapsed panes take part and collapse them again over the
  result. `resize_whole_tab` already does this for fullscreen a few lines above.

### Scope and tests

452 insertions, 5 deletions, 11 files, 202 of the insertions tests. No default plugin
touched, so nothing changes for anyone who does not call it.

Eight tests in `tab_tests.rs` cover the neighbor absorbing the row, expanding
restoring the exact `PaneGeom`, both no-op cases, surviving a fullscreen round trip,
forgetting state on close, and following a tab resize. 

```
cargo test -p zellij-server --lib   1584 pass
cargo test -p zellij-utils --lib     450 pass
cargo fmt --all --check             clean
```

### Origin
I discovered the need for this after finishing the work to resolve #5561 and updating
my https://github.com/myah-mitchell/zjstatus-hints to use the new API. I was able
to hide hints inside nested panes but then if you made the nested zellij fullscreen
you no longer had a bottom bar. Additionally, when I hid the bottom bar there was
still an empty pane taking up the space that had been used, negating the whole reason
to hide the nested hints pane. I've already put this API to use with the work at
https://github.com/myah-mitchell/zjstatus-hints/tree/feat/collapse-when-empty.