### PR TITLE
fix(client): route ToggleMouseMode keybindings to client

### DIFF
--- a/zellij-client/src/input_handler.rs
+++ b/zellij-client/src/input_handler.rs
@@ -294,6 +294,9 @@ impl InputHandler {
                     self.os_input
                         .send_to_server(ClientToServerMsg::HostTerminalFocusChanged { focused });
                 },
+                Ok((InputInstruction::ToggleMouseMode, _error_context)) => {
+                    self.dispatch_action(Action::ToggleMouseMode, None);
+                },
                 Ok((InputInstruction::Exit, _error_context)) => {
                     self.should_exit = true;
                 },

--- a/zellij-client/src/lib.rs
+++ b/zellij-client/src/lib.rs
@@ -200,6 +200,7 @@ pub(crate) enum ClientInstruction {
         resolve_async: bool,
     },
     EmitNestedSessionFrame(Vec<u8>),
+    ToggleMouseMode,
 }
 
 impl From<ServerToClientMsg> for ClientInstruction {
@@ -234,6 +235,7 @@ impl From<ServerToClientMsg> for ClientInstruction {
             ServerToClientMsg::EmitNestedSessionFrame { payload_bytes } => {
                 ClientInstruction::EmitNestedSessionFrame(payload_bytes)
             },
+            ServerToClientMsg::ToggleMouseMode => ClientInstruction::ToggleMouseMode,
             // Subscribe-only messages — not handled by regular interactive clients
             ServerToClientMsg::PaneRenderUpdate { .. } => ClientInstruction::UnblockInputThread,
             ServerToClientMsg::SubscribedPaneClosed { .. } => ClientInstruction::UnblockInputThread,
@@ -263,6 +265,7 @@ impl From<&ClientInstruction> for ClientContext {
             ClientInstruction::ConfigFileUpdated => ClientContext::ConfigFileUpdated,
             ClientInstruction::ForwardQueryToHost { .. } => ClientContext::ForwardQueryToHost,
             ClientInstruction::EmitNestedSessionFrame(..) => ClientContext::EmitNestedSessionFrame,
+            ClientInstruction::ToggleMouseMode => ClientContext::ToggleMouseMode,
         }
     }
 }
@@ -562,6 +565,7 @@ pub(crate) enum InputInstruction {
     },
     NestedSessionFrameFromHost(Vec<u8>),
     HostTerminalFocusChanged(bool),
+    ToggleMouseMode,
     Exit,
 }
 
@@ -1592,6 +1596,9 @@ pub fn start_client(
                     let _ = out.write_all(&frame);
                     let _ = out.flush();
                 }
+            },
+            ClientInstruction::ToggleMouseMode => {
+                let _ = send_input_instructions.send(InputInstruction::ToggleMouseMode);
             },
             _ => {},
         }

--- a/zellij-client/src/unit/mod.rs
+++ b/zellij-client/src/unit/mod.rs
@@ -2,5 +2,16 @@
 #[cfg(feature = "web_server_capability")]
 mod terminal_loop_tests;
 
+#[test]
+fn toggle_mouse_mode_message_maps_to_client_instruction() {
+    use crate::ClientInstruction;
+    use zellij_utils::ipc::ServerToClientMsg;
+
+    assert!(matches!(
+        ClientInstruction::from(ServerToClientMsg::ToggleMouseMode),
+        ClientInstruction::ToggleMouseMode
+    ));
+}
+
 #[cfg(test)]
 mod teardown_tests;

