### PR TITLE
fix(plugins): avoid scrollback response memory exhaustion

### DIFF
--- a/default-plugins/fixture-plugin-for-tests/src/main.rs
+++ b/default-plugins/fixture-plugin-for-tests/src/main.rs
@@ -50,7 +50,7 @@ register_worker!(TestWorker, test_worker, TEST_WORKER);
 #[cfg(target_family = "wasm")]
 impl ZellijPlugin for State {
     fn load(&mut self, configuration: BTreeMap<String, String>) {
-        request_permission(&[
+        let mut permissions = vec![
             PermissionType::ChangeApplicationState,
             PermissionType::ReadApplicationState,
             PermissionType::ReadApplicationState,
@@ -66,7 +66,11 @@ impl ZellijPlugin for State {
             PermissionType::WriteToClipboard,
             PermissionType::RunActionsAsUser,
             PermissionType::ReadSessionEnvironmentVariables,
-        ]);
+        ];
+        if configuration.contains_key("test_large_scrollback") {
+            permissions.push(PermissionType::ReadPaneContents);
+        }
+        request_permission(&permissions);
         let should_subscribe_initial_keybinds = configuration
             .get("subscribe_initial_keybinds")
             .map(|v| v == "true")
@@ -993,6 +997,20 @@ impl ZellijPlugin for State {
             );
         } else if name == "message_to_plugin" {
             self.message_to_plugin_payload = payload.clone();
+        } else if name == "test_large_scrollback" {
+            for _ in 0..3 {
+                let contents = get_pane_scrollback(PaneId::Terminal(0), true).unwrap();
+                assert_eq!(contents.lines_above_viewport.len(), 10_000);
+                let expected_line = "x".repeat(150);
+                assert!(contents
+                    .lines_above_viewport
+                    .iter()
+                    .all(|line| line == &expected_line));
+                assert_eq!(contents.viewport, vec!["viewport".to_owned()]);
+                assert_eq!(contents.lines_below_viewport, vec!["below".to_owned()]);
+                assert_eq!(contents.cursor, Some((1, 2)));
+            }
+            self.explicit_string_to_render = Some("three complete scrollback reads".to_owned());
         } else if name == "panic_while_handling_pipe" {
             panic!("intentional panic for the pipe-release-on-crash test");
         }

--- a/zellij-server/src/plugins/unit/plugin_tests.rs
+++ b/zellij-server/src/plugins/unit/plugin_tests.rs
@@ -13299,3 +13299,130 @@ pub fn cli_pipe_is_released_when_plugin_panics_while_handling_it() {
          otherwise the `zellij pipe` client stays blocked until the plugin is unloaded"
     );
 }
+
+#[test]
+#[ignore] // Requires the WASM fixture built by the plugin test CI job.
+fn large_scrollback_response_fits_plugin_memory() {
+    use std::time::{Duration, Instant};
+    use zellij_utils::data::{PaneContents, PaneId, PaneScrollbackResponse};
+
+    let temp_folder = tempdir().unwrap();
+    let (sender, receiver, teardown) =
+        create_plugin_thread(Some(temp_folder.path().to_path_buf()), None);
+    let mut configuration = BTreeMap::new();
+    configuration.insert("test_large_scrollback".to_owned(), "true".to_owned());
+    let run_plugin = RunPluginOrAlias::RunPlugin(RunPlugin {
+        location: RunPluginLocation::File(PathBuf::from(&*PLUGIN_FIXTURE)),
+        configuration: PluginUserConfiguration::new(configuration),
+        ..Default::default()
+    });
+    sender.send(PluginInstruction::AddClient(1)).unwrap();
+    sender
+        .send(PluginInstruction::Load(
+            Some(false),
+            false,
+            false,
+            Some("scrollback test".to_owned()),
+            run_plugin,
+            Some(1),
+            None,
+            1,
+            Size {
+                cols: 121,
+                rows: 20,
+            },
+            None,
+            None,
+            false,
+            None,
+            None,
+            None,
+        ))
+        .unwrap();
+
+    // The debug WASM interpreter takes substantially longer than the released host.
+    let deadline = Instant::now() + Duration::from_secs(180);
+    let mut plugin_error = None;
+    let mut sent_request = false;
+    let mut response_count = 0;
+    let mut complete = false;
+    while let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
+        let Ok((instruction, _)) = receiver.recv_timeout(remaining) else {
+            break;
+        };
+        match instruction {
+            ScreenInstruction::RequestPluginPermissions(plugin_id, permission) => {
+                assert!(permission
+                    .permissions
+                    .contains(&PermissionType::ReadPaneContents));
+                sender
+                    .send(PluginInstruction::PermissionRequestResult(
+                        plugin_id,
+                        Some(1),
+                        permission.permissions,
+                        PermissionStatus::Granted,
+                        Some(temp_folder.path().join("permissions.kdl")),
+                    ))
+                    .unwrap();
+            },
+            ScreenInstruction::PluginBytes(assets) => {
+                if assets.iter().any(|asset| {
+                    String::from_utf8_lossy(&asset.bytes)
+                        .contains("three complete scrollback reads")
+                }) {
+                    complete = true;
+                    break;
+                }
+                if !sent_request {
+                    sender
+                        .send(PluginInstruction::CliPipe {
+                            pipe_id: "scrollback_test".to_owned(),
+                            name: "test_large_scrollback".to_owned(),
+                            payload: Some(String::new()),
+                            plugin: None,
+                            args: None,
+                            configuration: None,
+                            floating: None,
+                            pane_id_to_replace: None,
+                            pane_title: None,
+                            cwd: None,
+                            skip_cache: false,
+                            cli_client_id: 1,
+                        })
+                        .unwrap();
+                    sent_request = true;
+                }
+            },
+            ScreenInstruction::GetPaneScrollback {
+                pane_id,
+                get_full_scrollback,
+                response_channel,
+                ..
+            } => {
+                assert_eq!(pane_id, PaneId::Terminal(0).into());
+                assert!(get_full_scrollback);
+                response_count += 1;
+                response_channel
+                    .send(PaneScrollbackResponse::Ok(PaneContents {
+                        lines_above_viewport: vec!["x".repeat(150); 10_000],
+                        viewport: vec!["viewport".to_owned()],
+                        lines_below_viewport: vec!["below".to_owned()],
+                        selected_text: None,
+                        cursor: Some((1, 2)),
+                    }))
+                    .unwrap();
+            },
+            ScreenInstruction::UpdatePluginLoadingStage(_, stage) if stage.is_error() => {
+                plugin_error = Some(format!("{:?}", stage));
+                break;
+            },
+            _ => {},
+        }
+    }
+    teardown();
+    assert!(
+        complete,
+        "plugin failed to render after {response_count} scrollback responses: {plugin_error:?}"
+    );
+    assert_eq!(response_count, 3);
+}

