### PR TITLE
ci(release): strip CI build path from released sha256sum files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,9 +132,9 @@ jobs:
         run: |
           checksum_name="zellij-${{ matrix.target }}.sha256sum"
           if [[ "$RUNNER_OS" != "macOS" ]]; then
-            sha256sum "target/${{ matrix.target }}/release/zellij" > "${checksum_name}"
+            (cd "target/${{ matrix.target }}/release" && sha256sum zellij) > "${checksum_name}"
           else
-            shasum -a 256 "target/${{ matrix.target }}/release/zellij" > "${checksum_name}"
+            (cd "target/${{ matrix.target }}/release" && shasum -a 256 zellij) > "${checksum_name}"
           fi
           echo "checksum_name=${checksum_name}" >> "$GITHUB_OUTPUT"
 
@@ -144,7 +144,7 @@ jobs:
         run: |
           $checksum_name = "zellij-${{ matrix.target }}.sha256sum"
           $hash = (Get-FileHash "target/release/zellij.exe" -Algorithm SHA256).Hash.ToLower()
-          "$hash  target/release/zellij.exe" | Out-File -Encoding ascii $checksum_name
+          "$hash  zellij.exe" | Out-File -Encoding ascii $checksum_name
           echo "checksum_name=$checksum_name" >> $env:GITHUB_OUTPUT
 
       - name: Upload release archive
@@ -328,9 +328,9 @@ jobs:
         run: |
           checksum_name="zellij-no-web-${{ matrix.target }}.sha256sum"
           if [[ "$RUNNER_OS" != "macOS" ]]; then
-            sha256sum "target/${{ matrix.target }}/release/zellij" > "${checksum_name}"
+            (cd "target/${{ matrix.target }}/release" && sha256sum zellij) > "${checksum_name}"
           else
-            shasum -a 256 "target/${{ matrix.target }}/release/zellij" > "${checksum_name}"
+            (cd "target/${{ matrix.target }}/release" && shasum -a 256 zellij) > "${checksum_name}"
           fi
           echo "checksum_name=${checksum_name}" >> "$GITHUB_OUTPUT"
 
@@ -340,7 +340,7 @@ jobs:
         run: |
           $checksum_name = "zellij-no-web-${{ matrix.target }}.sha256sum"
           $hash = (Get-FileHash "target/release/zellij.exe" -Algorithm SHA256).Hash.ToLower()
-          "$hash  target/release/zellij.exe" | Out-File -Encoding ascii $checksum_name
+          "$hash  zellij.exe" | Out-File -Encoding ascii $checksum_name
           echo "checksum_name=$checksum_name" >> $env:GITHUB_OUTPUT
 
       - name: Upload release archive


### PR DESCRIPTION
sha256sum/shasum and Get-FileHash were run against the full build path (e.g. target/x86_64-unknown-linux-musl/release/zellij), so the released .sha256sum files record that path as the checked filename. The release archive only contains the bare zellij binary at its root, so running sha256sum --check against the downloaded, extracted files fails because the recorded path doesn't exist locally (#5598).

Generate each checksum from within the same directory used to build the archive (or drop the path prefix, for the Windows hash line) so the recorded filename matches what's actually in the archive.