--- a/zellij-client/src/web_client/server_listener.rs
+++ b/zellij-client/src/web_client/server_listener.rs
@@ -255,6 +255,7 @@ pub fn zellij_server_listener(
                             Some(ServerToClientMsg::PaneRenderUpdate { .. }) => {},
                             Some(ServerToClientMsg::SubscribedPaneClosed { .. }) => {},
                             Some(ServerToClientMsg::EmitNestedSessionFrame { .. }) => {},
+                            Some(ServerToClientMsg::ToggleMouseMode) => {},
                             Some(ServerToClientMsg::ForwardQueryToHost { token, .. }) => {
                                 // Reply immediately with empty reply_bytes.
                                 // This is the existing convention that signals

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -1320,7 +1320,14 @@ pub(crate) fn route_action(
                 .send_to_screen(instruction)
                 .with_context(err_context)?;
         },
-        Action::ToggleMouseMode => {}, // Handled client side
+        Action::ToggleMouseMode => {
+            if let Some(ref os_input) = os_input {
+                os_input
+                    .send_to_client(client_id, ServerToClientMsg::ToggleMouseMode)
+                    .with_context(err_context)?;
+            }
+            drop(NotificationEnd::new(completion_tx));
+        },
         Action::PreviousSwapLayout => {
             senders
                 .send_to_screen(ScreenInstruction::PreviousSwapLayout(

--- a/zellij-server/src/unit/screen_tests.rs
+++ b/zellij-server/src/unit/screen_tests.rs
@@ -179,6 +179,37 @@ fn route_arbitrary_action_to_server(
     .unwrap();
 }
 
+#[test]
+fn toggle_mouse_mode_action_is_forwarded_to_the_triggering_client() {
+    let client_id = 7;
+    let fake_os_input = FakeInputOutput::default();
+    let messages = fake_os_input.server_to_client_messages.clone();
+    let senders = ThreadSenders {
+        should_silently_fail: true,
+        ..Default::default()
+    };
+
+    let started_at = std::time::Instant::now();
+    route_action(
+        Action::ToggleMouseMode,
+        client_id,
+        None,
+        None,
+        senders,
+        None,
+        None,
+        InputMode::Normal,
+        Some(Box::new(fake_os_input)),
+    )
+    .unwrap();
+
+    assert!(started_at.elapsed() < std::time::Duration::from_millis(500));
+    assert_eq!(
+        messages.lock().unwrap().get(&client_id),
+        Some(&vec![ServerToClientMsg::ToggleMouseMode])
+    );
+}
+
 #[derive(Clone, Default)]
 struct FakeInputOutput {
     fake_filesystem: Arc<Mutex<HashMap<String, String>>>,

--- a/zellij-utils/assets/prost_ipc/client_server_contract.rs
+++ b/zellij-utils/assets/prost_ipc/client_server_contract.rs
@@ -3347,7 +3347,7 @@ impl HostTerminalThemeIndication {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServerToClientMsg {
-    #[prost(oneof="server_to_client_msg::Message", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19")]
+    #[prost(oneof="server_to_client_msg::Message", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20")]
     pub message: ::core::option::Option<server_to_client_msg::Message>,
 }
 /// Nested message and enum types in `ServerToClientMsg`.
@@ -3393,6 +3393,8 @@ pub mod server_to_client_msg {
         EmitNestedSessionFrame(super::EmitNestedSessionFrameMsg),
         #[prost(message, tag="19")]
         MobileState(super::MobileStateMsg),
+        #[prost(message, tag="20")]
+        ToggleMouseMode(super::ToggleMouseModeMsg),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -3513,6 +3515,11 @@ pub struct SetSoftKeyboardMsg {
 pub struct EmitNestedSessionFrameMsg {
     #[prost(bytes="vec", tag="1")]
     pub payload_bytes: ::prost::alloc::vec::Vec<u8>,
+}
+/// Empty message
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ToggleMouseModeMsg {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/zellij-utils/src/client_server_contract/server_to_client.proto
+++ b/zellij-utils/src/client_server_contract/server_to_client.proto
@@ -24,6 +24,7 @@ message ServerToClientMsg {
     SetSoftKeyboardMsg set_soft_keyboard = 17;
     EmitNestedSessionFrameMsg emit_nested_session_frame = 18;
     MobileStateMsg mobile_state = 19;
+    ToggleMouseModeMsg toggle_mouse_mode = 20;
   }
 }
 
@@ -105,6 +106,10 @@ message SetSoftKeyboardMsg {
 
 message EmitNestedSessionFrameMsg {
   bytes payload_bytes = 1;
+}
+
+message ToggleMouseModeMsg {
+  // Empty message
 }
 
 message MobileSizeMsg {

--- a/zellij-utils/src/errors.rs
+++ b/zellij-utils/src/errors.rs
@@ -594,6 +594,7 @@ pub enum ClientContext {
     ConfigFileUpdated,
     ForwardQueryToHost,
     EmitNestedSessionFrame,
+    ToggleMouseMode,
 }
 
 /// Stack call representations corresponding to the different types of [`ServerInstruction`]s.

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -302,6 +302,7 @@ pub enum ServerToClientMsg {
     MobileState {
         payload: MobileStatePayload,
     },
+    ToggleMouseMode,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/zellij-utils/src/ipc/protobuf_conversion.rs
+++ b/zellij-utils/src/ipc/protobuf_conversion.rs
@@ -20,7 +20,7 @@ use crate::{
         SetMobileRenderPreferencesMsg, SetSoftKeyboardMsg, SixelSupportMsg,
         SoftKeyboardVisibilityChangedMsg, StartWebServerMsg, SubscribeToPaneRendersMsg,
         SubscribedPaneClosedMsg, SwitchSessionMsg, TabMetadata as ProtoTabMetadata,
-        TerminalPixelDimensionsMsg, TerminalResizeMsg, UnblockCliPipeInputMsg,
+        TerminalPixelDimensionsMsg, TerminalResizeMsg, ToggleMouseModeMsg, UnblockCliPipeInputMsg,
         UnblockInputThreadMsg, WebServerStartedMsg,
     },
     data::{HostTerminalThemeMode, InputMode, PaneId},
@@ -460,6 +460,9 @@ impl From<ServerToClientMsg> for ProtoServerToClientMsg {
             ServerToClientMsg::MobileState { payload } => {
                 server_to_client_msg::Message::MobileState(mobile_state_payload_to_proto(payload))
             },
+            ServerToClientMsg::ToggleMouseMode => {
+                server_to_client_msg::Message::ToggleMouseMode(ToggleMouseModeMsg {})
+            },
         };
 
         ProtoServerToClientMsg {
@@ -705,6 +708,9 @@ impl TryFrom<ProtoServerToClientMsg> for ServerToClientMsg {
                 Ok(ServerToClientMsg::MobileState {
                     payload: mobile_state_payload_from_proto(msg),
                 })
+            },
+            Some(server_to_client_msg::Message::ToggleMouseMode(_)) => {
+                Ok(ServerToClientMsg::ToggleMouseMode)
             },
             None => Err(anyhow!("Empty ServerToClientMsg message")),
         }

--- a/zellij-utils/src/ipc/tests/roundtrip_tests.rs
+++ b/zellij-utils/src/ipc/tests/roundtrip_tests.rs
@@ -3949,6 +3949,7 @@ fn test_server_messages() {
     });
     test_server_roundtrip!(ServerToClientMsg::SetSoftKeyboard { on: true });
     test_server_roundtrip!(ServerToClientMsg::SetSoftKeyboard { on: false });
+    test_server_roundtrip!(ServerToClientMsg::ToggleMouseMode);
     test_server_roundtrip!(ServerToClientMsg::MobileState {
         payload: MobileStatePayload {
             session_name: String::new(),


### PR DESCRIPTION
## Summary

Route `ToggleMouseMode` through the client instruction path so the client can update terminal mouse capture instead of treating it as a server-only action.

Includes a unit test covering the action-to-instruction mapping.

## Validation

- `cargo xtask format --check`
- `cargo xtask test --no-web`