--- a/zellij-tile/src/input_pipe.rs
+++ b/zellij-tile/src/input_pipe.rs
@@ -1,0 +1,95 @@
+use std::io::{self, BufRead, Read};
+
+// Host messages are newline-delimited JSON. Stream one message without keeping
+// its JSON representation alongside the decoded value in the plugin's memory.
+pub(crate) fn read_bytes(reader: &mut impl BufRead) -> serde_json::Result<Vec<u8>> {
+    let mut line = JsonLine {
+        reader,
+        ended: false,
+    };
+    let result = serde_json::from_reader(&mut line);
+    // A malformed message must not leave the next call in the middle of a line.
+    io::copy(&mut line, &mut io::sink()).map_err(serde_json::Error::io)?;
+    result
+}
+
+struct JsonLine<'a, R> {
+    reader: &'a mut R,
+    ended: bool,
+}
+
+impl<R: BufRead> Read for JsonLine<'_, R> {
+    fn read(&mut self, output: &mut [u8]) -> io::Result<usize> {
+        if self.ended || output.is_empty() {
+            return Ok(0);
+        }
+        let available = self.reader.fill_buf()?;
+        let count = available.len().min(output.len());
+        let count = match available[..count].iter().position(|b| *b == b'\n') {
+            Some(position) => {
+                self.ended = true;
+                position + 1
+            },
+            None => count,
+        };
+        output[..count].copy_from_slice(&available[..count]);
+        self.reader.consume(count);
+        Ok(count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufReader, Cursor};
+
+    #[test]
+    fn reads_one_message_at_a_time_with_small_buffers() {
+        let mut reader = BufReader::with_capacity(2, Cursor::new(b"[0,255,10]\r\n[42]\n[]"));
+        assert_eq!(read_bytes(&mut reader).unwrap(), vec![0, 255, 10]);
+        assert_eq!(read_bytes(&mut reader).unwrap(), vec![42]);
+        assert_eq!(read_bytes(&mut reader).unwrap(), Vec::<u8>::new());
+        assert!(read_bytes(&mut reader).is_err());
+    }
+
+    #[test]
+    fn malformed_messages_do_not_consume_the_next_message() {
+        for invalid in ["[256]", "[1,", "[1] garbage", "", "null"] {
+            let input = format!("{}\n[42]\n", invalid);
+            let mut reader = Cursor::new(input);
+            assert!(read_bytes(&mut reader).is_err(), "{}", invalid);
+            assert_eq!(read_bytes(&mut reader).unwrap(), vec![42]);
+        }
+    }
+
+    #[test]
+    fn leaves_following_object_messages_for_the_existing_reader() {
+        let mut reader = Cursor::new(b"[1,2]\n{\"name\":\"next\"}\n");
+        assert_eq!(read_bytes(&mut reader).unwrap(), vec![1, 2]);
+        let mut next = String::new();
+        reader.read_line(&mut next).unwrap();
+        assert_eq!(next, "{\"name\":\"next\"}\n");
+    }
+
+    #[test]
+    fn propagates_io_errors() {
+        struct Broken;
+        impl Read for Broken {
+            fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+                Err(io::Error::other("broken pipe"))
+            }
+        }
+        let error = read_bytes(&mut BufReader::new(Broken)).unwrap_err();
+        assert!(error.is_io());
+        assert!(error.to_string().contains("broken pipe"));
+    }
+
+    #[test]
+    fn reads_large_byte_arrays_without_changing_contents() {
+        let expected: Vec<u8> = (0..1_500_000).map(|n| (n % 256) as u8).collect();
+        let mut input = serde_json::to_vec(&expected).unwrap();
+        input.push(b'\n');
+        let mut reader = BufReader::with_capacity(1024, Cursor::new(input));
+        assert_eq!(read_bytes(&mut reader).unwrap(), expected);
+    }
+}

