### PR TITLE
fix(kitty-graphics): zlib-compress images forwarded to the host terminal

### DIFF
--- a/zellij-server/src/output/mod.rs
+++ b/zellij-server/src/output/mod.rs
@@ -433,7 +433,7 @@ fn emit_kitty_transmit(
         if part_index == 0 {
             write!(
                 out,
-                "\u{1b}_Ga=t,q=2,f=32,t=d,i={},s={},v={},m={};{}\u{1b}\\",
+                "\u{1b}_Ga=t,q=2,f=32,o=z,t=d,i={},s={},v={},m={};{}\u{1b}\\",
                 host_image_id,
                 width,
                 height,

--- a/zellij-server/src/output/unit/output_tests.rs
+++ b/zellij-server/src/output/unit/output_tests.rs
@@ -1171,6 +1171,56 @@ fn store_test_kitty_image(
         .unwrap()
 }
 
+fn store_test_kitty_image_with_bytes(
+    kitty_image_store: &Rc<RefCell<KittyImageStore>>,
+    width: u32,
+    height: u32,
+    bytes: Vec<u8>,
+) -> InternalImageId {
+    kitty_image_store
+        .borrow_mut()
+        .store_image(DecodedImage {
+            bytes,
+            width,
+            height,
+            format: KittyFormat::Rgba32,
+        })
+        .unwrap()
+}
+
+fn kitty_transmit_control_and_payload(output: &str) -> (String, String) {
+    let mut control = String::new();
+    let mut payload = String::new();
+    let mut search_start = 0;
+    while let Some(position) = output[search_start..].find("\u{1b}_G") {
+        let start = search_start + position + 3;
+        let end = start + output[start..].find("\u{1b}\\").unwrap();
+        let (apc_control, apc_payload) = output[start..end]
+            .split_once(';')
+            .unwrap_or((&output[start..end], ""));
+        if apc_control.starts_with("a=t,") {
+            control = apc_control.to_owned();
+            payload.push_str(apc_payload);
+        } else if apc_control.starts_with("q=2,m=") {
+            payload.push_str(apc_payload);
+        }
+        search_start = end + 2;
+    }
+    (control, payload)
+}
+
+fn inflate_kitty_transmit_payload(payload_b64: &str) -> Vec<u8> {
+    use base64::engine::general_purpose::STANDARD;
+    use base64::Engine as _;
+    use std::io::Read;
+    let compressed = STANDARD.decode(payload_b64).unwrap();
+    let mut inflated = Vec::new();
+    flate2::read::ZlibDecoder::new(&compressed[..])
+        .read_to_end(&mut inflated)
+        .unwrap();
+    inflated
+}
+
 fn kitty_chunk(
     internal_image_id: InternalImageId,
     placement_uid: u64,
@@ -1295,14 +1345,49 @@ fn kitty_transmit_only_once_across_frames() {
 }
 
 #[test]
+fn kitty_transmit_payload_is_zlib_compressed_rgba() {
+    let parts = create_test_kitty_parts();
+    let internal = store_test_kitty_image(&parts.0, 30, 40);
+    let output = run_kitty_frame(&parts, vec![kitty_chunk(internal, 1, 0, 0)], None);
+    let (control, payload) = kitty_transmit_control_and_payload(&output);
+    assert!(control.starts_with("a=t,q=2,f=32,o=z,t=d,i=2000000000,s=30,v=40,m="));
+    assert!(payload.len() < 30 * 40 * 4);
+    assert_eq!(
+        inflate_kitty_transmit_payload(&payload),
+        vec![255u8; 30 * 40 * 4]
+    );
+}
+
+#[test]
+fn kitty_transmit_chunks_incompressible_payload() {
+    let parts = create_test_kitty_parts();
+    let mut state: u32 = 0x9e37_79b9;
+    let rgba: Vec<u8> = (0..64 * 64 * 4)
+        .map(|_| {
+            state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            (state >> 24) as u8
+        })
+        .collect();
+    let internal = store_test_kitty_image_with_bytes(&parts.0, 64, 64, rgba.clone());
+    let mut chunk = kitty_chunk(internal, 1, 0, 0);
+    chunk.source_px_width = 64;
+    chunk.source_px_height = 64;
+    let output = run_kitty_frame(&parts, vec![chunk], None);
+    assert!(output.contains("\u{1b}_Ga=t,q=2,f=32,o=z,t=d,i=2000000000,s=64,v=64,m=1;"));
+    assert!(output.contains("\u{1b}_Gq=2,m=1;"));
+    assert!(output.contains("\u{1b}_Gq=2,m=0;"));
+    let (_, payload) = kitty_transmit_control_and_payload(&output);
+    assert_eq!(inflate_kitty_transmit_payload(&payload), rgba);
+}
+
+#[test]
 fn kitty_placement_bytes_with_negative_z() {
     let parts = create_test_kitty_parts();
     let internal = store_test_kitty_image(&parts.0, 30, 40);
     let mut chunk = kitty_chunk(internal, 1, 5, 3);
     chunk.z_index = -1;
     let output = run_kitty_frame(&parts, vec![chunk], None);
-    assert!(output.contains("\u{1b}_Ga=t,q=2,f=32,t=d,i=2000000000,s=30,v=40,m=1;"));
-    assert!(output.contains("\u{1b}_Gq=2,m=0;"));
+    assert!(output.contains("\u{1b}_Ga=t,q=2,f=32,o=z,t=d,i=2000000000,s=30,v=40,m=0;"));
     let placement = "\u{1b}[4;6H\u{1b}[m\u{1b}_Ga=p,q=2,i=2000000000,p=1,x=0,y=0,w=30,h=40,X=0,Y=0,z=-1,C=1\u{1b}\\";
     assert!(output.contains(placement));
     let save_position = output.find("\u{1b}[s").unwrap();
@@ -1384,7 +1469,7 @@ fn kitty_diff_move_remove_free_retransmit() {
     assert!(frame_4.contains("\u{1b}_Ga=d,q=2,d=I,i=2000000000\u{1b}\\"));
     let new_internal = store_test_kitty_image(&parts.0, 30, 40);
     let frame_5 = run_kitty_frame(&parts, vec![kitty_chunk(new_internal, 2, 0, 0)], None);
-    assert!(frame_5.contains("\u{1b}_Ga=t,q=2,f=32,t=d,i=2000000001,"));
+    assert!(frame_5.contains("\u{1b}_Ga=t,q=2,f=32,o=z,t=d,i=2000000001,"));
 }
 
 #[test]

--- a/zellij-server/src/panes/kitty_graphics/store.rs
+++ b/zellij-server/src/panes/kitty_graphics/store.rs
@@ -1,5 +1,6 @@
 use base64::engine::general_purpose::STANDARD as BASE64_ENCODER;
 use base64::engine::Engine as _;
+use std::io::Write;
 
 use super::parser::{DecodedImage, KittyError, KittyErrorCode, KittyFormat};
 use std::collections::HashMap;
@@ -142,7 +143,16 @@ impl KittyImageStore {
             Some(cells) => stored.image.scaled_variants.get(&cells)?,
             None => &stored.image.rgba,
         };
-        let encoded = BASE64_ENCODER.encode(bytes);
+        // Paired with `o=z` in `emit_kitty_transmit`; zlib is part of the base kitty protocol.
+        let mut encoder = flate2::write::ZlibEncoder::new(
+            Vec::with_capacity(bytes.len() / 8),
+            flate2::Compression::fast(),
+        );
+        let compressed = encoder
+            .write_all(bytes)
+            .and_then(|_| encoder.finish())
+            .ok()?;
+        let encoded = BASE64_ENCODER.encode(&compressed);
         stored.base64_cache.insert(variant, encoded.clone());
         Some(encoded)
     }


### PR DESCRIPTION
Fixes #5596.

`emit_kitty_transmit` sends every image to the host as uncompressed RGBA base64 (`a=t,f=32,t=d`), regardless of what the application sent. 

For a PNG that is roughly 20× the application's bytes, and Zellij re-sends the whole payload whenever the host display is cleared: tab switch, pane split, fullscreen toggle, every step of a window resize. 

Over SSH ~10 MB/s, a single 943 KB PNG turns into ~2 s of saturated pipe, with every other pane's output queued behind it.

This compresses the cached host payload with zlib in `KittyImageStore::base64_for` and tags the transmit with `o=z`. `flate2` is already a dependency (it inflates `o=z` on ingest), and compression is part of the base kitty protocol with no feature gate, so any host that answers the startup probe can decode it. `Compression::fast()` was chosen after measuring level 1 vs 6 on real RGBA: ×13–15 vs ×15–18 for about twice the CPU; the wire is the bottleneck, so level 1 wins on latency.

The diff is the one @jzyrobert proposed in #5596 (I arrived at the same lines independently before finding the issue); this PR adds the tests and measurements. Happy to close it if they would rather open their own.

**Measurements** — headless client at 429×77 with 8×17 px cells, real PNGs (a map plot) shown with a small `a=T,f=100` script, bytes captured on the client's stdout:

| image | PNG | before | after |
|---|---|---|---|
| 828×790 | 121 KB | 2.42 MB | 163 KB | 
| 1600×1527 | 505 KB | 8.85 MB | 624 KB | 
| 2400×2290 | 943 KB | 19.9 MB | 1.94 MB | 

**Tests**: `kitty_placement_bytes_with_negative_z` and `kitty_host_display_clear_forces_replacement_next_frame` updated for the new control string (the 30×40 all-white test image now fits one chunk). Added `kitty_transmit_payload_is_zlib_compressed_rgba` (payload inflates to the stored RGBA) and `kitty_transmit_chunks_incompressible_payload` (a pseudo-random 64×64 image still splits into `m=1`/`m=0` chunks and round-trips).

`cargo test -p zellij-server kitty`: 144 passed. The one failure, `temp_file_medium_outside_temp_dir_is_not_deleted`, fails identically on unpatched `main` when the checkout lives under `/tmp` (`should_delete_temp_file` matches the prefix). `cargo fmt --check` is clean; clippy reports nothing at the changed lines.
