### PR TITLE
Add AGENTS.md describing the command surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md
+
+Notes for AI coding agents working in this repository. Written for a reader
+that has no memory of this project and cannot ask anyone.
+
+## Commands that change state
+
+`zellij` exposes 17 commands. 4 of them change something that
+outlives the process.
+
+| Command | What it changes | If you only meant to look |
+|---|---|---|
+| `zellij kill-session` | Terminates a running session and the processes in it. | `zellij list-sessions` |
+| `zellij kill-all-sessions` | Terminates every running session and the processes in them. | `zellij list-sessions` |
+| `zellij delete-session` | Deletes a session's saved state from disk. Not recoverable. | `zellij list-sessions` |
+| `zellij delete-all-sessions` | Deletes every session's saved state from disk. Not recoverable. | `zellij list-sessions` |
+
+## Commands that only read
+
+`zellij list-sessions`, `zellij list-aliases`, `zellij watch`, `zellij subscribe`
+
+## Commands that start or control a process
+
+These do not write files themselves. What they start can do anything.
+
+| Command | What it does |
+|---|---|
+| `zellij attach` | Attaches to a session, creating it if it does not exist. |
+| `zellij run` | Runs a command in a new pane. Whatever it runs can do anything. |
+| `zellij edit` | Opens a file in a new pane using $EDITOR, which may write it. |
+| `zellij plugin` | Loads a plugin in a new pane. |
+| `zellij web` | Runs a web server serving terminal sessions over the network. |
+
+## Commands not classified here
+
+`zellij action`, `zellij pipe`, `zellij options`, `zellij setup`
+
+**Unclassified is not the same as safe.** It means nobody has written it down
+yet. Read the implementation before running one.
+
+## Before running anything
+
+- Being able to run a command is not being allowed to run it.
+- `zellij kill-session` and `zellij list-sessions` differ by one word and do very different things.
+- If you cannot tell what a command does, say so rather than guessing. An
+  honest `unknown` costs a question; a confident wrong answer costs a rollback.
+
+<sub>Command list verified against af38660c5884 on 2026-09-09.</sub>


### PR DESCRIPTION

### What this is

A short `AGENTS.md` listing zellij's 17 commands, marking the 4
that change state and naming a read-only alternative for each.

### Why

Coding agents increasingly run project commands directly, and which of
zellij's commands change state is not written down anywhere in the
repository - an agent working from a clone has to infer it from the source.

Four of them destroy a session or its saved state, and the four names differ by one word from four that do not: `kill-session` and `delete-session` sit beside `list-sessions` and `watch`. An agent reading the source has to notice that `delete-all-sessions` and `list-sessions` are not the same kind of command.

### How the list was produced

Every command was read from zellij-utils/src/cli.rs — the `Command` enum and the `Sessions` enum it merges in with #[clap(flatten)], and checked by hand against this
repository at `af38660c5884`. The effect classes are mine and I may have a
judgement wrong - please correct anything that reads oddly, the file is plain
Markdown with no tooling behind it.

### What this does not add

No dependency, no CI step, no configuration. One Markdown file.

---

<sub>Disclosure: this file was drafted with an AI assistant (Claude), and the
command list was then checked by hand against the source at the commit named
above. Context: it came out of a survey of how legible command-line projects
are to agents working from a checkout. Happy to close it if it is not useful
to you.</sub>