--- a/zellij-tile/src/lib.rs
+++ b/zellij-tile/src/lib.rs
@@ -15,6 +15,7 @@
 //! For a working plugin example as well as a development environment, please see:
 //! [https://github.com/zellij-org/rust-plugin-example](https://github.com/zellij-org/rust-plugin-example)
 //!
+mod input_pipe;
 pub mod prelude;
 pub mod shim;
 pub mod ui_components;

--- a/zellij-tile/src/shim.rs
+++ b/zellij-tile/src/shim.rs
@@ -2861,9 +2861,7 @@ pub fn object_from_stdin<T: DeserializeOwned>() -> Result<T> {
 #[doc(hidden)]
 pub fn bytes_from_stdin() -> Result<Vec<u8>> {
     let err_context = || "failed to deserialize bytes from stdin".to_string();
-    let mut json = String::new();
-    io::stdin().read_line(&mut json).with_context(err_context)?;
-    serde_json::from_str(&json).with_context(err_context)
+    crate::input_pipe::read_bytes(&mut io::stdin().lock()).with_context(err_context)
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
Reading the scrollback attached to #5131 crashes a plugin with `growth operation limited` on the official macOS 0.45.1 host. `bytes_from_stdin` retains the expanded JSON byte-array string while decoding the protobuf bytes, exhausting the plugin's 16 MB memory budget.

Stream each newline-delimited JSON response into its byte vector instead. The reader preserves message boundaries and drains a malformed record so the next message remains readable. The wire format and host memory limits are unchanged.

Validation:
- Reproduced the original attachment failure on the official 0.45.1 host; the rebuilt plugin reads the full contents repeatedly with a SHA-256 match.
- Added a WASM-host regression that validates every line and metadata in three successive 1.5 MB scrollback responses. It fails with the original decoder and passes with the change.
- Added unit coverage for large arrays, CRLF/EOF, malformed-message recovery, mixed message readers and I/O errors.

This is an SDK fix: plugins must be rebuilt against the updated `zellij-tile`. It avoids retaining the JSON representation; it does not remove the memory limit or promise arbitrarily large reads.

Fixes #5131. Related to the scrollback capability in #1397.

To run the WASM regression locally from the repository root:

```sh
cargo build --locked -p fixture-plugin-for-tests --release --target wasm32-wasip1
mkdir -p target/e2e-data/plugins
cp target/wasm32-wasip1/release/fixture-plugin-for-tests.wasm target/e2e-data/plugins/fixture-plugin-for-tests.wasm
cargo test --locked -p zellij-server --lib large_scrollback_response_fits_plugin_memory -- --ignored --nocapture
cargo test --locked -p zellij-tile --lib
```

The runtime regression is ignored in the ordinary unit suite because it requires the built WASM fixture; the existing plugin-system CI job runs ignored tests. Debug interpreter runs take longer than release builds (approximately 71–90 seconds locally).
